### PR TITLE
Keep Windows device metadata stable across reconnects

### DIFF
--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -18,8 +18,6 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
     private const string OperatorClientDisplayName = "OpenClaw Windows Tray";
     private const string OperatorClientMode = "cli";
     private const string OperatorRole = "operator";
-    private const string OperatorPlatform = "windows";
-    private const string OperatorDeviceFamily = "desktop";
     private static readonly Regex s_pairingRequestIdRegex = new("^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$", RegexOptions.Compiled);
     private static readonly string[] s_operatorScopes =
     [
@@ -1444,11 +1442,11 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
         _logger.Info($"  nonce={(!string.IsNullOrEmpty(connectNonce) ? connectNonce[..Math.Min(12, connectNonce.Length)] + "..." : "(empty)")}");
         _logger.Info($"  signedAt={signedAt}");
         _logger.Info($"  sigToken(len)={signatureToken.Length}, preview=[REDACTED]");
-        _logger.Info($"  signature format={(_useV2Signature ? "v2" : "v3")}, platform={OperatorPlatform}, family={OperatorDeviceFamily}");
+        _logger.Info($"  signature format={(_useV2Signature ? "v2" : "v3")}, platform={WindowsClientMetadata.Platform}, family={WindowsClientMetadata.DeviceFamily}");
 
         var signedPayload = _useV2Signature
             ? _deviceIdentity.BuildConnectPayloadV2(connectNonce, signedAt, OperatorClientId, OperatorClientMode, role, requestedScopes, signatureToken)
-            : _deviceIdentity.BuildConnectPayloadV3(connectNonce, signedAt, OperatorClientId, OperatorClientMode, role, requestedScopes, signatureToken, OperatorPlatform, OperatorDeviceFamily);
+            : _deviceIdentity.BuildConnectPayloadV3(connectNonce, signedAt, OperatorClientId, OperatorClientMode, role, requestedScopes, signatureToken, WindowsClientMetadata.Platform, WindowsClientMetadata.DeviceFamily);
         _logger.Info($"[HANDSHAKE] signed: {TokenSanitizer.Sanitize(signedPayload)}");
 
         // Also log what auth field we're sending
@@ -1464,7 +1462,7 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
             : _deviceIdentity.SignConnectPayloadV3(
                 connectNonce, signedAt, OperatorClientId, OperatorClientMode,
                 role, requestedScopes, signatureToken,
-                OperatorPlatform, OperatorDeviceFamily);
+                WindowsClientMetadata.Platform, WindowsClientMetadata.DeviceFamily);
 
         var appVersion = AppVersionInfo.Version;
 
@@ -1482,7 +1480,8 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
                 {
                     id = OperatorClientId,  // Native client ID
                     version = appVersion,
-                    platform = OperatorPlatform,
+                    platform = WindowsClientMetadata.Platform,
+                    deviceFamily = WindowsClientMetadata.DeviceFamily,
                     mode = OperatorClientMode,
                     displayName = OperatorClientDisplayName
                 },

--- a/src/OpenClaw.Shared/WindowsClientMetadata.cs
+++ b/src/OpenClaw.Shared/WindowsClientMetadata.cs
@@ -1,0 +1,7 @@
+namespace OpenClaw.Shared;
+
+internal static class WindowsClientMetadata
+{
+    public const string Platform = "windows";
+    public const string DeviceFamily = "Windows";
+}

--- a/src/OpenClaw.Shared/WindowsNodeClient.cs
+++ b/src/OpenClaw.Shared/WindowsNodeClient.cs
@@ -24,9 +24,6 @@ public class WindowsNodeClient : WebSocketClientBase
     private FrozenDictionary<string, CommandDispatchEntry> _commandMap =
         FrozenDictionary<string, CommandDispatchEntry>.Empty;
     private readonly NodeRegistration _registration;
-    private const string WindowsPlatform = "windows";
-    private const string WindowsDeviceFamily = "Windows";
-    
     // Connection state
     private bool _isConnected;
     private string? _nodeId;
@@ -139,8 +136,8 @@ public class WindowsNodeClient : WebSocketClientBase
         {
             Id = _deviceIdentity.DeviceId,
             Version = AppVersionInfo.Version,
-            Platform = WindowsPlatform,
-            DeviceFamily = WindowsDeviceFamily,
+            Platform = WindowsClientMetadata.Platform,
+            DeviceFamily = WindowsClientMetadata.DeviceFamily,
             DisplayName = $"Windows Node ({Environment.MachineName})"
         };
     }

