### PR TITLE
Simplify session status presentation

### DIFF
--- a/docs/MISSION_CONTROL.md
+++ b/docs/MISSION_CONTROL.md
@@ -469,7 +469,7 @@ Recent native chat behavior implemented during this phase:
 
 - Queued-message UI tracks local send state (`Queued`, `Sending`, `Failed`) until the gateway confirms or rejects the turn.
 - Timeline virtualization keeps long chat histories responsive while preserving stable render identity for visible entries.
-- Completed sessions are hidden by default in the native chat session list, with active/in-progress sessions surfaced first.
+- The Sessions page hides only successful completed runs by default; reusable sessions remain available in the native chat picker, with working sessions surfaced first.
 - TTS notification speech preserves full assistant text while UI preview truncation remains visual-only.
 - Slash-command suggestions use the gateway command catalog grouped into Mac-compatible command buckets.
 - Local MCP chat automation exposes `app.chat.snapshot`, `app.chat.send`, and `app.chat.reset` for current-thread inspection, send, and reset flows.

--- a/src/OpenClaw.Shared/Models.cs
+++ b/src/OpenClaw.Shared/Models.cs
@@ -302,6 +302,11 @@ public class SessionInfo
     public string? VerboseLevel { get; set; }
     public bool SystemSent { get; set; }
     public bool AbortedLastRun { get; set; }
+    /// <summary>
+    /// Gateway-provided liveness for the session's current run. Null means an
+    /// older Gateway did not provide the field, so callers may use legacy status.
+    /// </summary>
+    public bool? HasActiveRun { get; set; }
     public long InputTokens { get; set; }
     public long OutputTokens { get; set; }
     public long TotalTokens { get; set; }

