### PR TITLE
fix(node): trust gateway session attribution only

### DIFF
--- a/docs/WINDOWS_NODE_TESTING.md
+++ b/docs/WINDOWS_NODE_TESTING.md
@@ -127,6 +127,7 @@ Local MCP clients also see MCP-only `app.*` commands such as `app.navigate`, `ap
 - **URL Validation**: Canvas blocks `file://`, `javascript:`, localhost, private IPs, IPv6 localhost
 - **Screen Capture Notification**: User is notified when screen snapshots are captured
 - **Screen Recording Allowlist**: `screen.record` must be explicitly allowed by the gateway and does not leave a hidden local MP4 copy on Windows
+- **Session Attribution**: Only the optional top-level `sessionKey` stamped by the Gateway on `node.invoke.request` is trusted. Older Gateways omit it, so those invokes remain unattributed; a caller-supplied nested `args.sessionKey` is never used as a fallback.
 - **Command Center Redaction**: recent node invoke activity records command name, status, duration, node id, and privacy class only; it does not store base64 payloads, screenshots, recordings, tokens, or command arguments
 - **Node Mode Toggle**: Must be explicitly enabled by user
 - **Command Validation**: Only alphanumeric commands with dots/hyphens allowed

--- a/src/OpenClaw.Shared/Capabilities/SystemCapability.cs
+++ b/src/OpenClaw.Shared/Capabilities/SystemCapability.cs
@@ -206,7 +206,6 @@ public class SystemCapability : NodeCapabilityBase
         var validated = validation.Request!;
         var argv = validated.Argv;
         var rawCommand = GetStringArg(request.Args, "rawCommand");
-        var sessionKey = request.SessionKey ?? validated.SessionKey;
 
         Logger.Info(
             $"system.run.prepare: {rawCommand ?? FormatExecCommand(argv)} (cwd={validated.Cwd ?? "default"})");
@@ -220,7 +219,7 @@ public class SystemCapability : NodeCapabilityBase
                 cwd = validated.Cwd,
                 rawCommand,
                 agentId = validated.AgentId,
-                sessionKey
+                sessionKey = validated.SessionKey
             }
         });
     }

--- a/src/OpenClaw.Shared/ExecApprovals/ExecApprovalV2InputValidator.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ExecApprovalV2InputValidator.cs
@@ -101,7 +101,7 @@ public static class ExecApprovalV2InputValidator
             timeoutMs,
             env,
             TryGetString(request.Args, "agentId"),
-            TryGetString(request.Args, "sessionKey"),
+            request.SessionKey,
             rawCommand));
     }
 

--- a/src/OpenClaw.Shared/NodeCapabilities.cs
+++ b/src/OpenClaw.Shared/NodeCapabilities.cs
@@ -26,7 +26,10 @@ public class NodeInvokeRequest
     public string Id { get; set; } = "";
     public string Command { get; set; } = "";
     public JsonElement Args { get; set; }
-    public string? SessionKey { get; set; }
+
+    /// <summary>Gateway-stamped run correlation; capability callers may read but not assign it.</summary>
+    [JsonIgnore]
+    public string? SessionKey { get; internal set; }
 
     [JsonIgnore]
     public NodeToolInvocation? Telemetry { get; set; }

--- a/src/OpenClaw.Shared/WindowsNodeClient.cs
+++ b/src/OpenClaw.Shared/WindowsNodeClient.cs
@@ -1809,11 +1809,11 @@ public class WindowsNodeClient : WebSocketClientBase
             return NodeInvokeSessionEnvelopeMode.Authoritative;
         }
 
-        // Before negotiation completes, the Gateway has not observed feature support and
-        // therefore sends the legacy nested binding. Preserve that receipt-time meaning.
+        // An explicit unknown-method response is the only authority for trusting the
+        // legacy nested binding. Omission remains fail-closed while negotiation is pending.
         if (!_nodeInvokeSessionEnvelopeNegotiationComplete)
         {
-            return NodeInvokeSessionEnvelopeMode.Legacy;
+            return NodeInvokeSessionEnvelopeMode.Authoritative;
         }
 
         return _nodeInvokeSessionEnvelopeMode.IsCompletedSuccessfully

--- a/src/OpenClaw.Shared/WindowsNodeClient.cs
+++ b/src/OpenClaw.Shared/WindowsNodeClient.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -17,6 +18,11 @@ namespace OpenClaw.Shared;
 /// </summary>
 public class WindowsNodeClient : WebSocketClientBase
 {
+    private const string NodeInvokeSessionKeyEnvelopeProtocolFeature =
+        "node-invoke-session-key-envelope-v1";
+    private static readonly TimeSpan s_protocolFeatureNegotiationTimeout =
+        TimeSpan.FromSeconds(5);
+
     private readonly DeviceIdentity _deviceIdentity;
     
     // Node capabilities registry
@@ -62,6 +68,14 @@ public class WindowsNodeClient : WebSocketClientBase
     // at 8. When full, the gateway receives an immediate "node busy, retry" error response.
     private readonly SemaphoreSlim _invokeSemaphore = new(8, 8);
     private readonly InvocationCancellationRegistry _activeInvocations = new();
+    private readonly ConcurrentDictionary<
+        string,
+        TaskCompletionSource<NodeInvokeSessionEnvelopeMode>> _protocolFeatureRequests = new();
+    private Task<NodeInvokeSessionEnvelopeMode> _nodeInvokeSessionEnvelopeMode =
+        Task.FromResult(NodeInvokeSessionEnvelopeMode.Authoritative);
+    private int _gatewayConnectionGeneration;
+    private readonly object _nodeInvokeEventDispatchLock = new();
+    private Task _nodeInvokeEventDispatch = Task.CompletedTask;
 
     // Events
     public event EventHandler<NodeInvokeRequest>? InvokeReceived;
@@ -340,10 +354,18 @@ public class WindowsNodeClient : WebSocketClientBase
                 await HandlePairingResolvedEventAsync(root, eventType);
                 break;
             case "node.invoke.request":
-                await HandleNodeInvokeEventAsync(root);
+                QueueNodeInvokeMessage(
+                    root.Clone(),
+                    QueuedNodeInvokeKind.Invoke,
+                    containerName: "payload",
+                    responseId: null);
                 break;
             case "node.invoke.cancel":
-                await HandleNodeInvokeCancelAsync(root, "payload", responseId: null);
+                QueueNodeInvokeMessage(
+                    root.Clone(),
+                    QueuedNodeInvokeKind.Cancel,
+                    containerName: "payload",
+                    responseId: null);
                 break;
             case "health":
                 if (root.TryGetProperty("payload", out var payload))
@@ -444,7 +466,67 @@ public class WindowsNodeClient : WebSocketClientBase
         }
     }
     
-    private async Task HandleNodeInvokeEventAsync(JsonElement root)
+    private void QueueNodeInvokeMessage(
+        JsonElement root,
+        QueuedNodeInvokeKind kind,
+        string containerName,
+        string? responseId)
+    {
+        var envelopeModeTask = _nodeInvokeSessionEnvelopeMode;
+        var connectionGeneration = _gatewayConnectionGeneration;
+        lock (_nodeInvokeEventDispatchLock)
+        {
+            _nodeInvokeEventDispatch = _nodeInvokeEventDispatch
+                .ContinueWith(
+                    _ => DispatchNodeInvokeEventAsync(
+                        root,
+                        kind,
+                        containerName,
+                        responseId,
+                        envelopeModeTask,
+                        connectionGeneration),
+                    CancellationToken.None,
+                    TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default)
+                .Unwrap();
+        }
+    }
+
+    private async Task DispatchNodeInvokeEventAsync(
+        JsonElement root,
+        QueuedNodeInvokeKind kind,
+        string containerName,
+        string? responseId,
+        Task<NodeInvokeSessionEnvelopeMode> envelopeModeTask,
+        int connectionGeneration)
+    {
+        try
+        {
+            var envelopeMode = await envelopeModeTask;
+            if (connectionGeneration != _gatewayConnectionGeneration)
+                return;
+
+            switch (kind)
+            {
+                case QueuedNodeInvokeKind.Invoke:
+                    // This returns after active-invocation registration and Task.Run handoff;
+                    // the next queued cancel is not serialized behind capability execution.
+                    await StartNodeInvokeEventAsync(root, envelopeMode);
+                    break;
+                case QueuedNodeInvokeKind.Cancel:
+                    await HandleNodeInvokeCancelAsync(root, containerName, responseId);
+                    break;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.Error("Node invoke event dispatch failed", ex);
+        }
+    }
+
+    private async Task StartNodeInvokeEventAsync(
+        JsonElement root,
+        NodeInvokeSessionEnvelopeMode envelopeMode)
     {
         var telemetry = new NodeToolInvocation(NodeToolTransport.Gateway);
         _logger.Info("[NODE] Received node.invoke.request event");
@@ -530,7 +612,7 @@ public class WindowsNodeClient : WebSocketClientBase
             }
         }
 
-        var sessionKey = ExtractGatewayNodeInvokeSessionKey(payload);
+        var sessionKey = ExtractGatewayNodeInvokeSessionKey(payload, args, envelopeMode);
         
         _logger.Info($"[NODE] Invoking command: {command}");
         
@@ -787,6 +869,22 @@ public class WindowsNodeClient : WebSocketClientBase
     
     internal void HandleResponse(JsonElement root)
     {
+        if (root.TryGetProperty("id", out var featureIdProp) &&
+            featureIdProp.ValueKind == JsonValueKind.String &&
+            featureIdProp.GetString() is { } featureResponseId &&
+            _protocolFeatureRequests.TryRemove(featureResponseId, out var negotiation))
+        {
+            var mode = IsUnsupportedNodeProtocolFeaturesResponse(root)
+                ? NodeInvokeSessionEnvelopeMode.Legacy
+                : NodeInvokeSessionEnvelopeMode.Authoritative;
+            negotiation.TrySetResult(mode);
+            if (mode == NodeInvokeSessionEnvelopeMode.Legacy)
+            {
+                _logger.Debug("[NODE] Gateway does not accept node protocol feature publication");
+            }
+            return;
+        }
+
         var responseId = root.TryGetProperty("id", out var idProp)
             ? idProp.GetString()
             : null;
@@ -821,6 +919,7 @@ public class WindowsNodeClient : WebSocketClientBase
 
             Volatile.Write(ref _pendingConnectRequestId, null);
             _logger.Info("[HANDSHAKE] Received hello-ok!");
+            _gatewayConnectionGeneration++;
             PublishGatewaySelf(GatewaySelfInfo.FromHelloOk(payload));
             var reconnectingAfterApproval = _pairingApprovedAwaitingReconnect;
             _isConnected = true;
@@ -900,8 +999,73 @@ public class WindowsNodeClient : WebSocketClientBase
             }
 
             RaiseStatusChanged(ConnectionStatus.Connected);
