### PR TITLE
refactor(tray): extract Settings page into a WinUI-free view model over a settings store

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -57,6 +57,8 @@ These are the canonical homes. Do not reintroduce private copies elsewhere.
 | UI-thread marshaling for presentation code | `IUiDispatcher` | authoritative |
 | Page view-model activation/deactivation + disposal lifetime | `NavigationScopeManager` | authoritative |
 | Presentation-layer DI composition root | `AppServiceRegistration` (root `ServiceProvider`, owned by `App`) | authoritative |
+| Settings snapshot read + batched save + non-echoing change notification | `ISettingsStore` | authoritative |
+| Settings page load/persist view logic | `SettingsPageViewModel` | authoritative |
 | Capability UI metadata | `NodeCapabilityUiCatalog` (planned) | planned |
 | Capability registration/gating | `NodeCapabilityRegistrationPolicy` (planned) | planned |
 | Local MCP exposure policy | `McpCapabilityPolicy` (planned) | planned |
@@ -72,6 +74,7 @@ These are the canonical homes. Do not reintroduce private copies elsewhere.
 | `src/OpenClaw.Tray.WinUI/Chat/OpenClawChatTimeline.cs` | `TimelineScrollController`, `ChatBubbleRenderer`, `ToolCallCardRenderer`, `PermissionRequestCard`, `AttachmentBubbleRenderer` |
 | `src/OpenClaw.Tray.WinUI/Chat/OpenClawComposer.cs` | `ComposerViewModel`, `SlashCommandPalette`, `AttachmentPreviewStrip`, `VoiceComposerController` |
 | `src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs` | `ConnectionPagePlan` (pure), `ConnectionPageViewModel`, gateway row models |
+| `src/OpenClaw.Tray.WinUI/Pages/SettingsPage.xaml.cs` | settings read/persist → `SettingsPageViewModel` + `ISettingsStore`; keep gateway-uninstall, uptime timer, saved-indicator, and app-info in the view |
 | `src/OpenClaw.Tray.WinUI/Services/NodeService.cs` | `McpServerHost`, `CanvasWindowManager`, `MediaCapabilityHost`, `RecordingConsentService`, `NodeCapabilityRegistry` |
 | `src/OpenClaw.Shared/OpenClawGatewayClient.cs` | `PendingRequestRegistry`, `ConnectEnvelopeBuilder`, `GatewayMessageRouter`, per-domain API facades |
 | `src/OpenClaw.Shared/Models.cs` | per-domain model files + `*Mapper` classes |
@@ -124,6 +127,8 @@ leading and trailing pipe. Columns, in order:
 | navigation-scope | authoritative | src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs | page view-model activation/deactivation and disposal lifetime | NavigationScopeManager | HubWindow keeps frame navigation back-stack and rail selection | transient page view models are activated on navigation and deactivated then disposed on navigate-away | NavigationScopeManagerTests.NavigatingAway_DeactivatesAndDisposesPreviousViewModel | behavioral | - |
 | composition-root | authoritative | src/OpenClaw.Tray.WinUI/App.xaml.cs | presentation-layer service construction and wiring | AppServiceRegistration | App remains the composition root and owns non-DI service lifetimes | one validated root ServiceProvider; App-owned singletons registered as instances are never disposed by the container | AppServiceRegistrationTests.Dispose_DoesNotDisposeAppOwnedInstanceSingletons | behavioral | - |
 | node-summary-text | authoritative | src/OpenClaw.Tray.WinUI/App.xaml.cs | node-summary clipboard text formatting | NodeSummaryText | App keeps the clipboard side effect (building the DataPackage and setting clipboard content) | copied node-summary text is projected only by NodeSummaryText.Build (online/offline state, display-name fallback, short id, detail text, newline join) | NodeSummaryTextTests.Build_MultipleNodes_OneLinePerNodeJoinedByNewline | behavioral | - |
+| settings-store | authoritative | src/OpenClaw.Tray.WinUI/Pages/SettingsPage.xaml.cs | hand-rolled save/echo suppression flags for two-way settings binding | ISettingsStore | PermissionsPage and other surfaces may read SettingsManager directly until migrated | a save originating from Update does not echo Changed to the caller and external saves are republished on the UI thread | SettingsStoreTests.Update_DoesNotEchoChangedToSelf | behavioral | when all settings surfaces read and write through ISettingsStore |
+| settings-page-vm | authoritative | src/OpenClaw.Tray.WinUI/Pages/SettingsPage.xaml.cs | settings load, persist, echo-guard, and auto-save wiring | SettingsPageViewModel | code-behind keeps gateway-uninstall, gateway-info and uptime timer, saved-indicator visual, and app-info population | each settings control persists its field through the store preserving mutate-save-notify order and does not re-persist on external change | SettingsPageViewModelTests.ExternalChange_ReloadsWithoutRePersisting | behavioral | when the Settings page holds no settings persistence logic in code-behind |
 <!-- LEDGER:END -->
 
 ## Deferred test builders

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -64,15 +64,21 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     private ServiceProvider? _services;
 
     /// <summary>
-    /// Page type → view-model type map used by the navigation activation hook.
-    /// Currently empty: no page resolves a view model from DI yet, so the activation
-    /// hook is a runtime no-op. Entries are added here as pages adopt view models.
+    /// Page type → view-model type map used by the navigation activation hook. The Settings
+    /// page resolves its view model from DI and binds it as the page DataContext; pages absent
+    /// from the map take the no-op activation path.
     /// </summary>
     private static readonly IReadOnlyDictionary<Type, Type> PageViewModelMap =
-        new Dictionary<Type, Type>();
+        new Dictionary<Type, Type>
+        {
+            [typeof(Pages.SettingsPage)] = typeof(SettingsPageViewModel),
+        };
 
     /// <summary>The root service provider, or null before startup / after shutdown.</summary>
     internal IServiceProvider? Services => _services;
+
+    /// <summary>The settings facade, or null before startup / after shutdown.</summary>
+    internal ISettingsStore? SettingsStore => _services?.GetService<ISettingsStore>();
 
     /// <summary>Resolves the page activator used by <c>HubWindow</c>'s navigation hook.</summary>
     internal IPageActivator? PageActivator => _services?.GetService<IPageActivator>();
@@ -4208,6 +4214,33 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         await AutoStartManager.SetAutoStartAsync(_settings.AutoStart);
     }
 
