### PR TITLE
fix(connection): recover saved SSH tunnels after disconnect

### DIFF
--- a/src/OpenClaw.Connection/GatewayConnectionManager.cs
+++ b/src/OpenClaw.Connection/GatewayConnectionManager.cs
@@ -884,7 +884,8 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
         try
         {
             var activeGateway = _registry.GetActive();
-            if (activeGateway?.SshTunnel != tunnelExit.Tunnel ||
+            if (tunnelExit.Owner != SshTunnelOwner.GatewayConnectionManager ||
+                activeGateway?.SshTunnel != tunnelExit.Tunnel ||
                 !IsAutomaticReconnectAllowed(activeGateway.Id) ||
                 _tunnelManager?.IsRestartPending(tunnelExit) != true)
             {
@@ -907,6 +908,8 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
 
             await ConnectCoreAsync(activeGateway.Id, "reconnect");
             return _stateMachine.Current.OperatorState is not RoleConnectionState.Error
+                && _registry.GetById(activeGateway.Id) is not null
+                && _tunnelManager?.IsActive == true
                 && string.Equals(_registry.ActiveGatewayId, activeGateway.Id, StringComparison.Ordinal);
         }
         finally

--- a/src/OpenClaw.Connection/GatewayConnectionManager.cs
+++ b/src/OpenClaw.Connection/GatewayConnectionManager.cs
@@ -877,6 +877,44 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
         }
     }
 
+    public async Task<bool> RecoverSshTunnelAsync(SshTunnelExit tunnelExit)
+    {
+        ThrowIfDisposed();
+        await _transitionSemaphore.WaitAsync();
+        try
+        {
+            var activeGateway = _registry.GetActive();
+            if (activeGateway?.SshTunnel != tunnelExit.Tunnel ||
+                !IsAutomaticReconnectAllowed(activeGateway.Id) ||
+                _tunnelManager?.IsRestartPending(tunnelExit) != true)
+            {
+                return false;
+            }
+
+            // DisconnectCoreAsync retires the gateway clients but deliberately leaves the
+            // tunnel alone. Keep its generation token valid until ConnectCoreAsync replaces
+            // the failed process, while preventing a delayed callback from reviving an old gateway.
+            await DisconnectCoreAsync();
+
+            var currentGateway = _registry.GetActive();
+            if (currentGateway?.Id != activeGateway.Id ||
+                currentGateway.SshTunnel != tunnelExit.Tunnel ||
+                !IsAutomaticReconnectAllowed(activeGateway.Id) ||
+                _tunnelManager?.IsRestartPending(tunnelExit) != true)
+            {
+                return false;
+            }
+
+            await ConnectCoreAsync(activeGateway.Id, "reconnect");
+            return _stateMachine.Current.OperatorState is not RoleConnectionState.Error
+                && string.Equals(_registry.ActiveGatewayId, activeGateway.Id, StringComparison.Ordinal);
+        }
+        finally
+        {
+            _transitionSemaphore.Release();
+        }
+    }
+
     public void SetGatewayConnectionIntent(string gatewayId, bool shouldBeConnected)
     {
         if (string.IsNullOrWhiteSpace(gatewayId))

--- a/src/OpenClaw.Connection/IGatewayConnectionManager.cs
+++ b/src/OpenClaw.Connection/IGatewayConnectionManager.cs
@@ -25,6 +25,7 @@ public interface IGatewayConnectionManager : IDisposable, IAsyncDisposable
     Task DisconnectByUserAsync();
     Task ReconnectAsync();
     Task<bool> ReconnectIfCurrentAsync(string gatewayId, CancellationToken cancellationToken = default);
+    Task<bool> RecoverSshTunnelAsync(SshTunnelExit tunnelExit);
     Task SwitchGatewayAsync(string gatewayId);
     void SetGatewayConnectionIntent(string gatewayId, bool shouldBeConnected);
     bool IsAutomaticReconnectAllowed(string gatewayId);

--- a/src/OpenClaw.Connection/ISshTunnelManager.cs
+++ b/src/OpenClaw.Connection/ISshTunnelManager.cs
@@ -7,6 +7,7 @@ namespace OpenClaw.Connection;
 public interface ISshTunnelManager : IDisposable
 {
     bool IsActive { get; }
+    bool IsRestartPending(SshTunnelExit tunnelExit);
     Task<string> StartAsync(SshTunnelConfig config, CancellationToken ct);
     Task StopAsync();
     string? LocalTunnelUrl { get; }

--- a/src/OpenClaw.Connection/SshTunnelRecoveryBudget.cs
+++ b/src/OpenClaw.Connection/SshTunnelRecoveryBudget.cs
@@ -1,0 +1,70 @@
+namespace OpenClaw.Connection;
+
+public sealed class SshTunnelRecoveryBudget
+{
+    private static readonly TimeSpan AttemptWindow = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan[] RetryDelays =
+    [
+        TimeSpan.FromSeconds(3),
+        TimeSpan.FromSeconds(10),
+        TimeSpan.FromSeconds(30)
+    ];
+
+    private readonly object _gate = new();
+    private readonly Queue<DateTimeOffset> _attempts = new();
+    private SshTunnelConfig? _tunnel;
+    private SshTunnelOwner _owner;
+
+    public bool TryReserve(
+        SshTunnelExit tunnelExit,
+        DateTimeOffset now,
+        out TimeSpan delay)
+    {
+        lock (_gate)
+        {
+            if (!Equals(_tunnel, tunnelExit.Tunnel) || _owner != tunnelExit.Owner)
+            {
+                _attempts.Clear();
+                _tunnel = tunnelExit.Tunnel;
+                _owner = tunnelExit.Owner;
+            }
+
+            while (_attempts.TryPeek(out var attempt) && now - attempt >= AttemptWindow)
+                _attempts.Dequeue();
+
+            if (_attempts.Count >= RetryDelays.Length)
+            {
+                delay = TimeSpan.Zero;
+                return false;
+            }
+
+            delay = RetryDelays[_attempts.Count];
+            _attempts.Enqueue(now);
+            return true;
+        }
+    }
+
+    public void ReportRecovered(SshTunnelExit tunnelExit)
+    {
+        lock (_gate)
+        {
+            if (!Equals(_tunnel, tunnelExit.Tunnel) || _owner != tunnelExit.Owner)
+                return;
+
+            ResetLocked();
+        }
+    }
+
+    public void Reset()
+    {
+        lock (_gate)
+            ResetLocked();
+    }
+
+    private void ResetLocked()
+    {
+        _attempts.Clear();
+        _tunnel = null;
+        _owner = SshTunnelOwner.Unspecified;
+    }
+}

--- a/src/OpenClaw.Connection/SshTunnelService.cs
+++ b/src/OpenClaw.Connection/SshTunnelService.cs
@@ -15,6 +15,7 @@ public sealed class SshTunnelService : ISshTunnelManager
     private Process? _process;
     private bool _processStarted;
     private SshTunnelConfig? _currentConfig;
+    private SshTunnelOwner _currentOwner;
     private string? _lastSpec;
     private long _lifecycleGeneration;
 
@@ -98,8 +99,37 @@ public sealed class SshTunnelService : ISshTunnelManager
         {
             return tunnelExit.Generation == _lifecycleGeneration &&
                    Equals(_currentConfig, tunnelExit.Tunnel) &&
+                   tunnelExit.Owner == _currentOwner &&
                    !IsRunningLocked() &&
                    Status == TunnelStatus.Restarting;
+        }
+    }
+
+    public bool TryMarkRecoveryFailed(SshTunnelExit tunnelExit, string reason)
+    {
+        lock (_stateLock)
+        {
+            if (!IsRestartPendingLocked(tunnelExit))
+                return false;
+
+            Status = TunnelStatus.Failed;
+            LastError = reason;
+            return true;
+        }
+    }
+
+    public bool TryRestart(SshTunnelExit tunnelExit)
+    {
+        lock (_operationLock)
+        {
+            lock (_stateLock)
+            {
+                if (!IsRestartPendingLocked(tunnelExit))
+                    return false;
+            }
+
+            EnsureStartedCore(tunnelExit.Tunnel, tunnelExit.Owner);
+            return true;
         }
     }
 
@@ -110,18 +140,31 @@ public sealed class SshTunnelService : ISshTunnelManager
         => EnsureStarted(user, host, remotePort, localPort, includeBrowserProxyForward, sshPort: 22);
 
     public void EnsureStarted(string user, string host, int remotePort, int localPort, bool includeBrowserProxyForward, int sshPort)
+        => EnsureStartedCore(
+            new SshTunnelConfig(user, host, remotePort, localPort, includeBrowserProxyForward, sshPort),
+            SshTunnelOwner.Settings);
+
+    private void EnsureStartedCore(SshTunnelConfig tunnel, SshTunnelOwner owner)
     {
         lock (_operationLock)
         {
-            user = user.Trim();
-            host = host.Trim();
+            var user = tunnel.User.Trim();
+            var host = tunnel.Host.Trim();
+            tunnel = tunnel with { User = user, Host = host };
 
-            var spec = BuildSpec(user, host, remotePort, localPort, includeBrowserProxyForward, sshPort);
+            var spec = BuildSpec(
+                user,
+                host,
+                tunnel.RemotePort,
+                tunnel.LocalPort,
+                tunnel.IncludeBrowserProxyForward,
+                tunnel.SshPort);
 
             lock (_stateLock)
             {
                 if (IsRunningLocked() && string.Equals(_lastSpec, spec, StringComparison.Ordinal))
                 {
+                    _currentOwner = ResolveOwnerForReuse(_currentOwner, owner);
                     Status = TunnelStatus.Up;
                     return;
                 }
@@ -132,7 +175,7 @@ public sealed class SshTunnelService : ISshTunnelManager
             {
                 Status = TunnelStatus.Starting;
             }
-            StartProcess(user, host, remotePort, localPort, includeBrowserProxyForward, sshPort, spec);
+            StartProcess(tunnel, owner, spec);
         }
     }
 
@@ -156,6 +199,7 @@ public sealed class SshTunnelService : ISshTunnelManager
             _process = null;
             _processStarted = false;
             _currentConfig = null;
+            _currentOwner = SshTunnelOwner.Unspecified;
             _lastSpec = null;
             CurrentBrowserProxyLocalPort = 0;
             CurrentBrowserProxyRemotePort = 0;
@@ -200,22 +244,14 @@ public sealed class SshTunnelService : ISshTunnelManager
         }
     }
 