+            _ = PublishNodeProtocolFeaturesAsync();
             HandshakeSucceeded?.Invoke(this, EventArgs.Empty);
         }
+    }
+
+    private async Task PublishNodeProtocolFeaturesAsync()
+    {
+        var requestId = Guid.NewGuid().ToString();
+        var negotiation = new TaskCompletionSource<NodeInvokeSessionEnvelopeMode>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        _nodeInvokeSessionEnvelopeMode = negotiation.Task;
+        var request = new
+        {
+            type = "req",
+            id = requestId,
+            method = "node.protocolFeatures.update",
+            @params = new
+            {
+                features = new[] { NodeInvokeSessionKeyEnvelopeProtocolFeature }
+            }
+        };
+
+        try
+        {
+            _protocolFeatureRequests.TryAdd(requestId, negotiation);
+            _ = ResolveNodeProtocolFeaturesTimeoutAsync(requestId, negotiation);
+            await SendRawAsync(JsonSerializer.Serialize(request));
+        }
+        catch (Exception ex)
+        {
+            _protocolFeatureRequests.TryRemove(requestId, out _);
+            negotiation.TrySetResult(NodeInvokeSessionEnvelopeMode.Authoritative);
+            // Only an explicit unknown-method response enables legacy attribution.
+            // Transport failures keep omitted envelopes fail-closed.
+            _logger.Warn($"[NODE] Failed to publish protocol features: {ex.Message}");
+        }
+    }
+
+    private async Task ResolveNodeProtocolFeaturesTimeoutAsync(
+        string requestId,
+        TaskCompletionSource<NodeInvokeSessionEnvelopeMode> negotiation)
+    {
+        await Task.Delay(s_protocolFeatureNegotiationTimeout);
+        if (_protocolFeatureRequests.TryGetValue(requestId, out var pending) &&
+            ReferenceEquals(pending, negotiation))
+        {
+            _logger.Warn("[NODE] Protocol feature publication timed out; using fail-closed envelopes");
+            negotiation.TrySetResult(NodeInvokeSessionEnvelopeMode.Authoritative);
+        }
+    }
+
+    private static bool IsUnsupportedNodeProtocolFeaturesResponse(JsonElement response)
+    {
+        if (!response.TryGetProperty("ok", out var ok) ||
+            ok.ValueKind != JsonValueKind.False ||
+            !response.TryGetProperty("error", out var error) ||
+            error.ValueKind != JsonValueKind.Object)
+        {
+            return false;
+        }
+
+        return error.TryGetProperty("code", out var code) &&
+            string.Equals(code.GetString(), "INVALID_REQUEST", StringComparison.OrdinalIgnoreCase) &&
+            error.TryGetProperty("message", out var message) &&
+            message.GetString()?.Contains(
+                "unknown method: node.protocolFeatures.update",
+                StringComparison.Ordinal) == true;
     }
 
     private void TryStoreHandshakeDeviceToken(string token, string[]? scopes)
@@ -1198,7 +1362,11 @@ public class WindowsNodeClient : WebSocketClientBase
                 await HandleNodeInvokeAsync(root, id);
                 break;
             case "node.invoke.cancel":
-                await HandleNodeInvokeCancelAsync(root, "params", id);
+                QueueNodeInvokeMessage(
+                    root.Clone(),
+                    QueuedNodeInvokeKind.Cancel,
+                    containerName: "params",
+                    responseId: id);
                 break;
             case "ping":
                 await SendPongAsync(id);
@@ -1647,17 +1815,46 @@ public class WindowsNodeClient : WebSocketClientBase
         return false;
     }
 
-    private static string? ExtractGatewayNodeInvokeSessionKey(JsonElement envelope)
+    private static string? ExtractGatewayNodeInvokeSessionKey(
+        JsonElement envelope,
+        JsonElement args,
+        NodeInvokeSessionEnvelopeMode envelopeMode)
     {
-        if (envelope.TryGetProperty("sessionKey", out var envelopeSessionKey) &&
-            envelopeSessionKey.ValueKind == JsonValueKind.String)
+        if (envelope.TryGetProperty("sessionKey", out var envelopeSessionKey))
         {
-            var sessionKey = envelopeSessionKey.GetString();
+            if (envelopeSessionKey.ValueKind == JsonValueKind.String)
+            {
+                var sessionKey = envelopeSessionKey.GetString();
+                if (!string.IsNullOrWhiteSpace(sessionKey))
+                    return sessionKey;
+            }
+
+            return null;
+        }
+
+        if (envelopeMode == NodeInvokeSessionEnvelopeMode.Legacy &&
+            args.ValueKind == JsonValueKind.Object &&
+            args.TryGetProperty("sessionKey", out var legacySessionKey) &&
+            legacySessionKey.ValueKind == JsonValueKind.String)
+        {
+            var sessionKey = legacySessionKey.GetString();
             if (!string.IsNullOrWhiteSpace(sessionKey))
                 return sessionKey;
         }
 
         return null;
+    }
+
+    private enum NodeInvokeSessionEnvelopeMode
+    {
+        Authoritative,
+        Legacy
+    }
+
+    private enum QueuedNodeInvokeKind
+    {
+        Invoke,
+        Cancel
     }
 
     private sealed record CommandDispatchEntry(
@@ -1811,6 +2008,7 @@ public class WindowsNodeClient : WebSocketClientBase
     protected override void OnDisconnected()
     {
         _activeInvocations.CancelAll();
+        ResetNodeInvokeSessionEnvelopeNegotiation();
         _isConnected = false;
         Volatile.Write(ref _pendingConnectRequestId, null);
         // Don't reset pairing state when disconnected due to pairing — gateway
@@ -1825,6 +2023,7 @@ public class WindowsNodeClient : WebSocketClientBase
     protected override void OnError(Exception ex)
     {
         _activeInvocations.CancelAll();
+        ResetNodeInvokeSessionEnvelopeNegotiation();
         _isConnected = false;
         if (!_pairingBlocked)
         {
@@ -1836,5 +2035,22 @@ public class WindowsNodeClient : WebSocketClientBase
     protected override void OnDisposing()
     {
         _activeInvocations.CancelAll();
+        ResetNodeInvokeSessionEnvelopeNegotiation();
+    }
+
+    private void ResetNodeInvokeSessionEnvelopeNegotiation()
+    {
+        _gatewayConnectionGeneration++;
+        foreach (var request in _protocolFeatureRequests.Values)
+        {
+            request.TrySetResult(NodeInvokeSessionEnvelopeMode.Authoritative);
+        }
+        _protocolFeatureRequests.Clear();
+        _nodeInvokeSessionEnvelopeMode =
+            Task.FromResult(NodeInvokeSessionEnvelopeMode.Authoritative);
+        lock (_nodeInvokeEventDispatchLock)
+        {
+            _nodeInvokeEventDispatch = Task.CompletedTask;
+        }
     }
 }

--- a/src/OpenClaw.Shared/WindowsNodeClient.cs
+++ b/src/OpenClaw.Shared/WindowsNodeClient.cs
@@ -530,7 +530,7 @@ public class WindowsNodeClient : WebSocketClientBase
             }
         }
 
-        var sessionKey = ExtractNodeInvokeSessionKey(payload, args);
+        var sessionKey = ExtractGatewayNodeInvokeSessionKey(payload);
         
         _logger.Info($"[NODE] Invoking command: {command}");
         
@@ -1262,8 +1262,6 @@ public class WindowsNodeClient : WebSocketClientBase
         var args = paramsEl.TryGetProperty("args", out var argsEl) 
             ? argsEl.Clone() 
             : default;
-        var sessionKey = ExtractNodeInvokeSessionKey(paramsEl, args);
-        
         _logger.Info($"Received node.invoke: {command}");
         
         var request = new NodeInvokeRequest
@@ -1271,7 +1269,8 @@ public class WindowsNodeClient : WebSocketClientBase
             Id = requestId,
             Command = command,
             Args = args,
-            SessionKey = sessionKey,
+            // Legacy request frames have no trusted gateway event envelope.
+            // Keep caller-controlled params out of approval/session correlation.
             Telemetry = telemetry
         };
         
@@ -1648,21 +1647,12 @@ public class WindowsNodeClient : WebSocketClientBase
         return false;
     }
 
-    private static string? ExtractNodeInvokeSessionKey(JsonElement envelope, JsonElement args)
+    private static string? ExtractGatewayNodeInvokeSessionKey(JsonElement envelope)
     {
         if (envelope.TryGetProperty("sessionKey", out var envelopeSessionKey) &&
             envelopeSessionKey.ValueKind == JsonValueKind.String)
         {
             var sessionKey = envelopeSessionKey.GetString();
-            if (!string.IsNullOrWhiteSpace(sessionKey))
-                return sessionKey;
-        }
-
-        if (args.ValueKind == JsonValueKind.Object &&
-            args.TryGetProperty("sessionKey", out var argsSessionKey) &&
-            argsSessionKey.ValueKind == JsonValueKind.String)
-        {
-            var sessionKey = argsSessionKey.GetString();
             if (!string.IsNullOrWhiteSpace(sessionKey))
                 return sessionKey;
         }

--- a/src/OpenClaw.Shared/WindowsNodeClient.cs
+++ b/src/OpenClaw.Shared/WindowsNodeClient.cs
@@ -73,9 +73,8 @@ public class WindowsNodeClient : WebSocketClientBase
         TaskCompletionSource<NodeInvokeSessionEnvelopeMode>> _protocolFeatureRequests = new();
     private Task<NodeInvokeSessionEnvelopeMode> _nodeInvokeSessionEnvelopeMode =
         Task.FromResult(NodeInvokeSessionEnvelopeMode.Authoritative);
+    private volatile bool _nodeInvokeSessionEnvelopeNegotiationComplete = true;
     private int _gatewayConnectionGeneration;
-    private readonly object _nodeInvokeEventDispatchLock = new();
-    private Task _nodeInvokeEventDispatch = Task.CompletedTask;
 
     // Events
     public event EventHandler<NodeInvokeRequest>? InvokeReceived;
@@ -354,18 +353,10 @@ public class WindowsNodeClient : WebSocketClientBase
                 await HandlePairingResolvedEventAsync(root, eventType);
                 break;
             case "node.invoke.request":
-                QueueNodeInvokeMessage(
-                    root.Clone(),
-                    QueuedNodeInvokeKind.Invoke,
-                    containerName: "payload",
-                    responseId: null);
+                await StartNodeInvokeEventAsync(root.Clone());
                 break;
             case "node.invoke.cancel":
-                QueueNodeInvokeMessage(
-                    root.Clone(),
-                    QueuedNodeInvokeKind.Cancel,
-                    containerName: "payload",
-                    responseId: null);
+                await HandleNodeInvokeCancelAsync(root, "payload", responseId: null);
                 break;
             case "health":
                 if (root.TryGetProperty("payload", out var payload))
@@ -466,67 +457,7 @@ public class WindowsNodeClient : WebSocketClientBase
         }
     }
     