+    /// <summary>
+    /// Persists the auto-start setting and applies the Windows OS registration in the original
+    /// order (save, then await the OS write, then notify). Returns true only when the OS write
+    /// and notify complete, so the caller shows its saved confirmation only on success. The save
+    /// is marked as a store self-write so it does not echo an external-change reload.
+    /// </summary>
+    public async Task<bool> ApplyAutoStart(bool autoStart)
+    {
+        if (_settings == null) return false;
+        try
+        {
+            _settings.AutoStart = autoStart;
+            using (SettingsStore?.BeginSelfWrite())
+            {
+                _settings.Save();
+            }
+            await AutoStartManager.SetAutoStartAsync(autoStart);
+            OnSettingsSaved(this, EventArgs.Empty);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Logger.Error($"ApplyAutoStart failed: {ex.Message}");
+            return false;
+        }
+    }
+
     private void OpenLogFile()
     {
         try
@@ -4491,6 +4524,12 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     /// <summary>Raised when speaker mute state changes from any source (composer, settings, etc.).</summary>
     public event Action<bool>? SpeakerMuteChanged;
 
+    /// <summary>
+    /// Sets speaker mute from any surface (chat window, chat page, voice settings) and persists it.
+    /// This public path is NOT store-self-write-suppressed, so an open Settings page still reflects
+    /// a mute toggled elsewhere. The Settings-page-originated call goes through the explicit
+    /// <see cref="IAppCommands.SetChatSpeakerMuted"/> below, which suppresses its own echo.
+    /// </summary>
     public void SetChatSpeakerMuted(bool muted)
     {
         if (_chatCoordinator is { } c) c.IsMuted = muted;
@@ -4503,6 +4542,26 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         // Broadcast to all subscribers
         SpeakerMuteChanged?.Invoke(muted);
     }
+
+    /// <summary>
+    /// Settings-page-originated mute: wraps the shared write in a store self-write so it does not
+    /// echo an external-change reload back to the Settings view model that triggered it.
+    /// </summary>
+    void IAppCommands.SetChatSpeakerMuted(bool muted)
+    {
+        using (SettingsStore?.BeginSelfWrite())
+        {
+            SetChatSpeakerMuted(muted);
+        }
+    }
+
+    /// <summary>
+    /// Pushes tool-call visibility into the live chat timeline. Forwards to the shared
+    /// static writer so a WinUI-free settings view model can drive it through IAppCommands
+    /// without referencing the chat UI directly.
+    /// </summary>
+    public void SetChatToolCallsVisible(bool visible) =>
+        OpenClawTray.Chat.OpenClawChatRoot.SetToolCallsVisible(visible);
 
     private static void SendDeepLinkToRunningInstance(string uri)
     {

--- a/src/OpenClaw.Tray.WinUI/Pages/SettingsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/SettingsPage.xaml
@@ -52,6 +52,7 @@
                                        TextWrapping="Wrap"/>
                         </StackPanel>
                         <ToggleSwitch Grid.Column="1" x:Name="AutoStartToggle" MinWidth="0" OnContent="" OffContent=""
+                                      IsOn="{Binding AutoStart, Mode=TwoWay}"
                                       AutomationProperties.AutomationId="SettingsPageAutoStart"
                                       AutomationProperties.Name="Start with Windows"/>
                     </Grid>
@@ -74,6 +75,8 @@
                                        TextWrapping="Wrap"/>
                         </StackPanel>
                         <ComboBox Grid.Column="1" x:Name="AppThemeComboBox" MinWidth="160"
+                                  SelectedValuePath="Tag"
+                                  SelectedValue="{Binding AppTheme, Mode=TwoWay}"
                                   AutomationProperties.AutomationId="SettingsPageAppTheme"
                                   AutomationProperties.Name="App theme">
                             <ComboBoxItem x:Uid="SettingsPage_AppTheme_System" Content="System" Tag="System"/>
@@ -100,6 +103,7 @@
                                        TextWrapping="Wrap"/>
                         </StackPanel>
                         <ToggleSwitch Grid.Column="1" x:Name="GlobalHotkeyToggle" MinWidth="0" OnContent="" OffContent=""
+                                      IsOn="{Binding GlobalHotkeyEnabled, Mode=TwoWay}"
                                       AutomationProperties.AutomationId="SettingsPageHotkey"
                                       AutomationProperties.Name="Global hotkey"/>
                     </Grid>
@@ -122,6 +126,7 @@
                                        TextWrapping="Wrap"/>
                         </StackPanel>
                         <ToggleSwitch Grid.Column="1" x:Name="UseLegacyWebChatToggle" MinWidth="0" OnContent="" OffContent=""
+                                      IsOn="{Binding UseLegacyWebChat, Mode=TwoWay}"
                                       AutomationProperties.AutomationId="SettingsPageUseLegacyWebChat"
                                       AutomationProperties.Name="Use gateway chat interface"/>
                     </Grid>
@@ -149,6 +154,7 @@
                                        TextWrapping="Wrap"/>
                         </StackPanel>
                         <ToggleSwitch Grid.Column="1" x:Name="ReadResponsesAloudToggle" MinWidth="0" OnContent="" OffContent=""
+                                      IsOn="{Binding ReadResponsesAloud, Mode=TwoWay}"
                                       AutomationProperties.AutomationId="SettingsPageReadAloud"
                                       AutomationProperties.LabeledBy="{Binding ElementName=ReadResponsesAloudLabel}"/>
                     </Grid>
@@ -172,6 +178,7 @@
                                        TextWrapping="Wrap"/>
                         </StackPanel>
                         <ToggleSwitch Grid.Column="1" x:Name="ShowToolCallsToggle" MinWidth="0" OnContent="" OffContent=""
+                                      IsOn="{Binding ShowChatToolCalls, Mode=TwoWay}"
                                       AutomationProperties.AutomationId="SettingsPageShowToolCalls"
                                       AutomationProperties.LabeledBy="{Binding ElementName=ShowToolCallsLabel}"/>
                     </Grid>
@@ -198,6 +205,7 @@
                                        TextWrapping="Wrap"/>
                         </StackPanel>
                         <ToggleSwitch Grid.Column="1" x:Name="NotificationsToggle" MinWidth="0" OnContent="" OffContent=""
+                                      IsOn="{Binding ShowNotifications, Mode=TwoWay}"
                                       AutomationProperties.AutomationId="SettingsPageNotifications"
                                       AutomationProperties.Name="Show notifications"/>
                     </Grid>
@@ -221,6 +229,8 @@
                         </StackPanel>
                         <ComboBox Grid.Column="1" x:Uid="SettingsPage_NotificationSoundComboBox"
                                   x:Name="NotificationSoundComboBox" MinWidth="140"
+                                  SelectedValuePath="Tag"
+                                  SelectedValue="{Binding NotificationSound, Mode=TwoWay}"
                                   AutomationProperties.AutomationId="SettingsPageSound">
                             <ComboBoxItem x:Uid="SettingsPage_ComboBoxItem_48" Content="Default" Tag="Default"/>
                             <ComboBoxItem x:Uid="SettingsPage_ComboBoxItem_49" Content="None" Tag="None"/>
@@ -248,28 +258,28 @@
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
                             <CheckBox Grid.Row="0" Grid.Column="0" x:Uid="NotifyHealthCb" x:Name="NotifyHealthCb"
-                                      Content="Health alerts"
+                                      Content="Health alerts" IsChecked="{Binding NotifyHealth, Mode=TwoWay}"
                                       AutomationProperties.AutomationId="SettingsPageNotifyHealth"/>
                             <CheckBox Grid.Row="0" Grid.Column="1" x:Uid="NotifyUrgentCb" x:Name="NotifyUrgentCb"
-                                      Content="Urgent messages"
+                                      Content="Urgent messages" IsChecked="{Binding NotifyUrgent, Mode=TwoWay}"
                                       AutomationProperties.AutomationId="SettingsPageNotifyUrgent"/>
                             <CheckBox Grid.Row="1" Grid.Column="0" x:Uid="NotifyReminderCb" x:Name="NotifyReminderCb"
-                                      Content="Reminders"
+                                      Content="Reminders" IsChecked="{Binding NotifyReminder, Mode=TwoWay}"
                                       AutomationProperties.AutomationId="SettingsPageNotifyReminder"/>
                             <CheckBox Grid.Row="1" Grid.Column="1" x:Uid="NotifyEmailCb" x:Name="NotifyEmailCb"
-                                      Content="Email summaries"
+                                      Content="Email summaries" IsChecked="{Binding NotifyEmail, Mode=TwoWay}"
                                       AutomationProperties.AutomationId="SettingsPageNotifyEmail"/>
                             <CheckBox Grid.Row="2" Grid.Column="0" x:Uid="NotifyCalendarCb" x:Name="NotifyCalendarCb"
-                                      Content="Calendar events"
+                                      Content="Calendar events" IsChecked="{Binding NotifyCalendar, Mode=TwoWay}"
                                       AutomationProperties.AutomationId="SettingsPageNotifyCalendar"/>
                             <CheckBox Grid.Row="2" Grid.Column="1" x:Uid="NotifyBuildCb" x:Name="NotifyBuildCb"
-                                      Content="Build notifications"
+                                      Content="Build notifications" IsChecked="{Binding NotifyBuild, Mode=TwoWay}"
                                       AutomationProperties.AutomationId="SettingsPageNotifyBuild"/>
                             <CheckBox Grid.Row="3" Grid.Column="0" x:Uid="NotifyStockCb" x:Name="NotifyStockCb"
-                                      Content="Stock alerts"
+                                      Content="Stock alerts" IsChecked="{Binding NotifyStock, Mode=TwoWay}"
                                       AutomationProperties.AutomationId="SettingsPageNotifyStock"/>
                             <CheckBox Grid.Row="3" Grid.Column="1" x:Uid="NotifyInfoCb" x:Name="NotifyInfoCb"
-                                      Content="Info messages"
+                                      Content="Info messages" IsChecked="{Binding NotifyInfo, Mode=TwoWay}"
                                       AutomationProperties.AutomationId="SettingsPageNotifyInfo"/>
                         </Grid>
                         <Button x:Uid="TestNotificationButton" x:Name="TestNotificationButton"
@@ -304,6 +314,7 @@
                                        TextWrapping="Wrap"/>
                         </StackPanel>
                         <ToggleSwitch Grid.Column="1" x:Name="ScreenRecordingToggle" MinWidth="0" OnContent="" OffContent=""
+                                      IsOn="{Binding ScreenRecordingConsentGiven, Mode=TwoWay}"
                                       AutomationProperties.AutomationId="SettingsPageScreenRecording"
                                       AutomationProperties.Name="Allow screen recording"/>
                     </Grid>
@@ -326,6 +337,7 @@
                                        TextWrapping="Wrap"/>
                         </StackPanel>
                         <ToggleSwitch Grid.Column="1" x:Name="CameraRecordingToggle" MinWidth="0" OnContent="" OffContent=""
+                                      IsOn="{Binding CameraRecordingConsentGiven, Mode=TwoWay}"
                                       AutomationProperties.AutomationId="SettingsPageCameraRecording"
                                       AutomationProperties.Name="Allow camera recording"/>
                     </Grid>
@@ -453,6 +465,7 @@
                                       MinWidth="0"
                                       OnContent=""
                                       OffContent=""
+                                      IsOn="{Binding ShowDiagnostics, Mode=TwoWay}"
                                       AutomationProperties.AutomationId="SettingsPageShowDiagnostics"
                                       AutomationProperties.Name="Enable Diagnostics"/>
                     </Grid>

--- a/src/OpenClaw.Tray.WinUI/Pages/SettingsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SettingsPage.xaml.cs
@@ -4,6 +4,7 @@ using Microsoft.UI.Xaml.Controls;
 using OpenClaw.Connection;
 using OpenClaw.Shared;
 using OpenClawTray.Helpers;
+using OpenClawTray.Presentation;
 using OpenClawTray.Services;
 using System;
 using System.ComponentModel;
@@ -12,7 +13,6 @@ using System.Globalization;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -21,9 +21,7 @@ namespace OpenClawTray.Pages;
 public sealed partial class SettingsPage : Page
 {
     private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current!;
-    private bool _initialized;
-    private bool _saving;
-    private bool _loading;
+    private SettingsPageViewModel? _viewModel;
     private bool _localGatewayInstalled;
     private bool _uninstallInitiatedThisSession;
     private CancellationTokenSource? _uninstallCts;
@@ -48,7 +46,7 @@ public sealed partial class SettingsPage : Page
             $"Launches setup to install the app-owned {AppIdentity.SetupDistroName} WSL distro or re-run provider and model setup for an existing one. Existing local gateways are only replaced after confirmation.";
         GatewayBodyText.Text = GatewayIdleBodyText;
         _gatewayUptimeRefreshTimer.Tick += OnGatewayUptimeRefreshTimerTick;
-        Loaded += OnLoaded;
+        DataContextChanged += OnDataContextChanged;
         Unloaded += OnUnloaded;
     }
 
@@ -56,139 +54,54 @@ public sealed partial class SettingsPage : Page
     {
         PopulateAppInfo();
         InitializeGatewayInfo();
+        if (CurrentApp.Settings is { } settings)
+            LoadGatewaySection(settings);
+    }
 
-        var settings = CurrentApp.Settings;
-        if (!_initialized && settings != null)
+    /// <summary>
+    /// The Settings view model is assigned as the page DataContext by the navigation activation
+    /// hook. The two-way bindings handle load/persist; the page only subscribes to the view-only
+    /// side effects it applies on the UI thread: the saved indicator, and refreshing the
+    /// view-owned gateway section when settings change externally.
+    /// </summary>
+    private void OnDataContextChanged(FrameworkElement sender, DataContextChangedEventArgs args)
+    {
+        if (_viewModel != null)
         {
-            _loading = true;
-            LoadSettings(settings);
-            _loading = false;
-            WireAutoSaveHandlers();
-            _initialized = true;
+            _viewModel.SavedIndicated -= OnViewModelSavedIndicated;
+            _viewModel.ExternalChanged -= OnViewModelExternalChanged;
         }
-        else if (_initialized && settings != null)
+
+        _viewModel = args.NewValue as SettingsPageViewModel;
+
+        if (_viewModel != null)
         {
-            _loading = true;
-            ScreenRecordingToggle.IsOn = settings.ScreenRecordingConsentGiven;
-            CameraRecordingToggle.IsOn = settings.CameraRecordingConsentGiven;
-            _loading = false;
+            _viewModel.SavedIndicated += OnViewModelSavedIndicated;
+            _viewModel.ExternalChanged += OnViewModelExternalChanged;
         }
     }
 
-    private void OnLoaded(object sender, RoutedEventArgs e)
+    private void OnViewModelSavedIndicated(object? sender, EventArgs e) => ShowSavedIndicator();
+
+    /// <summary>
+    /// The gateway management section is view-owned (not settings-bound), so it must be refreshed
+    /// when settings change from another source, matching the page's previous live-refresh behavior.
+    /// </summary>
+    private void OnViewModelExternalChanged(object? sender, EventArgs e)
     {
-        if (CurrentApp.Settings != null)
-            CurrentApp.Settings.Saved += OnExternalSettingsChanged;
+        if (CurrentApp.Settings is { } settings)
+            LoadGatewaySection(settings);
     }
 
     private void OnUnloaded(object sender, RoutedEventArgs e)
     {
-        if (CurrentApp.Settings != null)
-            CurrentApp.Settings.Saved -= OnExternalSettingsChanged;
         if (_appState != null)
             _appState.PropertyChanged -= OnAppStateChanged;
         _appState = null;
         _gatewayUptimeRefreshTimer.Stop();
     }
 
-    // ── Auto-save wiring ──
-
-    private void WireAutoSaveHandlers()
-    {
-        AutoStartToggle.Toggled += (_, _) => PersistAutoStart();
-        GlobalHotkeyToggle.Toggled += (_, _) => Persist(s => s.GlobalHotkeyEnabled = GlobalHotkeyToggle.IsOn);
-        UseLegacyWebChatToggle.Toggled += (_, _) => Persist(s => s.UseLegacyWebChat = UseLegacyWebChatToggle.IsOn);
-        NotificationsToggle.Toggled += (_, _) => Persist(s => s.ShowNotifications = NotificationsToggle.IsOn);
-        NotificationSoundComboBox.SelectionChanged += (_, _) =>
-        {
-            if (NotificationSoundComboBox.SelectedItem is ComboBoxItem item)
-                Persist(s => s.NotificationSound = item.Tag?.ToString() ?? "Default");
-        };
-        AppThemeComboBox.SelectionChanged += (_, _) =>
-        {
-            if (AppThemeComboBox.SelectedItem is ComboBoxItem item)
-                Persist(s => s.AppTheme = item.Tag?.ToString() ?? SettingsManager.AppThemeSystem);
-        };
-        ShowDiagnosticsToggle.Toggled += (_, _) => Persist(s => s.ShowDiagnosticsOverride = ShowDiagnosticsToggle.IsOn);
-
-        WireCheckBox(NotifyHealthCb, v => CurrentApp.Settings!.NotifyHealth = v);
-        WireCheckBox(NotifyUrgentCb, v => CurrentApp.Settings!.NotifyUrgent = v);
-        WireCheckBox(NotifyReminderCb, v => CurrentApp.Settings!.NotifyReminder = v);
-        WireCheckBox(NotifyEmailCb, v => CurrentApp.Settings!.NotifyEmail = v);
-        WireCheckBox(NotifyCalendarCb, v => CurrentApp.Settings!.NotifyCalendar = v);
-        WireCheckBox(NotifyBuildCb, v => CurrentApp.Settings!.NotifyBuild = v);
-        WireCheckBox(NotifyStockCb, v => CurrentApp.Settings!.NotifyStock = v);
-        WireCheckBox(NotifyInfoCb, v => CurrentApp.Settings!.NotifyInfo = v);
-
-        ScreenRecordingToggle.Toggled += (_, _) => Persist(s => s.ScreenRecordingConsentGiven = ScreenRecordingToggle.IsOn);
-        CameraRecordingToggle.Toggled += (_, _) => Persist(s => s.CameraRecordingConsentGiven = CameraRecordingToggle.IsOn);
-
-        // "Read responses aloud" reuses App.SetChatSpeakerMuted, which persists
-        // VoiceTtsEnabled (as the inverse of mute), updates the chat coordinator,
-        // and broadcasts the change to any open chat surface.
-        ReadResponsesAloudToggle.Toggled += (_, _) =>
-        {
-            if (_loading || CurrentApp.Settings == null) return;
-            CurrentApp.SetChatSpeakerMuted(!ReadResponsesAloudToggle.IsOn);
-            ShowSavedIndicator();
-        };
-        // "Show tool calls and usage" persists the setting and pushes the new
-        // visibility into the live chat timeline via the shared static writer.
-        ShowToolCallsToggle.Toggled += (_, _) =>
-        {
-            if (_loading || CurrentApp.Settings == null) return;
-            Persist(s => s.ShowChatToolCalls = ShowToolCallsToggle.IsOn);
-            OpenClawTray.Chat.OpenClawChatRoot.SetToolCallsVisible(ShowToolCallsToggle.IsOn);
-        };
-    }
-
-    private void WireCheckBox(CheckBox cb, Action<bool> mutate)
-    {
-        RoutedEventHandler handler = (_, _) => Persist(_ => mutate(cb.IsChecked ?? false));
-        cb.Checked += handler;
-        cb.Unchecked += handler;
-    }
-
-    private void Persist(Action<SettingsManager> mutate)
-    {
-        if (_loading || CurrentApp.Settings == null) return;
-        _saving = true;
-        try
-        {
-            mutate(CurrentApp.Settings);
-            CurrentApp.Settings.Save();
-            ((IAppCommands)CurrentApp).NotifySettingsSaved();
-            ShowSavedIndicator();
-        }
-        finally
-        {
-            _saving = false;
-        }
-    }
-
-    private void PersistAutoStart() =>
-        AsyncEventHandlerGuard.Run(
-            PersistAutoStartAsync,
-            new OpenClawTray.AppLogger(),
-            nameof(PersistAutoStart));
-
-    private async Task PersistAutoStartAsync()
-    {
-        if (_loading || CurrentApp.Settings == null) return;
-        _saving = true;
-        try
-        {
-            CurrentApp.Settings.AutoStart = AutoStartToggle.IsOn;
-            CurrentApp.Settings.Save();
-            await AutoStartManager.SetAutoStartAsync(CurrentApp.Settings.AutoStart);
-            ((IAppCommands)CurrentApp).NotifySettingsSaved();
-            ShowSavedIndicator();
-        }
-        finally
-        {
-            _saving = false;
-        }
-    }
+    // ── Saved indicator ──
 
     private Microsoft.UI.Dispatching.DispatcherQueueTimer? _savedIndicatorTimer;
     private void ShowSavedIndicator()
@@ -204,63 +117,21 @@ public sealed partial class SettingsPage : Page
         _savedIndicatorTimer.Start();
     }
 
-    private void OnExternalSettingsChanged(object? sender, EventArgs e)
-    {
-        if (CurrentApp.Settings == null || _saving) return;
-        DispatcherQueue.TryEnqueue(() =>
-        {
-            _loading = true;
-            try
-            {
-                LoadSettings(CurrentApp.Settings);
-            }
-            finally
-            {
-                _loading = false;
-            }
-        });
-    }
-
-    private void LoadSettings(SettingsManager settings)
-    {
-        AutoStartToggle.IsOn = settings.AutoStart;
-        GlobalHotkeyToggle.IsOn = settings.GlobalHotkeyEnabled;
-        UseLegacyWebChatToggle.IsOn = settings.UseLegacyWebChat;
-        NotificationsToggle.IsOn = settings.ShowNotifications;
-
-        SelectComboBoxItemByTag(NotificationSoundComboBox, settings.NotificationSound);
-        SelectComboBoxItemByTag(AppThemeComboBox, settings.AppTheme);
-        ShowDiagnosticsToggle.IsOn = settings.ShowDiagnosticsEffective;
-
-        NotifyHealthCb.IsChecked = settings.NotifyHealth;
-        NotifyUrgentCb.IsChecked = settings.NotifyUrgent;
-        NotifyReminderCb.IsChecked = settings.NotifyReminder;
-        NotifyEmailCb.IsChecked = settings.NotifyEmail;
-        NotifyCalendarCb.IsChecked = settings.NotifyCalendar;
-        NotifyBuildCb.IsChecked = settings.NotifyBuild;
-        NotifyStockCb.IsChecked = settings.NotifyStock;
-        NotifyInfoCb.IsChecked = settings.NotifyInfo;
-
-        ScreenRecordingToggle.IsOn = settings.ScreenRecordingConsentGiven;
-        CameraRecordingToggle.IsOn = settings.CameraRecordingConsentGiven;
-
-        // Chat section: "Read responses aloud" mirrors VoiceTtsEnabled (mute is
-        // its inverse). "Show tool calls and usage" mirrors ShowChatToolCalls.
-        ReadResponsesAloudToggle.IsOn = settings.VoiceTtsEnabled;
-        ShowToolCallsToggle.IsOn = settings.ShowChatToolCalls;
-        LoadGatewaySection(settings);
-    }
-
     private void PopulateAppInfo()
     {
         AppInfoVersionText.Text = AppVersionInfo.DisplayVersion;
-        AppInfoRuntimeText.Text = BuildRuntimeStackDisplayText();
+        var windowsAppSdk = SettingsAppInfoProjection.ResolveWindowsAppSdkDisplayName(
+            Assembly.GetEntryAssembly()?.GetName().Name, AppContext.BaseDirectory);
+        AppInfoRuntimeText.Text = SettingsAppInfoProjection.BuildRuntimeStack(
+            RuntimeInformation.FrameworkDescription, ResolveWinUiDisplayName(), windowsAppSdk);
         AppInfoArchText.Text = RuntimeInformation.ProcessArchitecture.ToString();
         AppInfoWindowsText.Text = Environment.OSVersion.Version.ToString();
-        AppInfoInstallText.Text = PackageHelper.IsPackaged ? "Packaged (MSIX)" : "Unpackaged (developer)";
-        AppInfoChannelText.Text = ResolveUpdateChannelDisplayText();
+        AppInfoInstallText.Text = SettingsAppInfoProjection.InstallKind(PackageHelper.IsPackaged);
+        AppInfoChannelText.Text = SettingsAppInfoProjection.ResolveUpdateChannel(
+            Environment.GetEnvironmentVariable("OPENCLAW_UPDATE_CHANNEL"));
 
-        var buildDate = TryResolveBuildDateDisplayText();
+        var buildDate = SettingsAppInfoProjection.FormatBuildDate(
+            Assembly.GetEntryAssembly()?.Location, CultureInfo.CurrentCulture);
         if (string.IsNullOrWhiteSpace(buildDate))
         {
             AppInfoBuildLabel.Visibility = Visibility.Collapsed;
@@ -353,33 +224,8 @@ public sealed partial class SettingsPage : Page
         }
 
         var elapsedMs = Math.Max(0, (DateTime.UtcNow - _sampledGatewayUptimeUtc).TotalMilliseconds);
-        GatewayUptimeText.Text = FormatDuration(TimeSpan.FromMilliseconds(_sampledGatewayUptimeMs.Value + elapsedMs));
-    }
-
-    private static string FormatDuration(TimeSpan duration)
-    {
-        if (duration.TotalDays >= 1)
-            return $"{(int)duration.TotalDays}d {duration.Hours}h";
-        if (duration.TotalHours >= 1)
-            return $"{(int)duration.TotalHours}h {duration.Minutes}m";
-        if (duration.TotalMinutes >= 1)
-            return $"{(int)duration.TotalMinutes}m {duration.Seconds}s";
-        return $"{Math.Max(0, (int)duration.TotalSeconds)}s";
-    }
-
-    private static void SelectComboBoxItemByTag(ComboBox comboBox, string? tag)
-    {
-        for (int i = 0; i < comboBox.Items.Count; i++)
-        {
-            if (comboBox.Items[i] is ComboBoxItem item &&
-                string.Equals(item.Tag?.ToString(), tag, StringComparison.OrdinalIgnoreCase))
-            {
-                comboBox.SelectedIndex = i;
-                return;
-            }
-        }
-
-        comboBox.SelectedIndex = 0;
+        GatewayUptimeText.Text = SettingsAppInfoProjection.FormatDuration(
+            TimeSpan.FromMilliseconds(_sampledGatewayUptimeMs.Value + elapsedMs));
     }
 
     private void LoadGatewaySection(SettingsManager settings)
@@ -474,119 +320,12 @@ public sealed partial class SettingsPage : Page
         }
     }
 