-    private void StartProcess(
-        string user,
-        string host,
-        int remotePort,
-        int localPort,
-        bool includeBrowserProxyForward,
-        int sshPort,
-        string spec)
+    private void StartProcess(SshTunnelConfig tunnel, SshTunnelOwner owner, string spec)
     {
-        var tunnel = new SshTunnelConfig(
-            user,
-            host,
-            remotePort,
-            localPort,
-            includeBrowserProxyForward,
-            sshPort);
+        var user = tunnel.User;
+        var host = tunnel.Host;
+        var remotePort = tunnel.RemotePort;
+        var localPort = tunnel.LocalPort;
+        var includeBrowserProxyForward = tunnel.IncludeBrowserProxyForward;
+        var sshPort = tunnel.SshPort;
         var psi = new ProcessStartInfo
         {
             FileName = "ssh",
@@ -250,13 +286,23 @@ public sealed class SshTunnelService : ISshTunnelManager
 
         process.Exited += (_, _) =>
         {
-            var exitCode = process.ExitCode;
             SshTunnelExit? tunnelExit = null;
             lock (_stateLock)
             {
                 if (generation == _lifecycleGeneration &&
                     ReferenceEquals(_process, process))
                 {
+                    int exitCode;
+                    try
+                    {
+                        exitCode = process.ExitCode;
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.Debug($"Ignoring SSH tunnel exit after process disposal: {ex.Message}");
+                        return;
+                    }
+
                     LastError = $"SSH tunnel exited unexpectedly with code {exitCode}.";
                     StartedAtUtc = null;
                     Status = TunnelStatus.Failed;
@@ -265,17 +311,17 @@ public sealed class SshTunnelService : ISshTunnelManager
                     _lastSpec = null;
                     CurrentBrowserProxyLocalPort = 0;
                     CurrentBrowserProxyRemotePort = 0;
-                    tunnelExit = new SshTunnelExit(exitCode, tunnel, generation);
+                    tunnelExit = new SshTunnelExit(exitCode, tunnel, generation, _currentOwner);
                 }
             }
 
             if (tunnelExit == null)
             {
-                _logger.Debug($"Ignoring stale SSH tunnel exit (code {exitCode})");
+                _logger.Debug("Ignoring stale SSH tunnel exit");
                 return;
             }
 
-            _logger.Warn($"SSH tunnel exited unexpectedly (code {exitCode})");
+            _logger.Warn($"SSH tunnel exited unexpectedly (code {tunnelExit.ExitCode})");
             try { process.Dispose(); }
             catch (Exception disposeEx) { _logger.Debug($"SshTunnelService: process dispose after unexpected exit failed: {disposeEx.Message}"); }
             TunnelExited?.Invoke(this, tunnelExit);
@@ -287,6 +333,7 @@ public sealed class SshTunnelService : ISshTunnelManager
             _process = process;
             _processStarted = false;
             _currentConfig = tunnel;
+            _currentOwner = owner;
             _lastSpec = spec;
         }
 
@@ -337,6 +384,7 @@ public sealed class SshTunnelService : ISshTunnelManager
                     _process = null;
                     _processStarted = false;
                     _currentConfig = null;
+                    _currentOwner = SshTunnelOwner.Unspecified;
                     _lastSpec = null;
                 }
             }
@@ -374,6 +422,20 @@ public sealed class SshTunnelService : ISshTunnelManager
 
     private bool IsRunningLocked() => _processStarted && _process is { HasExited: false };
 
+    private bool IsRestartPendingLocked(SshTunnelExit tunnelExit) =>
+        tunnelExit.Generation == _lifecycleGeneration &&
+        Equals(_currentConfig, tunnelExit.Tunnel) &&
+        tunnelExit.Owner == _currentOwner &&
+        !IsRunningLocked() &&
+        Status == TunnelStatus.Restarting;
+
+    internal static SshTunnelOwner ResolveOwnerForReuse(
+        SshTunnelOwner currentOwner,
+        SshTunnelOwner requestedOwner) =>
+        currentOwner == SshTunnelOwner.GatewayConnectionManager
+            ? currentOwner
+            : requestedOwner;
+
     private void MarkRestartingLocked(int exitCode)
     {
         Status = TunnelStatus.Restarting;
@@ -390,7 +452,7 @@ public sealed class SshTunnelService : ISshTunnelManager
 
     public Task<string> StartAsync(SshTunnelConfig config, CancellationToken ct)
     {
-        EnsureStarted(config.User, config.Host, config.RemotePort, config.LocalPort, config.IncludeBrowserProxyForward, config.SshPort);
+        EnsureStartedCore(config, SshTunnelOwner.GatewayConnectionManager);
         var localUrl = $"ws://localhost:{config.LocalPort}";
         return Task.FromResult(localUrl);
     }
@@ -405,4 +467,12 @@ public sealed class SshTunnelService : ISshTunnelManager
 public sealed record SshTunnelExit(
     int ExitCode,
     SshTunnelConfig Tunnel,
-    long Generation);
+    long Generation,
+    SshTunnelOwner Owner = SshTunnelOwner.Unspecified);
+
+public enum SshTunnelOwner
+{
+    Unspecified = 0,
+    Settings,
+    GatewayConnectionManager
+}