-    private void QueueNodeInvokeMessage(
-        JsonElement root,
-        QueuedNodeInvokeKind kind,
-        string containerName,
-        string? responseId)
-    {
-        var envelopeModeTask = _nodeInvokeSessionEnvelopeMode;
-        var connectionGeneration = _gatewayConnectionGeneration;
-        lock (_nodeInvokeEventDispatchLock)
-        {
-            _nodeInvokeEventDispatch = _nodeInvokeEventDispatch
-                .ContinueWith(
-                    _ => DispatchNodeInvokeEventAsync(
-                        root,
-                        kind,
-                        containerName,
-                        responseId,
-                        envelopeModeTask,
-                        connectionGeneration),
-                    CancellationToken.None,
-                    TaskContinuationOptions.ExecuteSynchronously,
-                    TaskScheduler.Default)
-                .Unwrap();
-        }
-    }
-
-    private async Task DispatchNodeInvokeEventAsync(
-        JsonElement root,
-        QueuedNodeInvokeKind kind,
-        string containerName,
-        string? responseId,
-        Task<NodeInvokeSessionEnvelopeMode> envelopeModeTask,
-        int connectionGeneration)
-    {
-        try
-        {
-            var envelopeMode = await envelopeModeTask;
-            if (connectionGeneration != _gatewayConnectionGeneration)
-                return;
-
-            switch (kind)
-            {
-                case QueuedNodeInvokeKind.Invoke:
-                    // This returns after active-invocation registration and Task.Run handoff;
-                    // the next queued cancel is not serialized behind capability execution.
-                    await StartNodeInvokeEventAsync(root, envelopeMode);
-                    break;
-                case QueuedNodeInvokeKind.Cancel:
-                    await HandleNodeInvokeCancelAsync(root, containerName, responseId);
-                    break;
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.Error("Node invoke event dispatch failed", ex);
-        }
-    }
-
-    private async Task StartNodeInvokeEventAsync(
-        JsonElement root,
-        NodeInvokeSessionEnvelopeMode envelopeMode)
+    private async Task StartNodeInvokeEventAsync(JsonElement root)
     {
         var telemetry = new NodeToolInvocation(NodeToolTransport.Gateway);
         _logger.Info("[NODE] Received node.invoke.request event");
@@ -612,6 +543,7 @@ public class WindowsNodeClient : WebSocketClientBase
             }
         }
 
+        var envelopeMode = ResolveNodeInvokeSessionEnvelopeModeAtReceipt(payload);
         var sessionKey = ExtractGatewayNodeInvokeSessionKey(payload, args, envelopeMode);
         
         _logger.Info($"[NODE] Invoking command: {command}");
@@ -878,6 +810,10 @@ public class WindowsNodeClient : WebSocketClientBase
                 ? NodeInvokeSessionEnvelopeMode.Legacy
                 : NodeInvokeSessionEnvelopeMode.Authoritative;
             negotiation.TrySetResult(mode);
+            if (ReferenceEquals(_nodeInvokeSessionEnvelopeMode, negotiation.Task))
+            {
+                _nodeInvokeSessionEnvelopeNegotiationComplete = true;
+            }
             if (mode == NodeInvokeSessionEnvelopeMode.Legacy)
             {
                 _logger.Debug("[NODE] Gateway does not accept node protocol feature publication");
@@ -1010,6 +946,7 @@ public class WindowsNodeClient : WebSocketClientBase
         var negotiation = new TaskCompletionSource<NodeInvokeSessionEnvelopeMode>(
             TaskCreationOptions.RunContinuationsAsynchronously);
         _nodeInvokeSessionEnvelopeMode = negotiation.Task;
+        _nodeInvokeSessionEnvelopeNegotiationComplete = false;
         var request = new
         {
             type = "req",
@@ -1031,6 +968,10 @@ public class WindowsNodeClient : WebSocketClientBase
         {
             _protocolFeatureRequests.TryRemove(requestId, out _);
             negotiation.TrySetResult(NodeInvokeSessionEnvelopeMode.Authoritative);
+            if (ReferenceEquals(_nodeInvokeSessionEnvelopeMode, negotiation.Task))
+            {
+                _nodeInvokeSessionEnvelopeNegotiationComplete = true;
+            }
             // Only an explicit unknown-method response enables legacy attribution.
             // Transport failures keep omitted envelopes fail-closed.
             _logger.Warn($"[NODE] Failed to publish protocol features: {ex.Message}");
@@ -1047,6 +988,10 @@ public class WindowsNodeClient : WebSocketClientBase
         {
             _logger.Warn("[NODE] Protocol feature publication timed out; using fail-closed envelopes");
             negotiation.TrySetResult(NodeInvokeSessionEnvelopeMode.Authoritative);
+            if (ReferenceEquals(_nodeInvokeSessionEnvelopeMode, negotiation.Task))
+            {
+                _nodeInvokeSessionEnvelopeNegotiationComplete = true;
+            }
         }
     }
 
@@ -1054,18 +999,31 @@ public class WindowsNodeClient : WebSocketClientBase
     {
         if (!response.TryGetProperty("ok", out var ok) ||
             ok.ValueKind != JsonValueKind.False ||
-            !response.TryGetProperty("error", out var error) ||
-            error.ValueKind != JsonValueKind.Object)
+            !response.TryGetProperty("error", out var error))
         {
             return false;
         }
 
-        return error.TryGetProperty("code", out var code) &&
-            string.Equals(code.GetString(), "INVALID_REQUEST", StringComparison.OrdinalIgnoreCase) &&
-            error.TryGetProperty("message", out var message) &&
-            message.GetString()?.Contains(
-                "unknown method: node.protocolFeatures.update",
-                StringComparison.Ordinal) == true;
+        string? message;
+        if (error.ValueKind == JsonValueKind.String)
+        {
+            message = error.GetString();
+        }
+        else if (error.ValueKind == JsonValueKind.Object &&
+                 error.TryGetProperty("code", out var code) &&
+                 string.Equals(code.GetString(), "INVALID_REQUEST", StringComparison.OrdinalIgnoreCase) &&
+                 error.TryGetProperty("message", out var objectMessage))
+        {
+            message = objectMessage.GetString();
+        }
+        else
+        {
+            return false;
+        }
+
+        return message?.Contains(
+            "unknown method: node.protocolFeatures.update",
+            StringComparison.OrdinalIgnoreCase) == true;
     }
 
     private void TryStoreHandshakeDeviceToken(string token, string[]? scopes)
@@ -1362,11 +1320,7 @@ public class WindowsNodeClient : WebSocketClientBase
                 await HandleNodeInvokeAsync(root, id);
                 break;
             case "node.invoke.cancel":
-                QueueNodeInvokeMessage(
-                    root.Clone(),
-                    QueuedNodeInvokeKind.Cancel,
-                    containerName: "params",
-                    responseId: id);
+                await HandleNodeInvokeCancelAsync(root, "params", id);
                 break;
             case "ping":
                 await SendPongAsync(id);
@@ -1437,8 +1391,10 @@ public class WindowsNodeClient : WebSocketClientBase
             Id = requestId,
             Command = command,
             Args = args,
-            // Legacy request frames have no trusted gateway event envelope.
-            // Keep caller-controlled params out of approval/session correlation.
+            SessionKey = ExtractGatewayNodeInvokeSessionKey(
+                paramsEl,
+                args,
+                NodeInvokeSessionEnvelopeMode.Authoritative),
             Telemetry = telemetry
         };
         
@@ -1845,16 +1801,30 @@ public class WindowsNodeClient : WebSocketClientBase
         return null;
     }
 
+    private NodeInvokeSessionEnvelopeMode ResolveNodeInvokeSessionEnvelopeModeAtReceipt(
+        JsonElement envelope)
+    {
+        if (envelope.TryGetProperty("sessionKey", out _))
+        {
+            return NodeInvokeSessionEnvelopeMode.Authoritative;
+        }
+
+        // Before negotiation completes, the Gateway has not observed feature support and
+        // therefore sends the legacy nested binding. Preserve that receipt-time meaning.
+        if (!_nodeInvokeSessionEnvelopeNegotiationComplete)
+        {
+            return NodeInvokeSessionEnvelopeMode.Legacy;
+        }
+
+        return _nodeInvokeSessionEnvelopeMode.IsCompletedSuccessfully
+            ? _nodeInvokeSessionEnvelopeMode.Result
+            : NodeInvokeSessionEnvelopeMode.Authoritative;
+    }
+
     private enum NodeInvokeSessionEnvelopeMode
     {
         Authoritative,
         Legacy
-    }
-
-    private enum QueuedNodeInvokeKind
-    {
-        Invoke,
-        Cancel
     }
 
     private sealed record CommandDispatchEntry(
@@ -2048,9 +2018,6 @@ public class WindowsNodeClient : WebSocketClientBase
         _protocolFeatureRequests.Clear();
         _nodeInvokeSessionEnvelopeMode =
             Task.FromResult(NodeInvokeSessionEnvelopeMode.Authoritative);
-        lock (_nodeInvokeEventDispatchLock)
-        {
-            _nodeInvokeEventDispatch = Task.CompletedTask;
-        }
+        _nodeInvokeSessionEnvelopeNegotiationComplete = true;
     }
 }

--- a/src/OpenClaw.Shared/WindowsNodeClient.cs
+++ b/src/OpenClaw.Shared/WindowsNodeClient.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -18,11 +17,6 @@ namespace OpenClaw.Shared;
 /// </summary>
 public class WindowsNodeClient : WebSocketClientBase
 {
-    private const string NodeInvokeSessionKeyEnvelopeProtocolFeature =
-        "node-invoke-session-key-envelope-v1";
-    private static readonly TimeSpan s_protocolFeatureNegotiationTimeout =
-        TimeSpan.FromSeconds(5);
-
     private readonly DeviceIdentity _deviceIdentity;
     
     // Node capabilities registry
@@ -68,13 +62,6 @@ public class WindowsNodeClient : WebSocketClientBase
     // at 8. When full, the gateway receives an immediate "node busy, retry" error response.
     private readonly SemaphoreSlim _invokeSemaphore = new(8, 8);
     private readonly InvocationCancellationRegistry _activeInvocations = new();
-    private readonly ConcurrentDictionary<
-        string,
-        TaskCompletionSource<NodeInvokeSessionEnvelopeMode>> _protocolFeatureRequests = new();
-    private Task<NodeInvokeSessionEnvelopeMode> _nodeInvokeSessionEnvelopeMode =
-        Task.FromResult(NodeInvokeSessionEnvelopeMode.Authoritative);
-    private volatile bool _nodeInvokeSessionEnvelopeNegotiationComplete = true;
-    private int _gatewayConnectionGeneration;
 
     // Events
     public event EventHandler<NodeInvokeRequest>? InvokeReceived;
@@ -543,8 +530,7 @@ public class WindowsNodeClient : WebSocketClientBase
             }
         }
 