--- a/tests/OpenClaw.Shared.Tests/WindowsClientMetadataTests.cs
+++ b/tests/OpenClaw.Shared.Tests/WindowsClientMetadataTests.cs
@@ -1,0 +1,240 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Text.Json;
+using OpenClaw.Shared;
+using Xunit;
+
+namespace OpenClaw.Shared.Tests;
+
+public sealed class WindowsClientMetadataTests
+{
+    [Fact]
+    public async Task OperatorConnect_SerializesCanonicalMetadataAndSignsTheSameV3Metadata()
+    {
+        var dataPath = CreateTempDirectory();
+        try
+        {
+            using var client = new CapturingGatewayClient(dataPath, "shared-token");
+
+            using var message = JsonDocument.Parse(await client.BuildConnectMessageAsync("nonce-v3"));
+            var parameters = message.RootElement.GetProperty("params");
+            var clientMetadata = parameters.GetProperty("client");
+
+            AssertCanonicalMetadata(clientMetadata);
+            Assert.Equal(
+                BuildExpectedSignature(client, parameters, useV2: false),
+                parameters.GetProperty("device").GetProperty("signature").GetString());
+        }
+        finally
+        {
+            Directory.Delete(dataPath, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task OperatorAndNodeConnect_SharedIdentityEmitIdenticalCanonicalMetadata()
+    {
+        var dataPath = CreateTempDirectory();
+        try
+        {
+            using var operatorClient = new CapturingGatewayClient(dataPath, "shared-token");
+            using var nodeClient = new WindowsNodeClient("ws://localhost:18789", "shared-token", dataPath);
+
+            using var operatorMessage = JsonDocument.Parse(
+                await operatorClient.BuildConnectMessageAsync("operator-nonce"));
+            using var nodeMessage = JsonDocument.Parse(BuildNodeConnectMessage(nodeClient, "node-nonce"));
+            var operatorParameters = operatorMessage.RootElement.GetProperty("params");
+            var nodeParameters = nodeMessage.RootElement.GetProperty("params");
+
+            Assert.Equal(
+                operatorParameters.GetProperty("device").GetProperty("id").GetString(),
+                nodeParameters.GetProperty("device").GetProperty("id").GetString());
+            Assert.Equal(
+                operatorParameters.GetProperty("client").GetProperty("platform").GetString(),
+                nodeParameters.GetProperty("client").GetProperty("platform").GetString());
+            Assert.Equal(
+                operatorParameters.GetProperty("client").GetProperty("deviceFamily").GetString(),
+                nodeParameters.GetProperty("client").GetProperty("deviceFamily").GetString());
+            AssertCanonicalMetadata(operatorParameters.GetProperty("client"));
+            AssertCanonicalMetadata(nodeParameters.GetProperty("client"));
+        }
+        finally
+        {
+            Directory.Delete(dataPath, recursive: true);
+        }
+    }
+
+    [IntegrationFact]
+    public async Task OperatorReconnect_AfterRestartPreservesIdentityTokenSourceAndMetadata()
+    {
+        var dataPath = CreateTempDirectory();
+        try
+        {
+            var identity = new DeviceIdentity(dataPath);
+            identity.Initialize();
+            identity.StoreDeviceTokenWithScopes("operator-device-token", ["operator.read"]);
+
+            using var firstClient = new CapturingGatewayClient(dataPath, "shared-token");
+            using var firstMessage = JsonDocument.Parse(
+                await firstClient.BuildConnectMessageAsync("before-restart"));
+
+            using var restartedClient = new CapturingGatewayClient(dataPath, "different-shared-token");
+            using var restartedMessage = JsonDocument.Parse(
+                await restartedClient.BuildConnectMessageAsync("after-restart"));
+
+            var before = firstMessage.RootElement.GetProperty("params");
+            var after = restartedMessage.RootElement.GetProperty("params");
+
+            Assert.Equal(
+                before.GetProperty("device").GetProperty("id").GetString(),
+                after.GetProperty("device").GetProperty("id").GetString());
+            Assert.Equal(
+                "operator-device-token",
+                before.GetProperty("auth").GetProperty("deviceToken").GetString());
+            Assert.Equal(
+                "operator-device-token",
+                after.GetProperty("auth").GetProperty("deviceToken").GetString());
+            Assert.False(after.GetProperty("auth").TryGetProperty("token", out _));
+            Assert.False(after.GetProperty("auth").TryGetProperty("bootstrapToken", out _));
+            AssertCanonicalMetadata(before.GetProperty("client"));
+            AssertCanonicalMetadata(after.GetProperty("client"));
+        }
+        finally
+        {
+            Directory.Delete(dataPath, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task OperatorConnect_V2CompatibilityKeepsProtocolAndCanonicalSerializedMetadata()
+    {
+        var dataPath = CreateTempDirectory();
+        try
+        {
+            using var client = new CapturingGatewayClient(
+                dataPath,
+                "bootstrap-token",
+                tokenIsBootstrapToken: true);
+
+            using var message = JsonDocument.Parse(await client.BuildConnectMessageAsync("nonce-v2"));
+            var parameters = message.RootElement.GetProperty("params");
+
+            Assert.True(client.UseV2Signature);
+            Assert.Equal(3, parameters.GetProperty("minProtocol").GetInt32());
+            Assert.Equal(4, parameters.GetProperty("maxProtocol").GetInt32());
+            AssertCanonicalMetadata(parameters.GetProperty("client"));
+            Assert.Equal(
+                BuildExpectedSignature(client, parameters, useV2: true),
+                parameters.GetProperty("device").GetProperty("signature").GetString());
+        }
+        finally
+        {
+            Directory.Delete(dataPath, recursive: true);
+        }
+    }
+
+    private static string BuildExpectedSignature(
+        CapturingGatewayClient client,
+        JsonElement parameters,
+        bool useV2)
+    {
+        var clientMetadata = parameters.GetProperty("client");
+        var device = parameters.GetProperty("device");
+        var auth = parameters.GetProperty("auth");
+        var scopes = parameters.GetProperty("scopes")
+            .EnumerateArray()
+            .Select(scope => scope.GetString()!)
+            .ToArray();
+        var token = auth.EnumerateObject().Single().Value.GetString()!;
+        var nonce = device.GetProperty("nonce").GetString()!;
+        var signedAt = device.GetProperty("signedAt").GetInt64();
+        var clientId = clientMetadata.GetProperty("id").GetString()!;
+        var clientMode = clientMetadata.GetProperty("mode").GetString()!;
+        var role = parameters.GetProperty("role").GetString()!;
+        var identity = client.DeviceIdentity;
+
+        return useV2
+            ? identity.SignConnectPayloadV2(
+                nonce,
+                signedAt,
+                clientId,
+                clientMode,
+                role,
+                scopes,
+                token)
+            : identity.SignConnectPayloadV3(
+                nonce,
+                signedAt,
+                clientId,
+                clientMode,
+                role,
+                scopes,
+                token,
+                clientMetadata.GetProperty("platform").GetString()!,
+                clientMetadata.GetProperty("deviceFamily").GetString()!);
+    }
+
+    private static string BuildNodeConnectMessage(WindowsNodeClient client, string nonce)
+    {
+        var method = typeof(WindowsNodeClient).GetMethod(
+            "BuildNodeConnectMessage",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(method);
+        return (string)method!.Invoke(client, [nonce, 0L])!;
+    }
+
+    private static void AssertCanonicalMetadata(JsonElement clientMetadata)
+    {
+        Assert.Equal(WindowsClientMetadata.Platform, clientMetadata.GetProperty("platform").GetString());
+        Assert.Equal(WindowsClientMetadata.DeviceFamily, clientMetadata.GetProperty("deviceFamily").GetString());
+    }
+
+    private static string CreateTempDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"openclaw-client-metadata-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private sealed class CapturingGatewayClient(
+        string dataPath,
+        string token,
+        bool tokenIsBootstrapToken = false)
+        : OpenClawGatewayClient(
+            "ws://localhost:18789",
+            token,
+            logger: null,
+            tokenIsBootstrapToken,
+            identityPath: dataPath)
+    {
+        private readonly ConcurrentQueue<string> _messages = new();
+
+        public DeviceIdentity DeviceIdentity
+        {
+            get
+            {
+                var identityField = typeof(OpenClawGatewayClient).GetField(
+                    "_deviceIdentity",
+                    BindingFlags.NonPublic | BindingFlags.Instance);
+                Assert.NotNull(identityField);
+                return (DeviceIdentity)identityField!.GetValue(this)!;
+            }
+        }
+
+        public async Task<string> BuildConnectMessageAsync(string nonce)
+        {
+            var method = typeof(OpenClawGatewayClient).GetMethod(
+                "SendConnectMessageAsync",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            await (Task)method!.Invoke(this, [nonce])!;
+            return Assert.Single(_messages);
+        }
+
+        protected override Task SendRawAsync(string message)
+        {
+            _messages.Enqueue(message);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/OpenClaw.Shared.Tests/WindowsClientMetadataTests.cs
+++ b/tests/OpenClaw.Shared.Tests/WindowsClientMetadataTests.cs
@@ -64,7 +64,7 @@ public sealed class WindowsClientMetadataTests
         }
     }
 
-    [IntegrationFact]
+    [Fact]
     public async Task OperatorReconnect_AfterRestartPreservesIdentityTokenSourceAndMetadata()
     {
         var dataPath = CreateTempDirectory();
@@ -185,8 +185,10 @@ public sealed class WindowsClientMetadataTests
 
     private static void AssertCanonicalMetadata(JsonElement clientMetadata)
     {
-        Assert.Equal(WindowsClientMetadata.Platform, clientMetadata.GetProperty("platform").GetString());
-        Assert.Equal(WindowsClientMetadata.DeviceFamily, clientMetadata.GetProperty("deviceFamily").GetString());
+        Assert.Equal("windows", WindowsClientMetadata.Platform);
+        Assert.Equal("Windows", WindowsClientMetadata.DeviceFamily);
+        Assert.Equal("windows", clientMetadata.GetProperty("platform").GetString());
+        Assert.Equal("Windows", clientMetadata.GetProperty("deviceFamily").GetString());
     }
 
     private static string CreateTempDirectory()


### PR DESCRIPTION
Related to #1031

## Root cause

The Windows operator and node clients share one persisted `DeviceIdentity`, but their connect metadata had drifted. The node pinned `platform=windows` and `deviceFamily=Windows`; the operator signed with a different family and omitted `deviceFamily` from `connect.params.client`. After a Gateway or Companion restart, the same device identity and token could therefore reconnect with missing or different family metadata, correctly triggering a `metadata-upgrade` repair pairing.

## Change

- **Old owner:** duplicate metadata literals in `OpenClawGatewayClient` and `WindowsNodeClient`.
- **New owner:** authoritative shared `WindowsClientMetadata` with `platform=windows` and `deviceFamily=Windows`.
- **Preserved invariant:** operator v3 signing now exactly matches serialized client metadata, node registration consumes the same values, v2 signing stays compatible, and core metadata pinning remains strict.

## Scope

Corrupt or unreadable identity-loader hardening is intentionally left to a separate PR. This change makes no OpenClaw core production changes and performs no stale pairing cleanup.

## Validation

- `.\build.ps1`: passed, all 5 projects.
- Shared tests: 3,248 passed, 0 failed, 32 skipped.
- Tray tests: 1,948 passed, 0 failed.
- Connection tests: 446 passed, 0 failed.
- Focused integration-enabled metadata tests: 4 passed, 0 failed.
- `git diff --check`: passed.

## Real behavior proof

An isolated synthetic restart test uses a temporary data directory and real `DeviceIdentity` persistence:

- A newly constructed operator client preserves the same `DeviceId`.
- It continues using the stored device-token source even when given a different shared fallback token.
- Operator and node clients sharing the identity emit identical `platform=windows` and `deviceFamily=Windows`.
- Recomputed v3 and v2 signatures exactly match the serialized connect payload fields.

Live Gateway restart proof is not included because the existing E2E harness requires configured WSL Gateway credentials and real Gateway state.

## Review

- Built-in code review: clean.
- Rubber-duck review: clean; the isolated restart test was accepted as valid credential-free integration-style persistence proof.
- Structured autoreview: blocked by Codex CLI authentication with HTTP 401, so no structured result was available.

## Compatibility

Identities previously pinned to `desktop` or a missing family may require one legitimate metadata-upgrade approval when first moving to canonical `Windows`. Subsequent reconnects retain the same metadata.