--- a/src/OpenClaw.Connection/SshTunnelService.cs
+++ b/src/OpenClaw.Connection/SshTunnelService.cs
@@ -10,19 +10,33 @@ namespace OpenClaw.Connection;
 public sealed class SshTunnelService : ISshTunnelManager
 {
     private readonly IOpenClawLogger _logger;
+    private readonly object _operationLock = new();
+    private readonly object _stateLock = new();
     private Process? _process;
+    private bool _processStarted;
+    private SshTunnelConfig? _currentConfig;
     private string? _lastSpec;
-    private bool _stopping;
+    private long _lifecycleGeneration;
 
     /// <summary>Raised when the SSH tunnel exits unexpectedly (not during shutdown).</summary>
-    public event EventHandler<int>? TunnelExited;
+    public event EventHandler<SshTunnelExit>? TunnelExited;
 
     public SshTunnelService(IOpenClawLogger logger)
     {
         _logger = logger;
     }
 
-    public bool IsRunning => _process is { HasExited: false };
+    public bool IsRunning
+    {
+        get
+        {
+            lock (_stateLock)
+            {
+                return IsRunningLocked();
+            }
+        }
+    }
+
     public bool IsActive => IsRunning;
     public string? LocalTunnelUrl => IsActive ? $"ws://localhost:{CurrentLocalPort}" : null;
     public string? CurrentUser { get; private set; }
@@ -35,22 +49,58 @@ public sealed class SshTunnelService : ISshTunnelManager
     public string? LastError { get; private set; }
     public TunnelStatus Status { get; private set; } = TunnelStatus.NotConfigured;
 
-    public SshTunnelSnapshot CreateSnapshot() => new(
-        IsRunning,
-        CurrentUser,
-        CurrentHost,
-        CurrentRemotePort,
-        CurrentLocalPort,
-        CurrentBrowserProxyRemotePort,
-        CurrentBrowserProxyLocalPort,
-        StartedAtUtc,
-        LastError,
-        Status);
+    public SshTunnelSnapshot CreateSnapshot()
+    {
+        lock (_stateLock)
+        {
+            return new SshTunnelSnapshot(
+                IsRunningLocked(),
+                CurrentUser,
+                CurrentHost,
+                CurrentRemotePort,
+                CurrentLocalPort,
+                CurrentBrowserProxyRemotePort,
+                CurrentBrowserProxyLocalPort,
+                StartedAtUtc,
+                LastError,
+                Status);
+        }
+    }
+
+    public bool TryMarkRestarting(SshTunnelExit tunnelExit)
+    {
+        lock (_stateLock)
+        {
+            if (tunnelExit.Generation != _lifecycleGeneration ||
+                !Equals(_currentConfig, tunnelExit.Tunnel) ||
+                IsRunningLocked() ||
+                Status != TunnelStatus.Failed)
+            {
+                return false;
+            }
+
+            MarkRestartingLocked(tunnelExit.ExitCode);
+            return true;
+        }
+    }
 
     public void MarkRestarting(int exitCode)
     {
-        Status = TunnelStatus.Restarting;
-        LastError = $"SSH tunnel exited unexpectedly with code {exitCode}; restart is scheduled.";
+        lock (_stateLock)
+        {
+            MarkRestartingLocked(exitCode);
+        }
+    }
+
+    public bool IsRestartPending(SshTunnelExit tunnelExit)
+    {
+        lock (_stateLock)
+        {
+            return tunnelExit.Generation == _lifecycleGeneration &&
+                   Equals(_currentConfig, tunnelExit.Tunnel) &&
+                   !IsRunningLocked() &&
+                   Status == TunnelStatus.Restarting;
+        }
     }
 
     public void EnsureStarted(string user, string host, int remotePort, int localPort)
@@ -61,43 +111,69 @@ public sealed class SshTunnelService : ISshTunnelManager
 
     public void EnsureStarted(string user, string host, int remotePort, int localPort, bool includeBrowserProxyForward, int sshPort)
     {
-        user = user.Trim();
-        host = host.Trim();
-
-        var spec = BuildSpec(user, host, remotePort, localPort, includeBrowserProxyForward, sshPort);
-
-        if (IsRunning && string.Equals(_lastSpec, spec, StringComparison.Ordinal))
+        lock (_operationLock)
         {
-            Status = TunnelStatus.Up;
-            return;
-        }
+            user = user.Trim();
+            host = host.Trim();
 
-        Stop();
-        Status = TunnelStatus.Starting;
-        StartProcess(user, host, remotePort, localPort, includeBrowserProxyForward, sshPort);
-        _lastSpec = spec;
+            var spec = BuildSpec(user, host, remotePort, localPort, includeBrowserProxyForward, sshPort);
+
+            lock (_stateLock)
+            {
+                if (IsRunningLocked() && string.Equals(_lastSpec, spec, StringComparison.Ordinal))
+                {
+                    Status = TunnelStatus.Up;
+                    return;
+                }
+            }
+
+            StopLocked();
+            lock (_stateLock)
+            {
+                Status = TunnelStatus.Starting;
+            }
+            StartProcess(user, host, remotePort, localPort, includeBrowserProxyForward, sshPort, spec);
+        }
     }
 
     public void Stop()
     {
-        if (_process == null)
+        lock (_operationLock)
         {
+            StopLocked();
+        }
+    }
+
+    private void StopLocked()
+    {
+        Process? process;
+        lock (_stateLock)
+        {
+            // Claim and clear the current process before stopping it. Exit callbacks can
+            // then only observe stale ownership and cannot overwrite a replacement.
+            _lifecycleGeneration++;
+            process = _process;
+            _process = null;
+            _processStarted = false;
+            _currentConfig = null;
+            _lastSpec = null;
             CurrentBrowserProxyLocalPort = 0;
             CurrentBrowserProxyRemotePort = 0;
+            StartedAtUtc = null;
             if (Status != TunnelStatus.NotConfigured)
                 Status = TunnelStatus.Stopped;
-            return;
         }
 
-        _stopping = true;
-        _logger.Info("Stopping SSH tunnel process");
+        if (process == null)
+            return;
 
+        _logger.Info("Stopping SSH tunnel process");
         try
         {
-            if (!_process.HasExited)
+            if (!process.HasExited)
             {
-                _process.Kill(entireProcessTree: true);
-                _process.WaitForExit(3000);
+                process.Kill(entireProcessTree: true);
+                process.WaitForExit(3000);
             }
         }
         catch (Exception ex)
@@ -106,28 +182,40 @@ public sealed class SshTunnelService : ISshTunnelManager
         }
         finally
         {
-            try { _process.Dispose(); }
+            try { process.Dispose(); }
             catch (Exception disposeEx) { _logger.Debug($"SshTunnelService.Stop: process dispose failed: {disposeEx.Message}"); }
-            _process = null;
-            _lastSpec = null;
-            CurrentBrowserProxyLocalPort = 0;
-            CurrentBrowserProxyRemotePort = 0;
-            StartedAtUtc = null;
-            if (Status != TunnelStatus.NotConfigured)
-                Status = TunnelStatus.Stopped;
-            _stopping = false;
         }
     }
 
     public void ResetNotConfigured()
     {
-        Stop();
-        LastError = null;
-        Status = TunnelStatus.NotConfigured;
+        lock (_operationLock)
+        {
+            StopLocked();
+            lock (_stateLock)
+            {
+                LastError = null;
+                Status = TunnelStatus.NotConfigured;
+            }
+        }
     }
 