-        var envelopeMode = ResolveNodeInvokeSessionEnvelopeModeAtReceipt(payload);
-        var sessionKey = ExtractGatewayNodeInvokeSessionKey(payload, args, envelopeMode);
+        var sessionKey = ExtractGatewayNodeInvokeSessionKey(payload);
         
         _logger.Info($"[NODE] Invoking command: {command}");
         
@@ -801,26 +787,6 @@ public class WindowsNodeClient : WebSocketClientBase
     
     internal void HandleResponse(JsonElement root)
     {
-        if (root.TryGetProperty("id", out var featureIdProp) &&
-            featureIdProp.ValueKind == JsonValueKind.String &&
-            featureIdProp.GetString() is { } featureResponseId &&
-            _protocolFeatureRequests.TryRemove(featureResponseId, out var negotiation))
-        {
-            var mode = IsUnsupportedNodeProtocolFeaturesResponse(root)
-                ? NodeInvokeSessionEnvelopeMode.Legacy
-                : NodeInvokeSessionEnvelopeMode.Authoritative;
-            negotiation.TrySetResult(mode);
-            if (ReferenceEquals(_nodeInvokeSessionEnvelopeMode, negotiation.Task))
-            {
-                _nodeInvokeSessionEnvelopeNegotiationComplete = true;
-            }
-            if (mode == NodeInvokeSessionEnvelopeMode.Legacy)
-            {
-                _logger.Debug("[NODE] Gateway does not accept node protocol feature publication");
-            }
-            return;
-        }
-
         var responseId = root.TryGetProperty("id", out var idProp)
             ? idProp.GetString()
             : null;
@@ -855,7 +821,6 @@ public class WindowsNodeClient : WebSocketClientBase
 
             Volatile.Write(ref _pendingConnectRequestId, null);
             _logger.Info("[HANDSHAKE] Received hello-ok!");
-            _gatewayConnectionGeneration++;
             PublishGatewaySelf(GatewaySelfInfo.FromHelloOk(payload));
             var reconnectingAfterApproval = _pairingApprovedAwaitingReconnect;
             _isConnected = true;
@@ -935,95 +900,8 @@ public class WindowsNodeClient : WebSocketClientBase
             }
 
             RaiseStatusChanged(ConnectionStatus.Connected);
-            _ = PublishNodeProtocolFeaturesAsync();
             HandshakeSucceeded?.Invoke(this, EventArgs.Empty);
         }
-    }
-
-    private async Task PublishNodeProtocolFeaturesAsync()
-    {
-        var requestId = Guid.NewGuid().ToString();
-        var negotiation = new TaskCompletionSource<NodeInvokeSessionEnvelopeMode>(
-            TaskCreationOptions.RunContinuationsAsynchronously);
-        _nodeInvokeSessionEnvelopeMode = negotiation.Task;
-        _nodeInvokeSessionEnvelopeNegotiationComplete = false;
-        var request = new
-        {
-            type = "req",
-            id = requestId,
-            method = "node.protocolFeatures.update",
-            @params = new
-            {
-                features = new[] { NodeInvokeSessionKeyEnvelopeProtocolFeature }
-            }
-        };
-
-        try
-        {
-            _protocolFeatureRequests.TryAdd(requestId, negotiation);
-            _ = ResolveNodeProtocolFeaturesTimeoutAsync(requestId, negotiation);
-            await SendRawAsync(JsonSerializer.Serialize(request));
-        }
-        catch (Exception ex)
-        {
-            _protocolFeatureRequests.TryRemove(requestId, out _);
-            negotiation.TrySetResult(NodeInvokeSessionEnvelopeMode.Authoritative);
-            if (ReferenceEquals(_nodeInvokeSessionEnvelopeMode, negotiation.Task))
-            {
-                _nodeInvokeSessionEnvelopeNegotiationComplete = true;
-            }
-            // Only an explicit unknown-method response enables legacy attribution.
-            // Transport failures keep omitted envelopes fail-closed.
-            _logger.Warn($"[NODE] Failed to publish protocol features: {ex.Message}");
-        }
-    }
-
-    private async Task ResolveNodeProtocolFeaturesTimeoutAsync(
-        string requestId,
-        TaskCompletionSource<NodeInvokeSessionEnvelopeMode> negotiation)
-    {
-        await Task.Delay(s_protocolFeatureNegotiationTimeout);
-        if (_protocolFeatureRequests.TryGetValue(requestId, out var pending) &&
-            ReferenceEquals(pending, negotiation))
-        {
-            _logger.Warn("[NODE] Protocol feature publication timed out; using fail-closed envelopes");
-            negotiation.TrySetResult(NodeInvokeSessionEnvelopeMode.Authoritative);
-            if (ReferenceEquals(_nodeInvokeSessionEnvelopeMode, negotiation.Task))
-            {
-                _nodeInvokeSessionEnvelopeNegotiationComplete = true;
-            }
-        }
-    }
-
-    private static bool IsUnsupportedNodeProtocolFeaturesResponse(JsonElement response)
-    {
-        if (!response.TryGetProperty("ok", out var ok) ||
-            ok.ValueKind != JsonValueKind.False ||
-            !response.TryGetProperty("error", out var error))
-        {
-            return false;
-        }
-
-        string? message;
-        if (error.ValueKind == JsonValueKind.String)
-        {
-            message = error.GetString();
-        }
-        else if (error.ValueKind == JsonValueKind.Object &&
-                 error.TryGetProperty("code", out var code) &&
-                 string.Equals(code.GetString(), "INVALID_REQUEST", StringComparison.OrdinalIgnoreCase) &&
-                 error.TryGetProperty("message", out var objectMessage))
-        {
-            message = objectMessage.GetString();
-        }
-        else
-        {
-            return false;
-        }
-
-        return message?.Contains(
-            "unknown method: node.protocolFeatures.update",
-            StringComparison.OrdinalIgnoreCase) == true;
     }
 
     private void TryStoreHandshakeDeviceToken(string token, string[]? scopes)
@@ -1391,10 +1269,7 @@ public class WindowsNodeClient : WebSocketClientBase
             Id = requestId,
             Command = command,
             Args = args,
-            SessionKey = ExtractGatewayNodeInvokeSessionKey(
-                paramsEl,
-                args,
-                NodeInvokeSessionEnvelopeMode.Authoritative),
+            SessionKey = ExtractGatewayNodeInvokeSessionKey(paramsEl),
             Telemetry = telemetry
         };
         
@@ -1771,10 +1646,7 @@ public class WindowsNodeClient : WebSocketClientBase
         return false;
     }
 
-    private static string? ExtractGatewayNodeInvokeSessionKey(
-        JsonElement envelope,
-        JsonElement args,
-        NodeInvokeSessionEnvelopeMode envelopeMode)
+    private static string? ExtractGatewayNodeInvokeSessionKey(JsonElement envelope)
     {
         if (envelope.TryGetProperty("sessionKey", out var envelopeSessionKey))
         {
@@ -1787,44 +1659,7 @@ public class WindowsNodeClient : WebSocketClientBase
 
             return null;
         }
-
-        if (envelopeMode == NodeInvokeSessionEnvelopeMode.Legacy &&
-            args.ValueKind == JsonValueKind.Object &&
-            args.TryGetProperty("sessionKey", out var legacySessionKey) &&
-            legacySessionKey.ValueKind == JsonValueKind.String)
-        {
-            var sessionKey = legacySessionKey.GetString();
-            if (!string.IsNullOrWhiteSpace(sessionKey))
-                return sessionKey;
-        }
-
         return null;
-    }
-
-    private NodeInvokeSessionEnvelopeMode ResolveNodeInvokeSessionEnvelopeModeAtReceipt(
-        JsonElement envelope)
-    {
-        if (envelope.TryGetProperty("sessionKey", out _))
-        {
-            return NodeInvokeSessionEnvelopeMode.Authoritative;
-        }
-
-        // An explicit unknown-method response is the only authority for trusting the
-        // legacy nested binding. Omission remains fail-closed while negotiation is pending.
-        if (!_nodeInvokeSessionEnvelopeNegotiationComplete)
-        {
-            return NodeInvokeSessionEnvelopeMode.Authoritative;
-        }
-
-        return _nodeInvokeSessionEnvelopeMode.IsCompletedSuccessfully
-            ? _nodeInvokeSessionEnvelopeMode.Result
-            : NodeInvokeSessionEnvelopeMode.Authoritative;
-    }
-
-    private enum NodeInvokeSessionEnvelopeMode
-    {
-        Authoritative,
-        Legacy
     }
 
     private sealed record CommandDispatchEntry(
@@ -1978,7 +1813,6 @@ public class WindowsNodeClient : WebSocketClientBase
     protected override void OnDisconnected()
     {
         _activeInvocations.CancelAll();
-        ResetNodeInvokeSessionEnvelopeNegotiation();
         _isConnected = false;
         Volatile.Write(ref _pendingConnectRequestId, null);
         // Don't reset pairing state when disconnected due to pairing — gateway
@@ -1993,7 +1827,6 @@ public class WindowsNodeClient : WebSocketClientBase
     protected override void OnError(Exception ex)
     {
         _activeInvocations.CancelAll();
-        ResetNodeInvokeSessionEnvelopeNegotiation();
         _isConnected = false;
         if (!_pairingBlocked)
         {
@@ -2005,19 +1838,5 @@ public class WindowsNodeClient : WebSocketClientBase
     protected override void OnDisposing()
     {
         _activeInvocations.CancelAll();
-        ResetNodeInvokeSessionEnvelopeNegotiation();
-    }
-
-    private void ResetNodeInvokeSessionEnvelopeNegotiation()
-    {
-        _gatewayConnectionGeneration++;
-        foreach (var request in _protocolFeatureRequests.Values)
-        {
-            request.TrySetResult(NodeInvokeSessionEnvelopeMode.Authoritative);
-        }
-        _protocolFeatureRequests.Clear();
-        _nodeInvokeSessionEnvelopeMode =
-            Task.FromResult(NodeInvokeSessionEnvelopeMode.Authoritative);
-        _nodeInvokeSessionEnvelopeNegotiationComplete = true;
     }
 }

--- a/tests/OpenClaw.Shared.Tests/CapabilityTests.cs
+++ b/tests/OpenClaw.Shared.Tests/CapabilityTests.cs
@@ -241,7 +241,8 @@ public class SystemCapabilityTests
         {
             Id = "p3",
             Command = "system.run.prepare",
-            Args = Parse("""{"command":["ls","-la"],"cwd":"/tmp","agentId":"agent1","sessionKey":"sk1"}""")
+            Args = Parse("""{"command":["ls","-la"],"cwd":"/tmp","agentId":"agent1","sessionKey":"spoofed"}"""),
+            SessionKey = "trusted-session"
         };
 
         var res = await cap.ExecuteAsync(req);
@@ -254,6 +255,7 @@ public class SystemCapabilityTests
         Assert.Equal("/tmp", cwd.GetString());
         Assert.True(plan.TryGetProperty("agentId", out var agentId));
         Assert.Equal("agent1", agentId.GetString());
+        Assert.Equal("trusted-session", plan.GetProperty("sessionKey").GetString());
     }
 
     [Fact]

--- a/tests/OpenClaw.Shared.Tests/ExecApprovalV2InputValidationTests.cs
+++ b/tests/OpenClaw.Shared.Tests/ExecApprovalV2InputValidationTests.cs
@@ -18,8 +18,14 @@ public class ExecApprovalV2InputValidationTests
         return doc.RootElement.Clone();
     }
 
-    private static NodeInvokeRequest Req(string argsJson)
-        => new() { Id = "r1", Command = "system.run", Args = Parse(argsJson) };
+    private static NodeInvokeRequest Req(string argsJson, string? sessionKey = null)
+        => new()
+        {
+            Id = "r1",
+            Command = "system.run",
+            Args = Parse(argsJson),
+            SessionKey = sessionKey
+        };
 
     // -------------------------------------------------------------------------
     // Allow paths
@@ -62,9 +68,9 @@ public class ExecApprovalV2InputValidationTests
                 "cwd": "C:\\repo",
                 "timeoutMs": 5000,
                 "agentId": "agent-1",
-                "sessionKey": "sess-abc"
+                "sessionKey": "forged-session"
             }
