### PR TITLE
Standardize onboarding gateway choice on ListView pill selector

### DIFF
--- a/src/OpenClaw.SetupEngine.UI/Pages/WelcomePage.xaml
+++ b/src/OpenClaw.SetupEngine.UI/Pages/WelcomePage.xaml
@@ -26,81 +26,72 @@
                       IsTabStop="False"
                       VerticalScrollBarVisibility="Auto"
                       HorizontalScrollBarVisibility="Disabled">
-            <RadioButtons x:Name="GatewayChoiceSelector"
-                          AutomationProperties.Name="Gateway setup method"
-                          MaxWidth="560"
-                          MaxColumns="1"
-                          HorizontalAlignment="Stretch"
-                          SelectionChanged="GatewayChoice_SelectionChanged">
-                <RadioButton x:Name="InstallChoice"
-                             AutomationProperties.AutomationId="WelcomeInstallLocalGatewayChoice"
-                             AutomationProperties.Name="Install a local gateway (WSL), recommended"
-                             Margin="0,0,0,12"
-                             HorizontalAlignment="Stretch"
-                             HorizontalContentAlignment="Stretch">
-                    <Border x:Name="InstallCard"
-                            HorizontalAlignment="Stretch"
-                            Padding="16" CornerRadius="4"
-                            Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                            BorderBrush="{ThemeResource AccentFillColorDefaultBrush}"
-                            BorderThickness="2">
-                        <Grid ColumnDefinitions="Auto,*" ColumnSpacing="16">
-                            <Border Grid.Column="0" Width="44" Height="44" CornerRadius="6"
-                                    Background="{ThemeResource AccentFillColorDefaultBrush}" VerticalAlignment="Top">
-                                <FontIcon Glyph="&#xE756;" FontSize="20" IsTextScaleFactorEnabled="False"
-                                          Foreground="{ThemeResource TextOnAccentFillColorPrimaryBrush}" />
-                            </Border>
-                            <StackPanel Grid.Column="1" Spacing="3">
-                                <StackPanel Orientation="Horizontal" Spacing="8">
-                                    <TextBlock x:Name="InstallTitle"
-                                               Text="Install a local gateway (WSL)"
-                                               Style="{StaticResource BodyStrongTextBlockStyle}"
-                                               VerticalAlignment="Center" />
-                                    <Border CornerRadius="4" Padding="7,1" VerticalAlignment="Center"
-                                            BorderBrush="{ThemeResource AccentTextFillColorPrimaryBrush}" BorderThickness="1">
-                                        <TextBlock Text="Recommended"
-                                                   Style="{StaticResource CaptionTextBlockStyle}"
-                                                   Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" />
-                                    </Border>
-                                </StackPanel>
-                                <TextBlock TextWrapping="Wrap"
-                                           Style="{StaticResource CaptionTextBlockStyle}"
-                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                           Text="A private, self-hosted OpenClaw gateway in an isolated Ubuntu WSL instance. We'll show exactly what gets installed before anything runs." />
+            <ListView x:Name="GatewayChoiceSelector"
+                      AutomationProperties.Name="Gateway setup method"
+                      AutomationProperties.HelpText="Choose one gateway setup method."
+                      MaxWidth="560"
+                      HorizontalAlignment="Stretch"
+                      HorizontalContentAlignment="Stretch"
+                      SelectionMode="Single"
+                      ScrollViewer.VerticalScrollMode="Disabled"
+                      ScrollViewer.VerticalScrollBarVisibility="Disabled"
+                      SelectionChanged="GatewayChoice_SelectionChanged">
+                <ListViewItem x:Name="InstallChoice"
+                              AutomationProperties.AutomationId="WelcomeInstallLocalGatewayChoice"
+                              AutomationProperties.Name="Install a local gateway (WSL), recommended"
+                              HorizontalContentAlignment="Stretch"
+                              VerticalContentAlignment="Center"
+                              Padding="16,12">
+                    <Grid ColumnDefinitions="Auto,*" ColumnSpacing="16">
+                        <Border Grid.Column="0" Width="44" Height="44" CornerRadius="6"
+                                Background="{ThemeResource AccentFillColorDefaultBrush}" VerticalAlignment="Center">
+                            <FontIcon Glyph="&#xE756;" FontSize="20" IsTextScaleFactorEnabled="False"
+                                      Foreground="{ThemeResource TextOnAccentFillColorPrimaryBrush}" />
+                        </Border>
+                        <StackPanel Grid.Column="1" Spacing="3">
+                            <StackPanel Orientation="Horizontal" Spacing="8">
+                                <TextBlock x:Name="InstallTitle"
+                                           Text="Install a local gateway (WSL)"
+                                           Style="{StaticResource BodyStrongTextBlockStyle}"
+                                           VerticalAlignment="Center" />
+                                <Border CornerRadius="4" Padding="7,1" VerticalAlignment="Center"
+                                        BorderBrush="{ThemeResource AccentTextFillColorPrimaryBrush}" BorderThickness="1">
+                                    <TextBlock Text="Recommended"
+                                               Style="{StaticResource CaptionTextBlockStyle}"
+                                               Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" />
+                                </Border>
                             </StackPanel>