--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -3813,7 +3813,19 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
     private void PopulateSessionFromObject(SessionInfo session, JsonElement item)
     {
         if (item.TryGetProperty("status", out var status))
-            session.Status = status.GetString() ?? "active";
+            session.Status = status.ValueKind == JsonValueKind.String
+                ? status.GetString() ?? "unknown"
+                : "unknown";
+        else
+            session.Status = "unknown";
+        if (item.TryGetProperty("hasActiveRun", out var hasActiveRun))
+        {
+            session.HasActiveRun = hasActiveRun.ValueKind is JsonValueKind.True or JsonValueKind.False
+                ? hasActiveRun.GetBoolean()
+                : null;
+        }
+        else
+            session.HasActiveRun = null;
         if (item.TryGetProperty("model", out var model))
         {
             var newModel = model.GetString();

--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -3816,16 +3816,12 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
             session.Status = status.ValueKind == JsonValueKind.String
                 ? status.GetString() ?? "unknown"
                 : "unknown";
-        else
-            session.Status = "unknown";
         if (item.TryGetProperty("hasActiveRun", out var hasActiveRun))
         {
             session.HasActiveRun = hasActiveRun.ValueKind is JsonValueKind.True or JsonValueKind.False
                 ? hasActiveRun.GetBoolean()
                 : null;
         }
-        else
-            session.HasActiveRun = null;
         if (item.TryGetProperty("model", out var model))
         {
             var newModel = model.GetString();

--- a/src/OpenClaw.Shared/Sessions/SessionRunState.cs
+++ b/src/OpenClaw.Shared/Sessions/SessionRunState.cs
@@ -1,0 +1,86 @@
+using OpenClaw.Shared;
+
+namespace OpenClaw.Shared.Sessions;
+
+/// <summary>
+/// Canonical interpretation of the Gateway's latest-run outcome and live-run flag.
+/// Keep this separate from presentation: the Gateway records outcomes per run, while a
+/// session remains available for a later turn after that run finishes.
+/// </summary>
+public enum SessionRunStatus
+{
+    Unknown,
+    Running,
+    Completed,
+    Failed,
+    Stopped,
+    TimedOut,
+}
+
+/// <summary>The intentionally small set of session states shown by the Windows app.</summary>
+public enum SessionDisplayState
+{
+    Working,
+    Ready,
+    NeedsAttention,
+}
+
+public static class SessionRunState
+{
+    public static SessionRunStatus ResolveStatus(string? status) => status?.Trim().ToLowerInvariant() switch
+    {
+        "active" or "running" => SessionRunStatus.Running,
+        "done" or "completed" => SessionRunStatus.Completed,
+        "error" or "failed" or "failure" => SessionRunStatus.Failed,
+        "killed" or "aborted" or "cancelled" or "canceled" => SessionRunStatus.Stopped,
+        "timeout" or "timed_out" => SessionRunStatus.TimedOut,
+        _ => SessionRunStatus.Unknown,
+    };
+
+    /// <summary>
+    /// A terminal outcome wins over a stale live-run flag. For older Gateways which
+    /// do not send <c>hasActiveRun</c>, preserve the legacy <c>running</c> fallback.
+    /// </summary>
+    public static bool IsWorking(SessionInfo session)
+    {
+        var status = ResolveStatus(session.Status);
+        if (status is SessionRunStatus.Completed or SessionRunStatus.Failed
+            or SessionRunStatus.Stopped or SessionRunStatus.TimedOut)
+        {
+            return false;
+        }
+
+        return session.HasActiveRun ?? status == SessionRunStatus.Running;
+    }
+
+    public static SessionDisplayState GetDisplayState(SessionInfo session)
+    {
+        if (IsWorking(session))
+            return SessionDisplayState.Working;
+
+        return ResolveStatus(session.Status) is SessionRunStatus.Failed or SessionRunStatus.TimedOut
+            ? SessionDisplayState.NeedsAttention
+            : SessionDisplayState.Ready;
+    }
+
+    /// <summary>Stable priority for compact lists: live work, attention, then ready sessions.</summary>
+    public static int GetDisplaySortOrder(SessionInfo session) => GetDisplayState(session) switch
+    {
+        SessionDisplayState.Working => 0,
+        SessionDisplayState.NeedsAttention => 1,
+        _ => 2,
+    };
+
+    /// <summary>Successful completed runs may be hidden from the compact session list.</summary>
+    public static bool IsCompleted(SessionInfo session) =>
+        !IsWorking(session)
+        && !session.AbortedLastRun
+        && ResolveStatus(session.Status) == SessionRunStatus.Completed;
+
+    /// <summary>
+    /// A stopped run is useful context in a row or transcript, but is not a
+    /// fourth primary session status: the session is still ready for another turn.
+    /// </summary>
+    public static bool HasStoppedLastRun(SessionInfo session) =>
+        session.AbortedLastRun || ResolveStatus(session.Status) == SessionRunStatus.Stopped;
+}

--- a/src/OpenClaw.Shared/Sessions/SessionRunState.cs
+++ b/src/OpenClaw.Shared/Sessions/SessionRunState.cs
@@ -38,19 +38,15 @@ public static class SessionRunState
     };
 
     /// <summary>
-    /// A terminal outcome wins over a stale live-run flag. For older Gateways which
-    /// do not send <c>hasActiveRun</c>, preserve the legacy <c>running</c> fallback.
+    /// The Gateway's current-run flag is authoritative when present. Older Gateways
+    /// omit it, so only those payloads fall back to the latest recorded outcome.
     /// </summary>
     public static bool IsWorking(SessionInfo session)
     {
-        var status = ResolveStatus(session.Status);
-        if (status is SessionRunStatus.Completed or SessionRunStatus.Failed
-            or SessionRunStatus.Stopped or SessionRunStatus.TimedOut)
-        {
-            return false;
-        }
+        if (session.HasActiveRun is { } hasActiveRun)
+            return hasActiveRun;
 
-        return session.HasActiveRun ?? status == SessionRunStatus.Running;
+        return ResolveStatus(session.Status) == SessionRunStatus.Running;
     }
 
     public static SessionDisplayState GetDisplayState(SessionInfo session)

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
@@ -6405,7 +6405,7 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
             AgentId = display.AgentId,
             IsBackground = display.IsBackground,
             Status = SessionVisibilityFilter.ToChatThreadStatus(s),
-            Activity = string.IsNullOrEmpty(s.CurrentActivity) ? ChatActivity.Idle : ChatActivity.Working,
+            Activity = SessionVisibilityFilter.ToChatThreadActivity(s),
             Workspace = s.Channel,
             Model = s.Model,
             ModelProvider = s.Provider,

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
@@ -6,6 +6,7 @@ using Microsoft.UI.Xaml.Documents;
 using Microsoft.UI.Xaml.Media;
 using OpenClaw.Connection;
 using OpenClaw.Shared;
+using OpenClaw.Shared.Sessions;
 using OpenClawTray.Helpers;
 using OpenClawTray.Services;
 using System;
@@ -730,9 +731,7 @@ public sealed partial class ConnectionPage : Page
         // Status sub-row (mirrors PermissionsPage NodeStatusDot pattern):
         // colored dot + descriptive label that reflects the live state.
         var sessions = _appState?.Sessions;
-        int activeSessions = sessions?.Count(s =>
-            string.Equals(s.Status, "active", StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(s.Status, "running", StringComparison.OrdinalIgnoreCase)) ?? 0;
+        int activeSessions = sessions?.Count(SessionRunState.IsWorking) ?? 0;
 
         var (statusGlyph, statusBrushKey, statusText) = plan.OperatorCard switch
         {

--- a/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml
@@ -35,7 +35,7 @@
                     </SelectorBar>
 
                     <ToggleSwitch x:Uid="SessionsPage_ShowCompleted" x:Name="ShowCompletedToggle" Grid.Column="1"
-                                  Header="Show ended"
+                                  Header="Show completed"
                                   MinWidth="0"
                                   OnContent="" OffContent=""
                                   Toggled="OnShowCompletedToggled"
@@ -97,7 +97,7 @@
                                   HorizontalAlignment="Center"
                                   Foreground="{ThemeResource TextFillColorTertiaryBrush}"/>
                         <TextBlock x:Uid="SessionsPage_NoActiveSessions"
-                                   Text="No active sessions"
+                                   Text="No sessions"
                                    Style="{StaticResource BodyStrongTextBlockStyle}"
                                    HorizontalAlignment="Center"/>
                         <TextBlock x:Uid="SessionsPage_EmptyHint" Text="Sessions appear here when a channel is connected and traffic is flowing."
@@ -142,6 +142,10 @@
                                                      VerticalAlignment="Center"
                                                      Fill="{Binding StatusBrush}"
                                                      ToolTipService.ToolTip="{Binding StatusTooltip}"/>
+                                            <TextBlock Text="{Binding StatusText}"
+                                                       Style="{StaticResource CaptionTextBlockStyle}"
+                                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                       VerticalAlignment="Center"/>
                                             <TextBlock Text="{Binding DisplayName}"
                                                        Style="{StaticResource BodyStrongTextBlockStyle}"
                                                        TextTrimming="CharacterEllipsis"

--- a/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
@@ -112,12 +112,8 @@ public sealed partial class SessionsPage : Page
                     Status = "active",
                     HasActiveRun = true,
                     DisplayName = "Nightly cleanup",
-                    Presentation = new SessionPresentationInfo
-                    {
-                        Title = "Nightly cleanup",
-                        Family = "cron",
-                        IsBackground = true,
-                    },
+                    Classification = "cron",
+                    IsBackground = true,
                     UpdatedAt = DateTime.UtcNow.AddMinutes(-7),
                 },
                 new SessionInfo

--- a/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
@@ -186,12 +186,12 @@ public sealed partial class SessionsPage : Page
             return;
         }
 
-        var activeSessions = SessionVisibilityFilter.VisibleSessions(
+        var visibleSessions = SessionVisibilityFilter.VisibleSessions(
                 SessionsForCurrentBackgroundScope(),
                 ShowCompletedSessions)
             .ToList();
-        var activeTitles = SessionTitleFormatter.FormatUnique(activeSessions);
-        IEnumerable<(SessionInfo Session, string Title)> filtered = activeSessions
+        var activeTitles = SessionTitleFormatter.FormatUnique(visibleSessions);
+        IEnumerable<(SessionInfo Session, string Title)> filtered = visibleSessions
             .Select((session, index) => (Session: session, Title: activeTitles[index]));
 
         if (_activeChannel != "all")
@@ -201,7 +201,8 @@ public sealed partial class SessionsPage : Page
         }
 
         var viewModels = filtered
-            .OrderByDescending(item => item.Session.UpdatedAt ?? item.Session.LastSeen)
+            .OrderBy(item => SessionRunState.GetDisplaySortOrder(item.Session))
+            .ThenByDescending(item => item.Session.UpdatedAt ?? item.Session.LastSeen)
             .Select(item => ToViewModel(item.Session, item.Title))
             .ToList();
 
@@ -272,12 +273,14 @@ public sealed partial class SessionsPage : Page
     private SessionViewModel ToViewModel(SessionInfo s, string displayName)
     {
         var subtitle = SessionTitleFormatter.FormatSubtitle(s);
-        var parts = new List<string>(4);
+        var parts = new List<string>(5);
         if (!string.IsNullOrWhiteSpace(subtitle)) parts.Add(subtitle!);
         if (!string.IsNullOrWhiteSpace(s.Provider)) parts.Add(s.Provider!);
         if (!string.IsNullOrWhiteSpace(s.Model)) parts.Add(s.Model!);
         if (string.IsNullOrWhiteSpace(subtitle) && !string.IsNullOrWhiteSpace(s.Channel))
             parts.Add(s.Channel!);
+        if (SessionRunState.HasStoppedLastRun(s))
+            parts.Add(LocalizationHelper.GetString("SessionsPage_LastRunStopped"));
 
         var hasTokens = s.InputTokens > 0 || s.OutputTokens > 0;
         var tokensText = hasTokens
@@ -303,7 +306,8 @@ public sealed partial class SessionsPage : Page
             AgeText = s.AgeText,
             DetailLine = parts.Count > 0 ? string.Join(" · ", parts) : "",
             StatusBrush = ResolveStatusBrush(s),
-            StatusTooltip = ResolveStatusTooltip(s),
+            StatusText = ResolveStatusText(s),
+            StatusTooltip = ResolveStatusText(s),
             TokensText = tokensText,
             ContextPercent = contextPercent,
             HasTokenData = hasTokens || contextPercent > 0,
@@ -315,23 +319,22 @@ public sealed partial class SessionsPage : Page
 
     private static Brush ResolveStatusBrush(SessionInfo s)
     {
-        var status = s.Status?.Trim().ToLowerInvariant();
-        if (status is "error" or "failed" or "failure")
-            return s_criticalBrush.Value;
-        if (s.AbortedLastRun)
-            return s_cautionBrush.Value;
-        if (status is "active" or "running")
-            return s_successBrush.Value;
-        return s_neutralBrush.Value;
+        return SessionRunState.GetDisplayState(s) switch
+        {
+            SessionDisplayState.Working => s_successBrush.Value,
+            SessionDisplayState.NeedsAttention => s_criticalBrush.Value,
+            _ => s_neutralBrush.Value,
+        };
     }
 
-    private static string ResolveStatusTooltip(SessionInfo s)
+    private static string ResolveStatusText(SessionInfo s)
     {
-        var status = s.Status?.Trim().ToLowerInvariant();
-        if (status is "error" or "failed" or "failure") return "Error";
-        if (s.AbortedLastRun) return "Aborted last run";
-        if (status is "active" or "running") return "Running";
-        return "Idle";
+        return SessionRunState.GetDisplayState(s) switch
+        {
+            SessionDisplayState.Working => LocalizationHelper.GetString("SessionsPage_Status_Working"),
+            SessionDisplayState.NeedsAttention => LocalizationHelper.GetString("SessionsPage_Status_NeedsAttention"),
+            _ => LocalizationHelper.GetString("SessionsPage_Status_Ready"),
+        };
     }
 
     private static readonly Lazy<Brush> s_successBrush =
@@ -701,7 +704,8 @@ public class SessionViewModel
     public string AgeText { get; set; } = "";
     public string DetailLine { get; set; } = "";
     public Brush StatusBrush { get; set; } = new SolidColorBrush(Colors.Gray);
-    public string StatusTooltip { get; set; } = "Idle";
+    public string StatusText { get; set; } = "Ready";
+    public string StatusTooltip { get; set; } = "Ready";
     public string TokensText { get; set; } = "";
     public double ContextPercent { get; set; }
     public bool HasTokenData { get; set; }

--- a/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
@@ -108,6 +108,20 @@ public sealed partial class SessionsPage : Page
                 },
                 new SessionInfo
                 {
+                    Key = "agent:main:cron:nightly-cleanup",
+                    Status = "active",
+                    HasActiveRun = true,
+                    DisplayName = "Nightly cleanup",
+                    Presentation = new SessionPresentationInfo
+                    {
+                        Title = "Nightly cleanup",
+                        Family = "cron",
+                        IsBackground = true,
+                    },
+                    UpdatedAt = DateTime.UtcNow.AddMinutes(-7),
+                },
+                new SessionInfo
+                {
                     Key = "agent:main:completed-cleanup",
                     Status = "done",
                     DisplayName = "Completed cleanup",

--- a/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
@@ -73,15 +73,45 @@ public sealed partial class SessionsPage : Page
                     Key = "agent:main:main",
                     IsMain = true,
                     Status = "active",
+                    HasActiveRun = true,
                     DisplayName = "OpenClaw Windows Tray",
                     UpdatedAt = DateTime.UtcNow,
                 },
                 new SessionInfo
                 {
                     Key = "agent:main:fork",
-                    Status = "active",
+                    Status = "running",
+                    HasActiveRun = false,
                     DisplayName = "OpenClaw Windows Tray",
                     UpdatedAt = DateTime.UtcNow.AddSeconds(-1),
+                },
+                new SessionInfo
+                {
+                    Key = "agent:main:deploy-migration",
+                    Status = "failed",
+                    DisplayName = "Deploy migration",
+                    UpdatedAt = DateTime.UtcNow.AddMinutes(-2),
+                },
+                new SessionInfo
+                {
+                    Key = "agent:main:research-labels",
+                    Status = "timeout",
+                    DisplayName = "Research status labels",
+                    UpdatedAt = DateTime.UtcNow.AddMinutes(-4),
+                },
+                new SessionInfo
+                {
+                    Key = "agent:main:release-notes",
+                    Status = "killed",
+                    DisplayName = "Draft release notes",
+                    UpdatedAt = DateTime.UtcNow.AddMinutes(-6),
+                },
+                new SessionInfo
+                {
+                    Key = "agent:main:completed-cleanup",
+                    Status = "done",
+                    DisplayName = "Completed cleanup",
+                    UpdatedAt = DateTime.UtcNow.AddMinutes(-8),
                 },
             ]);
             return;