-    private void StartProcess(string user, string host, int remotePort, int localPort, bool includeBrowserProxyForward, int sshPort)
+    private void StartProcess(
+        string user,
+        string host,
+        int remotePort,
+        int localPort,
+        bool includeBrowserProxyForward,
+        int sshPort,
+        string spec)
     {
+        var tunnel = new SshTunnelConfig(
+            user,
+            host,
+            remotePort,
+            localPort,
+            includeBrowserProxyForward,
+            sshPort);
         var psi = new ProcessStartInfo
         {
             FileName = "ssh",
@@ -141,8 +229,8 @@ public sealed class SshTunnelService : ISshTunnelManager
         var process = new Process
         {
             StartInfo = psi,
-            EnableRaisingEvents = true,
         };
+        long generation = 0;
 
         process.OutputDataReceived += (_, e) =>
         {
@@ -163,59 +251,133 @@ public sealed class SshTunnelService : ISshTunnelManager
         process.Exited += (_, _) =>
         {
             var exitCode = process.ExitCode;
-            if (_stopping)
+            SshTunnelExit? tunnelExit = null;
+            lock (_stateLock)
             {
-                _logger.Info($"SSH tunnel exited during shutdown (code {exitCode})");
+                if (generation == _lifecycleGeneration &&
+                    ReferenceEquals(_process, process))
+                {
+                    LastError = $"SSH tunnel exited unexpectedly with code {exitCode}.";
+                    StartedAtUtc = null;
+                    Status = TunnelStatus.Failed;
+                    _process = null;
+                    _processStarted = false;
+                    _lastSpec = null;
+                    CurrentBrowserProxyLocalPort = 0;
+                    CurrentBrowserProxyRemotePort = 0;
+                    tunnelExit = new SshTunnelExit(exitCode, tunnel, generation);
+                }
             }
-            else
+
+            if (tunnelExit == null)
             {
-                _logger.Warn($"SSH tunnel exited unexpectedly (code {exitCode})");
-                LastError = $"SSH tunnel exited unexpectedly with code {exitCode}.";
-                StartedAtUtc = null;
-                Status = TunnelStatus.Failed;
-                try { process.Dispose(); }
-                catch (Exception disposeEx) { _logger.Debug($"SshTunnelService: process dispose after unexpected exit failed: {disposeEx.Message}"); }
-                _process = null;
-                _lastSpec = null;
-                CurrentBrowserProxyLocalPort = 0;
-                CurrentBrowserProxyRemotePort = 0;
-                TunnelExited?.Invoke(this, exitCode);
+                _logger.Debug($"Ignoring stale SSH tunnel exit (code {exitCode})");
+                return;
             }
+
+            _logger.Warn($"SSH tunnel exited unexpectedly (code {exitCode})");
+            try { process.Dispose(); }
+            catch (Exception disposeEx) { _logger.Debug($"SshTunnelService: process dispose after unexpected exit failed: {disposeEx.Message}"); }
+            TunnelExited?.Invoke(this, tunnelExit);
         };
 
+        lock (_stateLock)
+        {
+            generation = ++_lifecycleGeneration;
+            _process = process;
+            _processStarted = false;
+            _currentConfig = tunnel;
+            _lastSpec = spec;
+        }
+
+        var processStarted = false;
         try
         {
             if (!process.Start())
             {
                 throw new InvalidOperationException("Failed to start ssh process");
             }
+            processStarted = true;
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+
+            lock (_stateLock)
+            {
+                if (generation != _lifecycleGeneration ||
+                    !ReferenceEquals(_process, process))
+                {
+                    return;
+                }
+
+                _processStarted = true;
+                CurrentUser = user;
+                CurrentHost = host;
+                CurrentRemotePort = remotePort;
+                CurrentLocalPort = localPort;
+                CurrentBrowserProxyRemotePort = includeBrowserProxyForward ? remotePort + 2 : 0;
+                CurrentBrowserProxyLocalPort = includeBrowserProxyForward ? localPort + 2 : 0;
+                StartedAtUtc = DateTime.UtcNow;
+                LastError = null;
+                Status = TunnelStatus.Up;
+            }
+
+            // Enable exit delivery only after the process is fully published. If it already
+            // exited, Process raises the event now and the callback atomically claims it.
+            process.EnableRaisingEvents = true;
         }
         catch (Exception ex)
         {
-            LastError = ex.Message;
-            Status = TunnelStatus.Failed;
+            lock (_stateLock)
+            {
+                if (generation == _lifecycleGeneration &&
+                    ReferenceEquals(_process, process))
+                {
+                    LastError = ex.Message;
+                    Status = TunnelStatus.Failed;
+                    _process = null;
+                    _processStarted = false;
+                    _currentConfig = null;
+                    _lastSpec = null;
+                }
+            }
+            if (processStarted)
+            {
+                try
+                {
+                    if (!process.HasExited)
+                        process.Kill(entireProcessTree: true);
+                }
+                catch (Exception killEx)
+                {
+                    _logger.Debug($"SshTunnelService: process cleanup after start failure failed: {killEx.Message}");
+                }
+            }
             process.Dispose();
             throw new InvalidOperationException("Unable to start SSH tunnel process. Ensure OpenSSH client is installed and available in PATH.", ex);
         }
 
-        process.BeginOutputReadLine();
-        process.BeginErrorReadLine();
-        _process = process;
-        CurrentUser = user;
-        CurrentHost = host;
-        CurrentRemotePort = remotePort;
-        CurrentLocalPort = localPort;
-        CurrentBrowserProxyRemotePort = includeBrowserProxyForward ? remotePort + 2 : 0;
-        CurrentBrowserProxyLocalPort = includeBrowserProxyForward ? localPort + 2 : 0;
-        StartedAtUtc = DateTime.UtcNow;
-        LastError = null;
-        Status = TunnelStatus.Up;
+        lock (_stateLock)
+        {
+            if (generation != _lifecycleGeneration ||
+                !ReferenceEquals(_process, process))
+            {
+                return;
+            }
+        }
 
         _logger.Info($"SSH tunnel started: 127.0.0.1:{localPort} -> 127.0.0.1:{remotePort} via {user}@{host}:{sshPort}");
         if (includeBrowserProxyForward)
         {
             _logger.Info($"SSH tunnel browser proxy forward started: 127.0.0.1:{localPort + 2} -> 127.0.0.1:{remotePort + 2} via {user}@{host}:{sshPort}");
         }
+    }
+
+    private bool IsRunningLocked() => _processStarted && _process is { HasExited: false };
+
+    private void MarkRestartingLocked(int exitCode)
+    {
+        Status = TunnelStatus.Restarting;
+        LastError = $"SSH tunnel exited unexpectedly with code {exitCode}; restart is scheduled.";
     }
 
     private static string BuildSpec(string user, string host, int remotePort, int localPort, bool includeBrowserProxyForward, int sshPort)
@@ -239,3 +401,8 @@ public sealed class SshTunnelService : ISshTunnelManager
         return Task.CompletedTask;
     }
 }
+
+public sealed record SshTunnelExit(
+    int ExitCode,
+    SshTunnelConfig Tunnel,
+    long Generation);

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -169,6 +169,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             _settings.SshTunnelLocalPort,
             includeBrowserProxyForward,
             _settings.SshTunnelSshPort);
+        _sshTunnelRecoveryBudget.Reset();
     }
 
     /// <summary>
@@ -199,6 +200,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     private ConnectionSettingsSnapshot? _previousSettingsSnapshot;
     private OpenTelemetryEndpointConnection? _openTelemetryConnection;
     private SshTunnelService? _sshTunnelService;
+    private readonly SshTunnelRecoveryBudget _sshTunnelRecoveryBudget = new();
     private GlobalHotkeyService? _globalHotkey;
     private Mutex? _mutex;
     private Microsoft.UI.Dispatching.DispatcherQueue? _dispatcherQueue;
@@ -3773,6 +3775,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
                 return;
             }
 
+            _sshTunnelRecoveryBudget.Reset();
             ReconnectWithSyncedBrowserProxyForward();
 
             UpdateStatusDetailWindow();