-            """));
+            """, sessionKey: "sess-abc"));
 
         Assert.True(outcome.IsValid);
         var r = outcome.Request!;
@@ -446,10 +452,10 @@ public class ExecApprovalV2InputValidationTests
     }
 
     [Fact]
-    public void SessionKeyWrongType_TreatedAsAbsent()
+    public void ArgsSessionKey_IsIgnored()
     {
         var outcome = ExecApprovalV2InputValidator.Validate(
-            Req("""{"command":["echo"],"sessionKey":[]}"""));
+            Req("""{"command":["echo"],"sessionKey":"forged-session"}"""));
 
         Assert.True(outcome.IsValid);
         Assert.Null(outcome.Request!.SessionKey);

--- a/tests/OpenClaw.Shared.Tests/WindowsNodeClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/WindowsNodeClientTests.cs
@@ -2652,7 +2652,7 @@ public class WindowsNodeClientTests
     }
 
     [Fact]
-    public async Task CommandDispatch_EventPath_UsesLegacyBindingWhileNegotiationIsPending()
+    public async Task CommandDispatch_EventPath_FailsClosedWhileNegotiationIsPending()
     {
         var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
         Directory.CreateDirectory(dataPath);
@@ -2699,7 +2699,7 @@ public class WindowsNodeClientTests
                 }
                 """);
             await cap.ExecutedTask.WaitAsync(TimeSpan.FromSeconds(5));
-            Assert.Equal("nested-session", cap.LastRequest?.SessionKey);
+            Assert.Null(cap.LastRequest?.SessionKey);
 
             await InvokeProcessMessageAsync(
                 client,

--- a/tests/OpenClaw.Shared.Tests/WindowsNodeClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/WindowsNodeClientTests.cs
@@ -2237,7 +2237,7 @@ public class WindowsNodeClientTests
     }
 
     [Fact]
-    public async Task CommandDispatch_ReqPath_PropagatesParamsSessionKey()
+    public async Task CommandDispatch_ReqPath_DoesNotTrustParamsSessionKey()
     {
         var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
         Directory.CreateDirectory(dataPath);
@@ -2265,7 +2265,7 @@ public class WindowsNodeClientTests
             await InvokeProcessMessageAsync(client, json);
             await cap.ExecutedTask.WaitAsync(TimeSpan.FromSeconds(5));
 
-            Assert.Equal("chat-thread-from-params", cap.LastRequest?.SessionKey);
+            Assert.Null(cap.LastRequest?.SessionKey);
         }
         finally
         {
@@ -2275,7 +2275,7 @@ public class WindowsNodeClientTests
     }
 
     [Fact]
-    public async Task CommandDispatch_ReqPath_PropagatesArgsSessionKey()
+    public async Task CommandDispatch_ReqPath_DoesNotTrustArgsSessionKey()
     {
         var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
         Directory.CreateDirectory(dataPath);
@@ -2304,7 +2304,7 @@ public class WindowsNodeClientTests
             await InvokeProcessMessageAsync(client, json);
             await cap.ExecutedTask.WaitAsync(TimeSpan.FromSeconds(5));
 
-            Assert.Equal("chat-thread-from-args", cap.LastRequest?.SessionKey);
+            Assert.Null(cap.LastRequest?.SessionKey);
         }
         finally
         {
@@ -2314,7 +2314,7 @@ public class WindowsNodeClientTests
     }
 
     [Fact]
-    public async Task CommandDispatch_ReqPath_ParamsSessionKeyOverridesArgsSessionKey()
+    public async Task CommandDispatch_ReqPath_DoesNotCreateTrustedSessionBinding()
     {
         var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
         Directory.CreateDirectory(dataPath);
@@ -2344,7 +2344,7 @@ public class WindowsNodeClientTests
             await InvokeProcessMessageAsync(client, json);
             await cap.ExecutedTask.WaitAsync(TimeSpan.FromSeconds(5));
 
-            Assert.Equal("trusted-session", cap.LastRequest?.SessionKey);
+            Assert.Null(cap.LastRequest?.SessionKey);
         }
         finally
         {
@@ -2464,6 +2464,79 @@ public class WindowsNodeClientTests
 
             Assert.Equal(1, cap.ExecuteCount);
             Assert.Equal("mock.ping", cap.LastCommand);
+        }
+        finally
+        {
+            if (Directory.Exists(dataPath))
+                Directory.Delete(dataPath, true);
+        }
+    }
+
+    [Fact]
+    public async Task CommandDispatch_EventPath_UsesEnvelopeSessionKey()
+    {
+        var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dataPath);
+
+        try
+        {
+            using var client = new WindowsNodeClient("ws://localhost:18789", "test-token", dataPath);
+            var cap = new MockCapability("mock", "mock.ping");
+            client.RegisterCapability(cap);
+
+            await InvokeProcessMessageAsync(client, """
+                {
+                  "type": "event",
+                  "event": "node.invoke.request",
+                  "payload": {
+                    "requestId": "inv-event-session",
+                    "command": "mock.ping",
+                    "sessionKey": "gateway-session",
+                    "args": {
+                      "sessionKey": "spoofed-session"
+                    }
+                  }
+                }
+                """);
+            await cap.ExecutedTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.Equal("gateway-session", cap.LastRequest?.SessionKey);
+        }
+        finally
+        {
+            if (Directory.Exists(dataPath))
+                Directory.Delete(dataPath, true);
+        }
+    }
+
+    [Fact]
+    public async Task CommandDispatch_EventPath_DoesNotTrustArgsSessionKey()
+    {
+        var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dataPath);
+
+        try
+        {
+            using var client = new WindowsNodeClient("ws://localhost:18789", "test-token", dataPath);
+            var cap = new MockCapability("mock", "mock.ping");
+            client.RegisterCapability(cap);
+
+            await InvokeProcessMessageAsync(client, """
+                {
+                  "type": "event",
+                  "event": "node.invoke.request",
+                  "payload": {
+                    "requestId": "inv-event-args-session",
+                    "command": "mock.ping",
+                    "args": {
+                      "sessionKey": "spoofed-session"
+                    }
+                  }
+                }
+                """);
+            await cap.ExecutedTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.Null(cap.LastRequest?.SessionKey);
         }
         finally
         {

--- a/tests/OpenClaw.Shared.Tests/WindowsNodeClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/WindowsNodeClientTests.cs
@@ -17,34 +17,6 @@ namespace OpenClaw.Shared.Tests;
 [Collection(AppVersionInfoTestCollection.Name)]
 public class WindowsNodeClientTests
 {
-    private static string BuildProtocolFeatureErrorResponse(
-        string requestId,
-        bool structuredError)
-    {
-        if (structuredError)
-        {
-            return JsonSerializer.Serialize(new
-            {
-                type = "res",
-                id = requestId,
-                ok = false,
-                error = new
-                {
-                    code = "INVALID_REQUEST",
-                    message = "unknown method: node.protocolFeatures.update"
-                }
-            });
-        }
-
-        return JsonSerializer.Serialize(new
-        {
-            type = "res",
-            id = requestId,
-            ok = false,
-            error = "UnKnOwN MeThOd: node.protocolFeatures.update"
-        });
-    }
-
     private sealed class CapturingWindowsNodeClient(
         string gatewayUrl,
         string token,
@@ -494,7 +466,7 @@ public class WindowsNodeClientTests
     }
 
     [Fact]
-    public async Task HandleResponse_HelloOk_PublishesNodeProtocolFeatures()
+    public void HandleResponse_HelloOk_DoesNotPublishUnsupportedProtocolFeatureRequest()
     {
         var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
         Directory.CreateDirectory(dataPath);
@@ -519,71 +491,9 @@ public class WindowsNodeClientTests
 
             client.HandleResponse(document.RootElement);
 
-            var requestJson = await WaitForSentMessageAsync(
-                client,
-                message => message.Contains(
-                    "\"method\":\"node.protocolFeatures.update\"",
-                    StringComparison.Ordinal));
-            using var request = JsonDocument.Parse(requestJson);
-            var root = request.RootElement;
-            Assert.Equal("req", root.GetProperty("type").GetString());
-            Assert.Contains(
-                "node-invoke-session-key-envelope-v1",
-                root.GetProperty("params")
-                    .GetProperty("features")
-                    .EnumerateArray()
-                    .Select(feature => feature.GetString()));
-        }
-        finally
-        {
-            Directory.Delete(dataPath, true);
-        }
-    }
-
-    [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public async Task HandleResponse_ProtocolFeatureUnknownMethod_DoesNotFailConnection(
-        bool structuredError)
-    {
-        var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(dataPath);
-
-        try
-        {
-            using var client = new CapturingWindowsNodeClient(
-                "ws://localhost:18789",
-                "test-token",
-                dataPath);
-            var statuses = new List<ConnectionStatus>();
-            client.StatusChanged += (_, status) => statuses.Add(status);
-            using var hello = JsonDocument.Parse(
-                """
-                {
-                  "type": "res",
-                  "ok": true,
-                  "payload": {
-                    "type": "hello-ok",
-                    "nodeId": "test-node-id"
-                  }
-                }
-                """);
-            client.HandleResponse(hello.RootElement);
-            var requestJson = await WaitForSentMessageAsync(
-                client,
-                message => message.Contains(
-                    "\"method\":\"node.protocolFeatures.update\"",
-                    StringComparison.Ordinal));
-            using var request = JsonDocument.Parse(requestJson);
-            var requestId = request.RootElement.GetProperty("id").GetString();
-            Assert.NotNull(requestId);
-            using var error = JsonDocument.Parse(
-                BuildProtocolFeatureErrorResponse(requestId, structuredError));
-
-            client.HandleResponse(error.RootElement);
-
-            Assert.True(client.IsConnected);
-            Assert.DoesNotContain(ConnectionStatus.Error, statuses);
+            Assert.DoesNotContain(
+                client.SentMessages,
+                message => message.Contains("node.protocolFeatures", StringComparison.Ordinal));
         }
         finally
         {
@@ -2672,8 +2582,52 @@ public class WindowsNodeClientTests
         }
     }
 
+    [Theory]
+    [InlineData("[]")]
+    [InlineData("{}")]
+    [InlineData("123")]
+    [InlineData("true")]
+    public async Task CommandDispatch_EventPath_MalformedEnvelopeDoesNotTrustNestedSessionKey(
+        string malformedSessionKey)
+    {
+        var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dataPath);
+
+        try
+        {
+            using var client = new WindowsNodeClient("ws://localhost:18789", "test-token", dataPath);
+            var cap = new MockCapability("mock", "mock.ping");
+            client.RegisterCapability(cap);
+
+            await InvokeProcessMessageAsync(
+                client,
+                $$"""
+                {
+                  "type": "event",
+                  "event": "node.invoke.request",
+                  "payload": {
+                    "requestId": "inv-event-malformed-session",
+                    "command": "mock.ping",
+                    "sessionKey": {{malformedSessionKey}},
+                    "args": {
+                      "sessionKey": "forged-session"
+                    }
+                  }
+                }
+                """);
+            await cap.ExecutedTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.Null(cap.LastRequest?.SessionKey);
+        }
+        finally
+        {
+            if (Directory.Exists(dataPath))
+                Directory.Delete(dataPath, true);
+        }
+    }
+
     [Fact]
-    public async Task CommandDispatch_EventPath_FailsClosedWhileNegotiationIsPending()
+    public async Task CommandDispatch_EventPath_OmittedEnvelopeDoesNotTrustNestedSessionKey()
     {
         var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
         Directory.CreateDirectory(dataPath);
@@ -2686,204 +2640,22 @@ public class WindowsNodeClientTests
                 dataPath);
             var cap = new MockCapability("mock", "mock.ping");
             client.RegisterCapability(cap);
-            using var hello = JsonDocument.Parse(
-                """
-                {
-                  "type": "res",
-                  "ok": true,
-                  "payload": {
-                    "type": "hello-ok",
-                    "nodeId": "test-node-id"
-                  }
-                }
-                """);
-            client.HandleResponse(hello.RootElement);
-            var requestJson = await WaitForSentMessageAsync(
-                client,
-                message => message.Contains(
-                    "\"method\":\"node.protocolFeatures.update\"",
-                    StringComparison.Ordinal));
-            using var request = JsonDocument.Parse(requestJson);
-            var requestId = request.RootElement.GetProperty("id").GetString();
 
             await InvokeProcessMessageAsync(client, """
                 {
                   "type": "event",
                   "event": "node.invoke.request",
                   "payload": {
-                    "requestId": "inv-event-negotiating",
+                    "requestId": "inv-event-unattributed",
                     "command": "mock.ping",
                     "args": {
-                      "sessionKey": "nested-session"
+                      "sessionKey": "forged-session"
                     }
                   }
                 }
                 """);
             await cap.ExecutedTask.WaitAsync(TimeSpan.FromSeconds(5));
             Assert.Null(cap.LastRequest?.SessionKey);
-
-            await InvokeProcessMessageAsync(
-                client,
-                $$"""
-                {
-                  "type": "res",
-                  "id": "{{requestId}}",
-                  "ok": true,
-                  "payload": {}
-                }
-                """);
-        }
-        finally
-        {
-            if (Directory.Exists(dataPath))
-                Directory.Delete(dataPath, true);
-        }
-    }
-
-    [Fact]
-    public async Task CommandDispatch_EventPath_DispatchesCancelDuringNegotiation()
-    {
-        var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(dataPath);
-        var blocking = new BlockingCapability("mock", "mock.slow");
-
-        try
-        {
-            using var client = new CapturingWindowsNodeClient(
-                "ws://localhost:18789",
-                "test-token",
-                dataPath);
-            client.RegisterCapability(blocking);
-            using var hello = JsonDocument.Parse(
-                """
-                {
-                  "type": "res",
-                  "ok": true,
-                  "payload": {
-                    "type": "hello-ok",
-                    "nodeId": "test-node-id"
-                  }
-                }
-                """);
-            client.HandleResponse(hello.RootElement);
-            var requestJson = await WaitForSentMessageAsync(
-                client,
-                message => message.Contains(
-                    "\"method\":\"node.protocolFeatures.update\"",
-                    StringComparison.Ordinal));
-            using var request = JsonDocument.Parse(requestJson);
-            var requestId = request.RootElement.GetProperty("id").GetString();
-
-            await InvokeProcessMessageAsync(client, """
-                {
-                  "type": "event",
-                  "event": "node.invoke.request",
-                  "payload": {
-                    "requestId": "inv-event-negotiating-cancel",
-                    "command": "mock.slow",
-                    "args": {}
-                  }
-                }
-                """);
-            await blocking.ExpectedEnteredTask.WaitAsync(TimeSpan.FromSeconds(5));
-            await InvokeProcessMessageAsync(client, """
-                {
-                  "type": "req",
-                  "id": "cancel-negotiating",
-                  "method": "node.invoke.cancel",
-                  "params": {
-                    "requestId": "inv-event-negotiating-cancel"
-                  }
-                }
-                """);
-            await blocking.AllCompletedTask.WaitAsync(TimeSpan.FromSeconds(5));
-            Assert.Equal(1, blocking.ExecuteCount);
-            var cancelResponseJson = await WaitForSentMessageAsync(
-                client,
-                message => message.Contains("\"id\":\"cancel-negotiating\"", StringComparison.Ordinal));
-            using var cancelResponse = JsonDocument.Parse(cancelResponseJson);
-            Assert.True(
-                cancelResponse.RootElement
-                    .GetProperty("payload")
-                    .GetProperty("cancelled")
-                    .GetBoolean());
-
-            await InvokeProcessMessageAsync(
-                client,
-                $$"""
-                {
-                  "type": "res",
-                  "id": "{{requestId}}",
-                  "ok": true,
-                  "payload": {}
-                }
-                """);
-        }
-        finally
-        {
-            blocking.Release();
-            if (Directory.Exists(dataPath))
-                Directory.Delete(dataPath, true);
-        }
-    }
-
-    [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public async Task CommandDispatch_EventPath_PreservesLegacyArgsSessionKeyWithoutEnvelope(
-        bool structuredError)
-    {
-        var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(dataPath);
-
-        try
-        {
-            using var client = new CapturingWindowsNodeClient(
-                "ws://localhost:18789",
-                "test-token",
-                dataPath);
-            var cap = new MockCapability("mock", "mock.ping");
-            client.RegisterCapability(cap);
-            using var hello = JsonDocument.Parse(
-                """
-                {
-                  "type": "res",
-                  "ok": true,
-                  "payload": {
-                    "type": "hello-ok",
-                    "nodeId": "test-node-id"
-                  }
-                }
-                """);
-            client.HandleResponse(hello.RootElement);
-            var requestJson = await WaitForSentMessageAsync(
-                client,
-                message => message.Contains(
-                    "\"method\":\"node.protocolFeatures.update\"",
-                    StringComparison.Ordinal));
-            using var request = JsonDocument.Parse(requestJson);
-            var requestId = request.RootElement.GetProperty("id").GetString();
-            Assert.NotNull(requestId);
-            await InvokeProcessMessageAsync(
-                client,
-                BuildProtocolFeatureErrorResponse(requestId, structuredError));
-
-            await InvokeProcessMessageAsync(client, """
-                {
-                  "type": "event",
-                  "event": "node.invoke.request",
-                  "payload": {
-                    "requestId": "inv-event-legacy-session",
-                    "command": "mock.ping",
-                    "args": {
-                      "sessionKey": "legacy-session"
-                    }
-                  }
-                }
-                """);
-            await cap.ExecutedTask.WaitAsync(TimeSpan.FromSeconds(5));
-
-            Assert.Equal("legacy-session", cap.LastRequest?.SessionKey);
         }
         finally
         {

--- a/tests/OpenClaw.Shared.Tests/WindowsNodeClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/WindowsNodeClientTests.cs
@@ -17,6 +17,34 @@ namespace OpenClaw.Shared.Tests;
 [Collection(AppVersionInfoTestCollection.Name)]
 public class WindowsNodeClientTests
 {
+    private static string BuildProtocolFeatureErrorResponse(
+        string requestId,
+        bool structuredError)
+    {
+        if (structuredError)
+        {
+            return JsonSerializer.Serialize(new
+            {
+                type = "res",
+                id = requestId,
+                ok = false,
+                error = new
+                {
+                    code = "INVALID_REQUEST",
+                    message = "unknown method: node.protocolFeatures.update"
+                }
+            });
+        }
+
+        return JsonSerializer.Serialize(new
+        {
+            type = "res",
+            id = requestId,
+            ok = false,
+            error = "UnKnOwN MeThOd: node.protocolFeatures.update"
+        });
+    }
+
     private sealed class CapturingWindowsNodeClient(
         string gatewayUrl,
         string token,
@@ -513,11 +541,10 @@ public class WindowsNodeClientTests
     }
 
     [Theory]
-    [InlineData(
-        """{"code":"INVALID_REQUEST","message":"unknown method: node.protocolFeatures.update"}""")]
-    [InlineData(""""UnKnOwN MeThOd: node.protocolFeatures.update"""")]
+    [InlineData(true)]
+    [InlineData(false)]
     public async Task HandleResponse_ProtocolFeatureUnknownMethod_DoesNotFailConnection(
-        string errorJson)
+        bool structuredError)
     {
         var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
         Directory.CreateDirectory(dataPath);
@@ -549,15 +576,9 @@ public class WindowsNodeClientTests
                     StringComparison.Ordinal));
             using var request = JsonDocument.Parse(requestJson);
             var requestId = request.RootElement.GetProperty("id").GetString();
+            Assert.NotNull(requestId);
             using var error = JsonDocument.Parse(
-                $$"""
-                {
-                  "type": "res",
-                  "id": "{{requestId}}",
-                  "ok": false,
-                  "error": {{errorJson}}
-                }
-                """);
+                BuildProtocolFeatureErrorResponse(requestId, structuredError));
 
             client.HandleResponse(error.RootElement);
 
@@ -2807,11 +2828,10 @@ public class WindowsNodeClientTests
     }
 
     [Theory]
-    [InlineData(
-        """{"code":"INVALID_REQUEST","message":"unknown method: node.protocolFeatures.update"}""")]
-    [InlineData(""""UnKnOwN MeThOd: node.protocolFeatures.update"""")]
+    [InlineData(true)]
+    [InlineData(false)]
     public async Task CommandDispatch_EventPath_PreservesLegacyArgsSessionKeyWithoutEnvelope(
-        string errorJson)
+        bool structuredError)
     {
         var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
         Directory.CreateDirectory(dataPath);
@@ -2843,16 +2863,10 @@ public class WindowsNodeClientTests
                     StringComparison.Ordinal));
             using var request = JsonDocument.Parse(requestJson);
             var requestId = request.RootElement.GetProperty("id").GetString();
+            Assert.NotNull(requestId);
             await InvokeProcessMessageAsync(
                 client,
-                $$"""
-                {
-                  "type": "res",
-                  "id": "{{requestId}}",
-                  "ok": false,
-                  "error": {{errorJson}}
-                }
-                """);
+                BuildProtocolFeatureErrorResponse(requestId, structuredError));
 
             await InvokeProcessMessageAsync(client, """
                 {

--- a/tests/OpenClaw.Shared.Tests/WindowsNodeClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/WindowsNodeClientTests.cs
@@ -512,8 +512,12 @@ public class WindowsNodeClientTests
         }
     }
 