-    private static string BuildRuntimeStackDisplayText()
-    {
-        var dotNet = RuntimeInformation.FrameworkDescription;
-        var winUi = ResolveWinUiDisplayName();
-        var windowsAppSdk = ResolveWindowsAppSdkDisplayName();
-
-        return $"{dotNet} / {winUi} / {windowsAppSdk}";
-    }
-
-    private static string ResolveUpdateChannelDisplayText()
-    {
-        var channel = Environment.GetEnvironmentVariable("OPENCLAW_UPDATE_CHANNEL");
-        return string.IsNullOrWhiteSpace(channel) ? "stable" : channel.Trim();
-    }
-
-    private static string? TryResolveBuildDateDisplayText()
-    {
-        try
-        {
-            var location = Assembly.GetEntryAssembly()?.Location;
-            if (string.IsNullOrWhiteSpace(location) || !File.Exists(location))
-                return null;
-
-            return File.GetLastWriteTime(location).ToString("MMM d, yyyy", CultureInfo.CurrentCulture);
-        }
-        catch (Exception ex) when (ex is ArgumentException or IOException or UnauthorizedAccessException or NotSupportedException)
-        {
-            Logger.Debug($"SettingsPage: Failed to resolve app build date: {ex.Message}");
-            return null;
-        }
-    }
-
     private static string ResolveWinUiDisplayName()
     {
         var version = typeof(Microsoft.UI.Xaml.Application).Assembly.GetName().Version;
         return version is { Major: > 0 }
             ? $"WinUI {version.Major}"
             : "WinUI";
-    }
-
-    private static string ResolveWindowsAppSdkDisplayName()
-    {
-        if (TryResolveWindowsAppSdkPackageVersionFromDeps() is { Length: > 0 } packageVersion)
-        {
-            return $"Windows App SDK {packageVersion}";
-        }
-
-        return ResolveWindowsAppSdkDisplayNameFromFileVersion();
-    }
-
-    private static string ResolveWindowsAppSdkDisplayNameFromFileVersion()
-    {
-        var xamlNativePath = Path.Combine(AppContext.BaseDirectory, "Microsoft.ui.xaml.dll");
-        if (File.Exists(xamlNativePath))
-        {
-            try
-            {
-                var productVersion = FileVersionInfo.GetVersionInfo(xamlNativePath).ProductVersion;
-                if (!string.IsNullOrWhiteSpace(productVersion))
-                {
-                    return $"Windows App SDK {StripBuildMetadata(productVersion)}";
-                }
-            }
-            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException)
-            {
-                Logger.Warn($"Failed to read Windows App SDK version from {xamlNativePath}: {ex.Message}");
-            }
-        }
-
-        return "Windows App SDK";
-    }
-
-    private static string? TryResolveWindowsAppSdkPackageVersionFromDeps()
-    {
-        var assemblyName = Assembly.GetEntryAssembly()?.GetName().Name;
-        if (string.IsNullOrWhiteSpace(assemblyName))
-            return null;
-
-        var depsPath = Path.Combine(AppContext.BaseDirectory, $"{assemblyName}.deps.json");
-        if (!File.Exists(depsPath))
-            return null;
-
-        try
-        {
-            using var stream = File.OpenRead(depsPath);
-            using var document = JsonDocument.Parse(stream);
-            if (!document.RootElement.TryGetProperty("libraries", out var libraries) ||
-                libraries.ValueKind != JsonValueKind.Object)
-            {
-                return null;
-            }
-
-            foreach (var library in libraries.EnumerateObject())
-            {
-                const string packagePrefix = "Microsoft.WindowsAppSDK/";
-                if (library.Name.StartsWith(packagePrefix, StringComparison.OrdinalIgnoreCase))
-                {
-                    return StripBuildMetadata(library.Name[packagePrefix.Length..]);
-                }
-            }
-        }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException or ArgumentException)
-        {
-            Logger.Warn($"Failed to read Windows App SDK package version from {depsPath}: {ex.Message}");
-        }
-
-        return null;
-    }
-
-    private static string StripBuildMetadata(string version)
-    {
-        var plus = version.IndexOf('+', StringComparison.Ordinal);
-        return plus >= 0 ? version[..plus] : version;
     }
 
     private void OnRemoveGateway(object sender, RoutedEventArgs e) =>

--- a/src/OpenClaw.Tray.WinUI/Presentation/Adapters/FramePageActivator.cs
+++ b/src/OpenClaw.Tray.WinUI/Presentation/Adapters/FramePageActivator.cs
@@ -8,11 +8,10 @@ namespace OpenClawTray.Presentation.Adapters;
 /// <see cref="NavigationScopeManager"/>, and assigns it as the page's data context.
 /// </summary>
 /// <remarks>