@@ -4827,42 +4830,84 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     private async Task OnSshTunnelExitedAsync(SshTunnelExit tunnelExit)
     {
         var connectionManager = _connectionManager;
-        if (_sshTunnelService?.TryMarkRestarting(tunnelExit) != true)
+        var tunnelService = _sshTunnelService;
+        if (tunnelService?.TryMarkRestarting(tunnelExit) != true)
             return;
 
-        Logger.Warn($"SSH tunnel exited unexpectedly (code {tunnelExit.ExitCode}); restarting in 3s...");
+        if (!_sshTunnelRecoveryBudget.TryReserve(
+                tunnelExit,
+                DateTimeOffset.UtcNow,
+                out var retryDelay))
+        {
+            const string reason = "SSH tunnel recovery stopped after repeated failures. Restart it manually after correcting the tunnel configuration.";
+            tunnelService.TryMarkRecoveryFailed(tunnelExit, reason);
+            Logger.Warn(reason);
+            DiagnosticsJsonlService.Write("tunnel.restart_exhausted", new
+            {
+                owner = tunnelExit.Owner.ToString(),
+                tunnelExit.ExitCode
+            });
+            return;
+        }
+
+        Logger.Warn(
+            $"SSH tunnel exited unexpectedly (code {tunnelExit.ExitCode}); " +
+            $"restarting in {retryDelay.TotalSeconds:0}s...");
         DiagnosticsJsonlService.Write("tunnel.restart_scheduled", new
         {
             exitCode = tunnelExit.ExitCode,
-            localEndpoint = _sshTunnelService?.CurrentLocalPort > 0
-                ? $"127.0.0.1:{_sshTunnelService.CurrentLocalPort}"
+            retryDelaySeconds = retryDelay.TotalSeconds,
+            localEndpoint = tunnelService.CurrentLocalPort > 0
+                ? $"127.0.0.1:{tunnelService.CurrentLocalPort}"
                 : null
         });
-        await Task.Delay(3000);
+        await Task.Delay(retryDelay);
 
-        if (_sshTunnelService != null && connectionManager != null)
+        try
         {
-            try
+            bool recovered;
+            if (tunnelExit.Owner == SshTunnelOwner.GatewayConnectionManager)
             {
                 // The connection manager owns the registry-backed tunnel and both
                 // gateway clients. Reconnect through it so recovery cannot drift
                 // back to the legacy global SSH settings.
-                if (!await connectionManager.RecoverSshTunnelAsync(tunnelExit))
-                    return;
-
-                Logger.Info("SSH tunnel restarted successfully");
-                DiagnosticsJsonlService.Write("tunnel.restart_succeeded", new
-                {
-                    localEndpoint = _sshTunnelService.CurrentLocalPort > 0
-                        ? $"127.0.0.1:{_sshTunnelService.CurrentLocalPort}"
-                        : null
-                });
+                recovered = connectionManager != null &&
+                    await connectionManager.RecoverSshTunnelAsync(tunnelExit);
             }
-            catch (Exception ex)
+            else
             {
-                Logger.Error($"SSH tunnel restart failed: {ex.Message}");
-                DiagnosticsJsonlService.Write("tunnel.restart_failed", new { ex.Message });
+                // Settings-owned tunnels are tunnel-only. Restart the exact
+                // generation/configuration without promoting them into a gateway reconnect.
+                recovered = tunnelService.TryRestart(tunnelExit);
             }
+
+            if (!recovered)
+            {
+                const string reason = "SSH tunnel recovery was declined because its owner or connection intent changed.";
+                tunnelService.TryMarkRecoveryFailed(tunnelExit, reason);
+                Logger.Warn(reason);
+                DiagnosticsJsonlService.Write("tunnel.restart_declined", new
+                {
+                    owner = tunnelExit.Owner.ToString(),
+                    tunnelExit.ExitCode
+                });
+                return;
+            }
+
+            _sshTunnelRecoveryBudget.ReportRecovered(tunnelExit);
+            Logger.Info("SSH tunnel restarted successfully");
+            DiagnosticsJsonlService.Write("tunnel.restart_succeeded", new
+            {
+                localEndpoint = tunnelService.CurrentLocalPort > 0
+                    ? $"127.0.0.1:{tunnelService.CurrentLocalPort}"
+                    : null
+            });
+        }
+        catch (Exception ex)
+        {
+            tunnelService.TryMarkRecoveryFailed(tunnelExit, $"SSH tunnel restart failed: {ex.Message}");
+            Logger.Error($"SSH tunnel restart failed: {ex.Message}");
+            DiagnosticsJsonlService.Write("tunnel.restart_failed", new { ex.Message });
         }
     }
 }

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -4818,39 +4818,38 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
 
     #endregion
 
-    private void OnSshTunnelExited(object? sender, int exitCode) =>
+    private void OnSshTunnelExited(object? sender, SshTunnelExit tunnelExit) =>
         AsyncEventHandlerGuard.Run(
-            () => OnSshTunnelExitedAsync(exitCode),
+            () => OnSshTunnelExitedAsync(tunnelExit),
             new AppLogger(),
             nameof(OnSshTunnelExited));
 
-    private async Task OnSshTunnelExitedAsync(int exitCode)
+    private async Task OnSshTunnelExitedAsync(SshTunnelExit tunnelExit)
     {
-        Logger.Warn($"SSH tunnel exited unexpectedly (code {exitCode}); restarting in 3s...");
-        _sshTunnelService?.MarkRestarting(exitCode);
+        var connectionManager = _connectionManager;
+        if (_sshTunnelService?.TryMarkRestarting(tunnelExit) != true)
+            return;
+
+        Logger.Warn($"SSH tunnel exited unexpectedly (code {tunnelExit.ExitCode}); restarting in 3s...");
         DiagnosticsJsonlService.Write("tunnel.restart_scheduled", new
         {
-            exitCode,
+            exitCode = tunnelExit.ExitCode,
             localEndpoint = _sshTunnelService?.CurrentLocalPort > 0
                 ? $"127.0.0.1:{_sshTunnelService.CurrentLocalPort}"
                 : null
         });
         await Task.Delay(3000);
-        if (_sshTunnelService != null && _settings?.UseSshTunnel == true)
+
+        if (_sshTunnelService != null && connectionManager != null)
         {
             try
             {
-                var restartBrowserProxy = BrowserProxySshTunnelForwardPolicy.ShouldInclude(
-                    _settings.NodeBrowserProxyEnabled,
-                    _settings.SshTunnelRemotePort,
-                    _settings.SshTunnelLocalPort);
-                _sshTunnelService.EnsureStarted(
-                    _settings.SshTunnelUser,
-                    _settings.SshTunnelHost,
-                    _settings.SshTunnelRemotePort,
-                    _settings.SshTunnelLocalPort,
-                    restartBrowserProxy,
-                    _settings.SshTunnelSshPort);
+                // The connection manager owns the registry-backed tunnel and both
+                // gateway clients. Reconnect through it so recovery cannot drift
+                // back to the legacy global SSH settings.
+                if (!await connectionManager.RecoverSshTunnelAsync(tunnelExit))
+                    return;
+
                 Logger.Info("SSH tunnel restarted successfully");
                 DiagnosticsJsonlService.Write("tunnel.restart_succeeded", new
                 {

--- a/tests/OpenClaw.Connection.Tests/GatewayConnectionManagerTests.cs
+++ b/tests/OpenClaw.Connection.Tests/GatewayConnectionManagerTests.cs
@@ -150,7 +150,11 @@ public class GatewayConnectionManagerTests : IDisposable
 
         _registry.SetActive("gw-2");
         var recoveryTask = manager.RecoverSshTunnelAsync(
-            new SshTunnelExit(255, tunnelConfig, Generation: 7));
+            new SshTunnelExit(
+                255,
+                tunnelConfig,
+                Generation: 7,
+                SshTunnelOwner.GatewayConnectionManager));
         tunnel.AllowStart.SetResult(true);
 
         await connectTask.WaitAsync(TimeSpan.FromSeconds(2));
@@ -182,7 +186,11 @@ public class GatewayConnectionManagerTests : IDisposable
             tunnelManager: tunnel);
 
         var recovered = await manager.RecoverSshTunnelAsync(
-            new SshTunnelExit(255, tunnelConfig, Generation: 7));
+            new SshTunnelExit(
+                255,
+                tunnelConfig,
+                Generation: 7,
+                SshTunnelOwner.GatewayConnectionManager));
 
         Assert.True(recovered);
         Assert.Equal(1, tunnel.StartCount);
@@ -211,7 +219,42 @@ public class GatewayConnectionManagerTests : IDisposable
         manager.SetGatewayConnectionIntent("gw-1", shouldBeConnected: false);
 
         var recovered = await manager.RecoverSshTunnelAsync(
-            new SshTunnelExit(255, tunnelConfig, Generation: 7));
+            new SshTunnelExit(
+                255,
+                tunnelConfig,
+                Generation: 7,
+                SshTunnelOwner.GatewayConnectionManager));
+
+        Assert.False(recovered);
+        Assert.Empty(_factory.CreatedClients);
+        Assert.Equal(0, tunnel.StartCount);
+    }
+
+    [Fact]
+    public async Task RecoverSshTunnelAsync_SettingsOwnedTunnel_DoesNotReconnectGateway()
+    {
+        var tunnelConfig = new SshTunnelConfig("user", "host.example", 18789, 45678);
+        _registry.AddOrUpdate(new GatewayRecord
+        {
+            Id = "gw-1",
+            Url = "wss://test1",
+            SshTunnel = tunnelConfig
+        });
+        _registry.SetActive("gw-1");
+        var tunnel = new CountingTunnelManager { RestartPending = true };
+        using var manager = new GatewayConnectionManager(
+            _resolver,
+            _factory,
+            _registry,
+            NullLogger.Instance,
+            tunnelManager: tunnel);
+
+        var recovered = await manager.RecoverSshTunnelAsync(
+            new SshTunnelExit(
+                255,
+                tunnelConfig,
+                Generation: 7,
+                SshTunnelOwner.Settings));
 
         Assert.False(recovered);
         Assert.Empty(_factory.CreatedClients);

--- a/tests/OpenClaw.Connection.Tests/GatewayConnectionManagerTests.cs
+++ b/tests/OpenClaw.Connection.Tests/GatewayConnectionManagerTests.cs
@@ -122,6 +122,103 @@ public class GatewayConnectionManagerTests : IDisposable
     }
 
     [Fact]
