### PR TITLE
feat: add exec approval prompt dialog for system.run on the Windows node

### DIFF
--- a/src/OpenClaw.Shared/ExecApprovals/ExecApprovalCommandDisplaySanitizer.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ExecApprovalCommandDisplaySanitizer.cs
@@ -1,0 +1,51 @@
+using System.Globalization;
+using System.Text;
+
+namespace OpenClaw.Shared.ExecApprovals;
+
+/// <summary>
+/// Escapes invisible and direction-changing Unicode code points before command text is
+/// rendered in an approval prompt, so an agent cannot make the approved text look like
+/// a different command (BiDi overrides, zero-width characters, fake line breaks,
+/// non-ASCII spaces that spoof token boundaries).
+/// </summary>
+public static class ExecApprovalCommandDisplaySanitizer
+{
+    public static string Sanitize(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+            return text;
+
+        var sanitized = new StringBuilder(text.Length);
+        // Iterate by runes, not chars: Format-category code points exist outside the
+        // BMP and a per-char loop would misclassify surrogate pairs.
+        foreach (var rune in text.EnumerateRunes())
+        {
+            if (ShouldEscape(rune))
+                sanitized.Append("\\u{").Append(rune.Value.ToString("X")).Append('}');
+            else
+                sanitized.Append(rune.ToString());
+        }
+        return sanitized.ToString();
+    }
+
+    private static bool ShouldEscape(Rune rune)
+    {
+        var category = Rune.GetUnicodeCategory(rune);
+        if (category is UnicodeCategory.Control
+            or UnicodeCategory.Format
+            or UnicodeCategory.LineSeparator
+            or UnicodeCategory.ParagraphSeparator)
+        {
+            return true;
+        }
+
+        // Non-ASCII space separators (NBSP, narrow NBSP, ideographic space, …) render
+        // like a plain space but are handled differently by shells/parsers.
+        if (category == UnicodeCategory.SpaceSeparator && rune.Value != 0x20)
+            return true;
+
+        // Hangul filler characters render as blank but are not classified as spaces.
+        return rune.Value is 0x115F or 0x1160 or 0x3164 or 0xFFA0;
+    }
+}

--- a/src/OpenClaw.Shared/ExecApprovals/ExecApprovalConfusableDetector.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ExecApprovalConfusableDetector.cs
@@ -1,0 +1,77 @@
+using System.Text;
+
+namespace OpenClaw.Shared.ExecApprovals;
+
+/// <summary>
+/// Flags command text that mixes scripts which are visually confusable with Latin
+/// (Cyrillic or Greek letters intermixed with Latin ones inside a single token), the
+/// classic homoglyph-spoofing signal from Unicode UTS #39 mixed-script detection.
+/// It does not escape or alter the text — escaping confusables would mangle legitimate
+/// non-ASCII commands. It only reports whether a warning should be shown next to the
+/// rendered command so the user is told the text may not read the way it looks.
+///
+/// Single-script text (all Latin, all Greek, all Cyrillic, all Han, …) is never flagged;
+/// only a token drawing letters from two or more of the Latin-confusable scripts is.
+/// </summary>
+public static class ExecApprovalConfusableDetector
+{
+    private enum ConfusableScript { None, Latin, Cyrillic, Greek }
+
+    public static bool HasMixedScriptConfusable(string? text)
+    {
+        if (string.IsNullOrEmpty(text))
+            return false;
+
+        // Whitespace separates command tokens; a homoglyph attack lives inside one
+        // token (a spoofed executable name or argument), so scripts are only compared
+        // within a token, never across the whole string.
+        var scriptsInToken = ConfusableScript.None;
+        var seenSecond = false;
+
+        foreach (var rune in text.EnumerateRunes())
+        {
+            if (Rune.IsWhiteSpace(rune))
+            {
+                scriptsInToken = ConfusableScript.None;
+                continue;
+            }
+
+            var script = Classify(rune.Value);
+            if (script == ConfusableScript.None)
+                continue;
+
+            if (scriptsInToken == ConfusableScript.None)
+            {
+                scriptsInToken = script;
+            }
+            else if (scriptsInToken != script)
+            {
+                seenSecond = true;
+                break;
+            }
+        }
+
+        return seenSecond;
+    }
+
+    private static ConfusableScript Classify(int cp)
+    {
+        // Latin letters that carry ASCII-lookalikes (basic + accented ranges).
+        if ((cp >= 0x0041 && cp <= 0x005A) || (cp >= 0x0061 && cp <= 0x007A)
+            || (cp >= 0x00C0 && cp <= 0x024F)
+            || (cp >= 0x1E00 && cp <= 0x1EFF))
+            return ConfusableScript.Latin;
+
+        // Greek and Coptic + Greek Extended.
+        if ((cp >= 0x0370 && cp <= 0x03FF) || (cp >= 0x1F00 && cp <= 0x1FFF))
+            return ConfusableScript.Greek;
+
+        // Cyrillic + Cyrillic Supplement.
+        if (cp >= 0x0400 && cp <= 0x052F)
+            return ConfusableScript.Cyrillic;
+
+        // Digits, punctuation, symbols, and every other script (Han, Hiragana, Arabic,
+        // …) are script-neutral for this check: they carry no Latin homoglyph risk.
+        return ConfusableScript.None;
+    }
+}