-    [Fact]
-    public async Task HandleResponse_ProtocolFeatureError_DoesNotFailConnection()
+    [Theory]
+    [InlineData(
+        """{"code":"INVALID_REQUEST","message":"unknown method: node.protocolFeatures.update"}""")]
+    [InlineData(""""UnKnOwN MeThOd: node.protocolFeatures.update"""")]
+    public async Task HandleResponse_ProtocolFeatureUnknownMethod_DoesNotFailConnection(
+        string errorJson)
     {
         var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
         Directory.CreateDirectory(dataPath);
@@ -551,10 +555,7 @@ public class WindowsNodeClientTests
                   "type": "res",
                   "id": "{{requestId}}",
                   "ok": false,
-                  "error": {
-                    "code": "INVALID_REQUEST",
-                    "message": "unknown method: node.protocolFeatures.update"
-                  }
+                  "error": {{errorJson}}
                 }
                 """);
 
@@ -2341,7 +2342,7 @@ public class WindowsNodeClientTests
     }
 
     [Fact]
-    public async Task CommandDispatch_ReqPath_DoesNotTrustParamsSessionKey()
+    public async Task CommandDispatch_ReqPath_UsesEnvelopeSessionKey()
     {
         var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
         Directory.CreateDirectory(dataPath);
@@ -2369,7 +2370,7 @@ public class WindowsNodeClientTests
             await InvokeProcessMessageAsync(client, json);
             await cap.ExecutedTask.WaitAsync(TimeSpan.FromSeconds(5));
 
-            Assert.Null(cap.LastRequest?.SessionKey);
+            Assert.Equal("chat-thread-from-params", cap.LastRequest?.SessionKey);
         }
         finally
         {
@@ -2418,7 +2419,7 @@ public class WindowsNodeClientTests
     }
 
     [Fact]
-    public async Task CommandDispatch_ReqPath_DoesNotCreateTrustedSessionBinding()
+    public async Task CommandDispatch_ReqPath_EnvelopeSessionKeyOverridesArgs()
     {
         var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
         Directory.CreateDirectory(dataPath);
@@ -2448,7 +2449,7 @@ public class WindowsNodeClientTests
             await InvokeProcessMessageAsync(client, json);
             await cap.ExecutedTask.WaitAsync(TimeSpan.FromSeconds(5));
 
-            Assert.Null(cap.LastRequest?.SessionKey);
+            Assert.Equal("trusted-session", cap.LastRequest?.SessionKey);
         }
         finally
         {
@@ -2651,7 +2652,7 @@ public class WindowsNodeClientTests
     }
 
     [Fact]
-    public async Task CommandDispatch_EventPath_WaitsForEnvelopeNegotiation()
+    public async Task CommandDispatch_EventPath_UsesLegacyBindingWhileNegotiationIsPending()
     {
         var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
         Directory.CreateDirectory(dataPath);
@@ -2697,7 +2698,8 @@ public class WindowsNodeClientTests
                   }
                 }
                 """);
-            Assert.Equal(0, cap.ExecuteCount);
+            await cap.ExecutedTask.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.Equal("nested-session", cap.LastRequest?.SessionKey);
 
             await InvokeProcessMessageAsync(
                 client,
@@ -2709,9 +2711,6 @@ public class WindowsNodeClientTests
                   "payload": {}
                 }
                 """);
-            await cap.ExecutedTask.WaitAsync(TimeSpan.FromSeconds(5));
-
-            Assert.Null(cap.LastRequest?.SessionKey);
         }
         finally
         {
@@ -2721,7 +2720,7 @@ public class WindowsNodeClientTests
     }
 
     [Fact]
-    public async Task CommandDispatch_EventPath_PreservesCancelOrderingDuringNegotiation()
+    public async Task CommandDispatch_EventPath_DispatchesCancelDuringNegotiation()
     {
         var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
         Directory.CreateDirectory(dataPath);
@@ -2765,6 +2764,7 @@ public class WindowsNodeClientTests
                   }
                 }
                 """);