-                        </Grid>
-                    </Border>
-                </RadioButton>
+                            <TextBlock TextWrapping="Wrap"
+                                       Style="{StaticResource CaptionTextBlockStyle}"
+                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                       Text="A private, self-hosted OpenClaw gateway in an isolated Ubuntu WSL instance. We'll show exactly what gets installed before anything runs." />
+                        </StackPanel>
+                    </Grid>
+                </ListViewItem>
 
-                <RadioButton x:Name="ConnectChoice"
-                             AutomationProperties.AutomationId="WelcomeConnectExistingGatewayChoice"
-                             AutomationProperties.Name="Connect to an existing gateway"
-                             HorizontalAlignment="Stretch"
-                             HorizontalContentAlignment="Stretch">
-                    <Border x:Name="ConnectCard"
-                            HorizontalAlignment="Stretch"
-                            Padding="16" CornerRadius="4"
-                            Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                            BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                            BorderThickness="1">
-                        <Grid ColumnDefinitions="Auto,*" ColumnSpacing="16">
-                            <Border Grid.Column="0" Width="44" Height="44" CornerRadius="6"
-                                    Background="{ThemeResource SubtleFillColorSecondaryBrush}" VerticalAlignment="Top">
-                                <FontIcon Glyph="&#xE71B;" FontSize="20" IsTextScaleFactorEnabled="False"
-                                          Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
-                            </Border>
-                            <StackPanel Grid.Column="1" Spacing="3">
-                                <TextBlock Text="Connect to an existing gateway"
-                                           Style="{StaticResource BodyStrongTextBlockStyle}" />
-                                <TextBlock TextWrapping="Wrap"
-                                           Style="{StaticResource CaptionTextBlockStyle}"
-                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                           Text="Already run an OpenClaw gateway: here, on another machine, or remote? Pair without installing anything." />
-                            </StackPanel>
-                        </Grid>
-                    </Border>
-                </RadioButton>
-            </RadioButtons>
+                <ListViewItem x:Name="ConnectChoice"
+                              AutomationProperties.AutomationId="WelcomeConnectExistingGatewayChoice"
+                              AutomationProperties.Name="Connect to an existing gateway"
+                              HorizontalContentAlignment="Stretch"
+                              VerticalContentAlignment="Center"
+                              Padding="16,12">
+                    <Grid ColumnDefinitions="Auto,*" ColumnSpacing="16">
+                        <Border Grid.Column="0" Width="44" Height="44" CornerRadius="6"
+                                Background="{ThemeResource SubtleFillColorSecondaryBrush}" VerticalAlignment="Center">
+                            <FontIcon Glyph="&#xE71B;" FontSize="20" IsTextScaleFactorEnabled="False"
+                                      Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
+                        </Border>
+                        <StackPanel Grid.Column="1" Spacing="3">
+                            <TextBlock Text="Connect to an existing gateway"
+                                       Style="{StaticResource BodyStrongTextBlockStyle}" />
+                            <TextBlock TextWrapping="Wrap"
+                                       Style="{StaticResource CaptionTextBlockStyle}"
+                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                       Text="Already run an OpenClaw gateway: here, on another machine, or remote? Pair without installing anything." />
+                        </StackPanel>
+                    </Grid>
+                </ListViewItem>
+            </ListView>
         </ScrollViewer>
 
         <Grid Grid.Row="2" ColumnDefinitions="*,Auto" Margin="0,16,0,0">