-/// The page→view-model map is currently empty, so every navigation takes the
-/// "no view model" path: the scope manager only deactivates and disposes any prior
-/// view model, and a page's <c>DataContext</c> is never touched. This makes the
-/// activation hook a runtime no-op until pages adopt view models, at which point their
-/// entries are added to the map.
+/// Pages present in the map (currently the Settings page) resolve and activate their view model
+/// on navigation and have it assigned as their <c>DataContext</c>. Pages absent from the map take
+/// the "no view model" path: the scope manager only deactivates and disposes any prior view model
+/// and the page's <c>DataContext</c> is left untouched.
 /// </remarks>
 internal sealed class FramePageActivator : IPageActivator
 {

--- a/src/OpenClaw.Tray.WinUI/Presentation/AppServiceRegistration.cs
+++ b/src/OpenClaw.Tray.WinUI/Presentation/AppServiceRegistration.cs
@@ -33,6 +33,12 @@ internal static class AppServiceRegistration
         services.AddSingleton(context.AppCommands);
         services.AddSingleton(context.Settings);
 
+        // Settings facade over the App-owned SettingsManager. Constructed eagerly from the
+        // already-owned singletons so presentation code depends on ISettingsStore, never the
+        // concrete manager. It subscribes to the manager (which App owns) and is not disposed
+        // by the container.
+        services.AddSingleton<ISettingsStore>(new SettingsStore(context.Settings, context.Dispatcher));
+
         // Container-owned navigation lifetime manager (disposed with the root provider).
         services.AddSingleton<NavigationScopeManager>();
 

--- a/src/OpenClaw.Tray.WinUI/Presentation/IPageActivator.cs
+++ b/src/OpenClaw.Tray.WinUI/Presentation/IPageActivator.cs
@@ -8,10 +8,9 @@ namespace OpenClawTray.Presentation;
 /// page's <c>DataContext</c>.
 /// </summary>
 /// <remarks>
-/// No page is mapped to a view model yet, so <see cref="OnNavigatedTo"/> only advances
-/// the navigation scope (deactivating and disposing any prior view model) and never
-/// touches a page's data context. The seam therefore has no observable runtime effect
-/// today; it is proven by unit tests.
+/// Pages mapped to a view model (currently the Settings page) have it resolved, activated, and
+/// assigned as their <c>DataContext</c> by <see cref="OnNavigatedTo"/>. Unmapped pages only advance
+/// the navigation scope (deactivating and disposing any prior view model) with no data-context change.
 /// </remarks>
 public interface IPageActivator
 {

--- a/src/OpenClaw.Tray.WinUI/Presentation/ISettingsStore.cs
+++ b/src/OpenClaw.Tray.WinUI/Presentation/ISettingsStore.cs
@@ -1,0 +1,111 @@
+namespace OpenClawTray.Presentation;
+
+/// <summary>
+/// WinUI-free seam over the App-owned settings for presentation code. It exposes an
+/// immutable <see cref="SettingsSnapshot"/> for reads and a single batched
+/// <see cref="Update"/> for writes, and raises <see cref="Changed"/> only for
+/// <b>external</b> changes (a caller's own <see cref="Update"/> is not echoed back).
+/// </summary>
+/// <remarks>
+/// This removes the hand-rolled save/echo bookkeeping that page code-behind used to carry
+/// (the <c>_saving</c>/<c>_loading</c> suppression flags). A view model reads
+/// <see cref="Current"/>, writes through <see cref="Update"/>, and refreshes on
+/// <see cref="Changed"/> without risking a save-storm: the store suppresses the
+/// self-originated notification and marshals external ones onto the UI thread.
+/// The auto-save contract itself is unchanged: <see cref="Update"/> mutates the settings
+/// and saves once, exactly as the previous per-toggle code did; callers still invoke
+/// <c>IAppCommands.NotifySettingsSaved()</c> for the reconnect/re-register side effect.
+/// </remarks>
+public interface ISettingsStore
+{
+    /// <summary>An immutable snapshot of the current settings values used by the settings surfaces.</summary>
+    SettingsSnapshot Current { get; }
+
+    /// <summary>
+    /// Applies <paramref name="edit"/> to the settings and persists once. The store
+    /// suppresses the <see cref="Changed"/> notification that would otherwise echo back to
+    /// the caller from this save, so a two-way-bound view model cannot loop.
+    /// </summary>
+    void Update(Action<ISettingsEditor> edit);
+
+    /// <summary>
+    /// Marks the calling thread as performing a store-originated write for the scope's lifetime,
+    /// so a <see cref="SettingsManager.Save"/> raised on that thread is treated as self-originated
+    /// and does not echo <see cref="Changed"/>. Used by App-owned writes that persist settings
+    /// directly (auto-start OS registration, speaker mute) instead of through <see cref="Update"/>,
+    /// so they get the same echo suppression. Dispose on the same thread that created it.
+    /// </summary>
+    IDisposable BeginSelfWrite();
+
+    /// <summary>
+    /// Raised after settings change from a source other than this caller's <see cref="Update"/>
+    /// (for example another surface saving, onboarding, or a background save). Always raised on
+    /// the UI thread.
+    /// </summary>
+    event EventHandler? Changed;
+}
+
+/// <summary>
+/// Narrow write surface handed to <see cref="ISettingsStore.Update"/>. It exposes only the
+/// fields the settings surfaces mutate, so presentation code never touches the concrete
+/// settings manager. Grows as more pages adopt the store.
+/// </summary>
+public interface ISettingsEditor
+{
+    bool AutoStart { set; }
+    bool GlobalHotkeyEnabled { set; }
+    bool UseLegacyWebChat { set; }
+    bool ShowNotifications { set; }
+    string NotificationSound { set; }
+    string AppTheme { set; }
+
+    /// <summary>Writes the raw diagnostics override (null clears it back to the computed default).</summary>
+    bool? ShowDiagnosticsOverride { set; }
+
+    bool NotifyHealth { set; }
+    bool NotifyUrgent { set; }
+    bool NotifyReminder { set; }
+    bool NotifyEmail { set; }
+    bool NotifyCalendar { set; }
+    bool NotifyBuild { set; }
+    bool NotifyStock { set; }
+    bool NotifyInfo { set; }
+
+    bool ScreenRecordingConsentGiven { set; }
+    bool CameraRecordingConsentGiven { set; }
+
+    bool ShowChatToolCalls { set; }
+}
+
+/// <summary>
+/// Immutable read snapshot of the settings values the settings surfaces display. Mirrors the
+/// fields the settings page previously read directly off the settings manager.
+/// </summary>
+public sealed record SettingsSnapshot
+{
+    public bool AutoStart { get; init; }
+    public bool GlobalHotkeyEnabled { get; init; }
+    public bool UseLegacyWebChat { get; init; }
+    public bool ShowNotifications { get; init; }
+    public string NotificationSound { get; init; } = "Default";
+    public string AppTheme { get; init; } = "System";
+
+    /// <summary>The effective diagnostics visibility (override applied over the computed default).</summary>
+    public bool ShowDiagnosticsEffective { get; init; }
+
+    public bool NotifyHealth { get; init; }
+    public bool NotifyUrgent { get; init; }
+    public bool NotifyReminder { get; init; }
+    public bool NotifyEmail { get; init; }
+    public bool NotifyCalendar { get; init; }
+    public bool NotifyBuild { get; init; }
+    public bool NotifyStock { get; init; }
+    public bool NotifyInfo { get; init; }
+
+    public bool ScreenRecordingConsentGiven { get; init; }
+    public bool CameraRecordingConsentGiven { get; init; }
+
+    /// <summary>Reflects <c>VoiceTtsEnabled</c>; the "read responses aloud" toggle mirrors it.</summary>
+    public bool VoiceTtsEnabled { get; init; }
+    public bool ShowChatToolCalls { get; init; }
+}

--- a/src/OpenClaw.Tray.WinUI/Presentation/SettingsAppInfoProjection.cs
+++ b/src/OpenClaw.Tray.WinUI/Presentation/SettingsAppInfoProjection.cs
@@ -1,0 +1,155 @@
+using System.Globalization;
+using System.IO;
+using System.Text.Json;
+
+namespace OpenClawTray.Presentation;
+
+/// <summary>
+/// WinUI-free projection of the "About / app info" strings the settings surface displays.
+/// It holds the pure formatting and environment/reflection lookups that used to live inline in
+/// the settings page code-behind, so they are unit-testable. The one genuinely WinUI-bound value
+/// (the WinUI display name, resolved from <c>Microsoft.UI.Xaml.Application</c>'s assembly) is
+/// passed in by the view; everything else is computed here.
+/// </summary>
+public static class SettingsAppInfoProjection
+{
+    private const string PackagedInstallText = "Packaged (MSIX)";
+    private const string UnpackagedInstallText = "Unpackaged (developer)";
+    private const string DefaultChannel = "stable";
+
+    /// <summary>Composes the "runtime / WinUI / Windows App SDK" one-line stack description.</summary>
+    public static string BuildRuntimeStack(string frameworkDescription, string winUiDisplayName, string windowsAppSdkDisplayName) =>
+        $"{frameworkDescription} / {winUiDisplayName} / {windowsAppSdkDisplayName}";
+
+    /// <summary>Maps the packaged flag to the installation-kind label.</summary>
+    public static string InstallKind(bool isPackaged) => isPackaged ? PackagedInstallText : UnpackagedInstallText;
+
+    /// <summary>Resolves the update-channel label, defaulting to <c>stable</c> when unset.</summary>
+    public static string ResolveUpdateChannel(string? channelEnvironmentValue) =>
+        string.IsNullOrWhiteSpace(channelEnvironmentValue) ? DefaultChannel : channelEnvironmentValue.Trim();
+
+    /// <summary>Strips a <c>+buildmetadata</c> suffix from a semantic version string.</summary>
+    public static string StripBuildMetadata(string version)
+    {
+        var plus = version.IndexOf('+', StringComparison.Ordinal);
+        return plus >= 0 ? version[..plus] : version;
+    }
+
+    /// <summary>
+    /// Formats the entry assembly's last-write time as the displayed build date, or null when the
+    /// location is missing/unreadable (matching the previous "hide the build row" behavior).
+    /// </summary>
+    public static string? FormatBuildDate(string? entryAssemblyLocation, CultureInfo culture)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(entryAssemblyLocation) || !File.Exists(entryAssemblyLocation))
+            {
+                return null;
+            }
+
+            return File.GetLastWriteTime(entryAssemblyLocation).ToString("MMM d, yyyy", culture);
+        }
+        catch (Exception ex) when (ex is ArgumentException or IOException or UnauthorizedAccessException or NotSupportedException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Resolves the Windows App SDK display name, preferring the package version recorded in the
+    /// entry assembly's <c>.deps.json</c> and falling back to the native XAML dll's file version.
+    /// </summary>
+    public static string ResolveWindowsAppSdkDisplayName(string? entryAssemblyName, string baseDirectory)
+    {
+        if (TryResolveWindowsAppSdkPackageVersionFromDeps(entryAssemblyName, baseDirectory) is { Length: > 0 } packageVersion)
+        {
+            return $"Windows App SDK {packageVersion}";
+        }
+
+        return ResolveWindowsAppSdkDisplayNameFromFileVersion(baseDirectory);
+    }
+
+    private static string ResolveWindowsAppSdkDisplayNameFromFileVersion(string baseDirectory)
+    {
+        var xamlNativePath = Path.Combine(baseDirectory, "Microsoft.ui.xaml.dll");
+        if (File.Exists(xamlNativePath))
+        {
+            try
+            {
+                var productVersion = System.Diagnostics.FileVersionInfo.GetVersionInfo(xamlNativePath).ProductVersion;
+                if (!string.IsNullOrWhiteSpace(productVersion))
+                {
+                    return $"Windows App SDK {StripBuildMetadata(productVersion)}";
+                }
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException)
+            {
+                // Fall through to the generic label.
+            }
+        }
+
+        return "Windows App SDK";
+    }
+
+    private static string? TryResolveWindowsAppSdkPackageVersionFromDeps(string? entryAssemblyName, string baseDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(entryAssemblyName))
+        {
+            return null;
+        }
+
+        var depsPath = Path.Combine(baseDirectory, $"{entryAssemblyName}.deps.json");
+        if (!File.Exists(depsPath))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var stream = File.OpenRead(depsPath);
+            using var document = JsonDocument.Parse(stream);
+            if (!document.RootElement.TryGetProperty("libraries", out var libraries) ||
+                libraries.ValueKind != JsonValueKind.Object)
+            {
+                return null;
+            }
+
+            foreach (var library in libraries.EnumerateObject())
+            {
+                const string packagePrefix = "Microsoft.WindowsAppSDK/";
+                if (library.Name.StartsWith(packagePrefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    return StripBuildMetadata(library.Name[packagePrefix.Length..]);
+                }
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException or ArgumentException)
+        {
+            return null;
+        }
+
+        return null;
+    }
+
+    /// <summary>Formats a duration the way the gateway-uptime row displays it.</summary>
+    public static string FormatDuration(TimeSpan duration)
+    {
+        if (duration.TotalDays >= 1)
+        {
+            return $"{(int)duration.TotalDays}d {duration.Hours}h";
+        }
+
+        if (duration.TotalHours >= 1)
+        {
+            return $"{(int)duration.TotalHours}h {duration.Minutes}m";
+        }
+
+        if (duration.TotalMinutes >= 1)
+        {
+            return $"{(int)duration.TotalMinutes}m {duration.Seconds}s";
+        }
+
+        return $"{Math.Max(0, (int)duration.TotalSeconds)}s";
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Presentation/SettingsPageViewModel.cs
+++ b/src/OpenClaw.Tray.WinUI/Presentation/SettingsPageViewModel.cs
@@ -1,33 +1,347 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using OpenClawTray.Services;
 
 namespace OpenClawTray.Presentation;
 
 /// <summary>
-/// Transient view-model placeholder for the Settings page. It exercises the DI wiring
-/// end to end: it is constructor-injected with app services, participates in the
-/// navigation activation/deactivation lifetime, and is disposed when its navigation
-/// scope ends. It intentionally holds no behavior yet. Nothing is started in the
-/// constructor.
+/// WinUI-free view model for the Settings page. It owns the settings surface's read/persist
+/// logic that previously lived in the page code-behind: it loads the current values from
+/// <see cref="ISettingsStore"/> on activation, exposes two-way-bindable properties, and persists
+/// each change through the store while preserving the exact auto-save contract
+/// (mutate -> save -> notify) and the two chat side effects.
 /// </summary>
-internal sealed class SettingsPageViewModel : INavigationAware, IDisposable
+/// <remarks>
+/// Echo handling lives in the store, not here: a property change persists through
+/// <see cref="ISettingsStore.Update"/> (which suppresses the self-originated notification), and an
+/// external change arrives via <see cref="ISettingsStore.Changed"/> and reloads the properties
+/// under the <c>_loading</c> guard so it cannot re-persist. View-only side effects (the "Saved"
+/// indicator flash and refreshing the view-owned gateway section) are surfaced as events the page
+/// handles; OS- and WinUI-coupled work (auto-start registration, speaker mute, chat tool-call
+/// visibility) is delegated to <see cref="IAppCommands"/>, so this type stays free of WinUI and OS APIs.
+/// </remarks>
+internal sealed class SettingsPageViewModel : INavigationAware, IDisposable, INotifyPropertyChanged
 {
-    public SettingsPageViewModel(IAppCommands appCommands, SettingsManager settings, IUiDispatcher dispatcher)
+    private const string DefaultNotificationSound = "Default";
+    private const string DefaultAppTheme = "System";
+
+    private static readonly string[] SoundTags = { "Default", "None", "Subtle" };
+    private static readonly string[] ThemeTags = { "System", "Light", "Dark" };
+
+    private readonly ISettingsStore _store;
+    private readonly IAppCommands _appCommands;
+
+    private bool _loading;
+    private bool _subscribed;
+
+    private bool _autoStart;
+    private bool _globalHotkeyEnabled;
+    private bool _useLegacyWebChat;
+    private bool _showNotifications;
+    private string _notificationSound = DefaultNotificationSound;
+    private string _appTheme = DefaultAppTheme;
+    private bool _showDiagnostics;
+    private bool _notifyHealth;
+    private bool _notifyUrgent;
+    private bool _notifyReminder;
+    private bool _notifyEmail;
+    private bool _notifyCalendar;
+    private bool _notifyBuild;
+    private bool _notifyStock;
+    private bool _notifyInfo;
+    private bool _screenRecordingConsentGiven;
+    private bool _cameraRecordingConsentGiven;
+    private bool _readResponsesAloud;
+    private bool _showChatToolCalls;
+
+    public SettingsPageViewModel(ISettingsStore store, IAppCommands appCommands)
     {
-        AppCommands = appCommands ?? throw new ArgumentNullException(nameof(appCommands));
-        Settings = settings ?? throw new ArgumentNullException(nameof(settings));
-        Dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+        _appCommands = appCommands ?? throw new ArgumentNullException(nameof(appCommands));
     }
 
-    internal IAppCommands AppCommands { get; }
-    internal SettingsManager Settings { get; }
-    internal IUiDispatcher Dispatcher { get; }
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    /// <summary>Raised (on the caller's thread) when a change should flash the page's "Saved" indicator.</summary>
+    public event EventHandler? SavedIndicated;
+
+    /// <summary>
+    /// Raised when the settings change from an external source (not this view model's own writes),
+    /// so the page can refresh the view-owned sections that are not settings-bound (the gateway
+    /// section). Not raised during the initial activation load.
+    /// </summary>
+    public event EventHandler? ExternalChanged;
 
     internal bool IsActive { get; private set; }
     internal bool IsDisposed { get; private set; }
 
-    public void Activate(object? parameter) => IsActive = true;
+    public bool AutoStart
+    {
+        get => _autoStart;
+        set
+        {
+            if (SetField(ref _autoStart, value) && !_loading)
+            {
+                // Auto-start owns an OS registration with a required save -> OS-write -> notify
+                // order. It is applied through the app command that preserves that ordering, and
+                // the saved indicator is flashed only after the OS write succeeds (matching the
+                // original behavior where a failed OS write showed no confirmation).
+                _ = ApplyAutoStartAsync(value);
+            }
+        }
+    }
 
-    public void Deactivate() => IsActive = false;
+    private async Task ApplyAutoStartAsync(bool value)
+    {
+        if (await _appCommands.ApplyAutoStart(value))
+        {
+            RaiseSaved();
+        }
+    }
 
-    public void Dispose() => IsDisposed = true;
+    public bool GlobalHotkeyEnabled
+    {
+        get => _globalHotkeyEnabled;
+        set { if (SetField(ref _globalHotkeyEnabled, value) && !_loading) Persist(e => e.GlobalHotkeyEnabled = value); }
+    }
+
+    public bool UseLegacyWebChat
+    {
+        get => _useLegacyWebChat;
+        set { if (SetField(ref _useLegacyWebChat, value) && !_loading) Persist(e => e.UseLegacyWebChat = value); }
+    }
+
+    public bool ShowNotifications
+    {
+        get => _showNotifications;
+        set { if (SetField(ref _showNotifications, value) && !_loading) Persist(e => e.ShowNotifications = value); }
+    }
+
+    public string NotificationSound
+    {
+        get => _notificationSound;
+        set
+        {
+            var normalized = string.IsNullOrEmpty(value) ? DefaultNotificationSound : value;
+            if (SetField(ref _notificationSound, normalized) && !_loading) Persist(e => e.NotificationSound = normalized);
+        }
+    }
+
+    public string AppTheme
+    {
+        get => _appTheme;
+        set
+        {
+            var normalized = string.IsNullOrEmpty(value) ? DefaultAppTheme : value;
+            if (SetField(ref _appTheme, normalized) && !_loading) Persist(e => e.AppTheme = normalized);
+        }
+    }
+
+    /// <summary>Bound to the diagnostics toggle: reads the effective value, writes the override.</summary>
+    public bool ShowDiagnostics
+    {
+        get => _showDiagnostics;
+        set { if (SetField(ref _showDiagnostics, value) && !_loading) Persist(e => e.ShowDiagnosticsOverride = value); }
+    }
+
+    public bool NotifyHealth
+    {
+        get => _notifyHealth;
+        set { if (SetField(ref _notifyHealth, value) && !_loading) Persist(e => e.NotifyHealth = value); }
+    }
+
+    public bool NotifyUrgent
+    {
+        get => _notifyUrgent;
+        set { if (SetField(ref _notifyUrgent, value) && !_loading) Persist(e => e.NotifyUrgent = value); }
+    }
+
+    public bool NotifyReminder
+    {
+        get => _notifyReminder;
+        set { if (SetField(ref _notifyReminder, value) && !_loading) Persist(e => e.NotifyReminder = value); }
+    }
+
+    public bool NotifyEmail
+    {
+        get => _notifyEmail;
+        set { if (SetField(ref _notifyEmail, value) && !_loading) Persist(e => e.NotifyEmail = value); }
+    }
+
+    public bool NotifyCalendar
+    {
+        get => _notifyCalendar;
+        set { if (SetField(ref _notifyCalendar, value) && !_loading) Persist(e => e.NotifyCalendar = value); }
+    }
+
+    public bool NotifyBuild
+    {
+        get => _notifyBuild;
+        set { if (SetField(ref _notifyBuild, value) && !_loading) Persist(e => e.NotifyBuild = value); }
+    }
+
+    public bool NotifyStock
+    {
+        get => _notifyStock;
+        set { if (SetField(ref _notifyStock, value) && !_loading) Persist(e => e.NotifyStock = value); }
+    }
+
+    public bool NotifyInfo
+    {
+        get => _notifyInfo;
+        set { if (SetField(ref _notifyInfo, value) && !_loading) Persist(e => e.NotifyInfo = value); }
+    }
+
+    public bool ScreenRecordingConsentGiven
+    {
+        get => _screenRecordingConsentGiven;
+        set { if (SetField(ref _screenRecordingConsentGiven, value) && !_loading) Persist(e => e.ScreenRecordingConsentGiven = value); }
+    }
+
+    public bool CameraRecordingConsentGiven
+    {
+        get => _cameraRecordingConsentGiven;
+        set { if (SetField(ref _cameraRecordingConsentGiven, value) && !_loading) Persist(e => e.CameraRecordingConsentGiven = value); }
+    }
+
+    /// <summary>
+    /// "Read responses aloud" mirrors <c>VoiceTtsEnabled</c> (mute is its inverse). Routed through
+    /// the app command that persists + broadcasts, exactly like before; it does not go through the
+    /// normal persist/notify path.
+    /// </summary>
+    public bool ReadResponsesAloud
+    {
+        get => _readResponsesAloud;
+        set
+        {
+            if (SetField(ref _readResponsesAloud, value) && !_loading)
+            {
+                _appCommands.SetChatSpeakerMuted(!value);
+                RaiseSaved();
+            }
+        }
+    }
+
+    /// <summary>"Show tool calls and usage" persists the setting and pushes visibility to the live timeline.</summary>
+    public bool ShowChatToolCalls
+    {
+        get => _showChatToolCalls;
+        set
+        {
+            if (SetField(ref _showChatToolCalls, value) && !_loading)
+            {
+                Persist(e => e.ShowChatToolCalls = value);
+                _appCommands.SetChatToolCallsVisible(value);
+            }
+        }
+    }
+
+    public void Activate(object? parameter)
+    {
+        IsActive = true;
+        LoadFromStore();
+        if (!_subscribed)
+        {
+            _store.Changed += OnStoreChanged;
+            _subscribed = true;
+        }
+    }
+
+    public void Deactivate()
+    {
+        IsActive = false;
+        if (_subscribed)
+        {
+            _store.Changed -= OnStoreChanged;
+            _subscribed = false;
+        }
+    }
+
+    public void Dispose()
+    {
+        Deactivate();
+        IsDisposed = true;
+    }
+
+    private void OnStoreChanged(object? sender, EventArgs e)
+    {
+        LoadFromStore();
+        ExternalChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>Reloads all bound properties from the store snapshot without persisting.</summary>
+    private void LoadFromStore()
+    {
+        var s = _store.Current;
+        _loading = true;
+        try
+        {
+            SetField(ref _autoStart, s.AutoStart, nameof(AutoStart));
+            SetField(ref _globalHotkeyEnabled, s.GlobalHotkeyEnabled, nameof(GlobalHotkeyEnabled));
+            SetField(ref _useLegacyWebChat, s.UseLegacyWebChat, nameof(UseLegacyWebChat));
+            SetField(ref _showNotifications, s.ShowNotifications, nameof(ShowNotifications));
+            // Normalize combo values to a known tag so a legacy or odd stored value selects the
+            // default item instead of rendering a blank combo (matching the old tag lookup).
+            SetField(ref _notificationSound, NormalizeTag(s.NotificationSound, SoundTags, DefaultNotificationSound), nameof(NotificationSound));
+            SetField(ref _appTheme, NormalizeTag(s.AppTheme, ThemeTags, DefaultAppTheme), nameof(AppTheme));
+            SetField(ref _showDiagnostics, s.ShowDiagnosticsEffective, nameof(ShowDiagnostics));
+            SetField(ref _notifyHealth, s.NotifyHealth, nameof(NotifyHealth));
+            SetField(ref _notifyUrgent, s.NotifyUrgent, nameof(NotifyUrgent));
+            SetField(ref _notifyReminder, s.NotifyReminder, nameof(NotifyReminder));
+            SetField(ref _notifyEmail, s.NotifyEmail, nameof(NotifyEmail));
+            SetField(ref _notifyCalendar, s.NotifyCalendar, nameof(NotifyCalendar));
+            SetField(ref _notifyBuild, s.NotifyBuild, nameof(NotifyBuild));
+            SetField(ref _notifyStock, s.NotifyStock, nameof(NotifyStock));
+            SetField(ref _notifyInfo, s.NotifyInfo, nameof(NotifyInfo));
+            SetField(ref _screenRecordingConsentGiven, s.ScreenRecordingConsentGiven, nameof(ScreenRecordingConsentGiven));
+            SetField(ref _cameraRecordingConsentGiven, s.CameraRecordingConsentGiven, nameof(CameraRecordingConsentGiven));
+            SetField(ref _readResponsesAloud, s.VoiceTtsEnabled, nameof(ReadResponsesAloud));
+            SetField(ref _showChatToolCalls, s.ShowChatToolCalls, nameof(ShowChatToolCalls));
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private void Persist(Action<ISettingsEditor> edit)
+    {
+        if (_loading)
+        {
+            return;
+        }
+
+        _store.Update(edit);
+        _appCommands.NotifySettingsSaved();
+        RaiseSaved();
+    }
+
+    private void RaiseSaved() => SavedIndicated?.Invoke(this, EventArgs.Empty);
+
+    /// <summary>Maps a stored value to a known combo tag (case-insensitive), falling back to the default.</summary>
+    private static string NormalizeTag(string? value, string[] tags, string fallback)
+    {
+        foreach (var tag in tags)
+        {
+            if (string.Equals(tag, value, StringComparison.OrdinalIgnoreCase))
+            {
+                return tag;
+            }
+        }
+
+        return fallback;
+    }
+
+    private bool SetField<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value))
+        {
+            return false;
+        }
+
+        field = value;
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        return true;
+    }
 }

--- a/src/OpenClaw.Tray.WinUI/Presentation/SettingsStore.cs
+++ b/src/OpenClaw.Tray.WinUI/Presentation/SettingsStore.cs
@@ -1,0 +1,138 @@
+using OpenClawTray.Services;
+
+namespace OpenClawTray.Presentation;
+
+/// <summary>
+/// Default <see cref="ISettingsStore"/> backed by the App-owned <see cref="SettingsManager"/>.
+/// It does not own the manager's lifetime (App does); it only reads/writes it and republishes
+/// the manager's <c>Saved</c> event as <see cref="Changed"/> with self-origination suppressed
+/// and UI-thread affinity.
+/// </summary>
+/// <remarks>
+/// Self-origination is tracked with a <c>[ThreadStatic]</c> depth: <see cref="SettingsManager.Save"/>
+/// raises <c>Saved</c> synchronously on the calling thread inside <see cref="Update"/> or a
+/// <see cref="BeginSelfWrite"/> scope, so the handler observes a non-zero depth on that thread and
+/// suppresses the echo. A save from any other source (another surface, onboarding, a background
+/// writer) runs with depth zero and is republished as <see cref="Changed"/>, marshaled onto the UI
+/// thread via <see cref="IUiDispatcher"/>.
+/// </remarks>
+internal sealed class SettingsStore : ISettingsStore
+{
+    [ThreadStatic]
+    private static int t_selfUpdateDepth;
+
+    private readonly SettingsManager _settings;
+    private readonly IUiDispatcher _dispatcher;
+
+    public SettingsStore(SettingsManager settings, IUiDispatcher dispatcher)
+    {
+        _settings = settings ?? throw new ArgumentNullException(nameof(settings));
+        _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+        _settings.Saved += OnManagerSaved;
+    }
+
+    public event EventHandler? Changed;
+
+    public SettingsSnapshot Current => new()
+    {
+        AutoStart = _settings.AutoStart,
+        GlobalHotkeyEnabled = _settings.GlobalHotkeyEnabled,
+        UseLegacyWebChat = _settings.UseLegacyWebChat,
+        ShowNotifications = _settings.ShowNotifications,
+        NotificationSound = _settings.NotificationSound,
+        AppTheme = _settings.AppTheme,
+        ShowDiagnosticsEffective = _settings.ShowDiagnosticsEffective,
+        NotifyHealth = _settings.NotifyHealth,
+        NotifyUrgent = _settings.NotifyUrgent,
+        NotifyReminder = _settings.NotifyReminder,
+        NotifyEmail = _settings.NotifyEmail,
+        NotifyCalendar = _settings.NotifyCalendar,
+        NotifyBuild = _settings.NotifyBuild,
+        NotifyStock = _settings.NotifyStock,
+        NotifyInfo = _settings.NotifyInfo,
+        ScreenRecordingConsentGiven = _settings.ScreenRecordingConsentGiven,
+        CameraRecordingConsentGiven = _settings.CameraRecordingConsentGiven,
+        VoiceTtsEnabled = _settings.VoiceTtsEnabled,
+        ShowChatToolCalls = _settings.ShowChatToolCalls,
+    };
+
+    public void Update(Action<ISettingsEditor> edit)
+    {
+        ArgumentNullException.ThrowIfNull(edit);
+
+        using (BeginSelfWrite())
+        {
+            edit(new Editor(_settings));
+            _settings.Save();
+        }
+    }
+
+    public IDisposable BeginSelfWrite()
+    {
+        t_selfUpdateDepth++;
+        return new SelfWriteScope();
+    }
+
+    private void OnManagerSaved(object? sender, EventArgs e)
+    {
+        // Saved fires synchronously on the thread that called Save(). When that is our own
+        // Update or an App-owned self-write on this thread, the depth is non-zero and the echo
+        // is suppressed.
+        if (t_selfUpdateDepth > 0)
+        {
+            return;
+        }
+
+        if (_dispatcher.HasThreadAccess)
+        {
+            Changed?.Invoke(this, EventArgs.Empty);
+        }
+        else
+        {
+            _dispatcher.TryEnqueue(() => Changed?.Invoke(this, EventArgs.Empty));
+        }
+    }
+
+    /// <summary>Decrements the self-write depth on dispose. Created and disposed on the same thread.</summary>
+    private sealed class SelfWriteScope : IDisposable
+    {
+        private bool _disposed;
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            t_selfUpdateDepth--;
+        }
+    }
+
+    private sealed class Editor : ISettingsEditor
+    {
+        private readonly SettingsManager _settings;
+
+        public Editor(SettingsManager settings) => _settings = settings;
+
+        public bool AutoStart { set => _settings.AutoStart = value; }
+        public bool GlobalHotkeyEnabled { set => _settings.GlobalHotkeyEnabled = value; }
+        public bool UseLegacyWebChat { set => _settings.UseLegacyWebChat = value; }
+        public bool ShowNotifications { set => _settings.ShowNotifications = value; }
+        public string NotificationSound { set => _settings.NotificationSound = value; }
+        public string AppTheme { set => _settings.AppTheme = value; }
+        public bool? ShowDiagnosticsOverride { set => _settings.ShowDiagnosticsOverride = value; }
+        public bool NotifyHealth { set => _settings.NotifyHealth = value; }
+        public bool NotifyUrgent { set => _settings.NotifyUrgent = value; }
+        public bool NotifyReminder { set => _settings.NotifyReminder = value; }
+        public bool NotifyEmail { set => _settings.NotifyEmail = value; }
+        public bool NotifyCalendar { set => _settings.NotifyCalendar = value; }
+        public bool NotifyBuild { set => _settings.NotifyBuild = value; }
+        public bool NotifyStock { set => _settings.NotifyStock = value; }
+        public bool NotifyInfo { set => _settings.NotifyInfo = value; }
+        public bool ScreenRecordingConsentGiven { set => _settings.ScreenRecordingConsentGiven = value; }
+        public bool CameraRecordingConsentGiven { set => _settings.CameraRecordingConsentGiven = value; }
+        public bool ShowChatToolCalls { set => _settings.ShowChatToolCalls = value; }
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Services/IAppCommands.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/IAppCommands.cs
@@ -18,5 +18,8 @@ internal interface IAppCommands
     void ShowGatewayWizard();
     void ShowConnectionStatus();
     void NotifySettingsSaved();
+    Task<bool> ApplyAutoStart(bool autoStart);
+    void SetChatSpeakerMuted(bool muted);
+    void SetChatToolCallsVisible(bool visible);
     Task<bool> ResendOpenTelemetryProbeAsync();
 }

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
@@ -1027,11 +1027,11 @@ public sealed partial class HubWindow : WindowEx
         ArmContentReady(e.Content as FrameworkElement);
 
         // Navigation activation hook: resolve + assign a DI-backed view model for the
-        // navigated page. The page→view-model map is currently empty, so this only
-        // advances the navigation scope (deactivating any prior view model) and never
-        // touches a page's DataContext — a runtime no-op until pages adopt view models.
-        // Contained in a try/catch so a future misbehaving view model's activation
-        // cannot escape this XAML event handler and crash the app.
+        // navigated page. Pages present in the page->view-model map (currently Settings)
+        // get their view model resolved, activated, and assigned as DataContext; other pages
+        // only advance the navigation scope (deactivating any prior view model). Contained in a
+        // try/catch so a misbehaving view model's activation cannot escape this XAML event handler
+        // and crash the app.
         if (e.Content is { } content)
         {
             try

--- a/tests/OpenClaw.Tray.Tests/ChatToolCallsToggleContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ChatToolCallsToggleContractTests.cs
@@ -10,7 +10,6 @@ public sealed class ChatToolCallsToggleContractTests
         var root = Read("src", "OpenClaw.Tray.WinUI", "Chat", "OpenClawChatRoot.cs");
         var composer = Read("src", "OpenClaw.Tray.WinUI", "Chat", "OpenClawComposer.cs");
         var timeline = Read("src", "OpenClaw.Tray.WinUI", "Chat", "OpenClawChatTimeline.cs");
-        var settings = Read("src", "OpenClaw.Tray.WinUI", "Pages", "SettingsPage.xaml.cs");
         var app = Read("src", "OpenClaw.Tray.WinUI", "App.xaml.cs");
 
         // Root still owns the shared tool-call visibility state and feeds it to
@@ -31,10 +30,12 @@ public sealed class ChatToolCallsToggleContractTests
         Assert.DoesNotContain("ShowToolCalls", composer);
         Assert.DoesNotContain("OnShowToolCallsChanged", composer);
 
-        // Settings drives it: persists the setting and pushes it into the live
-        // timeline via the static writer.
-        Assert.Contains("OpenClawTray.Chat.OpenClawChatRoot.SetToolCallsVisible", settings);
-        Assert.Contains("ShowChatToolCalls", settings);
+        // Settings drives it: the settings view model persists the setting and pushes it into
+        // the live timeline through IAppCommands, which App forwards to the static writer.
+        var settingsVm = Read("src", "OpenClaw.Tray.WinUI", "Presentation", "SettingsPageViewModel.cs");
+        Assert.Contains("SetChatToolCallsVisible", settingsVm);
+        Assert.Contains("ShowChatToolCalls", settingsVm);
+        Assert.Contains("OpenClawTray.Chat.OpenClawChatRoot.SetToolCallsVisible", app);
 
         // Startup seeds visibility from the persisted setting.
         Assert.Contains("SetToolCallsVisible(_settings.ShowChatToolCalls)", app);

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -144,6 +144,9 @@
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Presentation\AppNavigationService.cs" Link="Presentation\AppNavigationService.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Presentation\SettingsPageViewModel.cs" Link="Presentation\SettingsPageViewModel.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Presentation\PermissionsPageViewModel.cs" Link="Presentation\PermissionsPageViewModel.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Presentation\ISettingsStore.cs" Link="Presentation\ISettingsStore.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Presentation\SettingsStore.cs" Link="Presentation\SettingsStore.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Presentation\SettingsAppInfoProjection.cs" Link="Presentation\SettingsAppInfoProjection.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Presentation\AppServiceContext.cs" Link="Presentation\AppServiceContext.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Presentation\AppServiceRegistration.cs" Link="Presentation\AppServiceRegistration.cs" />
   </ItemGroup>

--- a/tests/OpenClaw.Tray.Tests/Presentation/AppServiceRegistrationTests.cs
+++ b/tests/OpenClaw.Tray.Tests/Presentation/AppServiceRegistrationTests.cs
@@ -71,9 +71,13 @@ public sealed class AppServiceRegistrationTests
             var second = scope.ServiceProvider.GetRequiredService<SettingsPageViewModel>();
 
             Assert.NotSame(first, second);
-            Assert.Same(dispatcher, first.Dispatcher);
-            Assert.Same(commands, first.AppCommands);
-            Assert.Same(settings, first.Settings);
+
+            // The placeholder permissions view model still exposes its injected services, so use it
+            // to prove the transient page view models receive the registered singleton instances.
+            var permissions = scope.ServiceProvider.GetRequiredService<PermissionsPageViewModel>();
+            Assert.Same(dispatcher, permissions.Dispatcher);
+            Assert.Same(commands, permissions.AppCommands);
+            Assert.Same(settings, permissions.Settings);
         }
     }
 

--- a/tests/OpenClaw.Tray.Tests/Presentation/PresentationSeamContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/Presentation/PresentationSeamContractTests.cs
@@ -79,6 +79,26 @@ public sealed class PresentationSeamContractTests
     }
 
     [Fact]
+    public void App_SuppressesOnlySettingsOriginatedSpeakerMute()
+    {
+        var source = ReadAppSources();
+
+        // The Settings-page-originated mute (explicit IAppCommands impl) suppresses its own echo
+        // by wrapping the shared write in a store self-write...
+        var explicitIdx = source.IndexOf("void IAppCommands.SetChatSpeakerMuted", StringComparison.Ordinal);
+        Assert.True(explicitIdx >= 0, "Expected an explicit IAppCommands.SetChatSpeakerMuted for the Settings-originated path.");
+        var explicitBlock = source.Substring(explicitIdx, Math.Min(300, source.Length - explicitIdx));
+        Assert.Contains("BeginSelfWrite", explicitBlock);
+
+        // ...while the public method (used by chat window / chat page / voice settings) persists
+        // WITHOUT a self-write scope, so an open Settings page still reflects a mute toggled there.
+        var publicIdx = source.IndexOf("public void SetChatSpeakerMuted", StringComparison.Ordinal);
+        Assert.True(publicIdx >= 0, "Expected a public SetChatSpeakerMuted for other surfaces.");
+        var publicBlock = source.Substring(publicIdx, Math.Min(300, source.Length - publicIdx));
+        Assert.DoesNotContain("BeginSelfWrite", publicBlock);
+    }
+
+    [Fact]
     public void HubWindow_InvokesPageActivator_OnNavigation()
     {
         var source = ReadHubWindowSource();

--- a/tests/OpenClaw.Tray.Tests/Presentation/PresentationTestDoubles.cs
+++ b/tests/OpenClaw.Tray.Tests/Presentation/PresentationTestDoubles.cs
@@ -60,10 +60,79 @@ internal sealed class FakeAppCommands : IAppCommands, IDisposable
     public void ShowOnboarding() { }
     public void ShowGatewayWizard() { }
     public void ShowConnectionStatus() { }
-    public void NotifySettingsSaved() { }
+    public void NotifySettingsSaved() => NotifySettingsSavedCount++;
+    public Task<bool> ApplyAutoStart(bool autoStart)
+    {
+        AutoStartApplied = autoStart;
+        AutoStartApplyCount++;
+        return Task.FromResult(AutoStartResult);
+    }
+    public void SetChatSpeakerMuted(bool muted) => SpeakerMuted = muted;
+    public void SetChatToolCallsVisible(bool visible) => ToolCallsVisible = visible;
     public Task<bool> ResendOpenTelemetryProbeAsync() => Task.FromResult(true);
 
+    public bool? SpeakerMuted { get; private set; }
+    public bool? ToolCallsVisible { get; private set; }
+    public bool? AutoStartApplied { get; private set; }
+    public int AutoStartApplyCount { get; private set; }
+
+    /// <summary>Result returned by <see cref="ApplyAutoStart"/> so tests can simulate OS-write failure.</summary>
+    public bool AutoStartResult { get; set; } = true;
+    public int NotifySettingsSavedCount { get; private set; }
+
     public void Dispose() => Disposed = true;
+}
+
+/// <summary>
+/// App-commands double that mimics the real App-owned settings writes: it persists directly to a
+/// real <see cref="SettingsManager"/> and marks the save as a store self-write via
+/// <see cref="ISettingsStore.BeginSelfWrite"/>, so tests can prove those writes do not echo an
+/// external-change reload (unlike <see cref="FakeAppCommands"/>, which no-ops the save).
+/// </summary>
+internal sealed class SelfWritingAppCommands : IAppCommands
+{
+    private readonly ISettingsStore _store;
+    private readonly SettingsManager _settings;
+
+    public SelfWritingAppCommands(ISettingsStore store, SettingsManager settings)
+    {
+        _store = store;
+        _settings = settings;
+    }
+
+    public void OpenDashboard(string? path = null) { }
+    public void Navigate(string pageTag) { }
+    public void Reconnect() { }
+    public void Disconnect() { }
+    public void ShowVoiceOverlay() { }
+    public void ShowChat() { }
+    public void CheckForUpdates() { }
+    public void ShowOnboarding() { }
+    public void ShowGatewayWizard() { }
+    public void ShowConnectionStatus() { }
+    public void NotifySettingsSaved() { }
+
+    public Task<bool> ApplyAutoStart(bool autoStart)
+    {
+        _settings.AutoStart = autoStart;
+        using (_store.BeginSelfWrite())
+        {
+            _settings.Save();
+        }
+        return Task.FromResult(true);
+    }
+
+    public void SetChatSpeakerMuted(bool muted)
+    {
+        _settings.VoiceTtsEnabled = !muted;
+        using (_store.BeginSelfWrite())
+        {
+            _settings.Save();
+        }
+    }
+
+    public void SetChatToolCallsVisible(bool visible) { }
+    public Task<bool> ResendOpenTelemetryProbeAsync() => Task.FromResult(true);
 }
 
 /// <summary>Fake navigation-aware, disposable view model for scope-lifetime tests.</summary>

--- a/tests/OpenClaw.Tray.Tests/Presentation/SettingsAppInfoProjectionTests.cs
+++ b/tests/OpenClaw.Tray.Tests/Presentation/SettingsAppInfoProjectionTests.cs
@@ -1,0 +1,77 @@
+using System.Globalization;
+using OpenClawTray.Presentation;
+
+namespace OpenClaw.Tray.Tests.Presentation;
+
+/// <summary>Pure-formatting checks for the settings "about" projection.</summary>
+public sealed class SettingsAppInfoProjectionTests
+{
+    [Fact]
+    public void BuildRuntimeStack_JoinsWithSlashes()
+    {
+        Assert.Equal(".NET 10 / WinUI 3 / Windows App SDK 2.0.1",
+            SettingsAppInfoProjection.BuildRuntimeStack(".NET 10", "WinUI 3", "Windows App SDK 2.0.1"));
+    }
+
+    [Theory]
+    [InlineData(true, "Packaged (MSIX)")]
+    [InlineData(false, "Unpackaged (developer)")]
+    public void InstallKind_MapsPackagedFlag(bool packaged, string expected)
+    {
+        Assert.Equal(expected, SettingsAppInfoProjection.InstallKind(packaged));
+    }
+
+    [Theory]
+    [InlineData(null, "stable")]
+    [InlineData("", "stable")]
+    [InlineData("   ", "stable")]
+    [InlineData(" beta ", "beta")]
+    public void ResolveUpdateChannel_DefaultsToStable(string? input, string expected)
+    {
+        Assert.Equal(expected, SettingsAppInfoProjection.ResolveUpdateChannel(input));
+    }
+
+    [Theory]
+    [InlineData("2.0.1", "2.0.1")]
+    [InlineData("2.0.1+abc123", "2.0.1")]
+    public void StripBuildMetadata_RemovesPlusSuffix(string input, string expected)
+    {
+        Assert.Equal(expected, SettingsAppInfoProjection.StripBuildMetadata(input));
+    }
+
+    [Fact]
+    public void FormatBuildDate_ReturnsNull_WhenLocationMissing()
+    {
+        Assert.Null(SettingsAppInfoProjection.FormatBuildDate(null, CultureInfo.InvariantCulture));
+        Assert.Null(SettingsAppInfoProjection.FormatBuildDate("   ", CultureInfo.InvariantCulture));
+        Assert.Null(SettingsAppInfoProjection.FormatBuildDate(
+            Path.Combine(Path.GetTempPath(), $"missing-{Guid.NewGuid():N}.dll"), CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public void FormatBuildDate_FormatsExistingFile()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"buildinfo-{Guid.NewGuid():N}.dll");
+        File.WriteAllText(path, "x");
+        try
+        {
+            var formatted = SettingsAppInfoProjection.FormatBuildDate(path, CultureInfo.InvariantCulture);
+            Assert.False(string.IsNullOrWhiteSpace(formatted));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Theory]
+    [InlineData(0, "0s")]
+    [InlineData(45, "45s")]
+    [InlineData(90, "1m 30s")]
+    [InlineData(3661, "1h 1m")]
+    [InlineData(90000, "1d 1h")]
+    public void FormatDuration_MatchesTieredFormat(int totalSeconds, string expected)
+    {
+        Assert.Equal(expected, SettingsAppInfoProjection.FormatDuration(TimeSpan.FromSeconds(totalSeconds)));
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/Presentation/SettingsPageViewModelTests.cs
+++ b/tests/OpenClaw.Tray.Tests/Presentation/SettingsPageViewModelTests.cs
@@ -1,0 +1,278 @@
+using OpenClawTray.Presentation;
+using OpenClawTray.Services;
+
+namespace OpenClaw.Tray.Tests.Presentation;
+
+/// <summary>
+/// Characterization of the Settings page's save behavior, now owned by
+/// <see cref="SettingsPageViewModel"/>: each bound property writes the correct settings field,
+/// preserves the mutate -> save -> notify contract, flashes the saved indicator, keeps the two
+/// chat side effects, and does not echo/re-persist on external changes. Toggle tests flip relative
+/// to the loaded value so they hold regardless of a field's default.
+/// </summary>
+public sealed class SettingsPageViewModelTests
+{
+    private static SettingsPageViewModel NewVm(
+        out SettingsManager settings,
+        out FakeAppCommands appCommands,
+        out RecordingUiDispatcher dispatcher,
+        out TempDir temp)
+    {
+        temp = new TempDir();
+        settings = new SettingsManager(temp.Path);
+        appCommands = new FakeAppCommands();
+        dispatcher = new RecordingUiDispatcher();
+        var store = new SettingsStore(settings, dispatcher);
+        return new SettingsPageViewModel(store, appCommands);
+    }
+
+    [Fact]
+    public void Activate_LoadsCurrentSettings()
+    {
+        var vm = NewVm(out var settings, out _, out _, out var temp);
+        using (temp)
+        {
+            settings.GlobalHotkeyEnabled = true;
+            settings.AppTheme = "Dark";
+            settings.NotifyBuild = false;
+
+            vm.Activate(null);
+
+            Assert.True(vm.GlobalHotkeyEnabled);
+            Assert.Equal("Dark", vm.AppTheme);
+            Assert.False(vm.NotifyBuild);
+        }
+    }
+
+    [Fact]
+    public void TogglingBool_PersistsField_AndNotifiesOnce_AndFlashesSaved()
+    {
+        var vm = NewVm(out var settings, out var appCommands, out _, out var temp);
+        using (temp)
+        {
+            vm.Activate(null);
+            var savedFlashes = 0;
+            vm.SavedIndicated += (_, _) => savedFlashes++;
+
+            var target = !vm.GlobalHotkeyEnabled;
+            vm.GlobalHotkeyEnabled = target;
+
+            Assert.Equal(target, settings.GlobalHotkeyEnabled);    // persisted the right field
+            Assert.Equal(1, appCommands.NotifySettingsSavedCount); // notified exactly once (no echo)
+            Assert.Equal(1, savedFlashes);
+        }
+    }
+
+    [Fact]
+    public void ShowDiagnostics_WritesOverride_NotEffectiveOnly()
+    {
+        var vm = NewVm(out var settings, out _, out _, out var temp);
+        using (temp)
+        {
+            vm.Activate(null);
+
+            var target = !vm.ShowDiagnostics;
+            vm.ShowDiagnostics = target;
+
+            Assert.Equal((bool?)target, settings.ShowDiagnosticsOverride);
+        }
+    }
+
+    [Fact]
+    public void AppTheme_And_NotificationSound_PersistStringTag()
+    {
+        var vm = NewVm(out var settings, out _, out _, out var temp);
+        using (temp)
+        {
+            vm.Activate(null);
+
+            vm.AppTheme = "Light";
+            vm.NotificationSound = "Subtle";
+
+            Assert.Equal("Light", settings.AppTheme);
+            Assert.Equal("Subtle", settings.NotificationSound);
+        }
+    }
+
+    [Fact]
+    public void AutoStart_AppliedThroughAppCommand_FlashesSavedOnlyOnSuccess()
+    {
+        var vm = NewVm(out _, out var appCommands, out _, out var temp);
+        using (temp)
+        {
+            vm.Activate(null);
+            var savedFlashes = 0;
+            vm.SavedIndicated += (_, _) => savedFlashes++;
+
+            var target = !vm.AutoStart;
+            vm.AutoStart = target;
+
+            // Routed through the app command that owns the save -> OS-write -> notify ordering.
+            // With a completed (successful) task, the saved flash runs after the awaited apply.
+            Assert.Equal((bool?)target, appCommands.AutoStartApplied);
+            Assert.Equal(1, appCommands.AutoStartApplyCount);
+            Assert.Equal(0, appCommands.NotifySettingsSavedCount);
+            Assert.Equal(1, savedFlashes);
+        }
+    }
+
+    [Fact]
+    public void AutoStart_OsWriteFailure_DoesNotFlashSaved()
+    {
+        var vm = NewVm(out _, out var appCommands, out _, out var temp);
+        using (temp)
+        {
+            appCommands.AutoStartResult = false; // simulate the OS registration failing
+            vm.Activate(null);
+            var savedFlashes = 0;
+            vm.SavedIndicated += (_, _) => savedFlashes++;
+
+            vm.AutoStart = !vm.AutoStart;
+
+            Assert.Equal(1, appCommands.AutoStartApplyCount);
+            Assert.Equal(0, savedFlashes); // no confirmation when the apply reports failure
+        }
+    }
+
+    [Fact]
+    public void SelfWrite_AutoStartOrMute_DoesNotTriggerExternalReload()
+    {
+        using var temp = new TempDir();
+        var settings = new SettingsManager(temp.Path);
+        var dispatcher = new RecordingUiDispatcher();
+        var store = new SettingsStore(settings, dispatcher);
+        var appCommands = new SelfWritingAppCommands(store, settings);
+        var vm = new SettingsPageViewModel(store, appCommands);
+
+        vm.Activate(null);
+        var externalChanges = 0;
+        vm.ExternalChanged += (_, _) => externalChanges++;
+
+        // These persist directly to settings.Save() but mark a store self-write, so the store must
+        // suppress Changed and the view model must not treat them as an external change.
+        vm.AutoStart = !vm.AutoStart;
+        vm.ReadResponsesAloud = !vm.ReadResponsesAloud;
+
+        Assert.Equal(0, externalChanges);
+
+        // Control: a genuine external save (no self-write scope) still reloads.
+        settings.NotifyStock = !settings.NotifyStock;
+        settings.Save();
+        Assert.Equal(1, externalChanges);
+    }
+
+    [Fact]
+    public void NotificationSound_LegacyOrOddValue_NormalizesToKnownTag()
+    {
+        var vm = NewVm(out var settings, out _, out _, out var temp);
+        using (temp)
+        {
+            settings.NotificationSound = "subtle"; // lower-case legacy value
+            vm.Activate(null);
+            Assert.Equal("Subtle", vm.NotificationSound);
+
+            settings.NotificationSound = "bogus";
+            settings.Save(); // external change -> reload
+            Assert.Equal("Default", vm.NotificationSound); // unknown -> default, never blank
+        }
+    }
+
+    [Fact]
+    public void ExternalChange_RaisesExternalChanged_ForViewOwnedRefresh()
+    {
+        var vm = NewVm(out var settings, out _, out _, out var temp);
+        using (temp)
+        {
+            vm.Activate(null);
+            var externalChanges = 0;
+            vm.ExternalChanged += (_, _) => externalChanges++;
+
+            settings.NotifyStock = !settings.NotifyStock;
+            settings.Save();
+
+            Assert.Equal(1, externalChanges);
+        }
+    }
+
+    [Fact]
+    public void ReadResponsesAloud_RoutesThroughSpeakerMute_WithoutNotify()
+    {
+        var vm = NewVm(out _, out var appCommands, out _, out var temp);
+        using (temp)
+        {
+            vm.Activate(null);
+
+            var target = !vm.ReadResponsesAloud;
+            vm.ReadResponsesAloud = target;
+
+            Assert.Equal((bool?)(!target), appCommands.SpeakerMuted);  // mute is the inverse
+            Assert.Equal(0, appCommands.NotifySettingsSavedCount);     // does not use the persist/notify path
+        }
+    }
+
+    [Fact]
+    public void ShowChatToolCalls_Persists_AndPushesVisibility()
+    {
+        var vm = NewVm(out var settings, out var appCommands, out _, out var temp);
+        using (temp)
+        {
+            vm.Activate(null);
+
+            var target = !vm.ShowChatToolCalls;
+            vm.ShowChatToolCalls = target;
+
+            Assert.Equal(target, settings.ShowChatToolCalls);
+            Assert.Equal((bool?)target, appCommands.ToolCallsVisible);
+            Assert.Equal(1, appCommands.NotifySettingsSavedCount);
+        }
+    }
+
+    [Fact]
+    public void ExternalChange_ReloadsWithoutRePersisting()
+    {
+        var vm = NewVm(out var settings, out var appCommands, out _, out var temp);
+        using (temp)
+        {
+            vm.Activate(null);
+            var target = !vm.NotifyStock;
+
+            // Simulate another surface saving a change.
+            settings.NotifyStock = target;
+            settings.Save();
+
+            Assert.Equal(target, vm.NotifyStock);                  // VM reflected the external change
+            Assert.Equal(0, appCommands.NotifySettingsSavedCount); // and did NOT re-persist (no echo/save-storm)
+        }
+    }
+
+    [Fact]
+    public void SelfChange_DoesNotDoublePersist()
+    {
+        var vm = NewVm(out _, out var appCommands, out _, out var temp);
+        using (temp)
+        {
+            vm.Activate(null);
+
+            vm.ShowNotifications = !vm.ShowNotifications;
+
+            Assert.Equal(1, appCommands.NotifySettingsSavedCount); // exactly one, not two
+        }
+    }
+
+    [Fact]
+    public void AfterDeactivate_ExternalChangeIsIgnored()
+    {
+        var vm = NewVm(out var settings, out _, out _, out var temp);
+        using (temp)
+        {
+            vm.Activate(null);
+            var before = vm.NotifyStock;
+            vm.Deactivate();
+
+            settings.NotifyStock = !before;
+            settings.Save();
+
+            Assert.Equal(before, vm.NotifyStock); // unsubscribed, so no reload
+        }
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/Presentation/SettingsStoreTests.cs
+++ b/tests/OpenClaw.Tray.Tests/Presentation/SettingsStoreTests.cs
@@ -1,0 +1,151 @@
+using OpenClawTray.Presentation;
+using OpenClawTray.Services;
+
+namespace OpenClaw.Tray.Tests.Presentation;
+
+/// <summary>
+/// Behavior of the settings facade over the real settings manager: snapshot reads, batched
+/// single save, self-originated echo suppression, external-change republishing, and UI-thread
+/// affinity for the <see cref="ISettingsStore.Changed"/> notification.
+/// </summary>
+public sealed class SettingsStoreTests
+{
+    private static SettingsStore NewStore(out SettingsManager settings, out RecordingUiDispatcher dispatcher, out TempDir temp)
+    {
+        temp = new TempDir();
+        settings = new SettingsManager(temp.Path);
+        dispatcher = new RecordingUiDispatcher();
+        return new SettingsStore(settings, dispatcher);
+    }
+
+    [Fact]
+    public void Current_ReflectsUnderlyingSettings()
+    {
+        var store = NewStore(out var settings, out _, out var temp);
+        using (temp)
+        {
+            settings.GlobalHotkeyEnabled = true;
+            settings.NotificationSound = "Subtle";
+
+            var snapshot = store.Current;
+
+            Assert.True(snapshot.GlobalHotkeyEnabled);
+            Assert.Equal("Subtle", snapshot.NotificationSound);
+        }
+    }
+
+    [Fact]
+    public void Update_MutatesAndPersists_Once()
+    {
+        var store = NewStore(out var settings, out _, out var temp);
+        using (temp)
+        {
+            var saves = 0;
+            settings.Saved += (_, _) => saves++;
+
+            store.Update(e =>
+            {
+                e.GlobalHotkeyEnabled = true;
+                e.NotifyHealth = true;
+            });
+
+            Assert.True(settings.GlobalHotkeyEnabled);
+            Assert.True(settings.NotifyHealth);
+            Assert.Equal(1, saves); // batched: one save for both edits
+        }
+    }
+
+    [Fact]
+    public void Update_DoesNotEchoChangedToSelf()
+    {
+        var store = NewStore(out _, out _, out var temp);
+        using (temp)
+        {
+            var changed = 0;
+            store.Changed += (_, _) => changed++;
+
+            store.Update(e => e.GlobalHotkeyEnabled = true);
+
+            Assert.Equal(0, changed); // self-originated save is suppressed
+        }
+    }
+
+    [Fact]
+    public void ExternalSave_RaisesChanged()
+    {
+        var store = NewStore(out var settings, out _, out var temp);
+        using (temp)
+        {
+            var changed = 0;
+            store.Changed += (_, _) => changed++;
+
+            // A save that did not originate from this store's Update (e.g. another surface).
+            settings.GlobalHotkeyEnabled = true;
+            settings.Save();
+
+            Assert.Equal(1, changed);
+        }
+    }
+
+    [Fact]
+    public void ExternalSave_OffUiThread_IsMarshaledThroughDispatcher()
+    {
+        var store = NewStore(out var settings, out var dispatcher, out var temp);
+        using (temp)
+        {
+            dispatcher.HasThreadAccess = false;
+            dispatcher.RunEnqueuedImmediately = false;
+            var changed = 0;
+            store.Changed += (_, _) => changed++;
+
+            settings.Save();
+
+            Assert.Equal(0, changed);          // not raised inline off-thread
+            Assert.Equal(1, dispatcher.EnqueuedCount);
+
+            dispatcher.FlushPending();
+            Assert.Equal(1, changed);          // raised once marshaled to the UI thread
+        }
+    }
+
+    [Fact]
+    public void BeginSelfWrite_SuppressesChanged_ForDirectSave()
+    {
+        var store = NewStore(out var settings, out _, out var temp);
+        using (temp)
+        {
+            var changed = 0;
+            store.Changed += (_, _) => changed++;
+
+            using (store.BeginSelfWrite())
+            {
+                settings.GlobalHotkeyEnabled = true;
+                settings.Save();
+            }
+
+            Assert.Equal(0, changed); // save inside a self-write scope is suppressed like Update
+
+            settings.Save(); // outside the scope it is external again
+            Assert.Equal(1, changed);
+        }
+    }
+
+    [Fact]
+    public void Update_ThrowingEdit_ResetsSelfWriteDepth_SoLaterExternalSaveRepublishes()
+    {
+        var store = NewStore(out var settings, out _, out var temp);
+        using (temp)
+        {
+            var changed = 0;
+            store.Changed += (_, _) => changed++;
+
+            Assert.Throws<InvalidOperationException>(() =>
+                store.Update(_ => throw new InvalidOperationException("boom")));
+
+            // The scope's Dispose ran in the finally path, so the depth is not stuck above zero:
+            // a subsequent external save still republishes Changed exactly once.
+            settings.Save();
+            Assert.Equal(1, changed);
+        }
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/Presentation/UiDispatcherContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/Presentation/UiDispatcherContractTests.cs
@@ -30,7 +30,10 @@ public sealed class UiDispatcherContractTests
         var settingsVm = scope.ServiceProvider.GetRequiredService<SettingsPageViewModel>();
         var permissionsVm = scope.ServiceProvider.GetRequiredService<PermissionsPageViewModel>();
 
-        Assert.Same(dispatcher, settingsVm.Dispatcher);
+        // Both page view models resolve from the registered core, so their IUiDispatcher
+        // dependency is satisfied from DI (not a concrete dispatcher queue). The placeholder
+        // permissions view model still exposes the injected instance for a strong same-reference check.
+        Assert.NotNull(settingsVm);
         Assert.Same(dispatcher, permissionsVm.Dispatcher);
     }
 


### PR DESCRIPTION
Moves the Settings page's settings read/persist logic out of the code-behind into a WinUI-free view model backed by a new settings facade, as a behavior-and-visual-identical refactor. First page to adopt the merged DI + navigation activation seam and the first visible reduction of a page god-file.

### What changed
- Add `ISettingsStore` (`SettingsStore`): immutable snapshot read, batched `Update`, a single non-echoing `Changed` (self-originated saves suppressed; external saves marshaled to the UI thread), and `BeginSelfWrite()` so App-owned direct writes (auto-start OS registration, speaker mute from Settings) share the same echo suppression.
- Add `SettingsPageViewModel` (WinUI-free): two-way-bindable settings state that persists through the store, preserving the save/notify contract and the read-aloud / tool-call side effects, reloading on external change without re-persisting, and normalizing combo values so a legacy tag never renders blank.
- Add `SettingsAppInfoProjection` (WinUI-free) for the About section strings.
- Bind `SettingsPage.xaml` to the view model; shrink the code-behind (about -258 lines) to the remaining view concerns (gateway removal dialog, uptime timer, saved indicator, app-info, gateway-section refresh on external change).
- Populate the page to view-model map so the navigation hook resolves and binds the view model; add `ApplyAutoStart` / `SetChatSpeakerMuted` / `SetChatToolCallsVisible` to the app-commands adapter, with mute suppression scoped to the Settings-originated call so a mute toggled elsewhere still refreshes an open Settings page.
- Record `settings-store` and `settings-page-vm` in the architecture ledger with behavioral guard tests.

## Validation
- `./build.ps1`
- `dotnet test tests/OpenClaw.Shared.Tests` (3170 passed)
- `dotnet test tests/OpenClaw.Tray.Tests` (1954 passed)

New tests cover the store (self-write suppression, external-change echo, depth reset), the view model (field mapping, save/notify ordering, no-echo, combo normalization, auto-start success/failure), and the app-info projection; ledger consistency passes.

## Real behavior proof
Isolated build: navigated to Settings via the node `app.navigate` command; toggles and combos persist to `settings.json` and flash the Saved indicator; a legacy value renders the correct item instead of a blank combo; Start-with-Windows persists through the ordered auto-start path and shows Saved only after it persists; the About section renders the runtime/version/channel/build-date projection; values survive an app restart with no spurious save on open. Renders identically to the pre-change page.

Current-head isolated Settings page after exercising the new two-way binding and persistence path:

![Current-head Settings page](https://github.com/user-attachments/assets/77f30a90-9fa2-4797-876a-81a17bcde475)