+            await blocking.ExpectedEnteredTask.WaitAsync(TimeSpan.FromSeconds(5));
             await InvokeProcessMessageAsync(client, """
                 {
                   "type": "req",
@@ -2775,20 +2775,6 @@ public class WindowsNodeClientTests
                   }
                 }
                 """);
-            Assert.Equal(0, blocking.ExecuteCount);
-
-            await InvokeProcessMessageAsync(
-                client,
-                $$"""
-                {
-                  "type": "res",
-                  "id": "{{requestId}}",
-                  "ok": true,
-                  "payload": {}
-                }
-                """);
-
-            await blocking.ExpectedEnteredTask.WaitAsync(TimeSpan.FromSeconds(5));
             await blocking.AllCompletedTask.WaitAsync(TimeSpan.FromSeconds(5));
             Assert.Equal(1, blocking.ExecuteCount);
             var cancelResponseJson = await WaitForSentMessageAsync(
@@ -2800,6 +2786,17 @@ public class WindowsNodeClientTests
                     .GetProperty("payload")
                     .GetProperty("cancelled")
                     .GetBoolean());
+
+            await InvokeProcessMessageAsync(
+                client,
+                $$"""
+                {
+                  "type": "res",
+                  "id": "{{requestId}}",
+                  "ok": true,
+                  "payload": {}
+                }
+                """);
         }
         finally
         {
@@ -2809,8 +2806,12 @@ public class WindowsNodeClientTests
         }
     }
 
-    [Fact]
-    public async Task CommandDispatch_EventPath_PreservesLegacyArgsSessionKeyWithoutEnvelope()
+    [Theory]
+    [InlineData(
+        """{"code":"INVALID_REQUEST","message":"unknown method: node.protocolFeatures.update"}""")]
+    [InlineData(""""UnKnOwN MeThOd: node.protocolFeatures.update"""")]
+    public async Task CommandDispatch_EventPath_PreservesLegacyArgsSessionKeyWithoutEnvelope(
+        string errorJson)
     {
         var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
         Directory.CreateDirectory(dataPath);
@@ -2849,10 +2850,7 @@ public class WindowsNodeClientTests
                   "type": "res",
                   "id": "{{requestId}}",
                   "ok": false,
-                  "error": {
-                    "code": "INVALID_REQUEST",
-                    "message": "unknown method: node.protocolFeatures.update"
-                  }
+                  "error": {{errorJson}}
                 }
                 """);
 

--- a/tests/OpenClaw.Shared.Tests/WindowsNodeClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/WindowsNodeClientTests.cs
@@ -489,7 +489,7 @@ public class WindowsNodeClientTests
                 }
                 """);
 
-            client.HandleResponse(document.RootElement);
+            HandleCorrelatedHelloOk(client, document.RootElement);
 
             Assert.DoesNotContain(
                 client.SentMessages,

--- a/tests/OpenClaw.Shared.Tests/WindowsNodeClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/WindowsNodeClientTests.cs
@@ -465,6 +465,110 @@ public class WindowsNodeClientTests
         }
     }
 
+    [Fact]
+    public async Task HandleResponse_HelloOk_PublishesNodeProtocolFeatures()
+    {
+        var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dataPath);
+
+        try
+        {
+            using var client = new CapturingWindowsNodeClient(
+                "ws://localhost:18789",
+                "test-token",
+                dataPath);
+            using var document = JsonDocument.Parse(
+                """
+                {
+                  "type": "res",
+                  "ok": true,
+                  "payload": {
+                    "type": "hello-ok",
+                    "nodeId": "test-node-id"
+                  }
+                }
+                """);
+
+            client.HandleResponse(document.RootElement);
+
+            var requestJson = await WaitForSentMessageAsync(
+                client,
+                message => message.Contains(
+                    "\"method\":\"node.protocolFeatures.update\"",
+                    StringComparison.Ordinal));
+            using var request = JsonDocument.Parse(requestJson);
+            var root = request.RootElement;
+            Assert.Equal("req", root.GetProperty("type").GetString());
+            Assert.Contains(
+                "node-invoke-session-key-envelope-v1",
+                root.GetProperty("params")
+                    .GetProperty("features")
+                    .EnumerateArray()
+                    .Select(feature => feature.GetString()));
+        }
+        finally
+        {
+            Directory.Delete(dataPath, true);
+        }
+    }
+
+    [Fact]
+    public async Task HandleResponse_ProtocolFeatureError_DoesNotFailConnection()
+    {
+        var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dataPath);
+
+        try
+        {
+            using var client = new CapturingWindowsNodeClient(
+                "ws://localhost:18789",
+                "test-token",
+                dataPath);
+            var statuses = new List<ConnectionStatus>();
+            client.StatusChanged += (_, status) => statuses.Add(status);
+            using var hello = JsonDocument.Parse(
+                """
+                {
+                  "type": "res",
+                  "ok": true,
+                  "payload": {
+                    "type": "hello-ok",
+                    "nodeId": "test-node-id"
+                  }
+                }
+                """);
+            client.HandleResponse(hello.RootElement);
+            var requestJson = await WaitForSentMessageAsync(
+                client,
+                message => message.Contains(
+                    "\"method\":\"node.protocolFeatures.update\"",
+                    StringComparison.Ordinal));
+            using var request = JsonDocument.Parse(requestJson);
+            var requestId = request.RootElement.GetProperty("id").GetString();
+            using var error = JsonDocument.Parse(
+                $$"""
+                {
+                  "type": "res",
+                  "id": "{{requestId}}",
+                  "ok": false,
+                  "error": {
+                    "code": "INVALID_REQUEST",
+                    "message": "unknown method: node.protocolFeatures.update"
+                  }
+                }
+                """);
+
+            client.HandleResponse(error.RootElement);
+
+            Assert.True(client.IsConnected);
+            Assert.DoesNotContain(ConnectionStatus.Error, statuses);
+        }
+        finally
+        {
+            Directory.Delete(dataPath, true);
+        }
+    }
+
     /// <summary>
     /// When hello-ok has no token and no stored token, fires exactly one Pending event.
     /// </summary>