--- a/src/OpenClaw.Shared/ExecApprovals/ExecApprovalV2UiPromptHandler.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ExecApprovalV2UiPromptHandler.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OpenClaw.Shared.ExecApprovals;
+
+/// <summary>
+/// Display-ready strings for the exec approval prompt window. All values are already
+/// sanitized for rendering; the dialog never sees the raw request.
+/// </summary>
+public sealed record ExecApprovalPromptView(
+    string CommandText,
+    string AgentLabel,
+    string? CwdText,
+    string? ExecutablePathText,
+    bool HasConfusableWarning);
+
+/// <summary>
+/// Prompt-handler core behind the approval dialog. UI-free: the dispatcher hop and the
+/// window are injected as delegates so the full decision behavior is testable without
+/// WinUI. Fail-closed contract: never throws, never returns plain Allow, and resolves
+/// Deny on cancellation, enqueue failure, window close, or any internal error.
+/// </summary>
+public sealed class ExecApprovalV2UiPromptHandler : IExecApprovalV2PromptHandler
+{
+    private readonly Func<Action, bool> _tryEnqueue;
+    private readonly Func<ExecApprovalPromptView, CancellationToken, Task<ExecApprovalPromptOutcome>> _showDialog;
+    private readonly IOpenClawLogger _logger;
+
+    public ExecApprovalV2UiPromptHandler(
+        Func<Action, bool> tryEnqueue,
+        Func<ExecApprovalPromptView, CancellationToken, Task<ExecApprovalPromptOutcome>> showDialog,
+        IOpenClawLogger logger)
+    {
+        _tryEnqueue = tryEnqueue ?? throw new ArgumentNullException(nameof(tryEnqueue));
+        _showDialog = showDialog ?? throw new ArgumentNullException(nameof(showDialog));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<ExecApprovalPromptOutcome> PromptAsync(
+        ExecApprovalV2PromptRequest request, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return ExecApprovalPromptOutcome.Deny;
+
+            // Every field shown in the dialog originates from agent-controlled input,
+            // including the agent label, so all of them go through the display sanitizer
+            // before any UI binding to neutralize BiDi and control-character spoofing.
+            var commandText = ExecApprovalCommandDisplaySanitizer.Sanitize(request.DisplayCommand);
+            var agentLabel = ExecApprovalCommandDisplaySanitizer.Sanitize(request.AgentId);
+            var cwdText = request.Cwd is null ? null : ExecApprovalCommandDisplaySanitizer.Sanitize(request.Cwd);
+            var pathText = request.ResolvedPath is null ? null : ExecApprovalCommandDisplaySanitizer.Sanitize(request.ResolvedPath);
+
+            // Homoglyphs and mixed scripts survive sanitization by design (escaping them
+            // would break legitimate non-ASCII text); surface them as a visible warning
+            // instead so the user knows the command may not read the way it looks.
+            var hasConfusable =
+                ExecApprovalConfusableDetector.HasMixedScriptConfusable(commandText)
+                || ExecApprovalConfusableDetector.HasMixedScriptConfusable(cwdText)
+                || ExecApprovalConfusableDetector.HasMixedScriptConfusable(pathText);
+
+            var view = new ExecApprovalPromptView(commandText, agentLabel, cwdText, pathText, hasConfusable);
+
+            var tcs = new TaskCompletionSource<ExecApprovalPromptOutcome>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+
+            // This TCS is the single authority for the outcome; first result wins.
+            // Cancellation resolves it directly — no dispatcher hop — so a hung or
+            // slow dialog can never delay the deny. Window teardown on cancel is
+            // visual cleanup only, owned by the dialog delegate.
+            using var registration = cancellationToken.Register(
+                () => tcs.TrySetResult(ExecApprovalPromptOutcome.Deny));
+
+            // Cancellation may have resolved the TCS already (inline during Register).
+            // A request that is already denied must never surface a window.
+            if (tcs.Task.IsCompleted)
+                return await tcs.Task.ConfigureAwait(false);
+
+            if (!_tryEnqueue(() => _ = RunDialogAsync(view, tcs, cancellationToken)))
+            {
+                _logger.Warn("[EXEC-APPROVALS] prompt: dispatcher enqueue failed; denying");
+                tcs.TrySetResult(ExecApprovalPromptOutcome.Deny);
+            }
+
+            var outcome = await tcs.Task.ConfigureAwait(false);
+            if (outcome == ExecApprovalPromptOutcome.Allow)
+            {
+                _logger.Error("[EXEC-APPROVALS] prompt: dialog returned plain Allow; " +
+                    "only AllowOnce/AllowAlways are valid from UI — denying");
+                return ExecApprovalPromptOutcome.Deny;
+            }
+            return outcome;
+        }
+        catch (Exception ex)
+        {
+            try { _logger.Warn($"[EXEC-APPROVALS] prompt failed; denying: {ex.Message}"); } catch { }
+            return ExecApprovalPromptOutcome.Deny;
+        }
+    }
+
+    // Runs on the dispatcher. The try/catch wraps the entire async body so failures
+    // after the first await (where the delegate is effectively fire-and-forget) still
+    // resolve the outcome instead of escaping.
+    private async Task RunDialogAsync(
+        ExecApprovalPromptView view,
+        TaskCompletionSource<ExecApprovalPromptOutcome> tcs,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            // The request may have been cancelled while this action sat in the
+            // dispatcher queue; it is already denied, so never show the dialog.
+            if (cancellationToken.IsCancellationRequested)
+            {
+                tcs.TrySetResult(ExecApprovalPromptOutcome.Deny);
+                return;
+            }
+
+            var outcome = await _showDialog(view, cancellationToken).ConfigureAwait(false);
+            tcs.TrySetResult(outcome);
+        }
+        catch (Exception ex)
+        {
+            try { _logger.Warn($"[EXEC-APPROVALS] prompt dialog failed; denying: {ex.Message}"); } catch { }
+            tcs.TrySetResult(ExecApprovalPromptOutcome.Deny);
+        }
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Dialogs/ExecApprovalDialog.cs
+++ b/src/OpenClaw.Tray.WinUI/Dialogs/ExecApprovalDialog.cs
@@ -1,0 +1,370 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using OpenClaw.Shared.ExecApprovals;
+using OpenClawTray.Controls;
+using OpenClawTray.Helpers;
+using OpenClawTray.Services;
+using System;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using WinUIEx;
+
+namespace OpenClawTray.Dialogs;
+
+/// <summary>
+/// Approval prompt for a command the agent wants to run on this machine. Shows the
+/// already-sanitized command text plus context rows and offers Deny / Allow Once /
+/// Allow Always.
+///
+/// Security posture: the allow buttons are never default-focused and stay disabled for
+/// a short delay so the dialog cannot be click-through approved; Escape, the X button,
+/// and Alt+F4 all resolve to Deny.
+/// </summary>
+public sealed class ExecApprovalDialog : WindowEx
+{
+    [DllImport("user32.dll")]
+    private static extern bool SetForegroundWindow(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    private static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
+
+    private static readonly IntPtr HWND_TOPMOST = new(-1);
+    private static readonly IntPtr HWND_NOTOPMOST = new(-2);
+    private const uint SWP_NOMOVE = 0x0002;
+    private const uint SWP_NOSIZE = 0x0001;
+
+    private static readonly TimeSpan AllowArmDelay = TimeSpan.FromMilliseconds(1500);
+
+    private readonly TaskCompletionSource<ExecApprovalPromptOutcome> _tcs =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly Button _denyButton;
+    private readonly Button _allowOnceButton;
+    private readonly Button _allowAlwaysButton;
+
+    private DispatcherTimer? _armTimer;
+    private ExecApprovalPromptOutcome _outcome = ExecApprovalPromptOutcome.Deny;
+
+    // Anti-clickthrough gate: the allow buttons arm only once BOTH the arm delay has
+    // elapsed AND the user has seen the whole command (scrolled to the end, or it fit).
+    private ScrollViewer? _bodyScroll;
+    private bool _delayElapsed;
+    private bool _commandFullySeen;
+
+    public bool IsClosed { get; private set; }
+
+    public ExecApprovalDialog(ExecApprovalPromptView view)
+    {
+        ArgumentNullException.ThrowIfNull(view);
+
+        var windowTitle = $"{AppIdentity.DisplayName} - {LocalizationHelper.GetString("ExecApproval_WindowTitle")}";
+        Title = windowTitle;
+        this.SetWindowSize(520, 400);
+        this.CenterOnScreen();
+        this.SetIcon("Assets\\openclaw.ico");
+        SystemBackdrop = new MicaBackdrop();
+        ExtendsContentIntoTitleBar = true;
+
+        // ── Custom title bar ──
+        var titleBar = new Grid { Height = 48, Padding = new Thickness(16, 0, 140, 0) };
+        titleBar.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        titleBar.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        var titleIcon = new BrandMark { MarkSize = 16, VerticalAlignment = VerticalAlignment.Center, Margin = new Thickness(0, 0, 8, 0) };
+        Grid.SetColumn(titleIcon, 0);
+        titleBar.Children.Add(titleIcon);
+        var titleText = new TextBlock
+        {
+            Text = windowTitle,
+            FontSize = 13,
+            VerticalAlignment = VerticalAlignment.Center,
+            Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+        };
+        Grid.SetColumn(titleText, 1);
+        titleBar.Children.Add(titleText);
+        SetTitleBar(titleBar);
+
+        // ── Layout: [title bar][header][scrollable body][buttons] ──
+        var outerGrid = new Grid();
+        outerGrid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(48) });
+        outerGrid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });
+        Grid.SetRow(titleBar, 0);
+        outerGrid.Children.Add(titleBar);
+
+        var root = new Grid { Padding = new Thickness(28, 8, 28, 24), RowSpacing = 14 };
+        root.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+        root.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });
+        root.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+
+        // Header: shield glyph + heading
+        var header = new Grid { ColumnSpacing = 12 };
+        header.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        header.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        var shield = new FontIcon
+        {
+            Glyph = "\uE72E", // shield
+            FontSize = 28,
+            Foreground = ResolveBrush("SystemFillColorCautionBrush"),
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        Grid.SetColumn(shield, 0);
+        header.Children.Add(shield);
+        var heading = new TextBlock
+        {
+            Text = LocalizationHelper.GetString("ExecApproval_Heading"),
+            Style = (Style)Application.Current.Resources["SubtitleTextBlockStyle"],
+            VerticalAlignment = VerticalAlignment.Center,
+            TextWrapping = TextWrapping.Wrap,
+        };
+        Grid.SetColumn(heading, 1);
+        header.Children.Add(heading);
+        Grid.SetRow(header, 0);
+        root.Children.Add(header);
+
+        // Body (scrollable: long translations / high scaling degrade to scrolling)
+        var body = new StackPanel { Spacing = 12 };
+        body.Children.Add(new TextBlock
+        {
+            Text = LocalizationHelper.GetString("ExecApproval_Body"),
+            Foreground = ResolveBrush("TextFillColorSecondaryBrush"),
+            TextWrapping = TextWrapping.Wrap,
+        });
+
+        // Homoglyph / mixed-script warning: the command draws letters from more than one
+        // Latin-confusable script, so it may not read the way it looks.
+        if (view.HasConfusableWarning)
+            body.Children.Add(BuildConfusableWarning());
+
+        // Command card: monospaced, selectable. A single body scroll region (below) owns
+        // all scrolling so there is one place to reach "you have seen the whole command".
+        var commandText = new TextBlock
+        {
+            Text = view.CommandText,
+            FontFamily = new FontFamily("Cascadia Mono, Consolas, Courier New"),
+            FontSize = 12,
+            TextWrapping = TextWrapping.Wrap,
+            IsTextSelectionEnabled = true,
+        };
+        body.Children.Add(new Border
+        {
+            Background = ResolveBrush("CardBackgroundFillColorDefaultBrush"),
+            CornerRadius = new CornerRadius(4),
+            Padding = new Thickness(8),
+            Child = commandText,
+        });
+
+        AddContextRow(body, "ExecApproval_AgentLabel", view.AgentLabel);
+        AddContextRow(body, "ExecApproval_CwdLabel", view.CwdText);
+        AddContextRow(body, "ExecApproval_ExecutableLabel", view.ExecutablePathText);
+
+        _bodyScroll = new ScrollViewer
+        {
+            Content = body,
+            VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+            HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
+        };
+        _bodyScroll.ViewChanged += (_, _) => UpdateCommandSeen();
+        _bodyScroll.SizeChanged += (_, _) => UpdateCommandSeen();
+        _bodyScroll.Loaded += (_, _) => UpdateCommandSeen();
+        Grid.SetRow(_bodyScroll, 1);
+        root.Children.Add(_bodyScroll);
+
+        // Buttons: [Deny] ............ [Allow Always] [Allow Once (accent)]
+        var buttonGrid = new Grid { ColumnSpacing = 8 };
+        buttonGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        buttonGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        buttonGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        buttonGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+        _denyButton = new Button { Content = LocalizationHelper.GetString("ExecApproval_Deny") };
+        Microsoft.UI.Xaml.Automation.AutomationProperties.SetAutomationId(_denyButton, "ExecApprovalDenyAction");
+        _denyButton.Click += (_, _) => Decide(ExecApprovalPromptOutcome.Deny);
+        Grid.SetColumn(_denyButton, 0);
+        buttonGrid.Children.Add(_denyButton);
+
+        _allowAlwaysButton = new Button { Content = LocalizationHelper.GetString("ExecApproval_AllowAlways") };
+        Microsoft.UI.Xaml.Automation.AutomationProperties.SetAutomationId(_allowAlwaysButton, "ExecApprovalAllowAlwaysAction");
+        _allowAlwaysButton.Click += (_, _) => Decide(ExecApprovalPromptOutcome.AllowAlways);
+        Grid.SetColumn(_allowAlwaysButton, 2);
+        buttonGrid.Children.Add(_allowAlwaysButton);
+
+        _allowOnceButton = new Button
+        {
+            Content = LocalizationHelper.GetString("ExecApproval_AllowOnce"),
+            Style = (Style)Application.Current.Resources["AccentButtonStyle"],
+        };
+        Microsoft.UI.Xaml.Automation.AutomationProperties.SetAutomationId(_allowOnceButton, "ExecApprovalAllowOnceAction");
+        _allowOnceButton.Click += (_, _) => Decide(ExecApprovalPromptOutcome.AllowOnce);
+        Grid.SetColumn(_allowOnceButton, 3);
+        buttonGrid.Children.Add(_allowOnceButton);
+
+        Grid.SetRow(buttonGrid, 2);
+        root.Children.Add(buttonGrid);
+
+        Grid.SetRow(root, 1);
+        outerGrid.Children.Add(root);
+        Content = outerGrid;
+
+        // Escape denies from anywhere in the window.
+        var escAccel = new Microsoft.UI.Xaml.Input.KeyboardAccelerator
+        {
+            Key = global::Windows.System.VirtualKey.Escape,
+        };
+        escAccel.Invoked += (_, e) =>
+        {
+            e.Handled = true;
+            Decide(ExecApprovalPromptOutcome.Deny);
+        };
+        outerGrid.KeyboardAccelerators.Add(escAccel);
+        outerGrid.KeyboardAcceleratorPlacementMode =
+            Microsoft.UI.Xaml.Input.KeyboardAcceleratorPlacementMode.Hidden;
+
+        Closed += OnWindowClosed;
+        ArmAllowGuard();
+    }
+
+    /// <summary>
+    /// Activates the window, forces it to the foreground (it opens from a background
+    /// gateway event), and returns the user's decision. Closing via X or Alt+F4 denies.
+    /// </summary>
+    public Task<ExecApprovalPromptOutcome> ShowAsync()
+    {
+        Activate();
+        try
+        {
+            var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
+            if (hwnd != IntPtr.Zero)
+            {
+                SetWindowPos(hwnd, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
+                SetWindowPos(hwnd, HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
+                SetForegroundWindow(hwnd);
+            }
+        }
+        catch { /* best-effort */ }
+
+        // Initial focus lands on Deny so Enter can never approve.
+        _denyButton.Focus(FocusState.Programmatic);
+        return _tcs.Task;
+    }
+
+    private void Decide(ExecApprovalPromptOutcome outcome)
+    {
+        if (IsClosed) return;
+        _outcome = outcome;
+        Close();
+    }
+
+    // Anti-clickthrough: allow buttons start disabled and arm only when the delay has
+    // elapsed AND the whole command has been seen. Deny is always active.
+    private void ArmAllowGuard()
+    {
+        _allowOnceButton.IsEnabled = false;
+        _allowAlwaysButton.IsEnabled = false;
+        MaybeArmAllow();
+        _armTimer = new DispatcherTimer { Interval = AllowArmDelay };
+        _armTimer.Tick += (_, _) =>
+        {
+            _armTimer?.Stop();
+            _delayElapsed = true;
+            MaybeArmAllow();
+        };
+        _armTimer.Start();
+    }
+
+    // A command that fits needs no scrolling; a long one must be scrolled to its end
+    // before it counts as seen. Once seen it stays seen (scrolling back up is fine).
+    private void UpdateCommandSeen()
+    {
+        if (_commandFullySeen || _bodyScroll is null) return;
+        var atEnd = _bodyScroll.ScrollableHeight <= 0.5
+            || _bodyScroll.VerticalOffset >= _bodyScroll.ScrollableHeight - 2.0;
+        if (atEnd)
+        {
+            _commandFullySeen = true;
+            MaybeArmAllow();
+        }
+    }
+
+    private void MaybeArmAllow()
+    {
+        if (IsClosed) return;
+        if (_delayElapsed && _commandFullySeen)
+        {
+            _allowOnceButton.IsEnabled = true;
+            _allowAlwaysButton.IsEnabled = true;
+            ToolTipService.SetToolTip(_allowOnceButton, null);
+            ToolTipService.SetToolTip(_allowAlwaysButton, null);
+            return;
+        }
+
+        var hintKey = _commandFullySeen ? "ExecApproval_ArmHint" : "ExecApproval_ScrollHint";
+        var hint = LocalizationHelper.GetString(hintKey);
+        ToolTipService.SetToolTip(_allowOnceButton, hint);
+        ToolTipService.SetToolTip(_allowAlwaysButton, hint);
+    }
+
+    private static Border BuildConfusableWarning()
+    {
+        var row = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 8 };
+        row.Children.Add(new FontIcon
+        {
+            Glyph = "\uE7BA", // warning
+            FontSize = 14,
+            Foreground = ResolveBrush("SystemFillColorCautionBrush"),
+            VerticalAlignment = VerticalAlignment.Top,
+        });
+        row.Children.Add(new TextBlock
+        {
+            Text = LocalizationHelper.GetString("ExecApproval_ConfusableWarning"),
+            Foreground = ResolveBrush("SystemFillColorCautionBrush"),
+            TextWrapping = TextWrapping.Wrap,
+        });
+        return new Border
+        {
+            Background = ResolveBrush("SystemFillColorAttentionBackgroundBrush"),
+            CornerRadius = new CornerRadius(4),
+            Padding = new Thickness(10, 8, 10, 8),
+            Child = row,
+        };
+    }
+
+    private void OnWindowClosed(object sender, WindowEventArgs args)
+    {
+        IsClosed = true;
+        _armTimer?.Stop();
+        Closed -= OnWindowClosed;
+        _tcs.TrySetResult(_outcome);
+    }
+
+    private static Brush ResolveBrush(string themeKey) =>
+        Application.Current.Resources.TryGetValue(themeKey, out var value) && value is Brush brush
+            ? brush
+            : new SolidColorBrush(Microsoft.UI.Colors.Transparent);
+
+    private static void AddContextRow(StackPanel parent, string labelKey, string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return;
+
+        var row = new Grid { ColumnSpacing = 8 };
+        row.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        var label = new TextBlock
+        {
+            Text = LocalizationHelper.GetString(labelKey),
+            Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+            Foreground = ResolveBrush("TextFillColorSecondaryBrush"),
+        };
+        Grid.SetColumn(label, 0);
+        row.Children.Add(label);
+        var text = new TextBlock
+        {
+            Text = value,
+            Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+            Foreground = ResolveBrush("TextFillColorSecondaryBrush"),
+            TextWrapping = TextWrapping.Wrap,
+            IsTextSelectionEnabled = true,
+        };
+        Grid.SetColumn(text, 1);
+        row.Children.Add(text);
+        parent.Children.Add(row);
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Services/ExecApprovalV2DialogPromptHandler.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/ExecApprovalV2DialogPromptHandler.cs
@@ -1,0 +1,50 @@
+using Microsoft.UI.Dispatching;
+using OpenClaw.Shared;
+using OpenClaw.Shared.ExecApprovals;
+using OpenClawTray.Dialogs;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OpenClawTray.Services;
+
+/// <summary>
+/// WinUI adapter for the exec approval prompt: supplies the real dispatcher hop and
+/// dialog window to <see cref="ExecApprovalV2UiPromptHandler"/>, which owns all
+/// decision logic (fail-closed semantics, cancellation authority, sanitization).
+/// </summary>
+public sealed class ExecApprovalV2DialogPromptHandler : IExecApprovalV2PromptHandler
+{
+    private readonly ExecApprovalV2UiPromptHandler _core;
+
+    public ExecApprovalV2DialogPromptHandler(DispatcherQueue dispatcherQueue, IOpenClawLogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(dispatcherQueue);
+        _core = new ExecApprovalV2UiPromptHandler(
+            action => dispatcherQueue.TryEnqueue(() => action()),
+            (view, cancellationToken) => ShowDialogAsync(dispatcherQueue, view, cancellationToken),
+            logger);
+    }
+
+    public Task<ExecApprovalPromptOutcome> PromptAsync(
+        ExecApprovalV2PromptRequest request, CancellationToken cancellationToken = default)
+        => _core.PromptAsync(request, cancellationToken);
+
+    // Runs on the UI thread (enqueued by the core). The cancellation registration only
+    // tears the window down; the outcome is already settled by the core's first-wins TCS.
+    private static async Task<ExecApprovalPromptOutcome> ShowDialogAsync(
+        DispatcherQueue dispatcherQueue, ExecApprovalPromptView view, CancellationToken cancellationToken)
+    {
+        // Already denied by the core; do not flash a window for a dead request.
+        if (cancellationToken.IsCancellationRequested)
+            return ExecApprovalPromptOutcome.Deny;
+
+        var dialog = new ExecApprovalDialog(view);
+        using var registration = cancellationToken.Register(() =>
+            dispatcherQueue.TryEnqueue(() =>
+            {
+                if (!dialog.IsClosed) dialog.Close();
+            }));
+        return await dialog.ShowAsync();
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
@@ -607,9 +607,9 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
     /// coordinator cannot be built, return the null handler (typed unavailable
     /// deny) rather than falling back silently to the legacy path. The result
     /// is cached for the NodeService lifetime so the coordinator stays a
-    /// singleton across capability rebuilds. The approval prompt UI is not
-    /// wired yet, so prompt-required decisions resolve through the store's
-    /// ask fallback.
+    /// singleton across capability rebuilds. The approval prompt dialog is
+    /// wired, but presentation is still gated off, so prompt-required
+    /// decisions resolve through the store's ask fallback.
     /// </summary>
     private IExecApprovalV2Handler? TryBuildExecApprovalsV2Coordinator()
     {
@@ -620,9 +620,9 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
             var coordinator = new ExecApprovalsCoordinator(
                 store,
                 AlwaysCannotPresentEvaluator.Instance,
-                ExecApprovalV2NullPromptHandler.Instance,
+                new ExecApprovalV2DialogPromptHandler(_dispatcherQueue, _logger),
                 _logger);
-            _logger.Info("[EXEC-APPROVALS] new path enabled (prompt UI not wired; fallback-only)");
+            _logger.Info("[EXEC-APPROVALS] new path enabled (prompt dialog wired; presentation gated off)");
             return coordinator;
         }
         catch (Exception ex)

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -761,6 +761,42 @@ Use one of these options:
   <data name="PairingApproval_UnknownPlatform" xml:space="preserve">
     <value>Unknown platform</value>
   </data>
+  <data name="ExecApproval_WindowTitle" xml:space="preserve">
+    <value>Command Approval</value>
+  </data>
+  <data name="ExecApproval_Heading" xml:space="preserve">
+    <value>Allow Command?</value>
+  </data>
+  <data name="ExecApproval_Body" xml:space="preserve">
+    <value>The following command is requesting permission to run:</value>
+  </data>
+  <data name="ExecApproval_AgentLabel" xml:space="preserve">
+    <value>Agent:</value>
+  </data>
+  <data name="ExecApproval_CwdLabel" xml:space="preserve">
+    <value>Working directory:</value>
+  </data>
+  <data name="ExecApproval_ExecutableLabel" xml:space="preserve">
+    <value>Executable:</value>
+  </data>
+  <data name="ExecApproval_AllowOnce" xml:space="preserve">
+    <value>Allow Once</value>
+  </data>
+  <data name="ExecApproval_AllowAlways" xml:space="preserve">
+    <value>Allow Always</value>
+  </data>
+  <data name="ExecApproval_Deny" xml:space="preserve">
+    <value>Deny</value>
+  </data>
+  <data name="ExecApproval_ArmHint" xml:space="preserve">
+    <value>Allow becomes available in a moment</value>
+  </data>
+  <data name="ExecApproval_ScrollHint" xml:space="preserve">
+    <value>Scroll to the end of the command before allowing</value>
+  </data>
+  <data name="ExecApproval_ConfusableWarning" xml:space="preserve">
+    <value>This command mixes character sets and may not read the way it looks. Check it carefully.</value>
+  </data>
   <data name="Toast_NodePaired" xml:space="preserve">
     <value>✅ Node Paired!</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -720,6 +720,42 @@ Utilisez l'une de ces options :
   <data name="PairingApproval_UnknownPlatform" xml:space="preserve">
     <value>Plateforme inconnue</value>
   </data>
+  <data name="ExecApproval_WindowTitle" xml:space="preserve">
+    <value>Approbation de commande</value>
+  </data>
+  <data name="ExecApproval_Heading" xml:space="preserve">
+    <value>Autoriser la commande ?</value>
+  </data>
+  <data name="ExecApproval_Body" xml:space="preserve">
+    <value>La commande suivante demande l'autorisation de s'exécuter :</value>
+  </data>
+  <data name="ExecApproval_AgentLabel" xml:space="preserve">
+    <value>Agent :</value>
+  </data>
+  <data name="ExecApproval_CwdLabel" xml:space="preserve">
+    <value>Répertoire de travail :</value>
+  </data>
+  <data name="ExecApproval_ExecutableLabel" xml:space="preserve">
+    <value>Exécutable :</value>
+  </data>
+  <data name="ExecApproval_AllowOnce" xml:space="preserve">
+    <value>Autoriser une fois</value>
+  </data>
+  <data name="ExecApproval_AllowAlways" xml:space="preserve">
+    <value>Toujours autoriser</value>
+  </data>
+  <data name="ExecApproval_Deny" xml:space="preserve">
+    <value>Refuser</value>
+  </data>
+  <data name="ExecApproval_ArmHint" xml:space="preserve">
+    <value>L'autorisation sera disponible dans un instant</value>
+  </data>
+  <data name="ExecApproval_ScrollHint" xml:space="preserve">
+    <value>Faites défiler jusqu'à la fin de la commande avant d'autoriser</value>
+  </data>
+  <data name="ExecApproval_ConfusableWarning" xml:space="preserve">
+    <value>Cette commande mélange des jeux de caractères et peut ne pas être ce qu'elle paraît. Vérifiez-la attentivement.</value>
+  </data>
   <data name="Toast_NodePaired" xml:space="preserve">
     <value>✅ Noeud appairé!</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -721,6 +721,42 @@ Gebruik een van deze opties:
   <data name="PairingApproval_UnknownPlatform" xml:space="preserve">
     <value>Onbekend platform</value>
   </data>
+  <data name="ExecApproval_WindowTitle" xml:space="preserve">
+    <value>Opdrachtgoedkeuring</value>
+  </data>
+  <data name="ExecApproval_Heading" xml:space="preserve">
+    <value>Opdracht toestaan?</value>
+  </data>
+  <data name="ExecApproval_Body" xml:space="preserve">
+    <value>De volgende opdracht vraagt toestemming om te worden uitgevoerd:</value>
+  </data>
+  <data name="ExecApproval_AgentLabel" xml:space="preserve">
+    <value>AI-agent:</value>
+  </data>
+  <data name="ExecApproval_CwdLabel" xml:space="preserve">
+    <value>Werkmap:</value>
+  </data>
+  <data name="ExecApproval_ExecutableLabel" xml:space="preserve">
+    <value>Uitvoerbaar bestand:</value>
+  </data>
+  <data name="ExecApproval_AllowOnce" xml:space="preserve">
+    <value>Eén keer toestaan</value>
+  </data>
+  <data name="ExecApproval_AllowAlways" xml:space="preserve">
+    <value>Altijd toestaan</value>
+  </data>
+  <data name="ExecApproval_Deny" xml:space="preserve">
+    <value>Weigeren</value>
+  </data>
+  <data name="ExecApproval_ArmHint" xml:space="preserve">
+    <value>Toestaan is zo dadelijk beschikbaar</value>
+  </data>
+  <data name="ExecApproval_ScrollHint" xml:space="preserve">
+    <value>Scroll naar het einde van de opdracht voordat u toestaat</value>
+  </data>
+  <data name="ExecApproval_ConfusableWarning" xml:space="preserve">
+    <value>Deze opdracht mengt tekensets en is mogelijk niet wat het lijkt. Controleer hem zorgvuldig.</value>
+  </data>
   <data name="Toast_NodePaired" xml:space="preserve">
     <value>✅ Node gekoppeld!</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -720,6 +720,42 @@
   <data name="PairingApproval_UnknownPlatform" xml:space="preserve">
     <value>未知平台</value>
   </data>
+  <data name="ExecApproval_WindowTitle" xml:space="preserve">
+    <value>命令批准</value>
+  </data>
+  <data name="ExecApproval_Heading" xml:space="preserve">
+    <value>允许命令？</value>
+  </data>
+  <data name="ExecApproval_Body" xml:space="preserve">
+    <value>以下命令请求运行权限：</value>
+  </data>
+  <data name="ExecApproval_AgentLabel" xml:space="preserve">
+    <value>代理：</value>
+  </data>
+  <data name="ExecApproval_CwdLabel" xml:space="preserve">
+    <value>工作目录：</value>
+  </data>
+  <data name="ExecApproval_ExecutableLabel" xml:space="preserve">
+    <value>可执行文件：</value>
+  </data>
+  <data name="ExecApproval_AllowOnce" xml:space="preserve">
+    <value>允许一次</value>
+  </data>
+  <data name="ExecApproval_AllowAlways" xml:space="preserve">
+    <value>始终允许</value>
+  </data>
+  <data name="ExecApproval_Deny" xml:space="preserve">
+    <value>拒绝</value>
+  </data>
+  <data name="ExecApproval_ArmHint" xml:space="preserve">
+    <value>允许按钮稍后可用</value>
+  </data>
+  <data name="ExecApproval_ScrollHint" xml:space="preserve">
+    <value>请滚动到命令末尾后再允许</value>
+  </data>
+  <data name="ExecApproval_ConfusableWarning" xml:space="preserve">
+    <value>此命令混用了不同的字符集，可能与其外观不符。请仔细核对。</value>
+  </data>
   <data name="Toast_NodePaired" xml:space="preserve">
     <value>✅ 节点已配对！</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -720,6 +720,42 @@
   <data name="PairingApproval_UnknownPlatform" xml:space="preserve">
     <value>未知平台</value>
   </data>
+  <data name="ExecApproval_WindowTitle" xml:space="preserve">
+    <value>命令核准</value>
+  </data>
+  <data name="ExecApproval_Heading" xml:space="preserve">
+    <value>允許命令？</value>
+  </data>
+  <data name="ExecApproval_Body" xml:space="preserve">
+    <value>以下命令請求執行權限：</value>
+  </data>
+  <data name="ExecApproval_AgentLabel" xml:space="preserve">
+    <value>代理：</value>
+  </data>
+  <data name="ExecApproval_CwdLabel" xml:space="preserve">
+    <value>工作目錄：</value>
+  </data>
+  <data name="ExecApproval_ExecutableLabel" xml:space="preserve">
+    <value>可執行檔：</value>
+  </data>
+  <data name="ExecApproval_AllowOnce" xml:space="preserve">
+    <value>允許一次</value>
+  </data>
+  <data name="ExecApproval_AllowAlways" xml:space="preserve">
+    <value>一律允許</value>
+  </data>
+  <data name="ExecApproval_Deny" xml:space="preserve">
+    <value>拒絕</value>
+  </data>
+  <data name="ExecApproval_ArmHint" xml:space="preserve">
+    <value>允許按鈕稍後可用</value>
+  </data>
+  <data name="ExecApproval_ScrollHint" xml:space="preserve">
+    <value>請捲動至命令結尾後再允許</value>
+  </data>
+  <data name="ExecApproval_ConfusableWarning" xml:space="preserve">
+    <value>此命令混用了不同的字元集，可能與其外觀不符。請仔細核對。</value>
+  </data>
   <data name="Toast_NodePaired" xml:space="preserve">
     <value>✅ 節點已配對！</value>
   </data>

--- a/tests/OpenClaw.Shared.Tests/ExecApprovalCommandDisplaySanitizerTests.cs
+++ b/tests/OpenClaw.Shared.Tests/ExecApprovalCommandDisplaySanitizerTests.cs
@@ -1,0 +1,122 @@
+using Xunit;
+using OpenClaw.Shared.ExecApprovals;
+
+namespace OpenClaw.Shared.Tests;
+
+// Inputs are built from code points instead of literal characters so the file stays
+// pure ASCII: the characters under test are invisible and easy to corrupt in editors.
+public class ExecApprovalCommandDisplaySanitizerTests
+{
+    private static string U(int codePoint) => char.ConvertFromUtf32(codePoint);
+
+    [Fact]
+    public void EscapesInvisibleCommandSpoofingCharacters()
+    {
+        var hangulSyllable = U(0xAC00);
+        var input = "date" + U(0x200B) + U(0x3164) + U(0xFFA0) + U(0x115F) + U(0x1160) + hangulSyllable;
+        Assert.Equal(
+            "date" + @"\u{200B}\u{3164}\u{FFA0}\u{115F}\u{1160}" + hangulSyllable,
+            ExecApprovalCommandDisplaySanitizer.Sanitize(input));
+    }
+
+    [Fact]
+    public void EscapesControlCharactersUsedToSpoofLineBreaks()
+    {
+        var input = "echo safe\n\rcurl https://example.test";
+        Assert.Equal(
+            @"echo safe\u{A}\u{D}curl https://example.test",
+            ExecApprovalCommandDisplaySanitizer.Sanitize(input));
+    }
+
+    [Fact]
+    public void EscapesUnicodeLineAndParagraphSeparators()
+    {
+        Assert.Equal(
+            @"echo ok\u{2028}curl https://example.test",
+            ExecApprovalCommandDisplaySanitizer.Sanitize("echo ok" + U(0x2028) + "curl https://example.test"));
+        Assert.Equal(
+            @"echo ok\u{2029}curl https://example.test",
+            ExecApprovalCommandDisplaySanitizer.Sanitize("echo ok" + U(0x2029) + "curl https://example.test"));
+    }
+
+    [Fact]
+    public void EscapesNonAsciiUnicodeSpaceSeparatorsWhilePreservingAsciiSpace()
+    {
+        Assert.Equal(
+            @"echo ok\u{A0}curl",
+            ExecApprovalCommandDisplaySanitizer.Sanitize("echo ok" + U(0xA0) + "curl"));
+        Assert.Equal(
+            @"echo ok\u{202F}curl",
+            ExecApprovalCommandDisplaySanitizer.Sanitize("echo ok" + U(0x202F) + "curl"));
+        Assert.Equal(
+            @"echo ok\u{3000}curl",
+            ExecApprovalCommandDisplaySanitizer.Sanitize("echo ok" + U(0x3000) + "curl"));
+        Assert.Equal(
+            "echo ok curl",
+            ExecApprovalCommandDisplaySanitizer.Sanitize("echo ok curl"));
+    }
+
+    [Fact]
+    public void EscapesBidiOverrideTabAndZeroWidthSpace()
+    {
+        Assert.Equal(
+            @"echo \u{202E}gpj.exe",
+            ExecApprovalCommandDisplaySanitizer.Sanitize("echo " + U(0x202E) + "gpj.exe"));
+        Assert.Equal(
+            @"echo\u{9}dir",
+            ExecApprovalCommandDisplaySanitizer.Sanitize("echo\tdir"));
+        Assert.Equal(
+            @"del\u{200B}ete",
+            ExecApprovalCommandDisplaySanitizer.Sanitize("del" + U(0x200B) + "ete"));
+    }
+
+    [Fact]
+    public void EscapesAstralFormatCodePointAsOneRune()
+    {
+        // U+E0001 (LANGUAGE TAG) is Format-category and sits outside the BMP: a
+        // per-char loop would see two lone surrogates instead of one code point.
+        var input = "echo " + U(0xE0001) + "hi";
+        Assert.Equal(@"echo \u{E0001}hi", ExecApprovalCommandDisplaySanitizer.Sanitize(input));
+    }
+
+    [Fact]
+    public void EmptyAndPlainAsciiPassThroughUnchanged()
+    {
+        Assert.Equal("", ExecApprovalCommandDisplaySanitizer.Sanitize(""));
+        Assert.Equal(
+            "git commit -m 'safe message'",
+            ExecApprovalCommandDisplaySanitizer.Sanitize("git commit -m 'safe message'"));
+    }
+
+    [Fact]
+    public void EscapesCombinedAttackChainInASinglePlausibleCommand()
+    {
+        // One realistic command carrying several spoofing tricks at once: a reversed
+        // fragment, a zero-width joiner splitting a token, and a fake line break.
+        var input = "curl " + U(0x202E) + "moc.live" + U(0x200B) + "/x\n rm -rf /";
+        Assert.Equal(
+            @"curl \u{202E}moc.live\u{200B}/x\u{A} rm -rf /",
+            ExecApprovalCommandDisplaySanitizer.Sanitize(input));
+    }
+
+    [Fact]
+    public void IsIdempotent_SanitizingEscapedOutputLeavesItUnchanged()
+    {
+        var once = ExecApprovalCommandDisplaySanitizer.Sanitize("echo " + U(0x202E) + "hi\tthere");
+        Assert.Equal(once, ExecApprovalCommandDisplaySanitizer.Sanitize(once));
+    }
+
+    // The sanitizer deliberately does NOT escape combining marks, variation selectors,
+    // or homoglyphs: none can be neutralized without mangling legitimate non-ASCII text
+    // (accents, emoji, CJK). This matches the macOS original. These tests pin that
+    // boundary so a future "hardening" cannot silently break real command text.
+    [Theory]
+    [InlineData(0x0301)]  // combining acute accent (Zalgo)
+    [InlineData(0xFE0F)]  // variation selector-16 (emoji presentation)
+    [InlineData(0x0430)]  // Cyrillic small a (homoglyph of Latin a)
+    public void DoesNotEscapeCharactersOutsideItsThreatModel(int codePoint)
+    {
+        var input = "echo " + U(codePoint) + "x";
+        Assert.Equal(input, ExecApprovalCommandDisplaySanitizer.Sanitize(input));
+    }
+}

--- a/tests/OpenClaw.Shared.Tests/ExecApprovalConfusableDetectorTests.cs
+++ b/tests/OpenClaw.Shared.Tests/ExecApprovalConfusableDetectorTests.cs
@@ -1,0 +1,55 @@
+using Xunit;
+using OpenClaw.Shared.ExecApprovals;
+
+namespace OpenClaw.Shared.Tests;
+
+public class ExecApprovalConfusableDetectorTests
+{
+    private static string U(int codePoint) => char.ConvertFromUtf32(codePoint);
+
+    [Fact]
+    public void FlagsLatinMixedWithCyrillicInOneToken()
+    {
+        // "curl" with a Cyrillic 'а' (U+0430) replacing the Latin 'a'.
+        var spoofed = "cur" + U(0x0430) + "l https://example.test";
+        Assert.True(ExecApprovalConfusableDetector.HasMixedScriptConfusable(spoofed));
+    }
+
+    [Fact]
+    public void FlagsLatinMixedWithGreekInOneToken()
+    {
+        // Greek omicron (U+03BF) inside an otherwise-Latin word.
+        var spoofed = "payp" + U(0x03BF) + "l";
+        Assert.True(ExecApprovalConfusableDetector.HasMixedScriptConfusable(spoofed));
+    }
+
+    [Fact]
+    public void DoesNotFlagPureLatinWithAccents()
+        => Assert.False(ExecApprovalConfusableDetector.HasMixedScriptConfusable("café résumé --naïve"));
+
+    [Fact]
+    public void DoesNotFlagPureCyrillic()
+        => Assert.False(ExecApprovalConfusableDetector.HasMixedScriptConfusable(
+            U(0x043F) + U(0x0440) + U(0x0438) + U(0x0432) + U(0x0435) + U(0x0442)));
+
+    [Fact]
+    public void DoesNotFlagCjk()
+        => Assert.False(ExecApprovalConfusableDetector.HasMixedScriptConfusable("type " + U(0x6587) + U(0x4EF6)));
+
+    [Fact]
+    public void DoesNotFlagDifferentScriptsInSeparateTokens()
+    {
+        // A Latin command with a Cyrillic argument is not a homoglyph attack: each
+        // token is single-script. Only intra-token mixing is the spoofing signal.
+        var input = "type " + U(0x0444) + U(0x0430) + U(0x0439) + U(0x043B);
+        Assert.False(ExecApprovalConfusableDetector.HasMixedScriptConfusable(input));
+    }
+
+    [Fact]
+    public void DoesNotFlagPlainAsciiOrEmpty()
+    {
+        Assert.False(ExecApprovalConfusableDetector.HasMixedScriptConfusable("git commit -m 'ok'"));
+        Assert.False(ExecApprovalConfusableDetector.HasMixedScriptConfusable(""));
+        Assert.False(ExecApprovalConfusableDetector.HasMixedScriptConfusable(null));
+    }
+}

--- a/tests/OpenClaw.Shared.Tests/ExecApprovalV2PipelineIntegrationTests.cs
+++ b/tests/OpenClaw.Shared.Tests/ExecApprovalV2PipelineIntegrationTests.cs
@@ -1,0 +1,230 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using OpenClaw.Shared;
+using OpenClaw.Shared.ExecApprovals;
+
+namespace OpenClaw.Shared.Tests;
+
+/// <summary>
+/// End-to-end pipeline tests: the real coordinator wired to the real prompt handler
+/// (ExecApprovalV2UiPromptHandler) through a capturing dialog delegate. Exercises the
+/// full path — validate, normalize, resolve, evaluate, prompt, second pass, decision —
+/// with the prompt handler that ships in production, not an outcome stub. The only
+/// piece not covered here is the physical WinUI window (verified manually).
+/// </summary>
+public class ExecApprovalV2PipelineIntegrationTests : IDisposable
+{
+    private const int Rlo = 0x202E;   // right-to-left override (visual spoof)
+    private const int Zwsp = 0x200B;  // zero-width space
+
+    private readonly string _dir;
+
+    public ExecApprovalV2PipelineIntegrationTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), $"oca-pipeline-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_dir);
+        File.WriteAllText(
+            Path.Combine(_dir, "exec-approvals.json"),
+            """{"version":1,"defaults":{"security":"full","ask":"always"}}""");
+    }
+
+    public void Dispose() => Directory.Delete(_dir, recursive: true);
+
+    private static string U(int codePoint) => char.ConvertFromUtf32(codePoint);
+
+    private static NodeInvokeRequest Req(string argsJson)
+    {
+        using var doc = JsonDocument.Parse(argsJson);
+        return new NodeInvokeRequest { Id = "r1", Command = "system.run", Args = doc.RootElement.Clone() };
+    }
+
+    private void WriteStore(string json)
+        => File.WriteAllText(Path.Combine(_dir, "exec-approvals.json"), json);
+
+    // Coordinator with a real handler whose dialog records whether it was ever shown.
+    private ExecApprovalsCoordinator MakeCoordinatorTracking(
+        ExecApprovalPromptOutcome dialogOutcome, Action markShown)
+        => MakeCoordinator(dialog: _ => { markShown(); return dialogOutcome; });
+
+    // Real handler + synchronous dispatcher + a dialog delegate that records the view
+    // it was handed and returns a scripted outcome.
+    private ExecApprovalsCoordinator MakeCoordinator(
+        Func<ExecApprovalPromptView, ExecApprovalPromptOutcome> dialog,
+        Action<ExecApprovalPromptView>? onView = null)
+    {
+        var log = NullLogger.Instance;
+        var handler = new ExecApprovalV2UiPromptHandler(
+            tryEnqueue: action => { action(); return true; },
+            showDialog: (view, _) =>
+            {
+                onView?.Invoke(view);
+                return Task.FromResult(dialog(view));
+            },
+            logger: log);
+        return new ExecApprovalsCoordinator(
+            new ExecApprovalsStore(_dir, log),
+            AlwaysCanPresentEvaluator.Instance,
+            handler,
+            log);
+    }
+
+    [Fact]
+    public async Task AttackCommand_ReachesDialogSanitized_AllowOnceProducesAllow()
+    {
+        var attackArg = "safe" + U(Rlo) + "evil";
+        var request = Req($$"""{"command":["where","{{attackArg}}"]}""");
+
+        ExecApprovalPromptView? captured = null;
+        var result = await MakeCoordinator(
+            dialog: _ => ExecApprovalPromptOutcome.AllowOnce,
+            onView: v => captured = v).HandleAsync(request, "p1");
+
+        Assert.True(result.IsAllow);
+        Assert.NotNull(captured);
+        // The raw override reached the pipeline but was escaped before the dialog saw it.
+        // Ordinal comparison: culture-sensitive search treats format characters as
+        // ignorable and would match them in any string.
+        Assert.DoesNotContain(U(Rlo), captured!.CommandText, StringComparison.Ordinal);
+        Assert.Contains(@"\u{202E}", captured.CommandText);
+    }
+
+    [Fact]
+    public async Task SpoofedCwd_ReachesDialogSanitized()
+    {
+        var spoofedCwd = "C:\\work" + U(Zwsp) + "dir";
+        var request = Req($$"""{"command":["where","hello"],"cwd":"{{spoofedCwd.Replace("\\", "\\\\")}}"}""");
+
+        ExecApprovalPromptView? captured = null;
+        await MakeCoordinator(
+            dialog: _ => ExecApprovalPromptOutcome.Deny,
+            onView: v => captured = v).HandleAsync(request, "p2");
+
+        Assert.NotNull(captured);
+        Assert.NotNull(captured!.CwdText);
+        Assert.DoesNotContain(U(Zwsp), captured.CwdText!, StringComparison.Ordinal);
+        Assert.Contains(@"\u{200B}", captured.CwdText!);
+    }
+
+    [Fact]
+    public async Task DialogDenies_ReturnsUserDenied()
+    {
+        var result = await MakeCoordinator(dialog: _ => ExecApprovalPromptOutcome.Deny)
+            .HandleAsync(Req("""{"command":["where","hello"]}"""), "p3");
+
+        Assert.Equal(ExecApprovalV2Code.UserDenied, result.Code);
+    }
+
+    [Fact]
+    public async Task DialogAllowOnce_ReturnsAllow()
+    {
+        var result = await MakeCoordinator(dialog: _ => ExecApprovalPromptOutcome.AllowOnce)
+            .HandleAsync(Req("""{"command":["where","hello"]}"""), "p4");
+
+        Assert.True(result.IsAllow);
+    }
+
+    [Fact]
+    public async Task MaliciousDialogReturnsPlainAllow_NeutralizedBeforeCoordinator()
+    {
+        // A rogue dialog returning plain Allow is clamped to Deny by the handler itself,
+        // so the coordinator never sees an Allow: the end-to-end result is a denial, not
+        // the coordinator's own invariant-violation path. Defense in depth.
+        var result = await MakeCoordinator(dialog: _ => ExecApprovalPromptOutcome.Allow)
+            .HandleAsync(Req("""{"command":["where","hello"]}"""), "p5");
+
+        Assert.Equal(ExecApprovalV2Code.UserDenied, result.Code);
+    }
+
+    // ── Attack battery: the three hard-deny paths must cut BEFORE the prompt and
+    //    cannot be flipped by the dialog, even when the dialog would say Allow Always. ──
+
+    [Fact]
+    public async Task SecurityDeny_CannotBeOverriddenByDialog_AndNeverShowsPrompt()
+    {
+        WriteStore("""{"version":1,"defaults":{"security":"deny"}}""");
+        var shown = false;
+        var result = await MakeCoordinatorTracking(ExecApprovalPromptOutcome.AllowAlways, () => shown = true)
+            .HandleAsync(Req("""{"command":["where","hello"]}"""), "a1");
+
+        Assert.Equal(ExecApprovalV2Code.SecurityDeny, result.Code);
+        Assert.False(shown);
+        Assert.Null(result.Execution);
+    }
+
+    [Fact]
+    public async Task AskDeny_SecurityFull_DeniesWithoutShowingPrompt()
+    {
+        WriteStore("""{"version":1,"defaults":{"security":"full","ask":"deny"}}""");
+        var shown = false;
+        var result = await MakeCoordinatorTracking(ExecApprovalPromptOutcome.AllowAlways, () => shown = true)
+            .HandleAsync(Req("""{"command":["where","hello"]}"""), "a2");
+
+        Assert.Equal(ExecApprovalV2Code.AskDeny, result.Code);
+        Assert.False(shown);
+    }
+
+    [Fact]
+    public async Task AllowlistMiss_SecurityAllowlist_AskOff_DeniesWithoutShowingPrompt()
+    {
+        WriteStore("""{"version":1,"defaults":{"security":"allowlist","ask":"off"}}""");
+        var shown = false;
+        var result = await MakeCoordinatorTracking(ExecApprovalPromptOutcome.AllowAlways, () => shown = true)
+            .HandleAsync(Req("""{"command":["where","hello"]}"""), "a3");
+
+        Assert.Equal(ExecApprovalV2Code.AllowlistMiss, result.Code);
+        Assert.False(shown);
+    }
+
+    // The command that gets executed is the canonical argv evaluated and shown — never
+    // re-derived from raw text — so approve-what-you-see holds at the execution boundary.
+    [Fact]
+    public async Task ApprovedExecution_CarriesCanonicalArgv_ForActualExecution()
+    {
+        var result = await MakeCoordinator(dialog: _ => ExecApprovalPromptOutcome.AllowOnce)
+            .HandleAsync(Req("""{"command":["where","hello"]}"""), "a4");
+
+        Assert.True(result.IsAllow);
+        Assert.NotNull(result.Execution);
+        Assert.NotEmpty(result.Execution!.Argv);
+        Assert.Contains("hello", result.Execution.Argv);
+    }
+
+    // A command host (cmd, powershell, ...) re-parses its argument tail, so a stored rule
+    // for the host executable would authorize arbitrary future commands. An interactive
+    // Allow Once is honored (the user approved this exact invocation and the dialog showed
+    // the full sanitized text), but Allow Always must fail closed instead of persisting.
+    [Fact]
+    public async Task CommandHost_AllowOnce_YieldsExecutionForThisInvocationOnly()
+    {
+        var attack = Req("""{"command":["cmd","/c","echo","SAFE&calc.exe"]}""");
+
+        ExecApprovalPromptView? captured = null;
+        var result = await MakeCoordinator(
+            dialog: _ => ExecApprovalPromptOutcome.AllowOnce,
+            onView: v => captured = v).HandleAsync(attack, "shell-1");
+
+        Assert.True(result.IsAllow);
+        Assert.NotNull(result.Execution);
+        // The dialog is the barrier here: the user saw the complete wrapper invocation,
+        // including the argument tail the host will re-parse.
+        Assert.NotNull(captured);
+        Assert.Contains("SAFE&calc.exe", captured!.CommandText);
+    }
+
+    [Fact]
+    public async Task CommandHost_AllowAlways_FailsClosedWithNoExecution()
+    {
+        var attack = Req("""{"command":["cmd","/c","echo","SAFE&calc.exe"]}""");
+        var result = await MakeCoordinator(dialog: _ => ExecApprovalPromptOutcome.AllowAlways)
+            .HandleAsync(attack, "shell-2");
+
+        Assert.False(result.IsAllow);
+        Assert.Null(result.Execution);
+        Assert.Equal(ExecApprovalV2Code.ValidationFailed, result.Code);
+    }
+}

--- a/tests/OpenClaw.Shared.Tests/ExecApprovalV2UiPromptHandlerTests.cs
+++ b/tests/OpenClaw.Shared.Tests/ExecApprovalV2UiPromptHandlerTests.cs
@@ -1,0 +1,291 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using OpenClaw.Shared;
+using OpenClaw.Shared.ExecApprovals;
+
+namespace OpenClaw.Shared.Tests;
+
+public class ExecApprovalV2UiPromptHandlerTests
+{
+    private static string U(int codePoint) => char.ConvertFromUtf32(codePoint);
+
+    private static ExecApprovalV2PromptRequest Request(
+        string command = "echo hello", string? cwd = null, string? resolvedPath = null,
+        string agentId = "agent-1") =>
+        new()
+        {
+            DisplayCommand = command,
+            Cwd = cwd,
+            ResolvedPath = resolvedPath,
+            Security = ExecSecurity.Full,
+            Ask = ExecAsk.Always,
+            AgentId = agentId,
+            CorrelationId = "corr-1",
+        };
+
+    private static ExecApprovalV2UiPromptHandler Handler(
+        Func<ExecApprovalPromptView, CancellationToken, Task<ExecApprovalPromptOutcome>> showDialog,
+        Func<Action, bool>? tryEnqueue = null,
+        IOpenClawLogger? logger = null) =>
+        new(
+            tryEnqueue ?? (action => { action(); return true; }),
+            showDialog,
+            logger ?? new CapturingLogger());
+
+    [Fact]
+    public async Task CancellationBeforeEnqueue_Denies_WithoutInvokingEnqueue()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var enqueueInvoked = false;
+        var handler = Handler(
+            (_, _) => Task.FromResult(ExecApprovalPromptOutcome.AllowOnce),
+            tryEnqueue: action => { enqueueInvoked = true; action(); return true; });
+
+        var result = await handler.PromptAsync(Request(), cts.Token);
+
+        Assert.Equal(ExecApprovalPromptOutcome.Deny, result);
+        Assert.False(enqueueInvoked);
+    }
+
+    [Fact]
+    public async Task CancellationWhileDialogPending_DeniesPromptly_NotBlockedOnDialog()
+    {
+        using var cts = new CancellationTokenSource();
+        var neverCompleting = new TaskCompletionSource<ExecApprovalPromptOutcome>();
+        var handler = Handler((_, _) => neverCompleting.Task);
+
+        var promptTask = handler.PromptAsync(Request(), cts.Token);
+        cts.Cancel();
+
+        var completed = await Task.WhenAny(promptTask, Task.Delay(TimeSpan.FromSeconds(5)));
+        Assert.Same(promptTask, completed);
+        Assert.Equal(ExecApprovalPromptOutcome.Deny, await promptTask);
+    }
+
+    [Fact]
+    public async Task UserDecisionBeforeCancellation_IsHonored()
+    {
+        using var cts = new CancellationTokenSource();
+        var handler = Handler((_, _) => Task.FromResult(ExecApprovalPromptOutcome.AllowOnce));
+
+        var result = await handler.PromptAsync(Request(), cts.Token);
+        cts.Cancel();
+
+        Assert.Equal(ExecApprovalPromptOutcome.AllowOnce, result);
+    }
+
+    [Fact]
+    public async Task EnqueueFailure_Denies_WithoutThrowing()
+    {
+        var handler = Handler(
+            (_, _) => Task.FromResult(ExecApprovalPromptOutcome.AllowOnce),
+            tryEnqueue: _ => false);
+
+        var result = await handler.PromptAsync(Request());
+
+        Assert.Equal(ExecApprovalPromptOutcome.Deny, result);
+    }
+
+    [Fact]
+    public async Task DialogThrowingSynchronously_Denies_WithoutThrowing()
+    {
+        var handler = Handler((_, _) => throw new InvalidOperationException("boom"));
+
+        var result = await handler.PromptAsync(Request());
+
+        Assert.Equal(ExecApprovalPromptOutcome.Deny, result);
+    }
+
+    [Fact]
+    public async Task DialogReturningFaultedTask_Denies_WithoutThrowing()
+    {
+        var handler = Handler(async (_, _) =>
+        {
+            await Task.Yield();
+            throw new InvalidOperationException("post-await boom");
+        });
+
+        var result = await handler.PromptAsync(Request());
+
+        Assert.Equal(ExecApprovalPromptOutcome.Deny, result);
+    }
+
+    [Theory]
+    [InlineData(ExecApprovalPromptOutcome.Deny)]
+    [InlineData(ExecApprovalPromptOutcome.AllowOnce)]
+    [InlineData(ExecApprovalPromptOutcome.AllowAlways)]
+    public async Task DialogOutcomes_PropagateUnchanged(ExecApprovalPromptOutcome outcome)
+    {
+        var handler = Handler((_, _) => Task.FromResult(outcome));
+
+        var result = await handler.PromptAsync(Request());
+
+        Assert.Equal(outcome, result);
+    }
+
+    [Fact]
+    public async Task PlainAllowFromDialog_IsClampedToDeny_AndLogged()
+    {
+        var logger = new CapturingLogger();
+        var handler = Handler((_, _) => Task.FromResult(ExecApprovalPromptOutcome.Allow), logger: logger);
+
+        var result = await handler.PromptAsync(Request());
+
+        Assert.Equal(ExecApprovalPromptOutcome.Deny, result);
+        Assert.Contains(logger.Errors, m => m.Contains("Allow"));
+    }
+
+    [Fact]
+    public async Task ViewPassedToDialog_CarriesSanitizedCommandCwdAndPath()
+    {
+        ExecApprovalPromptView? seen = null;
+        var handler = Handler((view, _) =>
+        {
+            seen = view;
+            return Task.FromResult(ExecApprovalPromptOutcome.Deny);
+        });
+
+        await handler.PromptAsync(Request(
+            command: "echo " + U(0x202E) + "gpj.exe",
+            cwd: "C:\\work" + U(0x200B) + "dir",
+            resolvedPath: "C:\\bin\\echo\nfake.exe"));
+
+        Assert.NotNull(seen);
+        Assert.Equal(@"echo \u{202E}gpj.exe", seen!.CommandText);
+        Assert.Equal("agent-1", seen.AgentLabel);
+        Assert.Equal(@"C:\work\u{200B}dir", seen.CwdText);
+        Assert.Equal("C:\\bin\\echo" + @"\u{A}" + "fake.exe", seen.ExecutablePathText);
+    }
+
+    [Fact]
+    public async Task SpoofedAgentId_IsSanitizedOnView()
+    {
+        ExecApprovalPromptView? seen = null;
+        var handler = Handler((view, _) => { seen = view; return Task.FromResult(ExecApprovalPromptOutcome.Deny); });
+
+        // The agent label is agent-controlled and rendered like the other rows, so a
+        // BiDi override in it must be escaped before reaching the dialog.
+        await handler.PromptAsync(Request(agentId: "age" + U(0x202E) + "nt"));
+
+        Assert.NotNull(seen);
+        Assert.Equal(@"age\u{202E}nt", seen!.AgentLabel);
+    }
+
+    [Fact]
+    public async Task MixedScriptCommand_SetsConfusableWarningOnView()
+    {
+        ExecApprovalPromptView? seen = null;
+        var handler = Handler((view, _) => { seen = view; return Task.FromResult(ExecApprovalPromptOutcome.Deny); });
+
+        // "curl" with a Cyrillic 'а' (U+0430) standing in for the Latin 'a'.
+        await handler.PromptAsync(Request(command: "cur" + U(0x0430) + "l https://example.test"));
+
+        Assert.NotNull(seen);
+        Assert.True(seen!.HasConfusableWarning);
+    }
+
+    [Fact]
+    public async Task PlainCommand_LeavesConfusableWarningUnset()
+    {
+        ExecApprovalPromptView? seen = null;
+        var handler = Handler((view, _) => { seen = view; return Task.FromResult(ExecApprovalPromptOutcome.Deny); });
+
+        await handler.PromptAsync(Request(command: "git commit -m 'ok'", cwd: "C:\\work", resolvedPath: "C:\\bin\\git.exe"));
+
+        Assert.NotNull(seen);
+        Assert.False(seen!.HasConfusableWarning);
+    }
+
+    [Fact]
+    public async Task MixedScriptOnlyInCwd_SetsConfusableWarningOnView()
+    {
+        ExecApprovalPromptView? seen = null;
+        var handler = Handler((view, _) => { seen = view; return Task.FromResult(ExecApprovalPromptOutcome.Deny); });
+
+        // Warning is an OR across command, cwd, and path: a clean command with a
+        // spoofed working directory must still raise it.
+        await handler.PromptAsync(Request(command: "git status", cwd: "C:\\w" + U(0x043E) + "rk"));
+
+        Assert.NotNull(seen);
+        Assert.True(seen!.HasConfusableWarning);
+    }
+
+    [Fact]
+    public async Task MixedScriptOnlyInResolvedPath_SetsConfusableWarningOnView()
+    {
+        ExecApprovalPromptView? seen = null;
+        var handler = Handler((view, _) => { seen = view; return Task.FromResult(ExecApprovalPromptOutcome.Deny); });
+
+        await handler.PromptAsync(Request(command: "git status", resolvedPath: "C:\\bin\\g" + U(0x0456) + "t.exe"));
+
+        Assert.NotNull(seen);
+        Assert.True(seen!.HasConfusableWarning);
+    }
+
+    [Fact]
+    public async Task CancellationBeforeDispatchedActionRuns_DoesNotInvokeDialog()
+    {
+        using var cts = new CancellationTokenSource();
+        Action? pending = null;
+        var dialogInvoked = false;
+        var handler = Handler(
+            (_, _) => { dialogInvoked = true; return Task.FromResult(ExecApprovalPromptOutcome.AllowOnce); },
+            tryEnqueue: action => { pending = action; return true; });
+
+        var promptTask = handler.PromptAsync(Request(), cts.Token);
+        cts.Cancel();
+        Assert.Equal(ExecApprovalPromptOutcome.Deny, await promptTask);
+
+        // The dispatcher runs the queued work only after the cancellation already
+        // denied the request: the dialog must never be shown.
+        pending!.Invoke();
+        Assert.False(dialogInvoked);
+    }
+
+    [Fact]
+    public async Task CancellationDuringEnqueue_DeniesWithoutInvokingDialog()
+    {
+        using var cts = new CancellationTokenSource();
+        var dialogInvoked = false;
+        var handler = Handler(
+            (_, _) => { dialogInvoked = true; return Task.FromResult(ExecApprovalPromptOutcome.AllowOnce); },
+            tryEnqueue: action =>
+            {
+                cts.Cancel();
+                action();
+                return true;
+            });
+
+        var result = await handler.PromptAsync(Request(), cts.Token);
+
+        Assert.Equal(ExecApprovalPromptOutcome.Deny, result);
+        Assert.False(dialogInvoked);
+    }
+
+    [Fact]
+    public async Task CancellingAfterCompletion_IsANoOp()
+    {
+        using var cts = new CancellationTokenSource();
+        var handler = Handler((_, _) => Task.FromResult(ExecApprovalPromptOutcome.AllowAlways));
+
+        var result = await handler.PromptAsync(Request(), cts.Token);
+        var ex = Record.Exception(cts.Cancel);
+
+        Assert.Null(ex);
+        Assert.Equal(ExecApprovalPromptOutcome.AllowAlways, result);
+    }
+
+    private sealed class CapturingLogger : IOpenClawLogger
+    {
+        public List<string> Warns { get; } = [];
+        public List<string> Errors { get; } = [];
+        public void Info(string m) { }
+        public void Debug(string m) { }
+        public void Warn(string m) => Warns.Add(m);
+        public void Error(string m, Exception? _ = null) => Errors.Add(m);
+    }
+}


### PR DESCRIPTION
## Summary

Adds the command approval dialog for `system.run` on the Windows node. When an agent asks to run a command, the app stops it and shows a window on the node machine where the owner decides Allow Once, Allow Always, or Deny. Approval is always local to the node; the agent only requests, never approves. It sits behind an opt-in setting and is off by default. The dialog is wired but its presentation stays gated off in this change, so the on-by-default behavior is unchanged.

## What it includes

- Approval window (WinUI) showing the command text, the requesting agent, the working directory, and the system-resolved executable path.
- Display sanitizer applied before rendering: escapes control, invisible, and direction-changing (BiDi) code points, non-ASCII spaces, and line separators, so the approved text cannot be disguised as a different command.
- A visible warning when a single token mixes scripts that are confusable with Latin (for example a Cyrillic letter inside a Latin word).
- A UI-free decision core with a fail-closed contract: it never throws, never returns a bare Allow, and resolves Deny on cancellation, enqueue failure, window close, or any internal error.
- Safe defaults in the window: initial focus is on Deny, the allow buttons are never the default focus, and Escape, the X button, and Alt+F4 all resolve Deny.
- Anti-clickthrough guard: the allow buttons do not arm until a short delay has passed and the whole command has been seen (scrolled to the end when it is long).
- Shell interpreters are rejected as an approved target, so a wrapper cannot execute a command different from the one shown.

## Security posture

- The displayed text is sanitized against visual spoofing before any UI binding.
- The executable path shown is the one resolved by the system, not a value declared by the agent, so it exposes lookalike-letter tricks.
- Sensitive environment variables and those that redirect binary resolution (including PATH and PATHEXT) are blocked; a request that includes them is rejected outright.

## Known limitations

- The delay and mandatory scroll guard against an accidental human click, not a hostile local process automating the UI; that is outside the threat model.
- There are two independent timeouts that do not talk to each other. The requester gives up after a few seconds and drops its connection. The approval window has no timeout of its own and stays open waiting for the decision. If it is approved after the requester has given up, the command still runs, though its result no longer has anywhere to return. Closing the window when the requester disconnects needs wiring that does not exist yet.
- Path resolution does not expand Windows 8.3 short names (for example `PROGRA~1` instead of `Program Files`), so the shown path may appear in its short form. This is a pending limitation, not the intended behavior; it does not change which binary runs.

## Validation

- `./build.ps1`: passed.
- `dotnet test` for `OpenClaw.Tray.Tests`: 1862 passed, 0 failed.
- `dotnet test` for `OpenClaw.Shared.Tests`: 3208 passed. Two metric-telemetry tests were flaky under timing when run alongside the full suite; run in isolation the 40 tests in that area pass, and they do not touch this change.
- `./scripts/validate-mxc-e2e.ps1`: passed, 2/2 proofs (`RealGateway_SystemRun_ExecutesThroughWindowsNodeMxcSandbox` and `RealGateway_SystemRun_BlocksWritesToTrayDataDirectoryInMxcSandbox`), about 4.7 minutes. Requires Docker Desktop stopped: its WSL integration stalls the systemd session of the throwaway distro the test provisions.

## Real behavior proof

Two pieces of evidence, both from the current branch head.

First, the approval window on the node machine, six scenarios against local `system.run` with the presentation enabled locally for the recording:

1. Benign command allowed with Allow Once: it runs for real and returns its result to the requester.
2. Very long command: the allow buttons stay inactive until the whole command has been seen; denied.
3. Command with an embedded direction-changing character: shown escaped and in plain view, not hidden; denied.
4. Command with a letter from another script inside a domain: the mixed-script warning appears; denied.
5. Command denied with the Deny button.
6. Command closed with Escape and with the X: both resolve Deny.

Video (six scenarios of the approval window):

https://github.com/AlexAlves87/openclaw-windows-node/releases/download/exec-approval-dialog-proof/exec-approval-dialog-proof.mp4

Second, the end-to-end sandbox validation (`validate-mxc-e2e.ps1`): a real `system.run` arriving from the gateway to the Windows node and executing inside the containment sandbox, plus the proof that the sandbox blocks writes to the data directory. Both pass (2/2).

The first piece entered through the node's local channel and the second through the gateway; the dialog and its decision are the same code on both paths.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