--- a/src/OpenClaw.Tray.WinUI/Services/SessionVisibilityFilter.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/SessionVisibilityFilter.cs
@@ -17,6 +17,9 @@ public static class SessionVisibilityFilter
     public static ChatThreadStatus ToChatThreadStatus(SessionInfo session)
         => SessionRunState.IsWorking(session) ? ChatThreadStatus.Running : ChatThreadStatus.Created;
 
+    public static ChatActivity ToChatThreadActivity(SessionInfo session)
+        => SessionRunState.IsWorking(session) ? ChatActivity.Working : ChatActivity.Idle;
+
     public static IEnumerable<ChatThread> VisibleChatPickerThreads(
         IEnumerable<ChatThread> threads,
         string? activeThreadId = null)

--- a/src/OpenClaw.Tray.WinUI/Services/SessionVisibilityFilter.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/SessionVisibilityFilter.cs
@@ -1,31 +1,21 @@
 using OpenClaw.Chat;
 using OpenClaw.Shared;
+using OpenClaw.Shared.Sessions;
 
 namespace OpenClawTray.Services;
 
 public static class SessionVisibilityFilter
 {
-    public static IEnumerable<SessionInfo> VisibleSessions(IEnumerable<SessionInfo> sessions, bool showEnded)
-        => showEnded ? sessions : sessions.Where(IsVisibleWhenEndedHidden);
+    public static IEnumerable<SessionInfo> VisibleSessions(IEnumerable<SessionInfo> sessions, bool showCompleted)
+        => showCompleted ? sessions : sessions.Where(IsVisibleWhenCompletedHidden);
 
-    public static bool IsVisibleWhenEndedHidden(SessionInfo session)
-        => !IsEnded(session);
+    public static bool IsVisibleWhenCompletedHidden(SessionInfo session)
+        => !IsCompleted(session);
 
-    public static bool IsEnded(SessionInfo session)
-    {
-        if (session.AbortedLastRun)
-            return false;
-
-        var status = session.Status?.Trim();
-        return string.Equals(status, "done", StringComparison.OrdinalIgnoreCase)
-            || string.Equals(status, "completed", StringComparison.OrdinalIgnoreCase)
-            || string.Equals(status, "failed", StringComparison.OrdinalIgnoreCase)
-            || string.Equals(status, "killed", StringComparison.OrdinalIgnoreCase)
-            || string.Equals(status, "timeout", StringComparison.OrdinalIgnoreCase);
-    }
+    public static bool IsCompleted(SessionInfo session) => SessionRunState.IsCompleted(session);
 
     public static ChatThreadStatus ToChatThreadStatus(SessionInfo session)
-        => IsEnded(session) ? ChatThreadStatus.Ended : ChatThreadStatus.Running;
+        => SessionRunState.IsWorking(session) ? ChatThreadStatus.Running : ChatThreadStatus.Created;
 
     public static IEnumerable<ChatThread> VisibleChatPickerThreads(
         IEnumerable<ChatThread> threads,

--- a/src/OpenClaw.Tray.WinUI/Services/TrayDashboardSummary.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/TrayDashboardSummary.cs
@@ -1,4 +1,5 @@
 using OpenClaw.Shared;
+using OpenClaw.Shared.Sessions;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -151,10 +152,9 @@ internal sealed class TrayDashboardSummaryBuilder
         var sessionCount = _snapshot.Sessions.Length;
         if (sessionCount > 0)
         {
-            var active = _snapshot.Sessions.Count(
-                s => string.Equals(s.Status, "active", StringComparison.OrdinalIgnoreCase));
+            var active = _snapshot.Sessions.Count(SessionRunState.IsWorking);
             parts.Add(active > 0
-                ? $"{sessionCount} {(sessionCount == 1 ? "session" : "sessions")} ({active} active)"
+                ? $"{sessionCount} {(sessionCount == 1 ? "session" : "sessions")} ({active} working)"
                 : $"{sessionCount} {(sessionCount == 1 ? "session" : "sessions")}");
         }
 
@@ -215,14 +215,11 @@ internal sealed class TrayDashboardSummaryBuilder
             return null;
         sessions = foregroundSessions;
 
-        static bool IsActive(SessionInfo s) =>
-            string.Equals(s.Status, "active", StringComparison.OrdinalIgnoreCase);
-
-        var activeMain = sessions.FirstOrDefault(s => s.IsMain && IsActive(s));
+        var activeMain = sessions.FirstOrDefault(s => s.IsMain && SessionRunState.IsWorking(s));
         if (activeMain != null) return activeMain;
 
         var activeRecent = sessions
-            .Where(IsActive)
+            .Where(SessionRunState.IsWorking)
             .OrderByDescending(s => s.UpdatedAt ?? s.LastSeen)
             .FirstOrDefault();
         if (activeRecent != null) return activeRecent;
@@ -230,13 +227,13 @@ internal sealed class TrayDashboardSummaryBuilder
         var main = sessions.FirstOrDefault(s => s.IsMain);
         if (main != null) return main;
 
-        // Prefer non-ended sessions as the dashboard fallback so a completed/failed
-        // session does not appear as "current" when live sessions remain.
-        var nonEnded = sessions
-            .Where(s => !SessionVisibilityFilter.IsEnded(s))
+        // Prefer sessions that are still relevant to the operator over a successful
+        // completed run when there is no working or main session to surface.
+        var nonCompleted = sessions
+            .Where(s => !SessionRunState.IsCompleted(s))
             .OrderByDescending(s => s.UpdatedAt ?? s.LastSeen)
             .FirstOrDefault();
-        if (nonEnded != null) return nonEnded;
+        if (nonCompleted != null) return nonCompleted;
 
         return sessions.OrderByDescending(s => s.UpdatedAt ?? s.LastSeen).First();
     }
@@ -247,8 +244,12 @@ internal sealed class TrayDashboardSummaryBuilder
         if (session == null)
             return null;
 
-        var isActive = string.Equals(session.Status, "active", StringComparison.OrdinalIgnoreCase);
-        var label = isActive ? "Active" : (session.IsMain ? "Main" : "Session");
+        var label = SessionRunState.GetDisplayState(session) switch
+        {
+            SessionDisplayState.Working => "Working",
+            SessionDisplayState.NeedsAttention => "Needs attention",
+            _ => "Ready",
+        };
 
         var title = SessionTitleFormatter.Format(session);
 

--- a/src/OpenClaw.Tray.WinUI/Services/TrayMenuStateBuilder.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/TrayMenuStateBuilder.cs
@@ -5,6 +5,7 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using OpenClaw.Chat;
 using OpenClaw.Shared;
+using OpenClaw.Shared.Sessions;
 using OpenClawTray.Chat;
 using OpenClawTray.Helpers;
 using OpenClawTray.Windows;
@@ -295,7 +296,7 @@ internal sealed class TrayMenuStateBuilder
             menu.AddSeparator();
 
             var sessionCount = foregroundSessions.Length;
-            var activeCount = foregroundSessions.Count(s => string.Equals(s.Status, "active", StringComparison.OrdinalIgnoreCase));
+            var activeCount = foregroundSessions.Count(SessionRunState.IsWorking);
             var totalTokensAll = foregroundSessions.Sum(TrayDashboardSummaryBuilder.SessionUsedTokens);
 
             // Single collapsed entry whose hover flyout reveals the session list.
@@ -634,9 +635,9 @@ internal sealed class TrayMenuStateBuilder
 
     // ── Sessions: collapsed entry + flyout list ─────────────────────────
 
-    private static UIElement BuildSessionsListRow(int total, int active, long totalTokens, Microsoft.UI.Xaml.Media.Brush secondaryText)
+    private static UIElement BuildSessionsListRow(int total, int working, long totalTokens, Microsoft.UI.Xaml.Media.Brush secondaryText)
     {
-        // Card row: [icon] Sessions    (N active · X tokens)
+        // Card row: [icon] Sessions    (N working · X tokens)
         var resources = Application.Current.Resources;
         var captionStyle = (Style)resources["CaptionTextBlockStyle"];
 
@@ -662,7 +663,7 @@ internal sealed class TrayMenuStateBuilder
 
         var summary = new TextBlock
         {
-            Text = $"{active} active · {FormatTokenCount(totalTokens)} tokens",
+            Text = $"{working} working · {FormatTokenCount(totalTokens)} tokens",
             Style = captionStyle,
             FontSize = 11,
             Foreground = secondaryText,
@@ -1208,7 +1209,7 @@ internal sealed class TrayMenuStateBuilder
 
         if (sessions.Count == 0)
         {
-            items.Add(new() { Text = "No active sessions" });
+            items.Add(new() { Text = "No sessions" });
             return items;
         }
 

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -4684,7 +4684,7 @@ Commands are blocked while sandboxing is unavailable because strict fallback blo
     <value>All</value>
   </data>
   <data name="SessionsPage_ShowCompleted.Header" xml:space="preserve">
-    <value>Show ended</value>
+    <value>Show completed</value>
   </data>
   <data name="SessionsPage_ShowBackground.Header" xml:space="preserve">
     <value>Show background</value>
@@ -4727,7 +4727,7 @@ Commands are blocked while sandboxing is unavailable because strict fallback blo
     <value>Loading sessions...</value>
   </data>
   <data name="SessionsPage_NoActiveSessions.Text" xml:space="preserve">
-    <value>No active sessions</value>
+    <value>No sessions</value>
   </data>
   <data name="SessionsPage_Reset.Text" xml:space="preserve">
     <value>Reset</value>
@@ -6918,5 +6918,16 @@ Make sure the gateway is running.</value>
   </data>
   <data name="PermissionsPage_ExecPolicySaveFailed" xml:space="preserve">
     <value>Save failed</value>
+  <data name="SessionsPage_Status_Working" xml:space="preserve">
+    <value>Working</value>
+  </data>
+  <data name="SessionsPage_Status_Ready" xml:space="preserve">
+    <value>Ready</value>
+  </data>
+  <data name="SessionsPage_Status_NeedsAttention" xml:space="preserve">
+    <value>Needs attention</value>
+  </data>
+  <data name="SessionsPage_LastRunStopped" xml:space="preserve">
+    <value>Last run stopped</value>
   </data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -6918,6 +6918,7 @@ Make sure the gateway is running.</value>
   </data>
   <data name="PermissionsPage_ExecPolicySaveFailed" xml:space="preserve">
     <value>Save failed</value>
+  </data>
   <data name="SessionsPage_Status_Working" xml:space="preserve">
     <value>Working</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -6878,6 +6878,7 @@ Le binaire wxc-exec est introuvable. {1} S'il s'agit d'une build développeur, c
   </data>
   <data name="PermissionsPage_ExecPolicySaveFailed" xml:space="preserve">
     <value>Échec de l’enregistrement</value>
+  </data>
   <data name="SessionsPage_Status_Working" xml:space="preserve">
     <value>En cours</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -4680,7 +4680,7 @@ Les commandes sont bloquées tant que le sandboxing est indisponible, car le blo
     <value>Chargement des sessions…</value>
   </data>
   <data name="SessionsPage_NoActiveSessions.Text" xml:space="preserve">
-    <value>Aucune session active</value>
+    <value>Aucune session</value>
   </data>
   <data name="SessionsPage_Reset.Text" xml:space="preserve">
     <value>Réinitialiser</value>
@@ -6878,5 +6878,16 @@ Le binaire wxc-exec est introuvable. {1} S'il s'agit d'une build développeur, c
   </data>
   <data name="PermissionsPage_ExecPolicySaveFailed" xml:space="preserve">
     <value>Échec de l’enregistrement</value>
+  <data name="SessionsPage_Status_Working" xml:space="preserve">
+    <value>En cours</value>
+  </data>
+  <data name="SessionsPage_Status_Ready" xml:space="preserve">
+    <value>Prête</value>
+  </data>
+  <data name="SessionsPage_Status_NeedsAttention" xml:space="preserve">
+    <value>À vérifier</value>
+  </data>
+  <data name="SessionsPage_LastRunStopped" xml:space="preserve">
+    <value>Dernière exécution arrêtée</value>
   </data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -4638,7 +4638,7 @@ Opdrachten worden geblokkeerd zolang sandboxing niet beschikbaar is, omdat strik
     <value>Alle</value>
   </data>
   <data name="SessionsPage_ShowCompleted.Header" xml:space="preserve">
-    <value>Beëindigde sessies tonen</value>
+    <value>Voltooide sessies weergeven</value>
   </data>
   <data name="SessionsPage_ShowBackground.Header" xml:space="preserve">
     <value>Achtergrondsessies tonen</value>
@@ -4681,7 +4681,7 @@ Opdrachten worden geblokkeerd zolang sandboxing niet beschikbaar is, omdat strik
     <value>Sessies worden geladen…</value>
   </data>
   <data name="SessionsPage_NoActiveSessions.Text" xml:space="preserve">
-    <value>Geen actieve sessies</value>
+    <value>Geen sessies</value>
   </data>
   <data name="SessionsPage_Reset.Text" xml:space="preserve">
     <value>Resetten</value>
@@ -6879,5 +6879,16 @@ Het binaire bestand wxc-exec is niet gevonden. {1} Als dit een ontwikkelaarsbuil
   </data>
   <data name="PermissionsPage_ExecPolicySaveFailed" xml:space="preserve">
     <value>Opslaan mislukt</value>
+  <data name="SessionsPage_Status_Working" xml:space="preserve">
+    <value>Bezig</value>
+  </data>
+  <data name="SessionsPage_Status_Ready" xml:space="preserve">
+    <value>Gereed</value>
+  </data>
+  <data name="SessionsPage_Status_NeedsAttention" xml:space="preserve">
+    <value>Heeft aandacht nodig</value>
+  </data>
+  <data name="SessionsPage_LastRunStopped" xml:space="preserve">
+    <value>Laatste uitvoering gestopt</value>
   </data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -6879,6 +6879,7 @@ Het binaire bestand wxc-exec is niet gevonden. {1} Als dit een ontwikkelaarsbuil
   </data>
   <data name="PermissionsPage_ExecPolicySaveFailed" xml:space="preserve">
     <value>Opslaan mislukt</value>
+  </data>
   <data name="SessionsPage_Status_Working" xml:space="preserve">
     <value>Bezig</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -6878,6 +6878,7 @@
   </data>
   <data name="PermissionsPage_ExecPolicySaveFailed" xml:space="preserve">
     <value>保存失败</value>
+  </data>
   <data name="SessionsPage_Status_Working" xml:space="preserve">
     <value>工作中</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -4637,7 +4637,7 @@
     <value>全部</value>
   </data>
   <data name="SessionsPage_ShowCompleted.Header" xml:space="preserve">
-    <value>显示已结束的会话</value>
+    <value>显示已完成的会话</value>
   </data>
   <data name="SessionsPage_ShowBackground.Header" xml:space="preserve">
     <value>显示后台会话</value>
@@ -4680,7 +4680,7 @@
     <value>正在加载会话…</value>
   </data>
   <data name="SessionsPage_NoActiveSessions.Text" xml:space="preserve">
-    <value>无活动会话</value>
+    <value>没有会话</value>
   </data>
   <data name="SessionsPage_Reset.Text" xml:space="preserve">
     <value>重置</value>
@@ -6878,5 +6878,16 @@
   </data>
   <data name="PermissionsPage_ExecPolicySaveFailed" xml:space="preserve">
     <value>保存失败</value>
+  <data name="SessionsPage_Status_Working" xml:space="preserve">
+    <value>工作中</value>
+  </data>
+  <data name="SessionsPage_Status_Ready" xml:space="preserve">
+    <value>就绪</value>
+  </data>
+  <data name="SessionsPage_Status_NeedsAttention" xml:space="preserve">
+    <value>需要注意</value>
+  </data>
+  <data name="SessionsPage_LastRunStopped" xml:space="preserve">
+    <value>上次运行已停止</value>
   </data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -6878,6 +6878,7 @@
   </data>
   <data name="PermissionsPage_ExecPolicySaveFailed" xml:space="preserve">
     <value>儲存失敗</value>
+  </data>
   <data name="SessionsPage_Status_Working" xml:space="preserve">
     <value>處理中</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -4637,7 +4637,7 @@
     <value>全部</value>
   </data>
   <data name="SessionsPage_ShowCompleted.Header" xml:space="preserve">
-    <value>顯示已結束的工作階段</value>
+    <value>顯示已完成的工作階段</value>
   </data>
   <data name="SessionsPage_ShowBackground.Header" xml:space="preserve">
     <value>顯示背景工作階段</value>
@@ -4680,7 +4680,7 @@
     <value>正在載入工作階段…</value>
   </data>
   <data name="SessionsPage_NoActiveSessions.Text" xml:space="preserve">
-    <value>沒有作用中的工作階段</value>
+    <value>沒有工作階段</value>
   </data>
   <data name="SessionsPage_Reset.Text" xml:space="preserve">
     <value>重設</value>
@@ -6878,5 +6878,16 @@
   </data>
   <data name="PermissionsPage_ExecPolicySaveFailed" xml:space="preserve">
     <value>儲存失敗</value>
+  <data name="SessionsPage_Status_Working" xml:space="preserve">
+    <value>處理中</value>
+  </data>
+  <data name="SessionsPage_Status_Ready" xml:space="preserve">
+    <value>就緒</value>
+  </data>
+  <data name="SessionsPage_Status_NeedsAttention" xml:space="preserve">
+    <value>需要注意</value>
+  </data>
+  <data name="SessionsPage_LastRunStopped" xml:space="preserve">
+    <value>上次執行已停止</value>
   </data>
 </root>

--- a/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
@@ -2180,6 +2180,24 @@ public class OpenClawGatewayClientTests
     }
 
     [Fact]
+    public void ParseSessions_RetainsRunStateWhenSparseUpdateOmitsIt()
+    {
+        var helper = new GatewayClientTestHelper();
+
+        helper.ParseSessionsPayload("""
+        [{ "key": "agent:main:stateful", "status": "failed", "hasActiveRun": false }]
+        """);
+        helper.ParseSessionsPayload("""
+        [{ "key": "agent:main:stateful", "displayName": "Current task" }]
+        """);
+
+        var session = Assert.Single(helper.GetSessionList());
+        Assert.Equal("failed", session.Status);
+        Assert.Equal(false, session.HasActiveRun);
+        Assert.Equal("Current task", session.DisplayName);
+    }
+
+    [Fact]
     public void ParseUsageStatusPayload_PopulatesProviderSummary()
     {
         var helper = new GatewayClientTestHelper();

--- a/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
@@ -2160,6 +2160,26 @@ public class OpenClawGatewayClientTests
     }
 
     [Fact]
+    public void ParseSessions_PreservesGatewayRunLivenessAndDoesNotInventActiveStatus()
+    {
+        var helper = new GatewayClientTestHelper();
+
+        helper.ParseSessionsPayload("""
+        [
+          { "key": "agent:main:working", "status": "running", "hasActiveRun": true },
+          { "key": "agent:main:idle", "status": "running", "hasActiveRun": false },
+          { "key": "agent:main:unknown" }
+        ]
+        """);
+
+        var sessions = helper.GetSessionList().ToDictionary(session => session.Key);
+        Assert.True(sessions["agent:main:working"].HasActiveRun == true);
+        Assert.True(sessions["agent:main:idle"].HasActiveRun == false);
+        Assert.Null(sessions["agent:main:unknown"].HasActiveRun);
+        Assert.Equal("unknown", sessions["agent:main:unknown"].Status);
+    }
+
+    [Fact]
     public void ParseUsageStatusPayload_PopulatesProviderSummary()
     {
         var helper = new GatewayClientTestHelper();

--- a/tests/OpenClaw.Shared.Tests/Protocol/gateway-protocol-snapshot.json
+++ b/tests/OpenClaw.Shared.Tests/Protocol/gateway-protocol-snapshot.json
@@ -66,7 +66,7 @@
       "responseEnvelope": ["sessions"],
       "responseEnvelopeSource": "TryGetSessionsPayload(JsonElement payload",
       "responseFields": [
-        "key", "isMain", "status", "model", "label", "channel", "displayName",
+        "key", "isMain", "status", "hasActiveRun", "model", "label", "channel", "displayName",
         "derivedTitle", "modelProvider", "provider", "subject", "groupChannel", "room",
         "space", "chatType", "execNode", "parentSessionKey", "spawnDepth", "origin",
         "worktree", "classification", "agentId", "accountId", "peerKind", "isBackground", "sessionId", "thinkingLevel", "verboseLevel",

--- a/tests/OpenClaw.Shared.Tests/SessionRunStateTests.cs
+++ b/tests/OpenClaw.Shared.Tests/SessionRunStateTests.cs
@@ -9,12 +9,12 @@ public sealed class SessionRunStateTests
     [InlineData("running", null, true)]
     [InlineData("running", false, false)]
     [InlineData("running", true, true)]
-    [InlineData("done", true, false)]
-    [InlineData("failed", true, false)]
-    [InlineData("killed", true, false)]
-    [InlineData("timeout", true, false)]
+    [InlineData("done", true, true)]
+    [InlineData("failed", true, true)]
+    [InlineData("killed", true, true)]
+    [InlineData("timeout", true, true)]
     [InlineData("unknown", true, true)]
-    public void IsWorking_UsesTerminalOutcomeBeforeGatewayLiveness(
+    public void IsWorking_PrefersGatewayCurrentRunLiveness(
         string status,
         bool? hasActiveRun,
         bool expected)

--- a/tests/OpenClaw.Shared.Tests/SessionRunStateTests.cs
+++ b/tests/OpenClaw.Shared.Tests/SessionRunStateTests.cs
@@ -1,0 +1,61 @@
+using OpenClaw.Shared;
+using OpenClaw.Shared.Sessions;
+
+namespace OpenClaw.Shared.Tests;
+
+public sealed class SessionRunStateTests
+{
+    [Theory]
+    [InlineData("running", null, true)]
+    [InlineData("running", false, false)]
+    [InlineData("running", true, true)]
+    [InlineData("done", true, false)]
+    [InlineData("failed", true, false)]
+    [InlineData("killed", true, false)]
+    [InlineData("timeout", true, false)]
+    [InlineData("unknown", true, true)]
+    public void IsWorking_UsesTerminalOutcomeBeforeGatewayLiveness(
+        string status,
+        bool? hasActiveRun,
+        bool expected)
+    {
+        var session = new SessionInfo { Status = status, HasActiveRun = hasActiveRun };
+
+        Assert.Equal(expected, SessionRunState.IsWorking(session));
+    }
+
+    [Theory]
+    [InlineData("running", true, SessionDisplayState.Working)]
+    [InlineData("running", false, SessionDisplayState.Ready)]
+    [InlineData("done", false, SessionDisplayState.Ready)]
+    [InlineData("killed", false, SessionDisplayState.Ready)]
+    [InlineData("failed", false, SessionDisplayState.NeedsAttention)]
+    [InlineData("timeout", false, SessionDisplayState.NeedsAttention)]
+    public void GetDisplayState_UsesOnlyThreeUserFacingStates(
+        string status,
+        bool hasActiveRun,
+        SessionDisplayState expected)
+    {
+        var session = new SessionInfo { Status = status, HasActiveRun = hasActiveRun };
+
+        Assert.Equal(expected, SessionRunState.GetDisplayState(session));
+    }
+
+    [Fact]
+    public void IsCompleted_RequiresACompletedRunThatIsNotWorking()
+    {
+        Assert.True(SessionRunState.IsCompleted(new SessionInfo { Status = "done", HasActiveRun = false }));
+        Assert.False(SessionRunState.IsCompleted(new SessionInfo { Status = "failed", HasActiveRun = false }));
+        Assert.False(SessionRunState.IsCompleted(new SessionInfo { Status = "running", HasActiveRun = false }));
+        Assert.False(SessionRunState.IsCompleted(new SessionInfo { Status = "done", AbortedLastRun = true }));
+    }
+
+    [Fact]
+    public void HasStoppedLastRun_SeparatesRunContextFromTheReadyState()
+    {
+        var session = new SessionInfo { Status = "killed", HasActiveRun = false };
+
+        Assert.Equal(SessionDisplayState.Ready, SessionRunState.GetDisplayState(session));
+        Assert.True(SessionRunState.HasStoppedLastRun(session));
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/ConnectionRegressionSourceTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ConnectionRegressionSourceTests.cs
@@ -80,6 +80,14 @@ public sealed class ConnectionRegressionSourceTests
     }
 
     [Fact]
+    public void SessionCount_UsesCanonicalRunLiveness()
+    {
+        var pageSource = ReadSource("src", "OpenClaw.Tray.WinUI", "Pages", "ConnectionPage.xaml.cs");
+
+        Assert.Contains("sessions?.Count(SessionRunState.IsWorking)", pageSource);
+    }
+
+    [Fact]
     public void PairingRequiredDisconnectGuard_RunsInsideTransitionSemaphore()
     {
         var managerSource = ReadSource("src", "OpenClaw.Connection", "GatewayConnectionManager.cs");

--- a/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
@@ -1716,7 +1716,14 @@ public class OpenClawChatDataProviderTests
     {
         var sessions = new[]
         {
-            new SessionInfo { Key = "done", DisplayName = "Done", Status = "done" },
+            new SessionInfo
+            {
+                Key = "done",
+                DisplayName = "Done",
+                Status = "done",
+                HasActiveRun = false,
+                CurrentActivity = "stale run detail",
+            },
             new SessionInfo { Key = "killed", DisplayName = "Killed", Status = "killed" },
             new SessionInfo
             {
@@ -1743,6 +1750,9 @@ public class OpenClawChatDataProviderTests
         Assert.Equal(
             ChatThreadStatus.Created,
             Assert.Single(snapshot.Threads, thread => thread.Id == "unknown").Status);
+        Assert.Equal(
+            ChatActivity.Idle,
+            Assert.Single(snapshot.Threads, thread => thread.Id == "done").Activity);
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
@@ -1712,7 +1712,7 @@ public class OpenClawChatDataProviderTests
     }
 
     [Fact]
-    public async Task LoadAsync_MapsOnlyEndedSessionsToEndedThreads()
+    public async Task LoadAsync_MapsRunLivenessWithoutEndingReusableThreads()
     {
         var sessions = new[]
         {
@@ -1732,16 +1732,16 @@ public class OpenClawChatDataProviderTests
         var snapshot = await provider.LoadAsync();
 
         Assert.Equal(
-            ChatThreadStatus.Ended,
+            ChatThreadStatus.Created,
             Assert.Single(snapshot.Threads, thread => thread.Id == "done").Status);
         Assert.Equal(
-            ChatThreadStatus.Ended,
+            ChatThreadStatus.Created,
             Assert.Single(snapshot.Threads, thread => thread.Id == "killed").Status);
         Assert.Equal(
-            ChatThreadStatus.Running,
+            ChatThreadStatus.Created,
             Assert.Single(snapshot.Threads, thread => thread.Id == "aborted").Status);
         Assert.Equal(
-            ChatThreadStatus.Running,
+            ChatThreadStatus.Created,
             Assert.Single(snapshot.Threads, thread => thread.Id == "unknown").Status);
     }
 

--- a/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
@@ -1787,10 +1787,10 @@ public class OpenClawChatDataProviderTests
     }
 
     [Fact]
-    public async Task LoadAsync_EndedAndBackgroundFiltering_ComposesCorrectly()
+    public async Task LoadAsync_RunLivenessAndBackgroundFiltering_ComposesCorrectly()
     {
-        // Verifies the full filtering pipeline: ended sessions get Status=Ended,
-        // background sessions get IsBackground=true, and both properties coexist.
+        // Verifies the full filtering pipeline: only live runs get Status=Running,
+        // ready sessions stay selectable, and background sessions get IsBackground=true.
         var sessions = new[]
         {
             new SessionInfo { Key = "agent:main:main", IsMain = true, Status = "active" },
@@ -1806,11 +1806,11 @@ public class OpenClawChatDataProviderTests
         Assert.False(main.IsBackground);
 
         var cron = Assert.Single(snapshot.Threads, t => t.Id == "agent:main:cron:daily");
-        Assert.Equal(ChatThreadStatus.Ended, cron.Status);
+        Assert.Equal(ChatThreadStatus.Created, cron.Status);
         Assert.True(cron.IsBackground);
 
         var task = Assert.Single(snapshot.Threads, t => t.Id == "agent:main:explicit:task");
-        Assert.Equal(ChatThreadStatus.Ended, task.Status);
+        Assert.Equal(ChatThreadStatus.Created, task.Status);
         Assert.False(task.IsBackground);
 
         var hook = Assert.Single(snapshot.Threads, t => t.Id == "agent:main:hook:pr-check");

--- a/tests/OpenClaw.Tray.Tests/Services/TrayDashboardSummaryBuilderTests.cs
+++ b/tests/OpenClaw.Tray.Tests/Services/TrayDashboardSummaryBuilderTests.cs
@@ -333,17 +333,17 @@ public sealed class TrayDashboardSummaryBuilderTests
     }
 
     [Fact]
-    public void MetricsLine_ShowsSessionsAndActiveCount()
+    public void MetricsLine_ShowsSessionsAndWorkingCount()
     {
         var sessions = new[]
         {
-            new SessionInfo { Key = "a", Status = "active" },
-            new SessionInfo { Key = "b", Status = "idle" },
+            new SessionInfo { Key = "a", Status = "running", HasActiveRun = true },
+            new SessionInfo { Key = "b", Status = "running", HasActiveRun = false },
         };
 
         var summary = Build(Base(sessions: sessions));
 
-        Assert.Contains("2 sessions (1 active)", summary.MetricsLine);
+        Assert.Contains("2 sessions (1 working)", summary.MetricsLine);
     }
 
     [Fact]
@@ -546,7 +546,7 @@ public sealed class TrayDashboardSummaryBuilderTests
     }
 
     [Fact]
-    public void ActiveSession_PrefersActiveSubOverIdleMain()
+    public void ActiveSession_PrefersWorkingSubOverReadyMain()
     {
         var sessions = new[]
         {
@@ -557,11 +557,11 @@ public sealed class TrayDashboardSummaryBuilderTests
         var summary = Build(Base(sessions: sessions));
 
         Assert.Equal("Worker", summary.ActiveSession!.Title);
-        Assert.Equal("Active", summary.ActiveSession.Label);
+        Assert.Equal("Working", summary.ActiveSession.Label);
     }
 
     [Fact]
-    public void ActiveSession_PrefersActiveMainOverActiveSub()
+    public void ActiveSession_PrefersWorkingMainOverWorkingSub()
     {
         var sessions = new[]
         {
@@ -580,11 +580,11 @@ public sealed class TrayDashboardSummaryBuilderTests
         var summary = Build(Base(sessions: sessions));
 
         Assert.Equal("Main", summary.ActiveSession!.Title);
-        Assert.Equal("Active", summary.ActiveSession.Label);
+        Assert.Equal("Working", summary.ActiveSession.Label);
     }
 
     [Fact]
-    public void ActiveSession_LabelIsMainForIdleMain()
+    public void ActiveSession_LabelIsReadyForIdleMain()
     {
         var sessions = new[]
         {
@@ -593,7 +593,7 @@ public sealed class TrayDashboardSummaryBuilderTests
 
         var summary = Build(Base(sessions: sessions));
 
-        Assert.Equal("Main", summary.ActiveSession!.Label);
+        Assert.Equal("Ready", summary.ActiveSession!.Label);
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/Services/TrayDashboardSummaryBuilderTests.cs
+++ b/tests/OpenClaw.Tray.Tests/Services/TrayDashboardSummaryBuilderTests.cs
@@ -749,10 +749,10 @@ public sealed class TrayDashboardSummaryBuilderTests
     }
 
     [Fact]
-    public void SelectActiveSession_FallsBackToEndedWhenAllEnded()
+    public void SelectActiveSession_PrefersNeedsAttentionOverSuccessfulCompletion()
     {
-        // When every session is ended, still return the most recent one
-        // rather than null (the tray should show something if sessions exist).
+        // Failed work remains actionable, so it should win over a newer successful
+        // completion when there is no working or main session.
         var failed = new SessionInfo
         {
             Key = "agent:main:explicit:task-a",
@@ -767,7 +767,7 @@ public sealed class TrayDashboardSummaryBuilderTests
         };
 
         var result = TrayDashboardSummaryBuilder.SelectActiveSession([failed, done]);
-        Assert.Same(done, result);
+        Assert.Same(failed, result);
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/SessionTitleFormatterTests.cs
+++ b/tests/OpenClaw.Tray.Tests/SessionTitleFormatterTests.cs
@@ -217,7 +217,7 @@ public sealed class SessionTitleFormatterTests
             "Pages",
             "SessionsPage.xaml.cs"));
 
-        var formatIndex = source.IndexOf("SessionTitleFormatter.FormatUnique(activeSessions)", StringComparison.Ordinal);
+        var formatIndex = source.IndexOf("SessionTitleFormatter.FormatUnique(visibleSessions)", StringComparison.Ordinal);
         var channelFilterIndex = source.IndexOf("if (_activeChannel != \"all\")", StringComparison.Ordinal);
 
         Assert.True(formatIndex >= 0);
@@ -267,5 +267,28 @@ public sealed class SessionTitleFormatterTests
 
         Assert.False(thread.IsVisibleInSessionPicker("agent:main:main"));
         Assert.True(thread.IsVisibleInSessionPicker(thread.Id));
+    }
+
+    [Fact]
+    public void SessionsPage_UsesCanonicalCompactSessionPresentation()
+    {
+        var source = File.ReadAllText(Path.Combine(
+            TestRepositoryPaths.GetRepositoryRoot(),
+            "src",
+            "OpenClaw.Tray.WinUI",
+            "Pages",
+            "SessionsPage.xaml.cs"));
+
+        Assert.Contains("SessionRunState.GetDisplaySortOrder(item.Session)", source, StringComparison.Ordinal);
+        Assert.Contains("StatusText = ResolveStatusText(s)", source, StringComparison.Ordinal);
+        Assert.Contains("SessionRunState.HasStoppedLastRun(s)", source, StringComparison.Ordinal);
+
+        var xaml = File.ReadAllText(Path.Combine(
+            TestRepositoryPaths.GetRepositoryRoot(),
+            "src",
+            "OpenClaw.Tray.WinUI",
+            "Pages",
+            "SessionsPage.xaml"));
+        Assert.Contains("Text=\"{Binding StatusText}\"", xaml, StringComparison.Ordinal);
     }
 }

--- a/tests/OpenClaw.Tray.Tests/SessionVisibilityFilterTests.cs
+++ b/tests/OpenClaw.Tray.Tests/SessionVisibilityFilterTests.cs
@@ -10,30 +10,30 @@ public class SessionVisibilityFilterTests
     [InlineData("done")]
     [InlineData("DONE")]
     [InlineData(" completed ")]
-    [InlineData("failed")]
-    [InlineData("killed")]
-    [InlineData("timeout")]
-    public void IsEnded_RecognizesTerminalStatuses(string status)
+    public void IsCompleted_RecognizesSuccessfulCompletedStatuses(string status)
     {
         var session = new SessionInfo { Status = status };
 
-        Assert.True(SessionVisibilityFilter.IsEnded(session));
-        Assert.False(SessionVisibilityFilter.IsVisibleWhenEndedHidden(session));
+        Assert.True(SessionVisibilityFilter.IsCompleted(session));
+        Assert.False(SessionVisibilityFilter.IsVisibleWhenCompletedHidden(session));
     }
 
     [Theory]
+    [InlineData("failed")]
+    [InlineData("killed")]
+    [InlineData("timeout")]
     [InlineData("running")]
     [InlineData("unknown")]
-    public void IsEnded_LeavesActiveAndUnknownStatusesVisible(string status)
+    public void IsCompleted_LeavesWorkingAndNonSuccessOutcomesVisible(string status)
     {
         var session = new SessionInfo { Status = status };
 
-        Assert.False(SessionVisibilityFilter.IsEnded(session));
-        Assert.True(SessionVisibilityFilter.IsVisibleWhenEndedHidden(session));
+        Assert.False(SessionVisibilityFilter.IsCompleted(session));
+        Assert.True(SessionVisibilityFilter.IsVisibleWhenCompletedHidden(session));
     }
 
     [Fact]
-    public void IsEnded_KeepsAbortedDoneSessionsVisible()
+    public void IsCompleted_LeavesAbortedDoneSessionsVisibleAsStoppedWork()
     {
         var session = new SessionInfo
         {
@@ -41,12 +41,12 @@ public class SessionVisibilityFilterTests
             AbortedLastRun = true,
         };
 
-        Assert.False(SessionVisibilityFilter.IsEnded(session));
-        Assert.True(SessionVisibilityFilter.IsVisibleWhenEndedHidden(session));
+        Assert.False(SessionVisibilityFilter.IsCompleted(session));
+        Assert.True(SessionVisibilityFilter.IsVisibleWhenCompletedHidden(session));
     }
 
     [Fact]
-    public void VisibleSessions_HidesEndedSessionsByDefault()
+    public void VisibleSessions_HidesOnlySuccessfulCompletedSessionsByDefault()
     {
         var sessions = new[]
         {
@@ -58,15 +58,15 @@ public class SessionVisibilityFilterTests
             new SessionInfo { Key = "running", Status = "running" },
         };
 
-        var visible = SessionVisibilityFilter.VisibleSessions(sessions, showEnded: false)
+        var visible = SessionVisibilityFilter.VisibleSessions(sessions, showCompleted: false)
             .Select(s => s.Key)
             .ToArray();
 
-        Assert.Equal(new[] { "aborted-done", "running" }, visible);
+        Assert.Equal(new[] { "failed", "killed", "timeout", "aborted-done", "running" }, visible);
     }
 
     [Fact]
-    public void VisibleSessions_ShowEndedPreservesAllSessions()
+    public void VisibleSessions_ShowCompletedPreservesAllSessions()
     {
         var sessions = new[]
         {
@@ -74,7 +74,7 @@ public class SessionVisibilityFilterTests
             new SessionInfo { Key = "failed", Status = "failed" },
         };
 
-        var visible = SessionVisibilityFilter.VisibleSessions(sessions, showEnded: true)
+        var visible = SessionVisibilityFilter.VisibleSessions(sessions, showCompleted: true)
             .Select(s => s.Key)
             .ToArray();
 
@@ -82,22 +82,21 @@ public class SessionVisibilityFilterTests
     }
 
     [Theory]
-    [InlineData("done", false, ChatThreadStatus.Ended)]
-    [InlineData("completed", false, ChatThreadStatus.Ended)]
-    [InlineData("failed", false, ChatThreadStatus.Ended)]
-    [InlineData("killed", false, ChatThreadStatus.Ended)]
-    [InlineData("timeout", false, ChatThreadStatus.Ended)]
-    [InlineData("done", true, ChatThreadStatus.Running)]
-    [InlineData("unknown", false, ChatThreadStatus.Running)]
-    public void ToChatThreadStatus_ReusesEndedSemantics(
+    [InlineData("running", true, ChatThreadStatus.Running)]
+    [InlineData("running", false, ChatThreadStatus.Created)]
+    [InlineData("done", false, ChatThreadStatus.Created)]
+    [InlineData("failed", false, ChatThreadStatus.Created)]
+    [InlineData("killed", false, ChatThreadStatus.Created)]
+    [InlineData("timeout", false, ChatThreadStatus.Created)]
+    public void ToChatThreadStatus_UsesCanonicalRunLiveness(
         string status,
-        bool abortedLastRun,
+        bool hasActiveRun,
         ChatThreadStatus expected)
     {
         var session = new SessionInfo
         {
             Status = status,
-            AbortedLastRun = abortedLastRun,
+            HasActiveRun = hasActiveRun,
         };
 
         Assert.Equal(expected, SessionVisibilityFilter.ToChatThreadStatus(session));


### PR DESCRIPTION
## Summary

- Add a shared `SessionRunState` adapter that combines Gateway run outcome with `hasActiveRun`, with current Gateway liveness taking precedence when present.
- Present only three primary statuses: **Working**, **Ready**, and **Needs attention**. A stopped run is secondary context, not a fourth badge.
- Hide only successful completed sessions by default; keep failed, timed-out, stopped, and reusable sessions visible and available in the chat picker.
- Use the same rule in Sessions, Connection, tray dashboard, tray menu, and session tests.
- Rebase onto current `main`, retain sparse Gateway run fields, and update the accessibility fixture for the flattened classification contract.

## Validation

Native Windows validation on a clean Parallels Windows 11 ARM64 VM (.NET SDK 10.0.302; Windows SDK 10.0.26100; WebView2 150.0.4078.65), at `782a112`:

- Passed: `./build.ps1` - Shared, CLI, WinNode CLI, SetupEngine, and WinUI.
- Passed: `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` - 3,400 passed, 32 expected integration skips.
- Passed: `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` - 2,054 passed, 0 skipped.
- Passed: `git diff --check origin/main...HEAD` and XML parsing for all five localized resource files.
- Passed: `./.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` - no accepted/actionable findings.

## Real behavior proof

Current-head tests exercise Gateway `hasActiveRun` parsing, terminal-outcome precedence, sparse-update retention, the three-state mapping, session-list visibility/sorting, dashboard/menu counters, and chat-thread liveness. In particular, a terminal historical outcome does not override an explicit active current run, while completed runs otherwise leave chat sessions ready and selectable rather than assigning the legacy `Ended` status.

Not verified / blocked: an interactive WinUI screenshot of the changed session list was not captured through the Parallels automation surface. The native WinUI assembly and focused tests passed; visible UI capture remains the only missing proof item.

## User-facing model

| Display state | Meaning |
| --- | --- |
| Working | A run is currently active |
| Ready | The session can receive the next turn |
| Needs attention | The last run failed or timed out |