@@ -2510,7 +2614,7 @@ public class WindowsNodeClientTests
     }
 
     [Fact]
-    public async Task CommandDispatch_EventPath_DoesNotTrustArgsSessionKey()
+    public async Task CommandDispatch_EventPath_ExplicitNullEnvelopeClearsArgsSessionKey()
     {
         var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
         Directory.CreateDirectory(dataPath);
@@ -2528,6 +2632,7 @@ public class WindowsNodeClientTests
                   "payload": {
                     "requestId": "inv-event-args-session",
                     "command": "mock.ping",
+                    "sessionKey": null,
                     "args": {
                       "sessionKey": "spoofed-session"
                     }
@@ -2537,6 +2642,236 @@ public class WindowsNodeClientTests
             await cap.ExecutedTask.WaitAsync(TimeSpan.FromSeconds(5));
 
             Assert.Null(cap.LastRequest?.SessionKey);
+        }
+        finally
+        {
+            if (Directory.Exists(dataPath))
+                Directory.Delete(dataPath, true);
+        }
+    }
+
+    [Fact]
+    public async Task CommandDispatch_EventPath_WaitsForEnvelopeNegotiation()
+    {
+        var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dataPath);
+
+        try
+        {
+            using var client = new CapturingWindowsNodeClient(
+                "ws://localhost:18789",
+                "test-token",
+                dataPath);
+            var cap = new MockCapability("mock", "mock.ping");
+            client.RegisterCapability(cap);
+            using var hello = JsonDocument.Parse(
+                """
+                {
+                  "type": "res",
+                  "ok": true,
+                  "payload": {
+                    "type": "hello-ok",
+                    "nodeId": "test-node-id"
+                  }
+                }
+                """);
+            client.HandleResponse(hello.RootElement);
+            var requestJson = await WaitForSentMessageAsync(
+                client,
+                message => message.Contains(
+                    "\"method\":\"node.protocolFeatures.update\"",
+                    StringComparison.Ordinal));
+            using var request = JsonDocument.Parse(requestJson);
+            var requestId = request.RootElement.GetProperty("id").GetString();
+
+            await InvokeProcessMessageAsync(client, """
+                {
+                  "type": "event",
+                  "event": "node.invoke.request",
+                  "payload": {
+                    "requestId": "inv-event-negotiating",
+                    "command": "mock.ping",
+                    "args": {
+                      "sessionKey": "nested-session"
+                    }
+                  }
+                }
+                """);
+            Assert.Equal(0, cap.ExecuteCount);
+
+            await InvokeProcessMessageAsync(
+                client,
+                $$"""
+                {
+                  "type": "res",
+                  "id": "{{requestId}}",
+                  "ok": true,
+                  "payload": {}
+                }
+                """);
+            await cap.ExecutedTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.Null(cap.LastRequest?.SessionKey);
+        }
+        finally
+        {
+            if (Directory.Exists(dataPath))
+                Directory.Delete(dataPath, true);
+        }
+    }
+
+    [Fact]
+    public async Task CommandDispatch_EventPath_PreservesCancelOrderingDuringNegotiation()
+    {
+        var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dataPath);
+        var blocking = new BlockingCapability("mock", "mock.slow");
+
+        try
+        {
+            using var client = new CapturingWindowsNodeClient(
+                "ws://localhost:18789",
+                "test-token",
+                dataPath);
+            client.RegisterCapability(blocking);
+            using var hello = JsonDocument.Parse(
+                """
+                {
+                  "type": "res",
+                  "ok": true,
+                  "payload": {
+                    "type": "hello-ok",
+                    "nodeId": "test-node-id"
+                  }
+                }
+                """);
+            client.HandleResponse(hello.RootElement);
+            var requestJson = await WaitForSentMessageAsync(
+                client,
+                message => message.Contains(
+                    "\"method\":\"node.protocolFeatures.update\"",
+                    StringComparison.Ordinal));
+            using var request = JsonDocument.Parse(requestJson);
+            var requestId = request.RootElement.GetProperty("id").GetString();
+
+            await InvokeProcessMessageAsync(client, """
+                {
+                  "type": "event",
+                  "event": "node.invoke.request",
+                  "payload": {
+                    "requestId": "inv-event-negotiating-cancel",
+                    "command": "mock.slow",
+                    "args": {}
+                  }
+                }
+                """);
+            await InvokeProcessMessageAsync(client, """
+                {
+                  "type": "req",
+                  "id": "cancel-negotiating",
+                  "method": "node.invoke.cancel",
+                  "params": {
+                    "requestId": "inv-event-negotiating-cancel"
+                  }
+                }
+                """);
+            Assert.Equal(0, blocking.ExecuteCount);
+
+            await InvokeProcessMessageAsync(
+                client,
+                $$"""
+                {
+                  "type": "res",
+                  "id": "{{requestId}}",
+                  "ok": true,
+                  "payload": {}
+                }
+                """);
+
+            await blocking.ExpectedEnteredTask.WaitAsync(TimeSpan.FromSeconds(5));
+            await blocking.AllCompletedTask.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.Equal(1, blocking.ExecuteCount);
+            var cancelResponseJson = await WaitForSentMessageAsync(
+                client,
+                message => message.Contains("\"id\":\"cancel-negotiating\"", StringComparison.Ordinal));
+            using var cancelResponse = JsonDocument.Parse(cancelResponseJson);
+            Assert.True(
+                cancelResponse.RootElement
+                    .GetProperty("payload")
+                    .GetProperty("cancelled")
+                    .GetBoolean());
+        }
+        finally
+        {
+            blocking.Release();
+            if (Directory.Exists(dataPath))
+                Directory.Delete(dataPath, true);
+        }
+    }
+
+    [Fact]
+    public async Task CommandDispatch_EventPath_PreservesLegacyArgsSessionKeyWithoutEnvelope()
+    {
+        var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dataPath);
+
+        try
+        {
+            using var client = new CapturingWindowsNodeClient(
+                "ws://localhost:18789",
+                "test-token",
+                dataPath);
+            var cap = new MockCapability("mock", "mock.ping");
+            client.RegisterCapability(cap);
+            using var hello = JsonDocument.Parse(
+                """
+                {
+                  "type": "res",
+                  "ok": true,
+                  "payload": {
+                    "type": "hello-ok",
+                    "nodeId": "test-node-id"
+                  }
+                }
+                """);
+            client.HandleResponse(hello.RootElement);
+            var requestJson = await WaitForSentMessageAsync(
+                client,
+                message => message.Contains(
+                    "\"method\":\"node.protocolFeatures.update\"",
+                    StringComparison.Ordinal));
+            using var request = JsonDocument.Parse(requestJson);
+            var requestId = request.RootElement.GetProperty("id").GetString();
+            await InvokeProcessMessageAsync(
+                client,
+                $$"""
+                {
+                  "type": "res",
+                  "id": "{{requestId}}",
+                  "ok": false,
+                  "error": {
+                    "code": "INVALID_REQUEST",
+                    "message": "unknown method: node.protocolFeatures.update"
+                  }
+                }
+                """);
+
+            await InvokeProcessMessageAsync(client, """
+                {
+                  "type": "event",
+                  "event": "node.invoke.request",
+                  "payload": {
+                    "requestId": "inv-event-legacy-session",
+                    "command": "mock.ping",
+                    "args": {
+                      "sessionKey": "legacy-session"
+                    }
+                  }
+                }
+                """);
+            await cap.ExecutedTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.Equal("legacy-session", cap.LastRequest?.SessionKey);
         }
         finally
         {


### PR DESCRIPTION
## What Problem This Solves

The Windows node must accept session attribution only from the Gateway-stamped top-level `node.invoke.request.payload.sessionKey`. Caller-controlled nested command data such as `args.sessionKey` or `params.sessionKey` must never be able to forge that attribution.

## Why This Change Was Made

Current Gateway runtime code sends `sessionKey` as an optional sibling of `paramsJSON`. Stable older Gateways omit it, and there is no supported feature-announcement request for this field.

This change therefore applies the contract per invocation:

- Read only the optional top-level Gateway envelope field.
- Treat an omitted, null, blank, or malformed field as unattributed.
- Ignore nested `sessionKey` data from command arguments.
- Preserve both event and legacy request transports.
- Emit no unsupported post-handshake feature-publication request.

`NodeInvokeRequest.SessionKey` remains transport-owned through `[JsonIgnore]` plus an internal setter. Approval validation and `system.run.prepare` consume only that trusted value.

This branch was replayed onto main at `603886a81d3495c173802af864a5c71c3c880cae`, preserving #1076's correlated node `hello-ok` response guard and immediate pre-credential handshake authorization.

## User Impact

New Gateways can provide trusted session attribution. Older Gateways remain compatible by omission: their invocations execute without attribution instead of trusting nested caller data.

## Validation

Exact head: `b5a37b8427cecf5725544af450de210fe3246142`.

- `git diff --check origin/main..HEAD`: passed.
- `$env:OPENCLAW_REPO_ROOT = (Get-Location).Path; .\build.ps1`: passed.
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore`: 3,631 passed, 32 skipped.
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj`: 2,241 passed.
- `dotnet test .\tests\OpenClaw.WinNode.Cli.Tests\OpenClaw.WinNode.Cli.Tests.csproj`: 126 passed.
- Focused attribution/handshake/approval tests: 191 passed.
- `.\scripts\validate-mxc-e2e.ps1` without `-AllowSkip`: 15 passed, 0 skipped.
- Rubber-duck review: no blocking or non-blocking findings.
- `python .\.agents\skills\autoreview\scripts\autoreview --mode branch --base origin/main --engine codex --model gpt-5.6-sol --thinking high`: clean, no actionable findings, correctness confidence 0.92.

## Real behavior proof

Strict Gateway-to-Windows-node MXC proof completed successfully on the current head:

```text
Test Run Successful.
Total tests: 15
Passed: 15
```

The proof included real Gateway `node.invoke` paths for bound executable execution, sandboxed `system.run`, and denied writes to the isolated tray data directory.

An isolated current-head tray instance was launched in MCP-only mode with a session-scoped data directory. No real tray settings, Gateway credentials, or identities were read or modified.

```text
winnode --list-tools
ToolCount=51
ProofTools=system.run,system.run.prepare,system.which

winnode --command system.which --params '{"bins":["git","node"]}'
git: resolved
node: resolved

winnode --command system.run.prepare --params '{"command":["where.exe","git.exe"]}'
plan.argv: ["where.exe","git.exe"]
plan.sessionKey: null
```

The isolated process was stopped and its generated token/data directory was deleted after proof collection.

The user's paired Gateway was not used because the strict disposable Gateway E2E proved the same real gateway-mediated invocation path without risking mutation of the user's saved profile or connection.