--- a/src/OpenClaw.SetupEngine.UI/Pages/WelcomePage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/WelcomePage.xaml.cs
@@ -2,7 +2,6 @@ using Microsoft.UI.Composition;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Hosting;
-using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
 using OpenClaw.SetupEngine;
 using OpenClaw.SetupEngine.UI;
@@ -23,8 +22,6 @@ public sealed partial class WelcomePage : Page
     {
         InitializeComponent();
         Loaded += OnLoaded;
-        ActualThemeChanged += (_, _) => UpdateCardSelection();
-        UpdateCardSelection();
     }
 
     protected override void OnNavigatedTo(NavigationEventArgs e)
@@ -40,7 +37,6 @@ public sealed partial class WelcomePage : Page
         {
             _suppressSelectionWrite = false;
         }
-        UpdateCardSelection();
     }
 
     private void OnLoaded(object sender, RoutedEventArgs e)
@@ -68,7 +64,25 @@ public sealed partial class WelcomePage : Page
 
     private void GatewayChoice_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
-        if (!_suppressSelectionWrite && GatewayChoiceSelector.SelectedIndex is 0 or 1)
+        // A single-select ListView can be cleared to no selection (Ctrl+click / automation).
+        // The Welcome choice must always have exactly one option selected, so restore the last
+        // known selection instead of leaving the persisted value stale behind an empty list.
+        if (GatewayChoiceSelector.SelectedIndex is not (0 or 1))
+        {
+            _suppressSelectionWrite = true;
+            try
+            {
+                GatewayChoiceSelector.SelectedIndex = _installSelected ? 0 : 1;
+            }
+            finally
+            {
+                _suppressSelectionWrite = false;
+            }
+
+            return;
+        }
+
+        if (!_suppressSelectionWrite)
             SetInstallSelected(GatewayChoiceSelector.SelectedIndex == 0);
     }
 
@@ -76,20 +90,6 @@ public sealed partial class WelcomePage : Page
     {
         _installSelected = installSelected;
         SetupWindow.Active?.SetWelcomeInstallSelected(installSelected);
-        UpdateCardSelection();
-    }
-
-    private void UpdateCardSelection()
-    {
-        InstallCard.BorderBrush = _installSelected
-            ? (Brush)Application.Current.Resources["AccentFillColorDefaultBrush"]
-            : (Brush)Application.Current.Resources["CardStrokeColorDefaultBrush"];
-        InstallCard.BorderThickness = new Thickness(_installSelected ? 2 : 1);
-
-        ConnectCard.BorderBrush = !_installSelected
-            ? (Brush)Application.Current.Resources["AccentFillColorDefaultBrush"]
-            : (Brush)Application.Current.Resources["CardStrokeColorDefaultBrush"];
-        ConnectCard.BorderThickness = new Thickness(!_installSelected ? 2 : 1);
     }
 
     private void Back_Click(object sender, RoutedEventArgs e)

--- a/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
@@ -825,10 +825,17 @@ public sealed class AppRefactorContractTests
 
         Assert.Contains("<ScrollViewer Grid.Row=\"1\"", xaml);
         Assert.Contains("VerticalScrollBarVisibility=\"Auto\"", xaml);