+    public async Task RecoverSshTunnelAsync_RevalidatesGatewayAfterWaitingForTransition()
+    {
+        var tunnelConfig = new SshTunnelConfig("user", "host.example", 18789, 45678);
+        _registry.AddOrUpdate(new GatewayRecord
+        {
+            Id = "gw-1",
+            Url = "wss://test1",
+            SshTunnel = tunnelConfig
+        });
+        _registry.AddOrUpdate(new GatewayRecord
+        {
+            Id = "gw-2",
+            Url = "wss://test2"
+        });
+        _registry.SetActive("gw-1");
+        _resolver.OperatorCredential = new GatewayCredential("tok", false, "test");
+        var tunnel = new BlockingTunnelManager { RestartPending = true };
+        using var manager = new GatewayConnectionManager(
+            _resolver,
+            _factory,
+            _registry,
+            NullLogger.Instance,
+            tunnelManager: tunnel);
+        var connectTask = manager.ConnectAsync("gw-1");
+        await tunnel.Started.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+        _registry.SetActive("gw-2");
+        var recoveryTask = manager.RecoverSshTunnelAsync(
+            new SshTunnelExit(255, tunnelConfig, Generation: 7));
+        tunnel.AllowStart.SetResult(true);
+
+        await connectTask.WaitAsync(TimeSpan.FromSeconds(2));
+        var recovered = await recoveryTask.WaitAsync(TimeSpan.FromSeconds(2));
+
+        Assert.False(recovered);
+        Assert.Single(_factory.CreatedClients);
+        Assert.Equal("gw-2", _registry.ActiveGatewayId);
+    }
+
+    [Fact]
+    public async Task RecoverSshTunnelAsync_CurrentTunnel_Reconnects()
+    {
+        var tunnelConfig = new SshTunnelConfig("user", "host.example", 18789, 45678);
+        _registry.AddOrUpdate(new GatewayRecord
+        {
+            Id = "gw-1",
+            Url = "wss://test1",
+            SshTunnel = tunnelConfig
+        });
+        _registry.SetActive("gw-1");
+        _resolver.OperatorCredential = new GatewayCredential("tok", false, "test");
+        var tunnel = new CountingTunnelManager { RestartPending = true };
+        using var manager = new GatewayConnectionManager(
+            _resolver,
+            _factory,
+            _registry,
+            NullLogger.Instance,
+            tunnelManager: tunnel);
+
+        var recovered = await manager.RecoverSshTunnelAsync(
+            new SshTunnelExit(255, tunnelConfig, Generation: 7));
+
+        Assert.True(recovered);
+        Assert.Equal(1, tunnel.StartCount);
+        Assert.Single(_factory.CreatedClients);
+        Assert.Equal("gw-1", manager.CurrentSnapshot.GatewayId);
+    }
+
+    [Fact]
+    public async Task RecoverSshTunnelAsync_UserDisconnected_DoesNotReconnect()
+    {
+        var tunnelConfig = new SshTunnelConfig("user", "host.example", 18789, 45678);
+        _registry.AddOrUpdate(new GatewayRecord
+        {
+            Id = "gw-1",
+            Url = "wss://test1",
+            SshTunnel = tunnelConfig
+        });
+        _registry.SetActive("gw-1");
+        var tunnel = new CountingTunnelManager { RestartPending = true };
+        using var manager = new GatewayConnectionManager(
+            _resolver,
+            _factory,
+            _registry,
+            NullLogger.Instance,
+            tunnelManager: tunnel);
+        manager.SetGatewayConnectionIntent("gw-1", shouldBeConnected: false);
+
+        var recovered = await manager.RecoverSshTunnelAsync(
+            new SshTunnelExit(255, tunnelConfig, Generation: 7));
+
+        Assert.False(recovered);
+        Assert.Empty(_factory.CreatedClients);
+        Assert.Equal(0, tunnel.StartCount);
+    }
+
+    [Fact]
     public async Task PassiveGatewayRestart_ReusesLiveClientsAndPreservesDurableIdentity()
     {
         _registry.AddOrUpdate(new GatewayRecord
@@ -3732,6 +3829,9 @@ public class GatewayConnectionManagerTests : IDisposable
         public SshTunnelConfig? LastConfig { get; private set; }
         public bool IsActive { get; private set; }
         public string? LocalTunnelUrl { get; private set; }
+        public bool RestartPending { get; set; }
+
+        public bool IsRestartPending(SshTunnelExit tunnelExit) => RestartPending;
 
         public Task<string> StartAsync(SshTunnelConfig config, CancellationToken ct)
         {
@@ -3760,6 +3860,9 @@ public class GatewayConnectionManagerTests : IDisposable
         public TaskCompletionSource<bool> AllowStart { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
         public bool IsActive => false;
         public string? LocalTunnelUrl => null;
+        public bool RestartPending { get; set; }
+
+        public bool IsRestartPending(SshTunnelExit tunnelExit) => RestartPending;
 
         public async Task<string> StartAsync(SshTunnelConfig config, CancellationToken ct)
         {
@@ -3776,6 +3879,8 @@ public class GatewayConnectionManagerTests : IDisposable
     {
         public bool IsActive => false;
         public string? LocalTunnelUrl => null;
+
+        public bool IsRestartPending(SshTunnelExit tunnelExit) => false;
 
         public Task<string> StartAsync(SshTunnelConfig config, CancellationToken ct) =>
             throw new InvalidOperationException("tunnel failed");

--- a/tests/OpenClaw.Connection.Tests/OperatorScopeHelperTests.cs
+++ b/tests/OpenClaw.Connection.Tests/OperatorScopeHelperTests.cs
@@ -174,6 +174,7 @@ public class ChatNavigationReadinessTests
         public Task ReconnectAsync() => Task.CompletedTask;
         public Task<bool> ReconnectIfCurrentAsync(string gatewayId, CancellationToken cancellationToken = default) =>
             Task.FromResult(true);
+        public Task<bool> RecoverSshTunnelAsync(SshTunnelExit tunnelExit) => Task.FromResult(false);
         public Task SwitchGatewayAsync(string gatewayId) => Task.CompletedTask;
         public void SetGatewayConnectionIntent(string gatewayId, bool shouldBeConnected) { }
         public bool IsAutomaticReconnectAllowed(string gatewayId) => true;

--- a/tests/OpenClaw.Connection.Tests/SshTunnelRecoveryBudgetTests.cs
+++ b/tests/OpenClaw.Connection.Tests/SshTunnelRecoveryBudgetTests.cs
@@ -1,0 +1,123 @@
+namespace OpenClaw.Connection.Tests;
+
+public sealed class SshTunnelRecoveryBudgetTests
+{
+    private static readonly SshTunnelConfig Tunnel =
+        new("user", "host.example", 18789, 45678);
+
+    [Fact]
+    public void TryReserve_BoundsAndBacksOffRepeatedFailures()
+    {
+        var budget = new SshTunnelRecoveryBudget();
+        var now = DateTimeOffset.Parse("2026-07-31T12:00:00Z");
+        var tunnelExit = new SshTunnelExit(
+            255,
+            Tunnel,
+            Generation: 7,
+            SshTunnelOwner.GatewayConnectionManager);
+
+        Assert.True(budget.TryReserve(tunnelExit, now, out var first));
+        Assert.Equal(TimeSpan.FromSeconds(3), first);
+        Assert.True(budget.TryReserve(tunnelExit, now.AddSeconds(3), out var second));
+        Assert.Equal(TimeSpan.FromSeconds(10), second);
+        Assert.True(budget.TryReserve(tunnelExit, now.AddSeconds(13), out var third));
+        Assert.Equal(TimeSpan.FromSeconds(30), third);
+        Assert.False(budget.TryReserve(tunnelExit, now.AddSeconds(43), out var exhausted));
+        Assert.Equal(TimeSpan.Zero, exhausted);
+    }
+
+    [Fact]
+    public void TryReserve_ResetsAfterHealthyWindow()
+    {
+        var budget = new SshTunnelRecoveryBudget();
+        var now = DateTimeOffset.Parse("2026-07-31T12:00:00Z");
+        var tunnelExit = new SshTunnelExit(
+            255,
+            Tunnel,
+            Generation: 7,
+            SshTunnelOwner.Settings);
+
+        Assert.True(budget.TryReserve(tunnelExit, now, out _));
+        Assert.True(budget.TryReserve(tunnelExit, now.AddMinutes(5), out var delay));
+        Assert.Equal(TimeSpan.FromSeconds(3), delay);
+    }
+
+    [Fact]
+    public void TryReserve_ResetsForDifferentTunnelOwner()
+    {
+        var budget = new SshTunnelRecoveryBudget();
+        var now = DateTimeOffset.Parse("2026-07-31T12:00:00Z");
+        var managerExit = new SshTunnelExit(
+            255,
+            Tunnel,
+            Generation: 7,
+            SshTunnelOwner.GatewayConnectionManager);
+        var settingsExit = managerExit with
+        {
+            Generation = 8,
+            Owner = SshTunnelOwner.Settings
+        };
+
+        Assert.True(budget.TryReserve(managerExit, now, out _));
+        Assert.True(budget.TryReserve(managerExit, now.AddSeconds(3), out _));
+        Assert.True(budget.TryReserve(settingsExit, now.AddSeconds(4), out var delay));
+        Assert.Equal(TimeSpan.FromSeconds(3), delay);
+    }
+
+    [Fact]
+    public void ReportRecovered_RearmsMatchingTunnel()
+    {
+        var budget = new SshTunnelRecoveryBudget();
+        var now = DateTimeOffset.Parse("2026-07-31T12:00:00Z");
+        var tunnelExit = new SshTunnelExit(
+            255,
+            Tunnel,
+            Generation: 7,
+            SshTunnelOwner.GatewayConnectionManager);
+
+        Assert.True(budget.TryReserve(tunnelExit, now, out _));
+        Assert.True(budget.TryReserve(tunnelExit, now.AddSeconds(3), out _));
+
+        budget.ReportRecovered(tunnelExit);
+
+        Assert.True(budget.TryReserve(tunnelExit, now.AddSeconds(13), out var delay));
+        Assert.Equal(TimeSpan.FromSeconds(3), delay);
+    }
+
+    [Fact]
+    public void ReportRecovered_DoesNotRearmDifferentOwner()
+    {
+        var budget = new SshTunnelRecoveryBudget();
+        var now = DateTimeOffset.Parse("2026-07-31T12:00:00Z");
+        var managerExit = new SshTunnelExit(
+            255,
+            Tunnel,
+            Generation: 7,
+            SshTunnelOwner.GatewayConnectionManager);
+        var settingsExit = managerExit with { Owner = SshTunnelOwner.Settings };
+
+        Assert.True(budget.TryReserve(managerExit, now, out _));
+        budget.ReportRecovered(settingsExit);
+
+        Assert.True(budget.TryReserve(managerExit, now.AddSeconds(3), out var delay));
+        Assert.Equal(TimeSpan.FromSeconds(10), delay);
+    }
+
+    [Fact]
+    public void Reset_RearmsCurrentTunnel()
+    {
+        var budget = new SshTunnelRecoveryBudget();
+        var now = DateTimeOffset.Parse("2026-07-31T12:00:00Z");
+        var tunnelExit = new SshTunnelExit(
+            255,
+            Tunnel,
+            Generation: 7,
+            SshTunnelOwner.Settings);
+
+        Assert.True(budget.TryReserve(tunnelExit, now, out _));
+        budget.Reset();
+
+        Assert.True(budget.TryReserve(tunnelExit, now.AddSeconds(3), out var delay));
+        Assert.Equal(TimeSpan.FromSeconds(3), delay);
+    }
+}

--- a/tests/OpenClaw.Connection.Tests/SshTunnelServiceTests.cs
+++ b/tests/OpenClaw.Connection.Tests/SshTunnelServiceTests.cs
@@ -74,6 +74,29 @@ public sealed class SshTunnelServiceTests
         Assert.Null(service.LastError);
     }
 
+    [Theory]
+    [InlineData(
+        SshTunnelOwner.Settings,
+        SshTunnelOwner.GatewayConnectionManager,
+        SshTunnelOwner.GatewayConnectionManager)]
+    [InlineData(
+        SshTunnelOwner.GatewayConnectionManager,
+        SshTunnelOwner.Settings,
+        SshTunnelOwner.GatewayConnectionManager)]
+    [InlineData(
+        SshTunnelOwner.Settings,
+        SshTunnelOwner.Settings,
+        SshTunnelOwner.Settings)]
+    public void ResolveOwnerForReuse_PreservesManagerOwnership(
+        SshTunnelOwner currentOwner,
+        SshTunnelOwner requestedOwner,
+        SshTunnelOwner expectedOwner)
+    {
+        Assert.Equal(
+            expectedOwner,
+            SshTunnelService.ResolveOwnerForReuse(currentOwner, requestedOwner));
+    }
+
     [Fact]
     public void Stop_FromNotConfigured_StatusRemainsNotConfigured()
     {

--- a/tests/OpenClaw.Connection.Tests/SshTunnelServiceTests.cs
+++ b/tests/OpenClaw.Connection.Tests/SshTunnelServiceTests.cs
@@ -58,6 +58,23 @@ public sealed class SshTunnelServiceTests
     }
 
     [Fact]
+    public void TryMarkRestarting_RejectsUnknownTunnelGeneration()
+    {
+        using var service = new SshTunnelService(NullLogger.Instance);
+        var tunnelExit = new SshTunnelExit(
+            ExitCode: 42,
+            Tunnel: new SshTunnelConfig("user", "host", 18789, 18789),
+            Generation: 1);
+
+        var accepted = service.TryMarkRestarting(tunnelExit);
+
+        Assert.False(accepted);
+        Assert.False(service.IsRestartPending(tunnelExit));
+        Assert.Equal(TunnelStatus.NotConfigured, service.Status);
+        Assert.Null(service.LastError);
+    }
+
+    [Fact]
     public void Stop_FromNotConfigured_StatusRemainsNotConfigured()
     {
         // Stop() when no process has been started and state is NotConfigured

--- a/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
@@ -179,6 +179,20 @@ public sealed class AppRefactorContractTests
     }
 
     [Fact]
+    public void SshTunnelExit_RecoversActiveRegistryGatewayThroughConnectionManager()
+    {
+        var source = ReadAppSources();
+        var method = ExtractMethod(source, "OnSshTunnelExitedAsync");
+
+        Assert.Contains("var connectionManager = _connectionManager;", method);
+        Assert.Contains("_sshTunnelService?.TryMarkRestarting(tunnelExit) != true", method);
+        Assert.Contains("await connectionManager.RecoverSshTunnelAsync(tunnelExit)", method);
+        Assert.DoesNotContain("_gatewayRegistry?.GetActive()", method);
+        Assert.DoesNotContain("_settings?.UseSshTunnel", method);
+        Assert.DoesNotContain("_sshTunnelService.EnsureStarted", method);
+    }
+
+    [Fact]
     public void ConnectionIssueNotification_PrefersNodeOwnedFailuresBeforeGenericGatewayError()
     {
         var source = ReadAppSources();

--- a/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
@@ -185,8 +185,12 @@ public sealed class AppRefactorContractTests
         var method = ExtractMethod(source, "OnSshTunnelExitedAsync");
 
         Assert.Contains("var connectionManager = _connectionManager;", method);
-        Assert.Contains("_sshTunnelService?.TryMarkRestarting(tunnelExit) != true", method);
+        Assert.Contains("tunnelService?.TryMarkRestarting(tunnelExit) != true", method);
         Assert.Contains("await connectionManager.RecoverSshTunnelAsync(tunnelExit)", method);
+        Assert.Contains("tunnelService.TryRestart(tunnelExit)", method);
+        Assert.Contains("tunnelService.TryMarkRecoveryFailed(tunnelExit", method);
+        Assert.Contains("_sshTunnelRecoveryBudget.TryReserve(", method);
+        Assert.Contains("_sshTunnelRecoveryBudget.ReportRecovered(tunnelExit)", method);
         Assert.DoesNotContain("_gatewayRegistry?.GetActive()", method);
         Assert.DoesNotContain("_settings?.UseSshTunnel", method);
         Assert.DoesNotContain("_sshTunnelService.EnsureStarted", method);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users connecting the Windows tray to a remote Gateway through a saved SSH tunnel would stay disconnected after the tunnel process exited. The tray scheduled a restart, but the recovery path checked obsolete global SSH settings instead of the active saved gateway.

## Why This Change Was Made

Recovery now goes through the owner of the failed tunnel:

- `GatewayConnectionManager` owns registry-backed tunnels and may reconnect the gateway clients.
- Settings-owned tunnels restart only the exact failed tunnel generation and configuration.

Tunnel exits carry the exact configuration, owner, and lifecycle generation that failed, so delayed callbacks cannot reconnect a different gateway or clear a replacement process. Automatic recovery uses bounded 3, 10, and 30 second retries, stops after three failures in five minutes, and re-arms after successful automatic or manual recovery.

## User Impact

Remote Gateway connections configured in the gateway registry recover automatically when their SSH forward drops and becomes available again. Existing device and node pairing remain valid; users do not need to pair again. Repeated failures stop with an honest failed state instead of causing an unlimited reconnect loop.

## Evidence

- Built and tested the original recovery patch in a native CRLF checkout on an on-demand AWS Windows desktop.
- Ran a Linux Gateway on a separate AWS Linux host and connected the Windows tray through an SSH forward.
- Completed both pairing stages: operator device approval, then Windows node approval.
- Verified local MCP tool discovery and `device.info`.
- Verified gateway-mediated `device.info`.
- Removed the transport carrying the Windows-to-Linux SSH route. The tray recorded `tunnel.restart_scheduled` and retried through the active gateway record.
- Restored the transport. The tray recreated one SSH process, returned to `Connected`, retained the same paired node identity, reported zero pending approvals, and passed local MCP plus gateway-mediated `device.info` again.
- Current-head ownership, generation, failure-state, retry-budget, and recovery re-arm behavior is covered by deterministic unit and contract tests.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs or instructions
- [x] Tests or validation
- [ ] Security hardening
- [ ] Chore or infrastructure

## Scope

- [x] Tray or WinUI UX
- [ ] Windows node capability
- [ ] Local MCP or `winnode`
- [x] Gateway, connection, or pairing
- [ ] Setup or onboarding
- [ ] Permissions, privacy, or security
- [x] Tests, CI, or docs

## Validation

Current head: `21fd3491a70ca5e865e607d08533c361a8f5ab63`

- `.\build.ps1`
  - passed: Shared, CLI, WinNode CLI, SetupEngine, WinUI
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore`
  - 3,399 passed, 32 skipped
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore`
  - 2,023 passed
- `dotnet test .\tests\OpenClaw.Connection.Tests\OpenClaw.Connection.Tests.csproj --no-restore`
  - 529 passed
- `git diff --check`
  - passed

## Real Behavior Proof

- Environment tested for the original recovery behavior: on-demand AWS Windows desktop, AWS Linux Gateway, and an SSH transport between them
- Runtime-tested commit: `0fa8a2e6`
- Exact steps:
  - launched the patched tray with an isolated data directory
  - approved operator device pairing and node pairing
  - ran `winnode --list-tools`
  - ran local `winnode --command device.info --params "{}"`
  - ran gateway-mediated `nodes invoke --command device.info`
  - removed and restored the task-owned SSH transport
- Evidence after fix:
  - one tray-owned SSH process listening on the configured local Gateway port
  - diagnostics progressed from `tunnel.restart_scheduled` to `Connected`
  - the same node identity remained `paired: true`, `connected: true`, and `approvalState: approved`
  - device pending count: 0
  - node pending count: 0
  - local MCP `device.info`: success
  - gateway-mediated `device.info`: success
- Observed result: the registry-backed tunnel recovered without restarting the tray or repeating either pairing stage
- Screenshot or artifact links verified? N/A
- Not verified or blocked: the external multi-host SSH fault-injection proof was not rerun on current head because the prior on-demand hosts are no longer available. Current-head state-machine behavior is covered by the validation above.
- Rubber-duck review: two independent final reviews found no blockers. Merge confidence was 97% and 93% after verifying ownership, lifecycle generation, bounded recovery, success re-arm, and manual recovery paths.

## Security Impact

- New permissions or capabilities? No
- Secrets or tokens handling changed? No
- New or changed network calls? No
- Command or tool execution surface changed? No
- Data access scope changed? No
- If any answer is `Yes`, explain the risk and mitigation: N/A

## Compatibility and Migration

- Backward compatible? Yes
- Config or environment changes? No
- Migration needed? No
- If yes, list the exact upgrade steps: N/A

## Review Conversations

- [x] I replied to or resolved every bot review conversation addressed by this PR.
- [ ] I left unresolved only conversations that still need maintainer judgment.