-        Assert.Contains("<RadioButtons x:Name=\"GatewayChoiceSelector\"", xaml);
+        Assert.Contains("<ListView x:Name=\"GatewayChoiceSelector\"", xaml);
+        Assert.Contains("SelectionMode=\"Single\"", xaml);
+        Assert.Contains("ScrollViewer.VerticalScrollMode=\"Disabled\"", xaml);
+        Assert.Contains("SelectionChanged=\"GatewayChoice_SelectionChanged\"", xaml);
         Assert.Contains("AutomationProperties.AutomationId=\"WelcomeInstallLocalGatewayChoice\"", xaml);
         Assert.Contains("AutomationProperties.AutomationId=\"WelcomeConnectExistingGatewayChoice\"", xaml);
         Assert.DoesNotContain("PointerPressed=", xaml);
+        // The old duplicate card-selection chrome and its border-swap logic must not return.
+        Assert.DoesNotContain("x:Name=\"InstallCard\"", xaml);
+        Assert.DoesNotContain("x:Name=\"ConnectCard\"", xaml);
+        Assert.DoesNotContain("UpdateCardSelection", welcomePage);
         AssertInOrder(xaml, "<ScrollViewer Grid.Row=\"1\"", "</ScrollViewer>", "<Grid Grid.Row=\"2\"");
         Assert.DoesNotContain("GatewayChoiceSelector.SelectedIndex = 0;", welcomePage);
         Assert.Contains("_suppressSelectionWrite = true", welcomePage);


### PR DESCRIPTION
## What & why

The onboarding **Welcome** step (gateway choice, step 2 of 6) rendered each option as an accent-bordered card wrapped in a `RadioButtons` group, while the code-behind `UpdateCardSelection()` also swapped the card border to accent on selection. The result was **two competing selection indicators** on every option: the default radio ellipse plus the highlighted card, which looked wrong.

Other onboarding surfaces (for example `WizardPage`'s `SelectOptions`) already use a single-select `ListView`, whose selected item shows the Fluent "thin vertical accent pill." This PR standardizes the Welcome choice on that same pattern.

## Changes

- Replace the `RadioButtons` + two `RadioButton` cards with a single-select `ListView` (`GatewayChoiceSelector`) containing two `ListViewItem`s. The ListView's built-in selection pill + row highlight is now the sole selection indicator.
- Remove the per-card `Border` chrome and delete the redundant `UpdateCardSelection()` border-swap logic and its call sites (plus an unused `using`).
- Keep the outer `ScrollViewer` and disable the ListView's own scroll so the outer scroller owns overflow (mirrors `WizardPage`).
- Vertically center the 44x44 icon tiles against the title/caption block and give items a bit more padding, fixing the icon-too-high misalignment.
- Enforce an "always exactly one selected" invariant in `SelectionChanged` (a single-select ListView can otherwise be cleared to no selection via Ctrl+click/automation, leaving the persisted value stale).
- Add `AutomationProperties.HelpText` for the choice group.
- Preserve the accessibility `AutomationId`s and the existing selection-state wiring. `SelectedIndex`/`SelectionChanged` are identical across both controls, so the code-behind's `_suppressSelectionWrite` / `IsWelcomeInstallSelected` / `SetWelcomeInstallSelected` flow is unchanged.

## Validation

- `./build.ps1`: all projects build.
- `dotnet test tests/OpenClaw.Shared.Tests`: 3170 passed, 31 skipped (unrelated MXC/device-identity integration).
- `dotnet test tests/OpenClaw.Tray.Tests`: 1916 passed, including the hardened `SetupWelcomePage_KeepsNavigationOutsideScrollableSemanticChoices` contract test (now asserts single-select, disabled inner scroll, the wired handler, and absence of the old card chrome).
- Rubber-duck review run before publishing: no blocking issues. Its no-selection edge case and contract-test hardening are included here.

## Real behavior proof

- Launched the isolated app at current head (`run-app-local.ps1 -NoBuild -Isolated`) and navigated to the Welcome step. The gateway choice now renders as a ListView with the Fluent selection pill on the selected row and a single selection indicator; the icon tiles are vertically centered against the title/caption. Developer-confirmed visually.

<img width="882" height="1016" alt="image" src="https://github.com/user-attachments/assets/9904ed24-841c-4eaf-94f6-5a1fe03a9a03" />

