### PR TITLE
refactor(chat): use Reactor theme resources

### DIFF
--- a/src/OpenClaw.Tray.WinUI/App.xaml
+++ b/src/OpenClaw.Tray.WinUI/App.xaml
@@ -34,6 +34,11 @@
                     <SolidColorBrush x:Key="SubtleFillColorSecondaryBrush" Color="{ThemeResource SubtleFillColorSecondary}" />
                     <SolidColorBrush x:Key="SubtleFillColorTertiaryBrush" Color="{ThemeResource SubtleFillColorTertiary}" />
                     <SolidColorBrush x:Key="TextFillColorSecondaryBrush" Color="{ThemeResource TextFillColorSecondary}" />
+                    <SolidColorBrush x:Key="ConnectionCapabilityPillSuccessBrush" Color="{ThemeResource SystemFillColorSuccess}" Opacity="0.14" />
+                    <SolidColorBrush x:Key="ConnectionCapabilityPillCautionBrush" Color="{ThemeResource SystemFillColorCaution}" Opacity="0.14" />
+                    <SolidColorBrush x:Key="ConnectionCapabilityPillCriticalBrush" Color="{ThemeResource SystemFillColorCritical}" Opacity="0.14" />
+                    <SolidColorBrush x:Key="ChatUserBubbleSelectionHighlightBrush" Color="{ThemeResource SystemAccentColorDark2}" />
+                    <x:Double x:Key="ChatAccessibleBorderThickness">1</x:Double>
 
                     <!-- Composer scrim: the chat timeline dissolves into the composer dock via a
                          vertical fade from transparent to the base surface fill. FunctionalUI
@@ -57,6 +62,11 @@
                     <SolidColorBrush x:Key="SubtleFillColorSecondaryBrush" Color="{ThemeResource SubtleFillColorSecondary}" />
                     <SolidColorBrush x:Key="SubtleFillColorTertiaryBrush" Color="{ThemeResource SubtleFillColorTertiary}" />
                     <SolidColorBrush x:Key="TextFillColorSecondaryBrush" Color="{ThemeResource TextFillColorSecondary}" />
+                    <SolidColorBrush x:Key="ConnectionCapabilityPillSuccessBrush" Color="{ThemeResource SystemFillColorSuccess}" Opacity="0.14" />
+                    <SolidColorBrush x:Key="ConnectionCapabilityPillCautionBrush" Color="{ThemeResource SystemFillColorCaution}" Opacity="0.14" />
+                    <SolidColorBrush x:Key="ConnectionCapabilityPillCriticalBrush" Color="{ThemeResource SystemFillColorCritical}" Opacity="0.14" />
+                    <SolidColorBrush x:Key="ChatUserBubbleSelectionHighlightBrush" Color="{ThemeResource SystemAccentColorDark2}" />
+                    <x:Double x:Key="ChatAccessibleBorderThickness">1</x:Double>
 
                     <!-- Light mirror of ChatComposerFadeBrush (SolidBackgroundFillColorBase light #F3F3F3). -->
                     <LinearGradientBrush x:Key="ChatComposerFadeBrush" StartPoint="0,0" EndPoint="0,1">
@@ -74,6 +84,11 @@
                     <SolidColorBrush x:Key="SubtleFillColorSecondaryBrush" Color="{ThemeResource SystemColorButtonFaceColor}" />
                     <SolidColorBrush x:Key="SubtleFillColorTertiaryBrush" Color="{ThemeResource SystemColorButtonFaceColor}" />
                     <SolidColorBrush x:Key="TextFillColorSecondaryBrush" Color="{ThemeResource SystemColorWindowTextColor}" />
+                    <SolidColorBrush x:Key="ConnectionCapabilityPillSuccessBrush" Color="{ThemeResource SystemColorWindowColor}" />
+                    <SolidColorBrush x:Key="ConnectionCapabilityPillCautionBrush" Color="{ThemeResource SystemColorWindowColor}" />
+                    <SolidColorBrush x:Key="ConnectionCapabilityPillCriticalBrush" Color="{ThemeResource SystemColorWindowColor}" />
+                    <SolidColorBrush x:Key="ChatUserBubbleSelectionHighlightBrush" Color="{ThemeResource SystemColorHighlightColor}" />
+                    <x:Double x:Key="ChatAccessibleBorderThickness">2</x:Double>
 
                     <!-- High-contrast follows the system window color so the scrim stays legible. -->
                     <LinearGradientBrush x:Key="ChatComposerFadeBrush" StartPoint="0,0" EndPoint="0,1">
@@ -82,6 +97,20 @@
                     </LinearGradientBrush>
                 </ResourceDictionary>
             </ResourceDictionary.ThemeDictionaries>
+
+            <Style x:Key="ChatUserBubbleSelectionStyle" TargetType="RichTextBlock">
+                <Setter Property="SelectionHighlightColor" Value="{ThemeResource ChatUserBubbleSelectionHighlightBrush}"/>
+            </Style>
+            <Style x:Key="ChatToolCardBorderStyle" TargetType="Border">
+                <Setter Property="Background" Value="{ThemeResource CardBackgroundFillColorDefaultBrush}"/>
+                <Setter Property="BorderBrush" Value="{ThemeResource ControlStrokeColorDefaultBrush}"/>
+                <Setter Property="BorderThickness" Value="{ThemeResource ChatAccessibleBorderThickness}"/>
+            </Style>
+            <Style x:Key="ChatCompactionCardStyle" TargetType="Border">
+                <Setter Property="Background" Value="{ThemeResource CardBackgroundFillColorDefaultBrush}"/>
+                <Setter Property="BorderBrush" Value="{ThemeResource ControlStrokeColorDefaultBrush}"/>
+                <Setter Property="BorderThickness" Value="{ThemeResource ChatAccessibleBorderThickness}"/>
+            </Style>
 
             <!-- Hub NavigationView selection indicator follows the user's Windows accent. -->
             <SolidColorBrush x:Key="NavigationViewSelectionIndicatorForeground"

--- a/src/OpenClaw.Tray.WinUI/App.xaml
+++ b/src/OpenClaw.Tray.WinUI/App.xaml
@@ -39,6 +39,7 @@
                     <SolidColorBrush x:Key="ConnectionCapabilityPillCriticalBrush" Color="{ThemeResource SystemFillColorCritical}" Opacity="0.14" />
                     <SolidColorBrush x:Key="ChatUserBubbleSelectionHighlightBrush" Color="{ThemeResource SystemAccentColorDark2}" />
                     <x:Double x:Key="ChatAccessibleBorderThickness">1</x:Double>
+                    <x:Boolean x:Key="HubNavigationUseHighContrastIcons">False</x:Boolean>
 
                     <!-- Composer scrim: the chat timeline dissolves into the composer dock via a
                          vertical fade from transparent to the base surface fill. FunctionalUI
@@ -67,6 +68,7 @@
                     <SolidColorBrush x:Key="ConnectionCapabilityPillCriticalBrush" Color="{ThemeResource SystemFillColorCritical}" Opacity="0.14" />
                     <SolidColorBrush x:Key="ChatUserBubbleSelectionHighlightBrush" Color="{ThemeResource SystemAccentColorDark2}" />
                     <x:Double x:Key="ChatAccessibleBorderThickness">1</x:Double>
+                    <x:Boolean x:Key="HubNavigationUseHighContrastIcons">False</x:Boolean>
 
                     <!-- Light mirror of ChatComposerFadeBrush (SolidBackgroundFillColorBase light #F3F3F3). -->
                     <LinearGradientBrush x:Key="ChatComposerFadeBrush" StartPoint="0,0" EndPoint="0,1">
@@ -89,6 +91,7 @@
                     <SolidColorBrush x:Key="ConnectionCapabilityPillCriticalBrush" Color="{ThemeResource SystemColorWindowColor}" />
                     <SolidColorBrush x:Key="ChatUserBubbleSelectionHighlightBrush" Color="{ThemeResource SystemColorHighlightColor}" />
                     <x:Double x:Key="ChatAccessibleBorderThickness">2</x:Double>
+                    <x:Boolean x:Key="HubNavigationUseHighContrastIcons">True</x:Boolean>
 
                     <!-- High-contrast follows the system window color so the scrim stays legible. -->
                     <LinearGradientBrush x:Key="ChatComposerFadeBrush" StartPoint="0,0" EndPoint="0,1">

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatTimeline.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatTimeline.cs
@@ -207,121 +207,6 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
         }
     }
 
-    // Per-DispatcherQueue selection-highlight brushes for the user
-    // bubble. The bubble background is the user's chosen system accent
-    // (which may be red, green, purple, …), so a hardcoded color would
-    // clash whenever the accent is non-blue. SystemAccentColorDark2 is
-    // the OS-defined "darker shade of the current accent" — guaranteed
-    // darker than the bubble's AccentFillColorDefault background and
-    // high-contrast against the bubble's white foreground for every
-    // accent. In High Contrast the bubble switches to
-    // SystemColorHighlight (often near-black), so we fall back to the
-    // OS-guaranteed SystemColorHighlightColor for the band there.
-    //
-    // SolidColorBrush is a DependencyObject with thread affinity, so a
-    // single static instance would crash with RPC_E_WRONG_THREAD if a
-    // second window on a different dispatcher ever tried to use it.
-    // Keying by DispatcherQueue keeps one shared brush per window while
-    // still avoiding per-render allocation. ConditionalWeakTable lets a
-    // closing window's brush be collected with its dispatcher. The
-    // brush's Color is mutated in place when the source color changes
-    // (e.g. user switches their accent in Windows Settings) so
-    // already-rendered TextBlocks update atomically.
-    private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<
-        Microsoft.UI.Dispatching.DispatcherQueue, SolidColorBrush> s_accentDarkByDispatcher = new();
-    private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<
-        Microsoft.UI.Dispatching.DispatcherQueue, SolidColorBrush> s_hcHighlightByDispatcher = new();
-    // AccessibilitySettings is a WinRT object with DispatcherQueue
-    // affinity: an instance created on one dispatcher cannot reliably
-    // be read from another. We deliberately avoid Lazy<>: Lazy
-    // permanently caches the factory's result, so a single failed
-    // construction would cache null forever and silently disable the
-    // High Contrast code path. Per-dispatcher cache keyed by
-    // ConditionalWeakTable lets each window have its own instance,
-    // collected when its dispatcher dies. On any thrown exception we
-    // drop the cached instance so the next render retries from scratch.
-    private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<
-        Microsoft.UI.Dispatching.DispatcherQueue,
-        global::Windows.UI.ViewManagement.AccessibilitySettings> s_a11yByDispatcher = new();
-
-    private static bool TryDetectHighContrast()
-    {
-        var dispatcher = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
-        if (dispatcher is null)
-        {
-            // Off-thread caller (tests, design-time). One-shot, no caching.
-            try { return new global::Windows.UI.ViewManagement.AccessibilitySettings().HighContrast; }
-            catch { return false; }
-        }
-        if (!s_a11yByDispatcher.TryGetValue(dispatcher, out var settings))
-        {
-            try
-            {
-                settings = new global::Windows.UI.ViewManagement.AccessibilitySettings();
-                s_a11yByDispatcher.Add(dispatcher, settings);
-            }
-            catch { return false; }
-        }
-        try { return settings.HighContrast; }
-        catch
-        {
-            // Drop the cached instance so the next call retries.
-            s_a11yByDispatcher.Remove(dispatcher);
-            return false;
-        }
-    }
-
-    private static SolidColorBrush GetUserBubbleSelectionBrush(bool isHighContrast)
-    {
-        var dispatcher = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
-        var table = isHighContrast ? s_hcHighlightByDispatcher : s_accentDarkByDispatcher;
-        var color = isHighContrast
-            ? TryGetThemeColor("SystemColorHighlightColor", Microsoft.UI.Colors.Blue)
-            : TryGetThemeColor("SystemAccentColorDark2", Microsoft.UI.Colors.DarkBlue);
-
-        // No dispatcher means we're being called off-thread (e.g.
-        // from a unit test). Allocate a one-shot brush — it can't be
-        // safely cached without a dispatcher to key it on.
-        if (dispatcher is null)
-            return new SolidColorBrush(color);
-
-        if (!table.TryGetValue(dispatcher, out var brush))
-        {
-            brush = new SolidColorBrush(color);
-            table.Add(dispatcher, brush);
-        }
-        else if (brush.Color != color)
-        {
-            // Mutate in place rather than reallocating: TextBlocks
-            // rendered earlier hold a reference to this brush, so
-            // updating .Color updates them atomically without waiting
-            // for the next render pass.
-            brush.Color = color;
-        }
-        return brush;
-    }
-
-    private static Color TryGetThemeColor(string key, Color fallback)
-    {
-        try
-        {
-            var app = Application.Current;
-            if (app is null) return fallback;
-            if (app.Resources.TryGetValue(key, out var v))
-            {
-                // Theme dictionaries usually store Color, but a custom
-                // theme override can supply a SolidColorBrush under the
-                // same key. Accept either rather than silently falling
-                // back to DarkBlue / Blue when the resource is present
-                // but wrapped in a brush.
-                if (v is Color c) return c;
-                if (v is SolidColorBrush brush) return brush.Color;
-            }
-        }
-        catch (Exception ex) { OpenClawTray.Services.Logger.Debug($"ChatTimeline: resource brush lookup failed (unpackaged/test host?): {ex.Message}"); }
-        return fallback;
-    }
-
     private static void ApplyPlainSelectableInlines(TextBlock textBlock, string? text)
     {
         var normalized = text ?? string.Empty;
@@ -1020,12 +905,7 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
         // the bubble surface below is opaque (Mica/acrylic isn't being
         // used directly), so the LayerOnAcrylic family would render
         // incorrectly in dark/HC themes.
-        var toolCardBgBrush     = themeBrush("CardBackgroundFillColorDefaultBrush");
         var toolCardBorderBrush = themeBrush("ControlStrokeColorDefaultBrush");
-        // High-contrast themes need a thicker border to render at all
-        // (WinUI guidance: 2px minimum). Detect once at render time so the
-        // tool card border stays visible when HC is on, normal 1px otherwise.
-        double toolCardBorderThickness = TryDetectHighContrast() ? 2 : 1;
 
         // Avatar: 36×36 circle (Kenny uses circular avatars). Same constructor
         // as before but radius defaults to half the size for a perfect circle.
@@ -1409,12 +1289,6 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
             var entryMeta = MetaFor(entry.Id);
             if (hasMessage)
             {
-                // Resolve HC + selection brush once per render method call
-                // rather than per Set-lambda re-run. HC state cannot change
-                // mid-render, and the brush is cached per-dispatcher so
-                // every user bubble in this render shares the same instance.
-                bool isHighContrast = TryDetectHighContrast();
-                var selectionHighlightBrush = GetUserBubbleSelectionBrush(isHighContrast);
                 bubbleChildren.Add(
                     RichTextBlock()
                         .Set(t =>
@@ -1431,23 +1305,7 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
                             t.Width = double.NaN;
                             t.MinWidth = 0;
                             t.MaxWidth = double.PositiveInfinity;
-                            // The default SelectionHighlightColor is the
-                            // system accent — which equals the user bubble's
-                            // background — so the highlight band is invisible
-                            // against the bubble, and WinUI does NOT auto-
-                            // invert an explicitly-set Foreground for
-                            // selected glyphs. Outside High Contrast, use a
-                            // darker shade of the current accent
-                            // (SystemAccentColorDark2) so the band tracks
-                            // whichever accent the user picked while keeping
-                            // the white foreground readable. In High Contrast
-                            // the bubble background switches to
-                            // SystemColorHighlight (often near-black), where
-                            // an accent-derived band may drop below WCAG
-                            // 3:1, so fall back to the system selection
-                            // color the OS guarantees contrasts with both
-                            // surfaces.
-                            t.SelectionHighlightColor = selectionHighlightBrush;
+                            t.Style = (Style)Application.Current.Resources["ChatUserBubbleSelectionStyle"];
                             // Render the message as a single Paragraph (one Run)
                             // so the whole user message is one continuous
                             // selection scope — matching the assistant bubble's
@@ -1974,10 +1832,9 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
                 ToolName: null, ToolResult: aggregateStatus, ToolOutput: null));
 
             Element CardOf(Element[] rowEls) => Border(VStack(0, rowEls))
-                .Background(toolCardBgBrush)
-                .WithBorder(toolCardBorderBrush, toolCardBorderThickness)
                 .Set(b =>
                 {
+                    b.Style = (Style)Application.Current.Resources["ChatToolCardBorderStyle"];
                     // CornerRadius is uniform across the card; setting it
                     // directly works because rounding nests under the
                     // Border's BorderThickness.
@@ -2349,8 +2206,6 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
                 LocalizationHelper.GetString("Chat_Compaction_Title"),
                 LocalizationHelper.GetString("Chat_Compaction_MetricsFormat"),
                 LocalizationHelper.GetString("Chat_Compaction_FallbackDetail"));
-            var borderThickness = TryDetectHighContrast() ? 2 : 1;
-
             return TimelineInset(
                 Border(
                     VStack(3,
@@ -2368,8 +2223,7 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
                             t.TextAlignment = TextAlignment.Center;
                         }).Foreground(themeBrush("TextFillColorSecondaryBrush"))
                     )
-                ).Background(themeBrush("CardBackgroundFillColorDefaultBrush"))
-                 .WithBorder(themeBrush("ControlStrokeColorDefaultBrush"), borderThickness)
+                ).Set(b => b.Style = (Style)Application.Current.Resources["ChatCompactionCardStyle"])
                  .CornerRadius(8)
                  .Padding(16, 10, 16, 10)
                  .HAlign(HorizontalAlignment.Stretch)

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawReactorChatRoot.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawReactorChatRoot.cs
@@ -1,6 +1,7 @@
 using Microsoft.UI;
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.Hosting;
 using Microsoft.UI.Reactor.Input;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -582,184 +583,11 @@ public sealed record ReactorChatComposerProps(
 public sealed class ReactorChatComposer : Component<ReactorChatComposerProps>
 {
     private static readonly string[] ThinkingLevels = ["off", "minimal", "low", "medium", "high"];
-    private static readonly ConditionalWeakTable<FrameworkElement, ThemeCallbackState> ThemeCallbacks = new();
-    private static readonly global::Windows.UI.ViewManagement.AccessibilitySettings? AccessibilitySettings =
-        CreateAccessibilitySettings();
-
-    private sealed class ThemeCallbackState(Action apply)
-    {
-        public Action Apply { get; set; } = apply;
-        public global::Windows.Foundation.TypedEventHandler<
-            global::Windows.UI.ViewManagement.AccessibilitySettings,
-            object>? HighContrastChanged { get; set; }
-        public bool HighContrastEventUnavailable { get; set; }
-    }
-
-    private static void ApplyTheme(FrameworkElement control, Action apply)
-    {
-        apply();
-        if (ThemeCallbacks.TryGetValue(control, out var state))
-        {
-            state.Apply = apply;
-            EnsureHighContrastCallback(control, state);
-            return;
-        }
-
-        state = new ThemeCallbackState(apply);
-        ThemeCallbacks.Add(control, state);
-        control.ActualThemeChanged += static (sender, _) =>
-        {
-            if (sender is FrameworkElement element
-                && ThemeCallbacks.TryGetValue(element, out var callback))
-                callback.Apply();
-        };
-        control.Loaded += static (sender, _) =>
-        {
-            if (sender is FrameworkElement element
-                && ThemeCallbacks.TryGetValue(element, out var callback))
-            {
-                callback.Apply();
-                EnsureHighContrastCallback(element, callback);
-            }
-        };
-        control.Unloaded += static (sender, _) =>
-        {
-            if (sender is FrameworkElement element
-                && ThemeCallbacks.TryGetValue(element, out var callback)
-                && callback.HighContrastChanged is { } handler
-                && AccessibilitySettings is { } accessibilitySettings)
-            {
-                try
-                {
-                    accessibilitySettings.HighContrastChanged -= handler;
-                }
-                catch (System.Runtime.InteropServices.COMException)
-                {
-                    // The optional WinRT event source can be unavailable while a view tears down.
-                }
-                callback.HighContrastChanged = null;
-            }
-        };
-        EnsureHighContrastCallback(control, state);
-    }
-
-    private static global::Windows.UI.ViewManagement.AccessibilitySettings? CreateAccessibilitySettings()
-    {
-        try
-        {
-            return new global::Windows.UI.ViewManagement.AccessibilitySettings();
-        }
-        catch
-        {
-            return null;
-        }
-    }
-
-    private static void EnsureHighContrastCallback(
-        FrameworkElement control,
-        ThemeCallbackState state)
-    {
-        if (AccessibilitySettings is null
-            || state.HighContrastChanged is not null
-            || state.HighContrastEventUnavailable)
-            return;
-
-        global::Windows.Foundation.TypedEventHandler<
-            global::Windows.UI.ViewManagement.AccessibilitySettings,
-            object> handler = (_, _) =>
-        {
-            control.DispatcherQueue?.TryEnqueue(() =>
-            {
-                if (ThemeCallbacks.TryGetValue(control, out var callback))
-                    callback.Apply();
-            });
-        };
-        try
-        {
-            AccessibilitySettings.HighContrastChanged += handler;
-            state.HighContrastChanged = handler;
-        }
-        catch (System.Runtime.InteropServices.COMException ex)
-        {
-            state.HighContrastEventUnavailable = true;
-            OpenClawTray.Services.Logger.Warn(
-                $"[ReactorChatComposer] High Contrast change notifications are unavailable: {ex.Message}");
-        }
-    }
-
-    private static Brush ResolveThemeBrush(string resourceKey, ElementTheme theme)
-    {
-        if (FindThemedResource(resourceKey, theme) is Brush themed)
-            return themed;
-        if (Application.Current?.Resources.TryGetValue(resourceKey, out var value) == true
-            && value is Brush brush)
-            return brush;
-        return new SolidColorBrush(Microsoft.UI.Colors.Transparent);
-    }
-
-    private static object? FindThemedResource(string resourceKey, ElementTheme theme)
-    {
-        if (Application.Current?.Resources is not { } root)
-            return null;
-
-        var themeNames = IsHighContrast()
-            ? new[] { "HighContrast" }
-            : theme switch
-            {
-                ElementTheme.Dark => ["Dark", "Default"],
-                ElementTheme.Light => ["Light"],
-                _ => Array.Empty<string>(),
-            };
-        return themeNames
-            .Select(themeName => SearchThemeDictionaries(root, resourceKey, themeName, 0))
-            .FirstOrDefault(value => value is not null);
-    }
-
-    private static bool IsHighContrast()
-    {
-        return AccessibilitySettings?.HighContrast ?? false;
-    }
-
-    private static object? SearchThemeDictionaries(
-        ResourceDictionary dictionary,
-        string resourceKey,
-        string themeName,
-        int depth)
-    {
-        if (depth > 6)
-            return null;
-
-        if (dictionary.ThemeDictionaries.TryGetValue(themeName, out var entry)
-            && entry is ResourceDictionary themed
-            && LookupResource(themed, resourceKey) is { } value)
-            return value;
-
-        foreach (var merged in dictionary.MergedDictionaries)
-        {
-            if (SearchThemeDictionaries(merged, resourceKey, themeName, depth + 1) is { } found)
-                return found;
-        }
-
-        return null;
-    }
-
-    private static object? LookupResource(ResourceDictionary dictionary, string resourceKey)
-    {
-        if (dictionary.TryGetValue(resourceKey, out var value))
-            return value;
-
-        foreach (var merged in dictionary.MergedDictionaries)
-        {
-            if (LookupResource(merged, resourceKey) is { } found)
-                return found;
-        }
-
-        return null;
-    }
 
     public override Element Render()
     {
         var props = Props;
+        var colorScheme = UseColorScheme();
         var (text, setText) = UseState(string.Empty, threadSafe: true);
         var (isSending, setIsSending) = UseState(false, threadSafe: true);
         var (isRecording, setIsRecording) = UseState(false, threadSafe: true);
@@ -903,26 +731,6 @@ public sealed class ReactorChatComposer : Component<ReactorChatComposerProps>
             : Localized("Chat_Composer_Tooltip_Send", "Send");
         var controlCornerRadius = new CornerRadius(4);
 
-        void ApplySubtleButtonStyle(Button button)
-        {
-            var transparent = new SolidColorBrush(Microsoft.UI.Colors.Transparent);
-            button.Background = transparent;
-            button.BorderBrush = transparent;
-            button.BorderThickness = new Thickness(0);
-            button.Resources["ButtonBackground"] = transparent;
-            button.Resources["ButtonBorderBrush"] = transparent;
-            button.Resources["ButtonBorderBrushPointerOver"] = transparent;
-            button.Resources["ButtonBorderBrushPressed"] = transparent;
-            ApplyTheme(button, () =>
-            {
-                button.Foreground = ResolveThemeBrush("TextFillColorSecondaryBrush", button.ActualTheme);
-                button.Resources["ButtonBackgroundPointerOver"] =
-                    ResolveThemeBrush("SubtleFillColorSecondaryBrush", button.ActualTheme);
-                button.Resources["ButtonBackgroundPressed"] =
-                    ResolveThemeBrush("SubtleFillColorTertiaryBrush", button.ActualTheme);
-            });
-        }
-
         Element IconButton(string glyph, string automationName, Action onClick, bool enabled = true)
         {
             return Button(
@@ -933,6 +741,14 @@ public sealed class ReactorChatComposer : Component<ReactorChatComposerProps>
                     }),
                     onClick)
                 .AutomationName(automationName)
+                .Foreground(Theme.SecondaryText)
+                .Resources(resources => resources
+                    .Set("ButtonBackground", Theme.Ref("SubtleFillColorTransparentBrush"))
+                    .Set("ButtonBackgroundPointerOver", Theme.SubtleFill)
+                    .Set("ButtonBackgroundPressed", Theme.Ref("SubtleFillColorTertiaryBrush"))
+                    .Set("ButtonBorderBrush", Theme.Ref("SubtleFillColorTransparentBrush"))
+                    .Set("ButtonBorderBrushPointerOver", Theme.Ref("SubtleFillColorTransparentBrush"))
+                    .Set("ButtonBorderBrushPressed", Theme.Ref("SubtleFillColorTransparentBrush")))
                 .Set(button =>
                 {
                     button.Width = 32;
@@ -942,7 +758,7 @@ public sealed class ReactorChatComposer : Component<ReactorChatComposerProps>
                     button.Padding = new Thickness(0);
                     button.CornerRadius = controlCornerRadius;
                     button.IsEnabled = enabled;
-                    ApplySubtleButtonStyle(button);
+                    button.BorderThickness = new Thickness(0);
                     ToolTipService.SetToolTip(button, automationName);
                 });
         }
@@ -967,6 +783,14 @@ public sealed class ReactorChatComposer : Component<ReactorChatComposerProps>
                         })),
                     () => { })
                 .AutomationName(automationName)
+                .Foreground(Theme.SecondaryText)
+                .Resources(resources => resources
+                    .Set("ButtonBackground", Theme.Ref("SubtleFillColorTransparentBrush"))
+                    .Set("ButtonBackgroundPointerOver", Theme.SubtleFill)
+                    .Set("ButtonBackgroundPressed", Theme.Ref("SubtleFillColorTertiaryBrush"))
+                    .Set("ButtonBorderBrush", Theme.Ref("SubtleFillColorTransparentBrush"))
+                    .Set("ButtonBorderBrushPointerOver", Theme.Ref("SubtleFillColorTransparentBrush"))
+                    .Set("ButtonBorderBrushPressed", Theme.Ref("SubtleFillColorTransparentBrush")))
                 .Set(button =>
                 {
                     button.Height = 32;
@@ -975,7 +799,7 @@ public sealed class ReactorChatComposer : Component<ReactorChatComposerProps>
                     button.Padding = new Thickness(8, 0, 8, 0);
                     button.CornerRadius = controlCornerRadius;
                     button.IsEnabled = enabled;
-                    ApplySubtleButtonStyle(button);
+                    button.BorderThickness = new Thickness(0);
                 });
         }
 
@@ -999,8 +823,7 @@ public sealed class ReactorChatComposer : Component<ReactorChatComposerProps>
                     .Height(2 + (audioLevel * (index % 3 == 1 ? 10 : 7)))
                     .CornerRadius(1)
                     .VAlign(VerticalAlignment.Center)
-                    .Set(border => ApplyTheme(border, () => border.Background =
-                        ResolveThemeBrush("TextFillColorSecondaryBrush", border.ActualTheme))))
+                    .Background(Theme.SecondaryText))
             .ToArray();
         Element voiceFeedback = !isRecording
             ? Empty()
@@ -1011,12 +834,10 @@ public sealed class ReactorChatComposer : Component<ReactorChatComposerProps>
                             .Width(6)
                             .Height(6)
                             .CornerRadius(3)
-                            .Set(border => ApplyTheme(border, () => border.Background =
-                                ResolveThemeBrush("TextFillColorSecondaryBrush", border.ActualTheme))),
+                            .Background(Theme.SecondaryText),
                         TextBlock(voiceFeedbackText)
                             .FontSize(11)
-                            .Set(textBlock => ApplyTheme(textBlock, () => textBlock.Foreground =
-                                ResolveThemeBrush("TextFillColorSecondaryBrush", textBlock.ActualTheme))),
+                            .Foreground(Theme.SecondaryText),
                         HStack(1, waveformBars)))
                 .Padding(8, 4)
                 .HAlign(HorizontalAlignment.Left);
@@ -1135,7 +956,8 @@ public sealed class ReactorChatComposer : Component<ReactorChatComposerProps>
             slashDisplay.Query,
             slashDisplay.SelectedIndex,
             slashDisplay.SelectableCount,
-            popupCatalogKey);
+            popupCatalogKey,
+            colorScheme);
         FrameworkElement? slashPopupContent;
         if (!slashPopupVisible)
         {
@@ -1148,27 +970,28 @@ public sealed class ReactorChatComposer : Component<ReactorChatComposerProps>
         }
         else if (slashDisplay.IsLoading)
         {
-            slashPopupContent = BuildSlashHintPopup(
-                Localized("Chat_Composer_Slash_Loading", "Loading commands..."));
+            slashPopupContent = CreateSlashPopupHost(BuildSlashHintPopup(
+                Localized("Chat_Composer_Slash_Loading", "Loading commands...")));
             slashPopupContentRef.Current = (popupStateKey, slashPopupContent);
         }
         else if (slashDisplay.IsArgsMode && slashDisplay.ArgCommand is { } argCommand)
         {
-            slashPopupContent = BuildSlashArgPopup(
+            slashPopupContent = CreateSlashPopupHost(BuildSlashArgPopup(
                 argCommand,
                 slashDisplay.ArgChoices,
                 slashDisplay.SelectedIndex,
                 choice => CommitSlashText(
                     argCommand.BuildArgInsertionText(choice.Value),
-                    ReactorSlashMenuState.Closed));
+                    ReactorSlashMenuState.Closed)));
             slashPopupContentRef.Current = (popupStateKey, slashPopupContent);
         }
         else
         {
-            slashPopupContent = BuildSlashPopup(
+            slashPopupContent = CreateSlashPopupHost(BuildSlashPopup(
                 slashDisplay.Groups,
                 slashDisplay.SelectedIndex,
                 slashDisplay.Query,
+                colorScheme,
                 command =>
                 {
                     CommitSlashText(
@@ -1176,7 +999,7 @@ public sealed class ReactorChatComposer : Component<ReactorChatComposerProps>
                         command.FirstArgChoices().Count > 0
                             ? new ReactorSlashMenuState(true, string.Empty, 0, true)
                             : ReactorSlashMenuState.Closed);
-                });
+                }));
             slashPopupContentRef.Current = (popupStateKey, slashPopupContent);
         }
 
@@ -1466,11 +1289,8 @@ public sealed class ReactorChatComposer : Component<ReactorChatComposerProps>
             .BorderThickness(1)
             .CornerRadius(8)
             .Margin(12)
-            .Set(border => ApplyTheme(border, () =>
-            {
-                border.Background = ResolveThemeBrush("ControlFillColorDefaultBrush", border.ActualTheme);
-                border.BorderBrush = ResolveThemeBrush("ControlStrokeColorDefaultBrush", border.ActualTheme);
-            }))
+            .Background(Theme.ControlFill)
+            .BorderBrush(Theme.ControlStroke)
             .HAlign(HorizontalAlignment.Stretch);
     }
 
@@ -1480,8 +1300,17 @@ public sealed class ReactorChatComposer : Component<ReactorChatComposerProps>
             return;
 
         popup.IsOpen = false;
+        if (popup.Child is ReactorHostControl host)
+            host.Dispose();
         popup.Child = null;
         popup.PlacementTarget = null;
+    }
+
+    private static ReactorHostControl CreateSlashPopupHost(Element content)
+    {
+        var host = new ReactorHostControl();
+        host.Mount(_ => content);
+        return host;
     }
 
     private static void DriveSlashPopup(
@@ -1511,350 +1340,265 @@ public sealed class ReactorChatComposer : Component<ReactorChatComposerProps>
         popup.XamlRoot = anchor.XamlRoot;
         popup.PlacementTarget = anchor;
         popup.DesiredPlacement = Microsoft.UI.Xaml.Controls.Primitives.PopupPlacementMode.Top;
+        if (popup.Child is ReactorHostControl previousHost
+            && !ReferenceEquals(previousHost, content))
+            previousHost.Dispose();
         popup.Child = content;
         popup.IsOpen = true;
     }
 
-    private static Border BuildSlashHintPopup(string text)
+    private static Element BuildSlashHintPopup(string text)
     {
-        var label = new TextBlock
-        {
-            Text = text,
-            FontSize = 12,
-            Margin = new Thickness(8, 6, 8, 6),
-        };
-        ApplyTheme(label, () => label.Foreground = ResolveThemeBrush("TextFillColorSecondaryBrush", label.ActualTheme));
-        return SlashShell(label);
+        return SlashShell(
+            TextBlock(text)
+                .FontSize(12)
+                .Foreground(Theme.SecondaryText)
+                .Margin(8, 6, 8, 6));
     }
 
-    private static Border BuildSlashPopup(
+    private static Element BuildSlashPopup(
         IReadOnlyList<CommandCategoryGroup> groups,
         int selectedIndex,
         string query,
+        ColorScheme colorScheme,
         Action<GatewayCommand> onPick)
     {
-        var list = new StackPanel { Orientation = Orientation.Vertical };
+        var rows = new List<Element>();
         var index = 0;
         foreach (var group in groups)
         {
-            list.Children.Add(SlashCategoryHeader(CommandCategories.Label(group.Category)));
+            rows.Add(SlashCategoryHeader(CommandCategories.Label(group.Category)));
             foreach (var command in group.Commands)
             {
-                list.Children.Add(SlashRow(command, index == selectedIndex, query, onPick));
+                rows.Add(SlashRow(command, index == selectedIndex, query, colorScheme, onPick));
                 index++;
             }
         }
 
-        return SlashShell(new ScrollViewer
-        {
-            VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
-            HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
-            MaxHeight = 280,
-            Content = list,
-        });
+        return SlashShell(
+            ScrollView(VStack(0, rows.ToArray()))
+                .MaxHeight(280)
+                .Set(scrollViewer =>
+                {
+                    scrollViewer.VerticalScrollBarVisibility = ScrollingScrollBarVisibility.Auto;
+                    scrollViewer.HorizontalScrollBarVisibility = ScrollingScrollBarVisibility.Hidden;
+                }));
     }
 
-    private static TextBlock SlashCategoryHeader(string text)
+    private static Element SlashCategoryHeader(string text)
     {
-        var header = new TextBlock
-        {
-            Text = (text ?? string.Empty).ToUpperInvariant(),
-            FontSize = 11,
-            FontWeight = Microsoft.UI.Text.FontWeights.Bold,
-            CharacterSpacing = 60,
-            Margin = new Thickness(8, 8, 8, 2),
-        };
-        ApplyTheme(header, () => header.Foreground = ResolveThemeBrush("TextFillColorTertiaryBrush", header.ActualTheme));
-        return header;
+        return TextBlock((text ?? string.Empty).ToUpperInvariant())
+            .FontSize(11)
+            .SemiBold()
+            .CharacterSpacing(60)
+            .Foreground(Theme.TertiaryText)
+            .Margin(8, 8, 8, 2);
     }
 
-    private static Border BuildSlashArgPopup(
+    private static Element BuildSlashArgPopup(
         GatewayCommand command,
         IReadOnlyList<GatewayCommandArgChoice> choices,
         int selectedIndex,
         Action<GatewayCommandArgChoice> onPick)
     {
-        var list = new StackPanel { Orientation = Orientation.Vertical };
         var argDescription = command.Args?.FirstOrDefault()?.Description;
         var headerText = !string.IsNullOrWhiteSpace(argDescription)
             ? $"{command.DisplayName()}  {argDescription}"
             : !string.IsNullOrWhiteSpace(command.Description)
                 ? $"{command.DisplayName()}  {command.Description}"
                 : command.DisplayName();
-        var header = new TextBlock
+        var rows = new List<Element>
         {
-            Text = headerText,
-            FontSize = 11,
-            FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
-            TextTrimming = TextTrimming.CharacterEllipsis,
-            MaxLines = 1,
-            Margin = new Thickness(8, 6, 8, 2),
+            TextBlock(headerText)
+                .FontSize(11)
+                .SemiBold()
+                .TextTrimming(TextTrimming.CharacterEllipsis)
+                .MaxLines(1)
+                .Foreground(Theme.TertiaryText)
+                .Margin(8, 6, 8, 2),
         };
-        ApplyTheme(header, () => header.Foreground = ResolveThemeBrush("TextFillColorTertiaryBrush", header.ActualTheme));
-        list.Children.Add(header);
         for (var index = 0; index < choices.Count; index++)
-            list.Children.Add(SlashArgRow(command, choices[index], index == selectedIndex, onPick));
+            rows.Add(SlashArgRow(command, choices[index], index == selectedIndex, onPick));
 
-        return SlashShell(new ScrollViewer
-        {
-            VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
-            HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
-            MaxHeight = 280,
-            Content = list,
-        });
+        return SlashShell(
+            ScrollView(VStack(0, rows.ToArray()))
+                .MaxHeight(280)
+                .Set(scrollViewer =>
+                {
+                    scrollViewer.VerticalScrollBarVisibility = ScrollingScrollBarVisibility.Auto;
+                    scrollViewer.HorizontalScrollBarVisibility = ScrollingScrollBarVisibility.Hidden;
+                }));
     }
 
-    private static Button SlashArgRow(
+    private static Element SlashArgRow(
         GatewayCommand command,
         GatewayCommandArgChoice choice,
         bool selected,
         Action<GatewayCommandArgChoice> onPick)
     {
         var label = string.IsNullOrWhiteSpace(choice.Label) ? choice.Value : choice.Label;
-        var row = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 8 };
-        var title = new TextBlock
-        {
-            Text = label,
-            FontSize = 13,
-            FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
-            VerticalAlignment = VerticalAlignment.Center,
-        };
-        ApplyTheme(title, () => title.Foreground = ResolveThemeBrush("TextFillColorPrimaryBrush", title.ActualTheme));
-        row.Children.Add(title);
-
-        var subtitle = new TextBlock
-        {
-            Text = $"{command.DisplayName()} {choice.Value}",
-            FontSize = 12,
-            VerticalAlignment = VerticalAlignment.Center,
-            TextTrimming = TextTrimming.CharacterEllipsis,
-            MaxLines = 1,
-        };
-        ApplyTheme(subtitle, () => subtitle.Foreground = ResolveThemeBrush("TextFillColorSecondaryBrush", subtitle.ActualTheme));
-        row.Children.Add(subtitle);
-
-        var button = new Button
-        {
-            Content = row,
-            Padding = new Thickness(8, 7, 8, 7),
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-            HorizontalContentAlignment = HorizontalAlignment.Left,
-            CornerRadius = new CornerRadius(6),
-            BorderThickness = new Thickness(0),
-        };
-        ApplyTheme(button, () =>
-        {
-            button.Background = selected
-                ? ResolveThemeBrush("SubtleFillColorSecondaryBrush", button.ActualTheme)
-                : new SolidColorBrush(Microsoft.UI.Colors.Transparent);
-            button.BorderBrush = new SolidColorBrush(Microsoft.UI.Colors.Transparent);
-        });
-        Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(
-            button,
-            $"Choose {label} for {command.DisplayName()}");
-        button.Click += (_, _) => onPick(choice);
-        if (selected)
-        {
-            button.Loaded += (_, _) => button.StartBringIntoView(
-                new BringIntoViewOptions { AnimationDesired = false });
-        }
-
-        return button;
+        var background = selected ? Theme.SubtleFill : Theme.Ref("SubtleFillColorTransparentBrush");
+        return Button(
+                HStack(
+                    8,
+                    TextBlock(label)
+                        .FontSize(13)
+                        .SemiBold()
+                        .VAlign(VerticalAlignment.Center)
+                        .Foreground(Theme.PrimaryText),
+                    TextBlock($"{command.DisplayName()} {choice.Value}")
+                        .FontSize(12)
+                        .VAlign(VerticalAlignment.Center)
+                        .TextTrimming(TextTrimming.CharacterEllipsis)
+                        .MaxLines(1)
+                        .Foreground(Theme.SecondaryText)),
+                () => onPick(choice))
+            .Padding(8, 7, 8, 7)
+            .HAlign(HorizontalAlignment.Stretch)
+            .CornerRadius(6)
+            .AutomationName($"Choose {label} for {command.DisplayName()}")
+            .Resources(resources => resources
+                .Set("ButtonBackground", background)
+                .Set("ButtonBorderBrush", Theme.Ref("SubtleFillColorTransparentBrush")))
+            .Set(button =>
+            {
+                button.HorizontalContentAlignment = HorizontalAlignment.Left;
+                button.BorderThickness = new Thickness(0);
+            })
+            .OnMount(element =>
+            {
+                if (selected)
+                    element.StartBringIntoView(new BringIntoViewOptions { AnimationDesired = false });
+            });
     }
 
-    private static Border SlashShell(UIElement child)
+    private static Element SlashShell(Element child)
     {
-        var shell = new Border
-        {
-            BorderThickness = new Thickness(1),
-            CornerRadius = new CornerRadius(8),
-            Padding = new Thickness(4),
-            Child = child,
-            Shadow = new ThemeShadow(),
-            Translation = new System.Numerics.Vector3(0, 0, 32),
-        };
-        ApplyTheme(shell, () =>
-        {
-            shell.Background = ResolvePopupBackgroundBrush(shell.ActualTheme);
-            shell.BorderBrush = ResolveThemeBrush("SurfaceStrokeColorDefaultBrush", shell.ActualTheme);
-        });
-        return shell;
+        return Border(child)
+            .Padding(4)
+            .CornerRadius(8)
+            .Background(Theme.Ref("AcrylicBackgroundFillColorDefaultBrush"))
+            .WithBorder(Theme.Ref("SurfaceStrokeColorFlyoutBrush"), 1)
+            .Translation(0, 0, 32)
+            .Set(border => border.Shadow = new ThemeShadow());
     }
 
-    private static Brush ResolvePopupBackgroundBrush(ElementTheme theme)
-    {
-        var overlay = FindThemedResource("TextControlBackground", theme) as SolidColorBrush
-            ?? Application.Current?.Resources["TextControlBackground"] as SolidColorBrush;
-        var baseBrush = FindThemedResource("SolidBackgroundFillColorBaseBrush", theme) as SolidColorBrush
-            ?? Application.Current?.Resources["SolidBackgroundFillColorBaseBrush"] as SolidColorBrush;
-        if (overlay is null || baseBrush is null)
-            return ResolveThemeBrush("SolidBackgroundFillColorBaseBrush", theme);
-
-        var alpha = overlay.Color.A / 255.0;
-        static byte Mix(byte background, byte foreground, double alpha) =>
-            (byte)Math.Round(background * (1 - alpha) + foreground * alpha);
-
-        return new SolidColorBrush(global::Windows.UI.Color.FromArgb(
-            255,
-            Mix(baseBrush.Color.R, overlay.Color.R, alpha),
-            Mix(baseBrush.Color.G, overlay.Color.G, alpha),
-            Mix(baseBrush.Color.B, overlay.Color.B, alpha)));
-    }
-
-    private static Button SlashRow(
+    private static Element SlashRow(
         GatewayCommand command,
         bool selected,
         string query,
+        ColorScheme colorScheme,
         Action<GatewayCommand> onPick)
     {
-        var mono = new FontFamily("Consolas");
-        var grid = new Microsoft.UI.Xaml.Controls.Grid
+        var cells = new List<Element>
         {
-            ColumnSpacing = 8,
-            VerticalAlignment = VerticalAlignment.Center,
+            TextBlock(SlashGlyph(command))
+                .FontFamily(FluentIconCatalog.SymbolThemeFontFamily)
+                .FontSize(14)
+                .VAlign(VerticalAlignment.Center)
+                .Foreground(Theme.SecondaryText)
+                .AccessibilityView(Microsoft.UI.Xaml.Automation.Peers.AccessibilityView.Raw)
+                .Grid(row: 0, column: 0),
+            TextBlock(command.DisplayName())
+                .FontSize(13)
+                .SemiBold()
+                .VAlign(VerticalAlignment.Center)
+                .Foreground(Theme.PrimaryText)
+                .Set(textBlock => ApplyQueryHighlight(textBlock, query, colorScheme))
+                .Grid(row: 0, column: 1),
         };
-        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
-        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
-        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
-        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
-        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
-
-        var icon = new FontIcon
-        {
-            FontFamily = (FontFamily)Application.Current.Resources["SymbolThemeFontFamily"],
-            Glyph = SlashGlyph(command),
-            FontSize = 14,
-            VerticalAlignment = VerticalAlignment.Center,
-        };
-        ApplyTheme(icon, () => icon.Foreground = ResolveThemeBrush("TextFillColorSecondaryBrush", icon.ActualTheme));
-        Microsoft.UI.Xaml.Automation.AutomationProperties.SetAccessibilityView(
-            icon,
-            Microsoft.UI.Xaml.Automation.Peers.AccessibilityView.Raw);
-        Microsoft.UI.Xaml.Controls.Grid.SetColumn(icon, 0);
-        grid.Children.Add(icon);
-
-        var name = new TextBlock
-        {
-            Text = command.DisplayName(),
-            FontSize = 13,
-            FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
-            VerticalAlignment = VerticalAlignment.Center,
-        };
-        ApplyTheme(name, () => name.Foreground = ResolveThemeBrush("TextFillColorPrimaryBrush", name.ActualTheme));
-        Microsoft.UI.Xaml.Controls.Grid.SetColumn(name, 1);
-        grid.Children.Add(name);
-        ApplyQueryHighlight(name, query);
-
         var args = command.ArgTemplate();
         if (!string.IsNullOrWhiteSpace(args))
         {
-            var argBlock = new TextBlock
-            {
-                Text = args,
-                FontSize = 12,
-                FontFamily = mono,
-                Opacity = 0.75,
-                VerticalAlignment = VerticalAlignment.Center,
-            };
-            ApplyTheme(argBlock, () => argBlock.Foreground = ResolveThemeBrush("TextFillColorSecondaryBrush", argBlock.ActualTheme));
-            Microsoft.UI.Xaml.Controls.Grid.SetColumn(argBlock, 2);
-            grid.Children.Add(argBlock);
+            cells.Add(
+                TextBlock(args)
+                    .FontSize(12)
+                    .FontFamily("Consolas")
+                    .VAlign(VerticalAlignment.Center)
+                    .Foreground(Theme.SecondaryText)
+                    .Grid(row: 0, column: 2));
         }
 
         if (!string.IsNullOrWhiteSpace(command.Description))
         {
-            var description = new TextBlock
-            {
-                Text = command.Description!,
-                FontSize = 12,
-                VerticalAlignment = VerticalAlignment.Center,
-                HorizontalAlignment = HorizontalAlignment.Right,
-                TextAlignment = TextAlignment.Right,
-                TextTrimming = TextTrimming.CharacterEllipsis,
-                MaxLines = 1,
-            };
-            ApplyTheme(description, () => description.Foreground = ResolveThemeBrush("TextFillColorSecondaryBrush", description.ActualTheme));
-            Microsoft.UI.Xaml.Controls.Grid.SetColumn(description, 3);
-            grid.Children.Add(description);
-            ApplyQueryHighlight(description, query);
+            cells.Add(
+                TextBlock(command.Description!)
+                    .FontSize(12)
+                    .VAlign(VerticalAlignment.Center)
+                    .HAlign(HorizontalAlignment.Right)
+                    .TextAlignment(TextAlignment.Right)
+                    .TextTrimming(TextTrimming.CharacterEllipsis)
+                    .MaxLines(1)
+                    .Foreground(Theme.SecondaryText)
+                    .Set(textBlock => ApplyQueryHighlight(textBlock, query, colorScheme))
+                    .Grid(row: 0, column: 3));
         }
 
         var options = command.OptionCount();
         if (options > 0)
         {
-            var badge = SlashBadge($"{options} options");
-            Microsoft.UI.Xaml.Controls.Grid.SetColumn(badge, 4);
-            grid.Children.Add(badge);
+            cells.Add(SlashBadge($"{options} options").Grid(row: 0, column: 4));
         }
 
-        var button = new Button
-        {
-            Content = grid,
-            Padding = new Thickness(8, 7, 8, 7),
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-            HorizontalContentAlignment = HorizontalAlignment.Stretch,
-            CornerRadius = new CornerRadius(6),
-            BorderThickness = new Thickness(0),
-        };
-        ApplyTheme(button, () =>
-        {
-            button.Background = selected
-                ? ResolveThemeBrush("SubtleFillColorSecondaryBrush", button.ActualTheme)
-                : new SolidColorBrush(Microsoft.UI.Colors.Transparent);
-            button.BorderBrush = new SolidColorBrush(Microsoft.UI.Colors.Transparent);
-        });
-        Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(button, $"Insert {command.DisplayName()}");
-        button.Click += (_, _) => onPick(command);
-        if (selected)
-        {
-            button.Loaded += (_, _) => button.StartBringIntoView(
-                new BringIntoViewOptions { AnimationDesired = false });
-        }
-        return button;
+        var background = selected ? Theme.SubtleFill : Theme.Ref("SubtleFillColorTransparentBrush");
+        return Button(
+                Grid(
+                    [GridSize.Auto, GridSize.Auto, GridSize.Auto, GridSize.Star(), GridSize.Auto],
+                    [GridSize.Auto],
+                    cells.ToArray())
+                    .Set(grid => grid.ColumnSpacing = 8)
+                    .VAlign(VerticalAlignment.Center),
+                () => onPick(command))
+            .Padding(8, 7, 8, 7)
+            .HAlign(HorizontalAlignment.Stretch)
+            .CornerRadius(6)
+            .AutomationName($"Insert {command.DisplayName()}")
+            .Resources(resources => resources
+                .Set("ButtonBackground", background)
+                .Set("ButtonBorderBrush", Theme.Ref("SubtleFillColorTransparentBrush")))
+            .Set(button =>
+            {
+                button.HorizontalContentAlignment = HorizontalAlignment.Stretch;
+                button.BorderThickness = new Thickness(0);
+            })
+            .OnMount(element =>
+            {
+                if (selected)
+                    element.StartBringIntoView(new BringIntoViewOptions { AnimationDesired = false });
+            });
     }
 
-    private static Border SlashBadge(string text)
+    private static Element SlashBadge(string text)
     {
-        var label = new TextBlock
-        {
-            Text = text,
-            FontSize = 10,
-            FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
-        };
-        var badge = new Border
-        {
-            Padding = new Thickness(6, 1, 6, 1),
-            CornerRadius = new CornerRadius(4),
-            VerticalAlignment = VerticalAlignment.Center,
-            Child = label,
-        };
-        ApplyTheme(badge, () =>
-        {
-            var accent = ResolveThemeBrush("AccentFillColorDefaultBrush", badge.ActualTheme);
-            badge.Background = accent is SolidColorBrush solid
-                ? new SolidColorBrush(solid.Color) { Opacity = 0.14 }
-                : accent;
-        });
-        ApplyTheme(label, () => label.Foreground = ResolveThemeBrush("AccentFillColorDefaultBrush", label.ActualTheme));
-        return badge;
+        return Border(
+                TextBlock(text)
+                    .FontSize(10)
+                    .SemiBold()
+                    .Foreground(Theme.Ref("TextOnAccentFillColorPrimaryBrush")))
+            .Padding(6, 1, 6, 1)
+            .CornerRadius(4)
+            .VAlign(VerticalAlignment.Center)
+            .Background(Theme.AccentSecondary);
     }
 
-    private static void ApplyQueryHighlight(TextBlock textBlock, string? query)
+    private static void ApplyQueryHighlight(TextBlock textBlock, string? query, ColorScheme colorScheme)
     {
         textBlock.TextHighlighters.Clear();
         var text = textBlock.Text ?? string.Empty;
         var normalized = (query ?? string.Empty).Trim().TrimStart('/').Trim();
-        if (normalized.Length == 0 || text.Length < normalized.Length)
+        if (normalized.Length == 0 || text.Length < normalized.Length || colorScheme == ColorScheme.HighContrast)
             return;
 
-        var accent = Application.Current.Resources["AccentFillColorDefaultBrush"] as SolidColorBrush
-            ?? new SolidColorBrush(Microsoft.UI.Colors.SteelBlue);
+        var isDark = colorScheme == ColorScheme.Dark;
+        if (ThemeRef.Resolve("AccentFillColorDefaultBrush", isDark) is not SolidColorBrush accent
+            || ThemeRef.Resolve("TextFillColorPrimaryBrush", isDark) is not Brush foreground)
+            return;
+
         var accentColor = accent.Color;
         var highlighter = new Microsoft.UI.Xaml.Documents.TextHighlighter
         {
             Background = new SolidColorBrush(global::Windows.UI.Color.FromArgb(31, accentColor.R, accentColor.G, accentColor.B)),
-            Foreground = Application.Current.Resources["TextFillColorPrimaryBrush"] as Brush
-                ?? new SolidColorBrush(Microsoft.UI.Colors.White),
+            Foreground = foreground,
         };
 
         for (var index = 0; index <= text.Length - normalized.Length;)

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml
@@ -19,6 +19,42 @@
             <Setter Property="Padding" Value="0"/>
             <Setter Property="MinHeight" Value="0"/>
         </Style>
+        <Style x:Key="ConnectionCapabilityPillActiveBorderStyle" TargetType="Border">
+            <Setter Property="Background" Value="{ThemeResource ConnectionCapabilityPillSuccessBrush}"/>
+        </Style>
+        <Style x:Key="ConnectionCapabilityPillPendingBorderStyle" TargetType="Border">
+            <Setter Property="Background" Value="{ThemeResource ConnectionCapabilityPillCautionBrush}"/>
+        </Style>
+        <Style x:Key="ConnectionCapabilityPillCriticalBorderStyle" TargetType="Border">
+            <Setter Property="Background" Value="{ThemeResource ConnectionCapabilityPillCriticalBrush}"/>
+        </Style>
+        <Style x:Key="ConnectionCapabilityPillOffBorderStyle" TargetType="Border">
+            <Setter Property="Background" Value="{ThemeResource SubtleFillColorTertiaryBrush}"/>
+        </Style>
+        <Style x:Key="ConnectionCapabilityPillActiveIconStyle" TargetType="FontIcon">
+            <Setter Property="Foreground" Value="{ThemeResource SystemFillColorSuccessBrush}"/>
+        </Style>
+        <Style x:Key="ConnectionCapabilityPillPendingIconStyle" TargetType="FontIcon">
+            <Setter Property="Foreground" Value="{ThemeResource SystemFillColorCautionBrush}"/>
+        </Style>
+        <Style x:Key="ConnectionCapabilityPillCriticalIconStyle" TargetType="FontIcon">
+            <Setter Property="Foreground" Value="{ThemeResource SystemFillColorCriticalBrush}"/>
+        </Style>
+        <Style x:Key="ConnectionCapabilityPillOffIconStyle" TargetType="FontIcon">
+            <Setter Property="Foreground" Value="{ThemeResource TextFillColorTertiaryBrush}"/>
+        </Style>
+        <Style x:Key="ConnectionCapabilityPillActiveTextStyle" TargetType="TextBlock">
+            <Setter Property="Foreground" Value="{ThemeResource SystemFillColorSuccessBrush}"/>
+        </Style>
+        <Style x:Key="ConnectionCapabilityPillPendingTextStyle" TargetType="TextBlock">
+            <Setter Property="Foreground" Value="{ThemeResource SystemFillColorCautionBrush}"/>
+        </Style>
+        <Style x:Key="ConnectionCapabilityPillCriticalTextStyle" TargetType="TextBlock">
+            <Setter Property="Foreground" Value="{ThemeResource SystemFillColorCriticalBrush}"/>
+        </Style>
+        <Style x:Key="ConnectionCapabilityPillOffTextStyle" TargetType="TextBlock">
+            <Setter Property="Foreground" Value="{ThemeResource TextFillColorSecondaryBrush}"/>
+        </Style>
     </Page.Resources>
 
     <!--

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
@@ -1346,7 +1346,7 @@ public sealed partial class ConnectionPage : Page
             {
                 Glyph = stateGlyph,
                 FontSize = 10,
-                Style = (Style)Resources[textStyleKey],
+                Style = (Style)Resources[iconStyleKey],
                 VerticalAlignment = VerticalAlignment.Center,
                 IsTextScaleFactorEnabled = false,
             };

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
@@ -38,7 +38,6 @@ public sealed partial class ConnectionPage : Page
     private IGatewayConnectionManager? _connectionManager;
     private GatewayRegistry? _gatewayRegistry;
     private GatewayDiscoveryService? _discoveryService;
-    private global::Windows.UI.ViewManagement.AccessibilitySettings? _accessibilitySettings;
     private IGatewayTerminalLauncher? _terminalLauncher;
     private WslGatewayController? _wslGatewayController;
 
@@ -127,7 +126,6 @@ public sealed partial class ConnectionPage : Page
             _gatewayRegistry.Changed += OnRegistryChanged;
 
         ActualThemeChanged += OnPageActualThemeChanged;
-        TrySubscribeAccessibilitySettings();
         Unloaded += OnPageUnloaded;
 
         // Initialize Node mode toggle from settings (suppressed event)
@@ -172,11 +170,6 @@ public sealed partial class ConnectionPage : Page
         if (_gatewayRegistry != null)
             _gatewayRegistry.Changed -= OnRegistryChanged;
         ActualThemeChanged -= OnPageActualThemeChanged;
-        if (_accessibilitySettings != null)
-        {
-            _accessibilitySettings.HighContrastChanged -= OnHighContrastChanged;
-            _accessibilitySettings = null;
-        }
         _discoveryService?.Dispose();
         _discoveryService = null;
         if (_reconnectMaskTimer != null)
@@ -200,31 +193,10 @@ public sealed partial class ConnectionPage : Page
         RefreshAfterThemeVisualChange();
     }
 
-    private void OnHighContrastChanged(
-        global::Windows.UI.ViewManagement.AccessibilitySettings sender,
-        object args)
-    {
-        DispatcherQueue?.TryEnqueue(RefreshAfterThemeVisualChange);
-    }
-
     private void RefreshAfterThemeVisualChange()
     {
         _capabilityPillsFingerprint = null;
         RefreshFromSnapshot(_lastSnapshot);
-    }
-
-    private void TrySubscribeAccessibilitySettings()
-    {
-        try
-        {
-            _accessibilitySettings = new global::Windows.UI.ViewManagement.AccessibilitySettings();
-            _accessibilitySettings.HighContrastChanged += OnHighContrastChanged;
-        }
-        catch (Exception ex)
-        {
-            Services.Logger.Warn($"[ConnectionPage] Could not subscribe to High Contrast changes: {ex.Message}");
-            _accessibilitySettings = null;
-        }
     }
 
     private void OnManagerStateChanged(object? sender, GatewayConnectionSnapshot snapshot)
@@ -1230,8 +1202,6 @@ public sealed partial class ConnectionPage : Page
         var pendingSet = new HashSet<string>(
             pendingDeclared.Where(c => !string.IsNullOrWhiteSpace(c)),
             StringComparer.OrdinalIgnoreCase);
-        var isHighContrast = IsHighContrastEnabled();
-
         var canonical = new (string Name, string LabelKey, string Glyph, bool Enabled)[]
         {
             ("browser",  "PermissionsPage_Cap_Browser_Label",  FluentIconCatalog.Browser,  settings.NodeBrowserProxyEnabled),
@@ -1273,7 +1243,6 @@ public sealed partial class ConnectionPage : Page
                 LocalizationHelper.GetString(labelKey),
                 glyph,
                 state,
-                isHighContrast,
                 kind,
                 remoteForPill));
             shown.Add(name);
@@ -1295,7 +1264,6 @@ public sealed partial class ConnectionPage : Page
                 label,
                 glyph,
                 state,
-                isHighContrast,
                 kind: state == CapabilityPillState.Active
                     ? BrowserProxyActivation.CapabilityPillKind.Active
                     : BrowserProxyActivation.CapabilityPillKind.PendingApproval,
@@ -1305,52 +1273,37 @@ public sealed partial class ConnectionPage : Page
         return panel;
     }
 
-    private const double CapabilityPillFillOpacity = 0.14;
-
     private Border MakeCapabilityPill(
         string label,
         string glyph,
         CapabilityPillState state,
-        bool isHighContrast,
         BrowserProxyActivation.CapabilityPillKind kind,
         bool requiresRemoteBrowserEndpoint)
     {
-        var (fillBrush, iconBrush, textBrush, stateKey, stateGlyph) = state switch
+        var (borderStyleKey, iconStyleKey, textStyleKey, stateKey, stateGlyph) = state switch
         {
             CapabilityPillState.Active => (
-                TintBrush(
-                    "SystemFillColorSuccessBrush",
-                    "SystemFillColorSuccessBackgroundBrush",
-                    CapabilityPillFillOpacity,
-                    isHighContrast),
-                ResolveBrush("SystemFillColorSuccessBrush"),
-                ResolveBrush("SystemFillColorSuccessBrush"),
+                "ConnectionCapabilityPillActiveBorderStyle",
+                "ConnectionCapabilityPillActiveIconStyle",
+                "ConnectionCapabilityPillActiveTextStyle",
                 "ConnectionPage_NodePillState_Active",
                 null),
             CapabilityPillState.Pending => (
-                TintBrush(
-                    "SystemFillColorCautionBrush",
-                    "SystemFillColorCautionBackgroundBrush",
-                    CapabilityPillFillOpacity,
-                    isHighContrast),
-                ResolveBrush("SystemFillColorCautionBrush"),
-                ResolveBrush("SystemFillColorCautionBrush"),
+                "ConnectionCapabilityPillPendingBorderStyle",
+                "ConnectionCapabilityPillPendingIconStyle",
+                "ConnectionCapabilityPillPendingTextStyle",
                 "ConnectionPage_NodePillState_Pending",
                 FluentIconCatalog.StatusWarn),
             CapabilityPillState.NeedsSharedToken => (
-                TintBrush(
-                    "SystemFillColorCriticalBrush",
-                    "SystemFillColorCriticalBackgroundBrush",
-                    CapabilityPillFillOpacity,
-                    isHighContrast),
-                ResolveBrush("SystemFillColorCriticalBrush"),
-                ResolveBrush("SystemFillColorCriticalBrush"),
+                "ConnectionCapabilityPillCriticalBorderStyle",
+                "ConnectionCapabilityPillCriticalIconStyle",
+                "ConnectionCapabilityPillCriticalTextStyle",
                 "ConnectionPage_NodePillState_NeedsGatewayToken",
                 FluentIconCatalog.StatusWarn),
             _ => (
-                ResolveBrush("SubtleFillColorTertiaryBrush"),
-                ResolveBrush("TextFillColorTertiaryBrush"),
-                ResolveBrush("TextFillColorSecondaryBrush"),
+                "ConnectionCapabilityPillOffBorderStyle",
+                "ConnectionCapabilityPillOffIconStyle",
+                "ConnectionCapabilityPillOffTextStyle",
                 "ConnectionPage_NodePillState_Off",
                 null),
         };
@@ -1365,7 +1318,7 @@ public sealed partial class ConnectionPage : Page
         {
             Glyph = glyph,
             FontSize = 12,
-            Foreground = iconBrush,
+            Style = (Style)Resources[iconStyleKey],
             VerticalAlignment = VerticalAlignment.Center,
             IsTextScaleFactorEnabled = false,
         };
@@ -1381,7 +1334,7 @@ public sealed partial class ConnectionPage : Page
         {
             Text = label,
             FontSize = 12,
-            Foreground = textBrush,
+            Style = (Style)Resources[textStyleKey],
             VerticalAlignment = VerticalAlignment.Center,
         };
         AutomationProperties.SetName(labelText, $"{label}: {detailText}");
@@ -1393,7 +1346,7 @@ public sealed partial class ConnectionPage : Page
             {
                 Glyph = stateGlyph,
                 FontSize = 10,
-                Foreground = textBrush,
+                Style = (Style)Resources[textStyleKey],
                 VerticalAlignment = VerticalAlignment.Center,
                 IsTextScaleFactorEnabled = false,
             };
@@ -1405,35 +1358,11 @@ public sealed partial class ConnectionPage : Page
         {
             CornerRadius = new CornerRadius(12),
             Padding = new Thickness(8, 3, 11, 3),
-            Background = fillBrush,
+            Style = (Style)Resources[borderStyleKey],
             Child = content,
         };
         ToolTipService.SetToolTip(pill, detailText);
         return pill;
-    }
-
-    private Brush TintBrush(string colorKey, string highContrastBrushKey, double opacity, bool isHighContrast)
-    {
-        if (isHighContrast)
-            return ResolveBrush(highContrastBrushKey);
-
-        var color = ResolveBrush(colorKey) is SolidColorBrush scb
-            ? scb.Color
-            : ((SolidColorBrush)ResolveBrush("TextFillColorPrimaryBrush")).Color;
-        return new SolidColorBrush(color) { Opacity = opacity };
-    }
-
-    private bool IsHighContrastEnabled()
-    {
-        if (_accessibilitySettings is null)
-            return false;
-
-        try { return _accessibilitySettings.HighContrast; }
-        catch (Exception ex)
-        {
-            Services.Logger.Warn($"[ConnectionPage] Could not read High Contrast state: {ex.Message}");
-            return false;
-        }
     }
 
     private static string BuildCapabilityPillFingerprint(

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -2987,6 +2987,9 @@ Use one of these options:
   <data name="Chat_Composer_Tooltip_More" xml:space="preserve">
     <value>More</value>
   </data>
+  <data name="Chat_Composer_Tooltip_Settings" xml:space="preserve">
+    <value>Settings</value>
+  </data>
   <data name="Chat_Composer_Tooltip_Send" xml:space="preserve">
     <value>Send</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -2940,6 +2940,9 @@ Utilisez l'une de ces options :
   <data name="Chat_Composer_Tooltip_More" xml:space="preserve">
     <value>Plus</value>
   </data>
+  <data name="Chat_Composer_Tooltip_Settings" xml:space="preserve">
+    <value>Paramètres</value>
+  </data>
   <data name="Chat_Composer_Tooltip_Send" xml:space="preserve">
     <value>Envoyer</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -2941,6 +2941,9 @@ Gebruik een van deze opties:
   <data name="Chat_Composer_Tooltip_More" xml:space="preserve">
     <value>Meer</value>
   </data>
+  <data name="Chat_Composer_Tooltip_Settings" xml:space="preserve">
+    <value>Instellingen</value>
+  </data>
   <data name="Chat_Composer_Tooltip_Send" xml:space="preserve">
     <value>Verzenden</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -2940,6 +2940,9 @@
   <data name="Chat_Composer_Tooltip_More" xml:space="preserve">
     <value>更多</value>
   </data>
+  <data name="Chat_Composer_Tooltip_Settings" xml:space="preserve">
+    <value>设置</value>
+  </data>
   <data name="Chat_Composer_Tooltip_Send" xml:space="preserve">
     <value>发送</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -2940,6 +2940,9 @@
   <data name="Chat_Composer_Tooltip_More" xml:space="preserve">
     <value>更多</value>
   </data>
+  <data name="Chat_Composer_Tooltip_Settings" xml:space="preserve">
+    <value>設定</value>
+  </data>
   <data name="Chat_Composer_Tooltip_Send" xml:space="preserve">
     <value>傳送</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml
@@ -382,51 +382,8 @@
                 SelectionChanged="NavView_SelectionChanged">
 
             <NavigationView.Resources>
-                <ResourceDictionary>
-                <ResourceDictionary.ThemeDictionaries>
-                    <ResourceDictionary x:Key="Default">
-                        <ImageIconSource x:Key="Chat_IconSource"><ImageIconSource.ImageSource><SvgImageSource UriSource="ms-appx:///Assets/SidebarIcons/Chat.svg"/></ImageIconSource.ImageSource></ImageIconSource>
-                        <ImageIconSource x:Key="Connection_IconSource"><ImageIconSource.ImageSource><SvgImageSource UriSource="ms-appx:///Assets/SidebarIcons/Connection.svg"/></ImageIconSource.ImageSource></ImageIconSource>
-                        <ImageIconSource x:Key="Sessions_IconSource"><ImageIconSource.ImageSource><SvgImageSource UriSource="ms-appx:///Assets/SidebarIcons/Sessions.svg"/></ImageIconSource.ImageSource></ImageIconSource>
-                        <ImageIconSource x:Key="Skills_IconSource"><ImageIconSource.ImageSource><SvgImageSource UriSource="ms-appx:///Assets/SidebarIcons/Skills.svg"/></ImageIconSource.ImageSource></ImageIconSource>
-                        <ImageIconSource x:Key="Channels_IconSource"><ImageIconSource.ImageSource><SvgImageSource UriSource="ms-appx:///Assets/SidebarIcons/Channels.svg"/></ImageIconSource.ImageSource></ImageIconSource>
-                        <ImageIconSource x:Key="Instances_IconSource"><ImageIconSource.ImageSource><SvgImageSource UriSource="ms-appx:///Assets/SidebarIcons/Instances.svg"/></ImageIconSource.ImageSource></ImageIconSource>
-                        <ImageIconSource x:Key="Advanced_IconSource"><ImageIconSource.ImageSource><SvgImageSource UriSource="ms-appx:///Assets/SidebarIcons/Advanced.svg"/></ImageIconSource.ImageSource></ImageIconSource>
-                        <ImageIconSource x:Key="AgentEvents_IconSource"><ImageIconSource.ImageSource><SvgImageSource UriSource="ms-appx:///Assets/SidebarIcons/AgentEvents.svg"/></ImageIconSource.ImageSource></ImageIconSource>
-                        <ImageIconSource x:Key="Agents_IconSource"><ImageIconSource.ImageSource><SvgImageSource UriSource="ms-appx:///Assets/SidebarIcons/Agents.svg"/></ImageIconSource.ImageSource></ImageIconSource>
-                        <ImageIconSource x:Key="Bindings_IconSource"><ImageIconSource.ImageSource><SvgImageSource UriSource="ms-appx:///Assets/SidebarIcons/Bindings.svg"/></ImageIconSource.ImageSource></ImageIconSource>
-                        <ImageIconSource x:Key="Config_IconSource"><ImageIconSource.ImageSource><SvgImageSource UriSource="ms-appx:///Assets/SidebarIcons/Config.svg"/></ImageIconSource.ImageSource></ImageIconSource>
-                        <ImageIconSource x:Key="Usage_IconSource"><ImageIconSource.ImageSource><SvgImageSource UriSource="ms-appx:///Assets/SidebarIcons/Usage.svg"/></ImageIconSource.ImageSource></ImageIconSource>
-                        <ImageIconSource x:Key="Cron_IconSource"><ImageIconSource.ImageSource><SvgImageSource UriSource="ms-appx:///Assets/SidebarIcons/Cron.svg"/></ImageIconSource.ImageSource></ImageIconSource>
-                        <ImageIconSource x:Key="Voice_IconSource"><ImageIconSource.ImageSource><SvgImageSource UriSource="ms-appx:///Assets/SidebarIcons/Voice.svg"/></ImageIconSource.ImageSource></ImageIconSource>
-                        <ImageIconSource x:Key="Settings_IconSource"><ImageIconSource.ImageSource><SvgImageSource UriSource="ms-appx:///Assets/SidebarIcons/Settings.svg"/></ImageIconSource.ImageSource></ImageIconSource>
-                        <ImageIconSource x:Key="Permissions_IconSource"><ImageIconSource.ImageSource><SvgImageSource UriSource="ms-appx:///Assets/SidebarIcons/Permissions.svg"/></ImageIconSource.ImageSource></ImageIconSource>
-                        <ImageIconSource x:Key="Sandbox_IconSource"><ImageIconSource.ImageSource><SvgImageSource UriSource="ms-appx:///Assets/SidebarIcons/Sandbox.svg"/></ImageIconSource.ImageSource></ImageIconSource>
-                        <ImageIconSource x:Key="Activity_IconSource"><ImageIconSource.ImageSource><SvgImageSource UriSource="ms-appx:///Assets/SidebarIcons/Activity.svg"/></ImageIconSource.ImageSource></ImageIconSource>
-                        <ImageIconSource x:Key="Debug_IconSource"><ImageIconSource.ImageSource><SvgImageSource UriSource="ms-appx:///Assets/SidebarIcons/Debug.svg"/></ImageIconSource.ImageSource></ImageIconSource>
-                    </ResourceDictionary>
-                    <ResourceDictionary x:Key="HighContrast">
-                        <SymbolIconSource x:Key="Chat_IconSource" Symbol="Message"/>
-                        <SymbolIconSource x:Key="Connection_IconSource" Symbol="Remote"/>
-                        <SymbolIconSource x:Key="Sessions_IconSource" Symbol="Switch"/>
-                        <SymbolIconSource x:Key="Skills_IconSource" Symbol="Library"/>
-                        <SymbolIconSource x:Key="Channels_IconSource" Symbol="Audio"/>
-                        <SymbolIconSource x:Key="Instances_IconSource" Symbol="OtherUser"/>
-                        <SymbolIconSource x:Key="Advanced_IconSource" Symbol="More"/>
-                        <SymbolIconSource x:Key="AgentEvents_IconSource" Symbol="List"/>
-                        <SymbolIconSource x:Key="Agents_IconSource" Symbol="People"/>
-                        <SymbolIconSource x:Key="Bindings_IconSource" Symbol="Link"/>
-                        <SymbolIconSource x:Key="Config_IconSource" Symbol="Edit"/>
-                        <SymbolIconSource x:Key="Usage_IconSource" Symbol="View"/>
-                        <SymbolIconSource x:Key="Cron_IconSource" Symbol="Calendar"/>
-                        <SymbolIconSource x:Key="Voice_IconSource" Symbol="Microphone"/>
-                        <SymbolIconSource x:Key="Settings_IconSource" Symbol="Setting"/>
-                        <SymbolIconSource x:Key="Permissions_IconSource" Symbol="Permissions"/>
-                        <SymbolIconSource x:Key="Sandbox_IconSource" Symbol="ProtectedDocument"/>
-                        <SymbolIconSource x:Key="Activity_IconSource" Symbol="View"/>
-                        <SymbolIconSource x:Key="Debug_IconSource" Symbol="Help"/>
-                    </ResourceDictionary>
-                </ResourceDictionary.ThemeDictionaries>
+                <!-- Keep nav icons as direct ImageIcon elements. ThemeResource-bound
+                     IconSourceElement resources failed to realize here and blocked navigation. -->
                 <!-- Match Windows 11 Settings: ~22px colorful icons in a default-height row.
                      Default row pitch (~50px) lines up with Settings' sidebar.
                      Only the Left-pane theme key has an override; Top and Compact modes are not used (PaneDisplayMode is hardcoded above). -->
@@ -435,60 +392,75 @@
                      as the WinUI default once rows are bigger. -->
                 <Thickness x:Key="NavigationViewItemSeparatorMargin">0,2,0,2</Thickness>
 
-                <Style x:Key="AgentNavigationIconStyle" TargetType="IconSourceElement">
-                    <Setter Property="IconSource" Value="{ThemeResource Agents_IconSource}"/>
-                </Style>
-                </ResourceDictionary>
+                <SvgImageSource x:Key="Chat_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Chat.svg"/>
+                <SvgImageSource x:Key="Connection_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Connection.svg"/>
+                <SvgImageSource x:Key="Sessions_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Sessions.svg"/>
+                <SvgImageSource x:Key="Skills_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Skills.svg"/>
+                <SvgImageSource x:Key="Channels_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Channels.svg"/>
+                <SvgImageSource x:Key="Instances_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Instances.svg"/>
+                <SvgImageSource x:Key="Advanced_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Advanced.svg"/>
+                <SvgImageSource x:Key="AgentEvents_Icon" UriSource="ms-appx:///Assets/SidebarIcons/AgentEvents.svg"/>
+                <SvgImageSource x:Key="Agents_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Agents.svg"/>
+                <SvgImageSource x:Key="Bindings_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Bindings.svg"/>
+                <SvgImageSource x:Key="Config_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Config.svg"/>
+                <SvgImageSource x:Key="Usage_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Usage.svg"/>
+                <SvgImageSource x:Key="Cron_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Cron.svg"/>
+                <SvgImageSource x:Key="Voice_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Voice.svg"/>
+                <SvgImageSource x:Key="Settings_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Settings.svg"/>
+                <SvgImageSource x:Key="Permissions_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Permissions.svg"/>
+                <SvgImageSource x:Key="Sandbox_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Sandbox.svg"/>
+                <SvgImageSource x:Key="Activity_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Activity.svg"/>
+                <SvgImageSource x:Key="Debug_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Debug.svg"/>
             </NavigationView.Resources>
 
             <NavigationView.MenuItems>
                 <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_82" x:Name="NavChat" Tag="chat" Content="Chat">
-                    <NavigationViewItem.Icon><IconSourceElement IconSource="{ThemeResource Chat_IconSource}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
+                    <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Chat_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
                 </NavigationViewItem>
                 <NavigationViewItemSeparator/>
 
             <NavigationViewItemHeader x:Uid="HubWindow_NavigationViewItemHeader_87" x:Name="NavGatewayHeader" Content="Gateway"/>
             <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_88" Tag="connection" Content="Connection">
-                <NavigationViewItem.Icon><IconSourceElement IconSource="{ThemeResource Connection_IconSource}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
+                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Connection_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
             </NavigationViewItem>
             <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_91" x:Name="NavSessions" Tag="sessions" Content="Sessions">
-                <NavigationViewItem.Icon><IconSourceElement IconSource="{ThemeResource Sessions_IconSource}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
+                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Sessions_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
             </NavigationViewItem>
             <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_97" x:Name="NavSkills" Tag="skills" Content="Skills">
-                <NavigationViewItem.Icon><IconSourceElement IconSource="{ThemeResource Skills_IconSource}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
+                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Skills_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
             </NavigationViewItem>
             <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_109" x:Name="NavChannels" Tag="channels" Content="Channels">
-                <NavigationViewItem.Icon><IconSourceElement IconSource="{ThemeResource Channels_IconSource}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
+                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Channels_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
             </NavigationViewItem>
             <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_112" x:Name="NavInstances" Tag="instances" Content="Instances">
-                <NavigationViewItem.Icon><IconSourceElement IconSource="{ThemeResource Instances_IconSource}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
+                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Instances_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
             </NavigationViewItem>
             <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_124" x:Name="NavCron" Tag="cron" Content="Cron">
-                <NavigationViewItem.Icon><IconSourceElement IconSource="{ThemeResource Cron_IconSource}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
+                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Cron_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
             </NavigationViewItem>
             <!-- Advanced — consolidates gateway-oriented pages -->
             <NavigationViewItem x:Uid="HubWindow_Advanced" x:Name="NavAdvanced" Content="Advanced" SelectsOnInvoked="False">
-                <NavigationViewItem.Icon><IconSourceElement IconSource="{ThemeResource Advanced_IconSource}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
+                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Advanced_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
                 <NavigationViewItem.MenuItems>
                     <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_94" Tag="agentevents" Content="Event Stream">
-                        <NavigationViewItem.Icon><IconSourceElement IconSource="{ThemeResource AgentEvents_IconSource}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
+                        <NavigationViewItem.Icon><ImageIcon Source="{StaticResource AgentEvents_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
                     </NavigationViewItem>
                     <NavigationViewItem x:Uid="AgentsNavItem" x:Name="AgentsNavItem" Content="Agents" SelectsOnInvoked="False" IsExpanded="True">
-                        <NavigationViewItem.Icon><IconSourceElement IconSource="{ThemeResource Agents_IconSource}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
+                        <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Agents_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
                         <NavigationViewItem.MenuItems>
                             <NavigationViewItem x:Uid="DefaultAgentNavItem" x:Name="DefaultAgentNavItem" Content="main" Tag="agent:main">
-                                <NavigationViewItem.Icon><IconSourceElement IconSource="{ThemeResource Agents_IconSource}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
+                                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Agents_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
                             </NavigationViewItem>
                         </NavigationViewItem.MenuItems>
                     </NavigationViewItem>
                     <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_115" Tag="bindings" Content="Bindings">
-                        <NavigationViewItem.Icon><IconSourceElement IconSource="{ThemeResource Bindings_IconSource}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
+                        <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Bindings_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
                     </NavigationViewItem>
                     <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_118" Tag="config" Content="Config">
-                        <NavigationViewItem.Icon><IconSourceElement IconSource="{ThemeResource Config_IconSource}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
+                        <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Config_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
                     </NavigationViewItem>
                     <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_121" Tag="usage" Content="Usage">
-                        <NavigationViewItem.Icon><IconSourceElement IconSource="{ThemeResource Usage_IconSource}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
+                        <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Usage_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
                     </NavigationViewItem>
                 </NavigationViewItem.MenuItems>
             </NavigationViewItem>
@@ -496,22 +468,22 @@
 
             <NavigationViewItemHeader x:Uid="HubWindow_NavigationViewItemHeader_129" Content="This Computer"/>
             <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_Voice" Tag="voice" Content="Voice &amp; Audio">
-                <NavigationViewItem.Icon><IconSourceElement IconSource="{ThemeResource Voice_IconSource}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
+                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Voice_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
             </NavigationViewItem>
             <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_136" Tag="permissions" Content="Permissions">
-                <NavigationViewItem.Icon><IconSourceElement IconSource="{ThemeResource Permissions_IconSource}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
+                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Permissions_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
             </NavigationViewItem>
             <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_Sandbox" Tag="sandbox" Content="Sandbox">
-                <NavigationViewItem.Icon><IconSourceElement IconSource="{ThemeResource Sandbox_IconSource}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
+                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Sandbox_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
             </NavigationViewItem>
         </NavigationView.MenuItems>
 
         <NavigationView.FooterMenuItems>
             <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_145" x:Name="NavDiagnostics" Tag="debug" Content="Debug">
-                <NavigationViewItem.Icon><IconSourceElement IconSource="{ThemeResource Debug_IconSource}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
+                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Debug_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
             </NavigationViewItem>
             <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_133" Tag="settings" Content="Settings">
-                <NavigationViewItem.Icon><IconSourceElement IconSource="{ThemeResource Settings_IconSource}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
+                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Settings_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
             </NavigationViewItem>
             </NavigationView.FooterMenuItems>
 

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml
@@ -385,25 +385,25 @@
                 <ResourceDictionary>
                 <ResourceDictionary.ThemeDictionaries>
                     <ResourceDictionary x:Key="Default">
-                        <ImageIconSource x:Key="Chat_IconSource" ImageSource="{StaticResource Chat_Icon}"/>
-                        <ImageIconSource x:Key="Connection_IconSource" ImageSource="{StaticResource Connection_Icon}"/>
-                        <ImageIconSource x:Key="Sessions_IconSource" ImageSource="{StaticResource Sessions_Icon}"/>
-                        <ImageIconSource x:Key="Skills_IconSource" ImageSource="{StaticResource Skills_Icon}"/>
-                        <ImageIconSource x:Key="Channels_IconSource" ImageSource="{StaticResource Channels_Icon}"/>
-                        <ImageIconSource x:Key="Instances_IconSource" ImageSource="{StaticResource Instances_Icon}"/>
-                        <ImageIconSource x:Key="Advanced_IconSource" ImageSource="{StaticResource Advanced_Icon}"/>
-                        <ImageIconSource x:Key="AgentEvents_IconSource" ImageSource="{StaticResource AgentEvents_Icon}"/>
-                        <ImageIconSource x:Key="Agents_IconSource" ImageSource="{StaticResource Agents_Icon}"/>
-                        <ImageIconSource x:Key="Bindings_IconSource" ImageSource="{StaticResource Bindings_Icon}"/>
-                        <ImageIconSource x:Key="Config_IconSource" ImageSource="{StaticResource Config_Icon}"/>
-                        <ImageIconSource x:Key="Usage_IconSource" ImageSource="{StaticResource Usage_Icon}"/>
-                        <ImageIconSource x:Key="Cron_IconSource" ImageSource="{StaticResource Cron_Icon}"/>
-                        <ImageIconSource x:Key="Voice_IconSource" ImageSource="{StaticResource Voice_Icon}"/>
-                        <ImageIconSource x:Key="Settings_IconSource" ImageSource="{StaticResource Settings_Icon}"/>
-                        <ImageIconSource x:Key="Permissions_IconSource" ImageSource="{StaticResource Permissions_Icon}"/>
-                        <ImageIconSource x:Key="Sandbox_IconSource" ImageSource="{StaticResource Sandbox_Icon}"/>
-                        <ImageIconSource x:Key="Activity_IconSource" ImageSource="{StaticResource Activity_Icon}"/>
-                        <ImageIconSource x:Key="Debug_IconSource" ImageSource="{StaticResource Debug_Icon}"/>
+                        <ImageIconSource x:Key="Chat_IconSource"><ImageIconSource.ImageSource><SvgImageSource UriSource="ms-appx:///Assets/SidebarIcons/Chat.svg"/></ImageIconSource.ImageSource></ImageIconSource>
+                        <ImageIconSource x:Key="Connection_IconSource"><ImageIconSource.ImageSource><SvgImageSource UriSource="ms-appx:///Assets/SidebarIcons/Connection.svg"/></ImageIconSource.ImageSource></ImageIconSource>
+                        <ImageIconSource x:Key="Sessions_IconSource"><ImageIconSource.ImageSource><SvgImageSource UriSource="ms-appx:///Assets/SidebarIcons/Sessions.svg"/></ImageIconSource.ImageSource></ImageIconSource>
+                        <ImageIconSource x:Key="Skills_IconSource"><ImageIconSource.ImageSource><SvgImageSource UriSource="ms-appx:///Assets/SidebarIcons/Skills.svg"/></ImageIconSource.ImageSource></ImageIconSource>
+                        <ImageIconSource x:Key="Channels_IconSource"><ImageIconSource.ImageSource><SvgImageSource UriSource="ms-appx:///Assets/SidebarIcons/Channels.svg"/></ImageIconSource.ImageSource></ImageIconSource>
+                        <ImageIconSource x:Key="Instances_IconSource"><ImageIconSource.ImageSource><SvgImageSource UriSource="ms-appx:///Assets/SidebarIcons/Instances.svg"/></ImageIconSource.ImageSource></ImageIconSource>
+                        <ImageIconSource x:Key="Advanced_IconSource"><ImageIconSource.ImageSource><SvgImageSource UriSource="ms-appx:///Assets/SidebarIcons/Advanced.svg"/></ImageIconSource.ImageSource></ImageIconSource>
+                        <ImageIconSource x:Key="AgentEvents_IconSource"><ImageIconSource.ImageSource><SvgImageSource UriSource="ms-appx:///Assets/SidebarIcons/AgentEvents.svg"/></ImageIconSource.ImageSource></ImageIconSource>
+                        <ImageIconSource x:Key="Agents_IconSource"><ImageIconSource.ImageSource><SvgImageSource UriSource="ms-appx:///Assets/SidebarIcons/Agents.svg"/></ImageIconSource.ImageSource></ImageIconSource>
+                        <ImageIconSource x:Key="Bindings_IconSource"><ImageIconSource.ImageSource><SvgImageSource UriSource="ms-appx:///Assets/SidebarIcons/Bindings.svg"/></ImageIconSource.ImageSource></ImageIconSource>
+                        <ImageIconSource x:Key="Config_IconSource"><ImageIconSource.ImageSource><SvgImageSource UriSource="ms-appx:///Assets/SidebarIcons/Config.svg"/></ImageIconSource.ImageSource></ImageIconSource>
+                        <ImageIconSource x:Key="Usage_IconSource"><ImageIconSource.ImageSource><SvgImageSource UriSource="ms-appx:///Assets/SidebarIcons/Usage.svg"/></ImageIconSource.ImageSource></ImageIconSource>
+                        <ImageIconSource x:Key="Cron_IconSource"><ImageIconSource.ImageSource><SvgImageSource UriSource="ms-appx:///Assets/SidebarIcons/Cron.svg"/></ImageIconSource.ImageSource></ImageIconSource>
+                        <ImageIconSource x:Key="Voice_IconSource"><ImageIconSource.ImageSource><SvgImageSource UriSource="ms-appx:///Assets/SidebarIcons/Voice.svg"/></ImageIconSource.ImageSource></ImageIconSource>
+                        <ImageIconSource x:Key="Settings_IconSource"><ImageIconSource.ImageSource><SvgImageSource UriSource="ms-appx:///Assets/SidebarIcons/Settings.svg"/></ImageIconSource.ImageSource></ImageIconSource>
+                        <ImageIconSource x:Key="Permissions_IconSource"><ImageIconSource.ImageSource><SvgImageSource UriSource="ms-appx:///Assets/SidebarIcons/Permissions.svg"/></ImageIconSource.ImageSource></ImageIconSource>
+                        <ImageIconSource x:Key="Sandbox_IconSource"><ImageIconSource.ImageSource><SvgImageSource UriSource="ms-appx:///Assets/SidebarIcons/Sandbox.svg"/></ImageIconSource.ImageSource></ImageIconSource>
+                        <ImageIconSource x:Key="Activity_IconSource"><ImageIconSource.ImageSource><SvgImageSource UriSource="ms-appx:///Assets/SidebarIcons/Activity.svg"/></ImageIconSource.ImageSource></ImageIconSource>
+                        <ImageIconSource x:Key="Debug_IconSource"><ImageIconSource.ImageSource><SvgImageSource UriSource="ms-appx:///Assets/SidebarIcons/Debug.svg"/></ImageIconSource.ImageSource></ImageIconSource>
                     </ResourceDictionary>
                     <ResourceDictionary x:Key="HighContrast">
                         <SymbolIconSource x:Key="Chat_IconSource" Symbol="Message"/>
@@ -435,31 +435,6 @@
                      as the WinUI default once rows are bigger. -->
                 <Thickness x:Key="NavigationViewItemSeparatorMargin">0,2,0,2</Thickness>
 
-                <!-- Shared SvgImageSource resources for colorful sidebar icons.
-                     Defined once so each NavigationViewItem references the same decoded SVG
-                     (avoids per-instance parse cost; also makes the XAML→ImageSource path
-                     explicit instead of relying on implicit URI→SvgImageSource conversion).
-                     The dynamic agent-list code (HubWindow.xaml.cs) also looks up the
-                     "Agents_Icon" key from this dictionary. -->
-                <SvgImageSource x:Key="Chat_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Chat.svg"/>
-                <SvgImageSource x:Key="Connection_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Connection.svg"/>
-                <SvgImageSource x:Key="Sessions_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Sessions.svg"/>
-                <SvgImageSource x:Key="Skills_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Skills.svg"/>
-                <SvgImageSource x:Key="Channels_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Channels.svg"/>
-                <SvgImageSource x:Key="Instances_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Instances.svg"/>
-                <SvgImageSource x:Key="Advanced_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Advanced.svg"/>
-                <SvgImageSource x:Key="AgentEvents_Icon" UriSource="ms-appx:///Assets/SidebarIcons/AgentEvents.svg"/>
-                <SvgImageSource x:Key="Agents_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Agents.svg"/>
-                <SvgImageSource x:Key="Bindings_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Bindings.svg"/>
-                <SvgImageSource x:Key="Config_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Config.svg"/>
-                <SvgImageSource x:Key="Usage_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Usage.svg"/>
-                <SvgImageSource x:Key="Cron_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Cron.svg"/>
-                <SvgImageSource x:Key="Voice_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Voice.svg"/>
-                <SvgImageSource x:Key="Settings_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Settings.svg"/>
-                <SvgImageSource x:Key="Permissions_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Permissions.svg"/>
-                <SvgImageSource x:Key="Sandbox_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Sandbox.svg"/>
-                <SvgImageSource x:Key="Activity_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Activity.svg"/>
-                <SvgImageSource x:Key="Debug_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Debug.svg"/>
                 <Style x:Key="AgentNavigationIconStyle" TargetType="IconSourceElement">
                     <Setter Property="IconSource" Value="{ThemeResource Agents_IconSource}"/>
                 </Style>

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml
@@ -382,6 +382,51 @@
                 SelectionChanged="NavView_SelectionChanged">
 
             <NavigationView.Resources>
+                <ResourceDictionary>
+                <ResourceDictionary.ThemeDictionaries>
+                    <ResourceDictionary x:Key="Default">
+                        <ImageIconSource x:Key="Chat_IconSource" ImageSource="{StaticResource Chat_Icon}"/>
+                        <ImageIconSource x:Key="Connection_IconSource" ImageSource="{StaticResource Connection_Icon}"/>
+                        <ImageIconSource x:Key="Sessions_IconSource" ImageSource="{StaticResource Sessions_Icon}"/>
+                        <ImageIconSource x:Key="Skills_IconSource" ImageSource="{StaticResource Skills_Icon}"/>
+                        <ImageIconSource x:Key="Channels_IconSource" ImageSource="{StaticResource Channels_Icon}"/>
+                        <ImageIconSource x:Key="Instances_IconSource" ImageSource="{StaticResource Instances_Icon}"/>
+                        <ImageIconSource x:Key="Advanced_IconSource" ImageSource="{StaticResource Advanced_Icon}"/>
+                        <ImageIconSource x:Key="AgentEvents_IconSource" ImageSource="{StaticResource AgentEvents_Icon}"/>
+                        <ImageIconSource x:Key="Agents_IconSource" ImageSource="{StaticResource Agents_Icon}"/>
+                        <ImageIconSource x:Key="Bindings_IconSource" ImageSource="{StaticResource Bindings_Icon}"/>
+                        <ImageIconSource x:Key="Config_IconSource" ImageSource="{StaticResource Config_Icon}"/>
+                        <ImageIconSource x:Key="Usage_IconSource" ImageSource="{StaticResource Usage_Icon}"/>
+                        <ImageIconSource x:Key="Cron_IconSource" ImageSource="{StaticResource Cron_Icon}"/>
+                        <ImageIconSource x:Key="Voice_IconSource" ImageSource="{StaticResource Voice_Icon}"/>
+                        <ImageIconSource x:Key="Settings_IconSource" ImageSource="{StaticResource Settings_Icon}"/>
+                        <ImageIconSource x:Key="Permissions_IconSource" ImageSource="{StaticResource Permissions_Icon}"/>
+                        <ImageIconSource x:Key="Sandbox_IconSource" ImageSource="{StaticResource Sandbox_Icon}"/>
+                        <ImageIconSource x:Key="Activity_IconSource" ImageSource="{StaticResource Activity_Icon}"/>
+                        <ImageIconSource x:Key="Debug_IconSource" ImageSource="{StaticResource Debug_Icon}"/>
+                    </ResourceDictionary>
+                    <ResourceDictionary x:Key="HighContrast">
+                        <FontIconSource x:Key="Chat_IconSource" Glyph="&#xE8BD;"/>
+                        <FontIconSource x:Key="Connection_IconSource" Glyph="&#xE839;"/>
+                        <FontIconSource x:Key="Sessions_IconSource" Glyph="&#xE8F2;"/>
+                        <FontIconSource x:Key="Skills_IconSource" Glyph="&#xE945;"/>
+                        <FontIconSource x:Key="Channels_IconSource" Glyph="&#xEC05;"/>
+                        <FontIconSource x:Key="Instances_IconSource" Glyph="&#xE977;"/>
+                        <FontIconSource x:Key="Advanced_IconSource" Glyph="&#xE950;"/>
+                        <FontIconSource x:Key="AgentEvents_IconSource" Glyph="&#xE943;"/>
+                        <FontIconSource x:Key="Agents_IconSource" Glyph="&#xE99A;"/>
+                        <FontIconSource x:Key="Bindings_IconSource" Glyph="&#xE8AD;"/>
+                        <FontIconSource x:Key="Config_IconSource" Glyph="&#xE90F;"/>
+                        <FontIconSource x:Key="Usage_IconSource" Glyph="&#xE9D9;"/>
+                        <FontIconSource x:Key="Cron_IconSource" Glyph="&#xE787;"/>
+                        <FontIconSource x:Key="Voice_IconSource" Glyph="&#xE720;"/>
+                        <FontIconSource x:Key="Settings_IconSource" Glyph="&#xE713;"/>
+                        <FontIconSource x:Key="Permissions_IconSource" Glyph="&#xEA18;"/>
+                        <FontIconSource x:Key="Sandbox_IconSource" Glyph="&#xE72E;"/>
+                        <FontIconSource x:Key="Activity_IconSource" Glyph="&#xEA95;"/>
+                        <FontIconSource x:Key="Debug_IconSource" Glyph="&#xEBE8;"/>
+                    </ResourceDictionary>
+                </ResourceDictionary.ThemeDictionaries>
                 <!-- Match Windows 11 Settings: ~22px colorful icons in a default-height row.
                      Default row pitch (~50px) lines up with Settings' sidebar.
                      Only the Left-pane theme key has an override; Top and Compact modes are not used (PaneDisplayMode is hardcoded above). -->
@@ -415,56 +460,60 @@
                 <SvgImageSource x:Key="Sandbox_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Sandbox.svg"/>
                 <SvgImageSource x:Key="Activity_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Activity.svg"/>
                 <SvgImageSource x:Key="Debug_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Debug.svg"/>
+                <Style x:Key="AgentNavigationIconStyle" TargetType="IconSourceElement">
+                    <Setter Property="IconSource" Value="{ThemeResource Agents_IconSource}"/>
+                </Style>
+                </ResourceDictionary>
             </NavigationView.Resources>
 
             <NavigationView.MenuItems>
                 <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_82" x:Name="NavChat" Tag="chat" Content="Chat">
-                    <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Chat_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
+                    <NavigationViewItem.Icon><IconSourceElement IconSource="{ThemeResource Chat_IconSource}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
                 </NavigationViewItem>
                 <NavigationViewItemSeparator/>
 
             <NavigationViewItemHeader x:Uid="HubWindow_NavigationViewItemHeader_87" x:Name="NavGatewayHeader" Content="Gateway"/>
             <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_88" Tag="connection" Content="Connection">
-                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Connection_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
+                <NavigationViewItem.Icon><IconSourceElement IconSource="{ThemeResource Connection_IconSource}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
             </NavigationViewItem>
             <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_91" x:Name="NavSessions" Tag="sessions" Content="Sessions">
-                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Sessions_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
+                <NavigationViewItem.Icon><IconSourceElement IconSource="{ThemeResource Sessions_IconSource}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
             </NavigationViewItem>
             <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_97" x:Name="NavSkills" Tag="skills" Content="Skills">
-                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Skills_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
+                <NavigationViewItem.Icon><IconSourceElement IconSource="{ThemeResource Skills_IconSource}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
             </NavigationViewItem>
             <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_109" x:Name="NavChannels" Tag="channels" Content="Channels">
-                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Channels_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
+                <NavigationViewItem.Icon><IconSourceElement IconSource="{ThemeResource Channels_IconSource}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
             </NavigationViewItem>
             <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_112" x:Name="NavInstances" Tag="instances" Content="Instances">
-                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Instances_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
+                <NavigationViewItem.Icon><IconSourceElement IconSource="{ThemeResource Instances_IconSource}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
             </NavigationViewItem>
             <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_124" x:Name="NavCron" Tag="cron" Content="Cron">
-                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Cron_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
+                <NavigationViewItem.Icon><IconSourceElement IconSource="{ThemeResource Cron_IconSource}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
             </NavigationViewItem>
             <!-- Advanced — consolidates gateway-oriented pages -->
             <NavigationViewItem x:Uid="HubWindow_Advanced" x:Name="NavAdvanced" Content="Advanced" SelectsOnInvoked="False">
-                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Advanced_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
+                <NavigationViewItem.Icon><IconSourceElement IconSource="{ThemeResource Advanced_IconSource}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
                 <NavigationViewItem.MenuItems>
                     <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_94" Tag="agentevents" Content="Event Stream">
-                        <NavigationViewItem.Icon><ImageIcon Source="{StaticResource AgentEvents_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
+                        <NavigationViewItem.Icon><IconSourceElement IconSource="{ThemeResource AgentEvents_IconSource}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
                     </NavigationViewItem>
                     <NavigationViewItem x:Uid="AgentsNavItem" x:Name="AgentsNavItem" Content="Agents" SelectsOnInvoked="False" IsExpanded="True">
-                        <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Agents_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
+                        <NavigationViewItem.Icon><IconSourceElement IconSource="{ThemeResource Agents_IconSource}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
                         <NavigationViewItem.MenuItems>
                             <NavigationViewItem x:Uid="DefaultAgentNavItem" x:Name="DefaultAgentNavItem" Content="main" Tag="agent:main">
-                                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Agents_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
+                                <NavigationViewItem.Icon><IconSourceElement IconSource="{ThemeResource Agents_IconSource}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
                             </NavigationViewItem>
                         </NavigationViewItem.MenuItems>
                     </NavigationViewItem>
                     <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_115" Tag="bindings" Content="Bindings">
-                        <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Bindings_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
+                        <NavigationViewItem.Icon><IconSourceElement IconSource="{ThemeResource Bindings_IconSource}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
                     </NavigationViewItem>
                     <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_118" Tag="config" Content="Config">
-                        <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Config_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
+                        <NavigationViewItem.Icon><IconSourceElement IconSource="{ThemeResource Config_IconSource}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
                     </NavigationViewItem>
                     <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_121" Tag="usage" Content="Usage">
-                        <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Usage_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
+                        <NavigationViewItem.Icon><IconSourceElement IconSource="{ThemeResource Usage_IconSource}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
                     </NavigationViewItem>
                 </NavigationViewItem.MenuItems>
             </NavigationViewItem>
@@ -472,22 +521,22 @@
 
             <NavigationViewItemHeader x:Uid="HubWindow_NavigationViewItemHeader_129" Content="This Computer"/>
             <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_Voice" Tag="voice" Content="Voice &amp; Audio">
-                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Voice_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
+                <NavigationViewItem.Icon><IconSourceElement IconSource="{ThemeResource Voice_IconSource}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
             </NavigationViewItem>
             <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_136" Tag="permissions" Content="Permissions">
-                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Permissions_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
+                <NavigationViewItem.Icon><IconSourceElement IconSource="{ThemeResource Permissions_IconSource}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
             </NavigationViewItem>
             <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_Sandbox" Tag="sandbox" Content="Sandbox">
-                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Sandbox_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
+                <NavigationViewItem.Icon><IconSourceElement IconSource="{ThemeResource Sandbox_IconSource}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
             </NavigationViewItem>
         </NavigationView.MenuItems>
 
         <NavigationView.FooterMenuItems>
             <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_145" x:Name="NavDiagnostics" Tag="debug" Content="Debug">
-                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Debug_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
+                <NavigationViewItem.Icon><IconSourceElement IconSource="{ThemeResource Debug_IconSource}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
             </NavigationViewItem>
             <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_133" Tag="settings" Content="Settings">
-                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Settings_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
+                <NavigationViewItem.Icon><IconSourceElement IconSource="{ThemeResource Settings_IconSource}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
             </NavigationViewItem>
             </NavigationView.FooterMenuItems>
 

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml
@@ -406,25 +406,25 @@
                         <ImageIconSource x:Key="Debug_IconSource" ImageSource="{StaticResource Debug_Icon}"/>
                     </ResourceDictionary>
                     <ResourceDictionary x:Key="HighContrast">
-                        <FontIconSource x:Key="Chat_IconSource" Glyph="&#xE8BD;"/>
-                        <FontIconSource x:Key="Connection_IconSource" Glyph="&#xE839;"/>
-                        <FontIconSource x:Key="Sessions_IconSource" Glyph="&#xE8F2;"/>
-                        <FontIconSource x:Key="Skills_IconSource" Glyph="&#xE945;"/>
-                        <FontIconSource x:Key="Channels_IconSource" Glyph="&#xEC05;"/>
-                        <FontIconSource x:Key="Instances_IconSource" Glyph="&#xE977;"/>
-                        <FontIconSource x:Key="Advanced_IconSource" Glyph="&#xE950;"/>
-                        <FontIconSource x:Key="AgentEvents_IconSource" Glyph="&#xE943;"/>
-                        <FontIconSource x:Key="Agents_IconSource" Glyph="&#xE99A;"/>
-                        <FontIconSource x:Key="Bindings_IconSource" Glyph="&#xE8AD;"/>
-                        <FontIconSource x:Key="Config_IconSource" Glyph="&#xE90F;"/>
-                        <FontIconSource x:Key="Usage_IconSource" Glyph="&#xE9D9;"/>
-                        <FontIconSource x:Key="Cron_IconSource" Glyph="&#xE787;"/>
-                        <FontIconSource x:Key="Voice_IconSource" Glyph="&#xE720;"/>
-                        <FontIconSource x:Key="Settings_IconSource" Glyph="&#xE713;"/>
-                        <FontIconSource x:Key="Permissions_IconSource" Glyph="&#xEA18;"/>
-                        <FontIconSource x:Key="Sandbox_IconSource" Glyph="&#xE72E;"/>
-                        <FontIconSource x:Key="Activity_IconSource" Glyph="&#xEA95;"/>
-                        <FontIconSource x:Key="Debug_IconSource" Glyph="&#xEBE8;"/>
+                        <SymbolIconSource x:Key="Chat_IconSource" Symbol="Message"/>
+                        <SymbolIconSource x:Key="Connection_IconSource" Symbol="Remote"/>
+                        <SymbolIconSource x:Key="Sessions_IconSource" Symbol="Switch"/>
+                        <SymbolIconSource x:Key="Skills_IconSource" Symbol="Library"/>
+                        <SymbolIconSource x:Key="Channels_IconSource" Symbol="Audio"/>
+                        <SymbolIconSource x:Key="Instances_IconSource" Symbol="OtherUser"/>
+                        <SymbolIconSource x:Key="Advanced_IconSource" Symbol="More"/>
+                        <SymbolIconSource x:Key="AgentEvents_IconSource" Symbol="List"/>
+                        <SymbolIconSource x:Key="Agents_IconSource" Symbol="People"/>
+                        <SymbolIconSource x:Key="Bindings_IconSource" Symbol="Link"/>
+                        <SymbolIconSource x:Key="Config_IconSource" Symbol="Edit"/>
+                        <SymbolIconSource x:Key="Usage_IconSource" Symbol="View"/>
+                        <SymbolIconSource x:Key="Cron_IconSource" Symbol="Calendar"/>
+                        <SymbolIconSource x:Key="Voice_IconSource" Symbol="Microphone"/>
+                        <SymbolIconSource x:Key="Settings_IconSource" Symbol="Setting"/>
+                        <SymbolIconSource x:Key="Permissions_IconSource" Symbol="Permissions"/>
+                        <SymbolIconSource x:Key="Sandbox_IconSource" Symbol="ProtectedDocument"/>
+                        <SymbolIconSource x:Key="Activity_IconSource" Symbol="View"/>
+                        <SymbolIconSource x:Key="Debug_IconSource" Symbol="Help"/>
                     </ResourceDictionary>
                 </ResourceDictionary.ThemeDictionaries>
                 <!-- Match Windows 11 Settings: ~22px colorful icons in a default-height row.

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
@@ -1395,9 +1395,9 @@ public sealed partial class HubWindow : WindowEx
 
     private IconElement BuildAgentItemIcon()
     {
-        return new IconSourceElement
+        return new ImageIcon
         {
-            Style = (Style)NavView.Resources["AgentNavigationIconStyle"]
+            Source = (ImageSource)NavView.Resources["Agents_Icon"]
         };
     }
 }

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
@@ -98,7 +98,6 @@ public sealed partial class HubWindow : WindowEx
         InitializeComponent();
         Title = AppIdentity.DisplayName;
         RefreshDiagnosticsNavVisibility();
-        ApplyHighContrastFallbackIfNeeded();
         ExtendsContentIntoTitleBar = true;
         SetTitleBar(AppTitleBar);
         Closed += (s, e) =>
@@ -1394,99 +1393,11 @@ public sealed partial class HubWindow : WindowEx
         }
     }
 
-    #region High Contrast icon fallback
-
-    // Maps NavigationViewItem.Tag -> Segoe Fluent Icons glyph used as fallback
-    // when Windows High Contrast is active. FontIcon uses the system foreground
-    // brush so it auto-adapts to every HC variant (HC Black/White/#1/#2); our
-    // multi-color SVGs don't, so we swap them out at construction. This mirrors
-    // the original gray Segoe Fluent Icons that were here before the colorful
-    // refresh — same glyphs as those Windows users learned in earlier builds.
-    private static readonly Dictionary<string, string> s_highContrastGlyphFallback = new()
-    {
-        { "chat",        "\uE8BD" },
-        { "connection",  "\uE839" },
-        { "sessions",    "\uE8F2" },
-        { "skills",      "\uE945" },
-        { "channels",    "\uEC05" },
-        { "instances",   "\uE977" },
-        { "agentevents", "\uE943" },
-        { "bindings",    "\uE8AD" },
-        { "config",      "\uE90F" },
-        { "usage",       "\uE9D9" },
-        { "cron",        "\uE787" },
-        { "voice",       "\uE720" },
-        { "settings",    "\uE713" },
-        { "permissions", "\uEA18" },
-        { "sandbox",     "\uE72E" },
-        { "activity",    "\uEA95" },
-        { "notifications", "\uE7F4" },
-        { "debug",       "\uEBE8" },
-    };
-
-    // Glyphs for the two parent NavigationViewItems that don't carry a Tag
-    // ("Advanced" group and "Agents" group). These also feed the dynamic agent
-    // items added at runtime.
-    private const string AdvancedGroupGlyph = "\uE950";
-    private const string AgentsGroupGlyph = "\uE99A";
-
-    private bool _isHighContrast;
-
-    private void ApplyHighContrastFallbackIfNeeded()
-    {
-        try
-        {
-            var settings = new global::Windows.UI.ViewManagement.AccessibilitySettings();
-            _isHighContrast = settings.HighContrast;
-        }
-        catch
-        {
-            _isHighContrast = false;
-            return;
-        }
-        if (!_isHighContrast) return;
-        SwapToFontIcons(NavView.MenuItems);
-        SwapToFontIcons(NavView.FooterMenuItems);
-    }
-
-    private void SwapToFontIcons(IList<object> items)
-    {
-        foreach (var obj in items)
-        {
-            if (obj is not NavigationViewItem item) continue;
-            item.Icon = ResolveHighContrastIcon(item);
-            if (item.MenuItems.Count > 0)
-                SwapToFontIcons(item.MenuItems);
-        }
-    }
-
-    private IconElement ResolveHighContrastIcon(NavigationViewItem item)
-    {
-        if (item.Tag is string tag)
-        {
-            if (s_highContrastGlyphFallback.TryGetValue(tag, out var glyph))
-                return new FontIcon { Glyph = glyph };
-            if (tag.StartsWith("agent:", StringComparison.Ordinal))
-                return new FontIcon { Glyph = AgentsGroupGlyph };
-        }
-        if (item == AgentsNavItem)
-            return new FontIcon { Glyph = AgentsGroupGlyph };
-        if (item.Content is string content && content.Equals("Advanced", StringComparison.OrdinalIgnoreCase))
-            return new FontIcon { Glyph = AdvancedGroupGlyph };
-        // Fall back to whatever the XAML provided (keeps the colorful icon
-        // rather than blanking it out for unmapped items).
-        return item.Icon ?? new FontIcon { Glyph = "\uE700" };
-    }
-
     private IconElement BuildAgentItemIcon()
     {
-        if (_isHighContrast)
-            return new FontIcon { Glyph = AgentsGroupGlyph };
-        return new ImageIcon
+        return new IconSourceElement
         {
-            Source = (Microsoft.UI.Xaml.Media.ImageSource)NavView.Resources["Agents_Icon"]
+            Style = (Style)NavView.Resources["AgentNavigationIconStyle"]
         };
     }
-
-    #endregion
 }

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
@@ -98,6 +98,7 @@ public sealed partial class HubWindow : WindowEx
         InitializeComponent();
         Title = AppIdentity.DisplayName;
         RefreshDiagnosticsNavVisibility();
+        ApplyHighContrastFallbackIfNeeded();
         ExtendsContentIntoTitleBar = true;
         SetTitleBar(AppTitleBar);
         Closed += (s, e) =>
@@ -1393,11 +1394,90 @@ public sealed partial class HubWindow : WindowEx
         }
     }
 
+    #region High Contrast icon fallback
+
+    // Fixed-color SVGs provide the normal Hub presentation. In High Contrast,
+    // App.xaml resolves this path to system-foreground Fluent glyphs without
+    // constructing or subscribing to the legacy WinRT accessibility API.
+    private static readonly Dictionary<string, string> s_highContrastGlyphFallback = new()
+    {
+        { "chat",        "\uE8BD" },
+        { "connection",  "\uE839" },
+        { "sessions",    "\uE8F2" },
+        { "skills",      "\uE945" },
+        { "channels",    "\uEC05" },
+        { "instances",   "\uE977" },
+        { "agentevents", "\uE943" },
+        { "bindings",    "\uE8AD" },
+        { "config",      "\uE90F" },
+        { "usage",       "\uE9D9" },
+        { "cron",        "\uE787" },
+        { "voice",       "\uE720" },
+        { "settings",    "\uE713" },
+        { "permissions", "\uEA18" },
+        { "sandbox",     "\uE72E" },
+        { "activity",    "\uEA95" },
+        { "notifications", "\uE7F4" },
+        { "debug",       "\uEBE8" },
+    };
+
+    private const string AdvancedGroupGlyph = "\uE950";
+    private const string AgentsGroupGlyph = "\uE99A";
+    private bool _isHighContrast;
+
+    private void ApplyHighContrastFallbackIfNeeded()
+    {
+        const string resourceKey = "HubNavigationUseHighContrastIcons";
+        _isHighContrast = Application.Current.Resources.ContainsKey(resourceKey)
+            && Application.Current.Resources[resourceKey] is true;
+        if (!_isHighContrast)
+            return;
+
+        SwapToFontIcons(NavView.MenuItems);
+        SwapToFontIcons(NavView.FooterMenuItems);
+    }
+
+    private void SwapToFontIcons(IList<object> items)
+    {
+        foreach (var value in items)
+        {
+            if (value is not NavigationViewItem item)
+                continue;
+
+            item.Icon = ResolveHighContrastIcon(item);
+            if (item.MenuItems.Count > 0)
+                SwapToFontIcons(item.MenuItems);
+        }
+    }
+
+    private IconElement ResolveHighContrastIcon(NavigationViewItem item)
+    {
+        if (item.Tag is string tag)
+        {
+            if (s_highContrastGlyphFallback.TryGetValue(tag, out var glyph))
+                return FluentIconCatalog.Build(glyph, 20);
+            if (tag.StartsWith("agent:", StringComparison.Ordinal))
+                return FluentIconCatalog.Build(AgentsGroupGlyph, 20);
+        }
+
+        if (item == AgentsNavItem)
+            return FluentIconCatalog.Build(AgentsGroupGlyph, 20);
+        if (item == NavAdvanced)
+            return FluentIconCatalog.Build(AdvancedGroupGlyph, 20);
+
+        return FluentIconCatalog.Build("\uE700", 20);
+    }
+
     private IconElement BuildAgentItemIcon()
     {
+        if (_isHighContrast)
+            return FluentIconCatalog.Build(AgentsGroupGlyph, 20);
+
         return new ImageIcon
         {
             Source = (ImageSource)NavView.Resources["Agents_Icon"]
         };
     }
+
+    #endregion
 }

--- a/tests/OpenClaw.Tray.Tests/AccessibilityThemeResourceSourceTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AccessibilityThemeResourceSourceTests.cs
@@ -29,6 +29,12 @@ public sealed class AccessibilityThemeResourceSourceTests
         Assert.Contains("NavView.Resources[\"Agents_Icon\"]", hub);
         Assert.DoesNotContain("<IconSourceElement", hubXaml);
         Assert.DoesNotContain("FontIconSource", hubXaml);
+        var stateIconBlock = connection[
+            connection.IndexOf("if (stateGlyph != null)", StringComparison.Ordinal)
+            ..connection.IndexOf("content.Children.Add(stateIcon)", connection.IndexOf(
+                "if (stateGlyph != null)", StringComparison.Ordinal), StringComparison.Ordinal)];
+        Assert.Contains("Style = (Style)Resources[iconStyleKey]", stateIconBlock);
+        Assert.DoesNotContain("Style = (Style)Resources[textStyleKey]", stateIconBlock);
         Assert.Contains("<ResourceDictionary x:Key=\"HighContrast\">", resources);
         Assert.Contains("SystemColorWindowColor", resources);
         Assert.Contains("ChatUserBubbleSelectionHighlightBrush", resources);

--- a/tests/OpenClaw.Tray.Tests/AccessibilityThemeResourceSourceTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AccessibilityThemeResourceSourceTests.cs
@@ -28,7 +28,8 @@ public sealed class AccessibilityThemeResourceSourceTests
         Assert.Contains("AgentNavigationIconStyle", hub);
         Assert.Contains("IconSource\" Value=\"{ThemeResource Agents_IconSource}\"", hubXaml);
         Assert.Contains("<ResourceDictionary x:Key=\"HighContrast\">", hubXaml);
-        Assert.Contains("FontIconSource x:Key=\"Chat_IconSource\"", hubXaml);
+        Assert.Contains("SymbolIconSource x:Key=\"Chat_IconSource\"", hubXaml);
+        Assert.DoesNotContain("FontIconSource", hubXaml);
         Assert.Contains("<ResourceDictionary x:Key=\"HighContrast\">", resources);
         Assert.Contains("SystemColorWindowColor", resources);
         Assert.Contains("ChatUserBubbleSelectionHighlightBrush", resources);

--- a/tests/OpenClaw.Tray.Tests/AccessibilityThemeResourceSourceTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AccessibilityThemeResourceSourceTests.cs
@@ -24,19 +24,11 @@ public sealed class AccessibilityThemeResourceSourceTests
         Assert.Contains("ChatUserBubbleSelectionStyle", timeline);
         Assert.Contains("ChatToolCardBorderStyle", timeline);
         Assert.Contains("ConnectionCapabilityPillSuccessBrush", connectionXaml);
-        Assert.Contains("IconSource=\"{ThemeResource Chat_IconSource}\"", hubXaml);
-        Assert.Contains("AgentNavigationIconStyle", hub);
-        Assert.Contains("IconSource\" Value=\"{ThemeResource Agents_IconSource}\"", hubXaml);
-        Assert.Contains("<ResourceDictionary x:Key=\"HighContrast\">", hubXaml);
-        Assert.Contains("SymbolIconSource x:Key=\"Chat_IconSource\"", hubXaml);
+        Assert.Contains("ImageIcon Source=\"{StaticResource Chat_Icon}\"", hubXaml);
+        Assert.Contains("new ImageIcon", hub);
+        Assert.Contains("NavView.Resources[\"Agents_Icon\"]", hub);
+        Assert.DoesNotContain("<IconSourceElement", hubXaml);
         Assert.DoesNotContain("FontIconSource", hubXaml);
-        var chatIconSource = hubXaml[
-            hubXaml.IndexOf("<ImageIconSource x:Key=\"Chat_IconSource\"", StringComparison.Ordinal)
-            ..hubXaml.IndexOf("</ImageIconSource>", hubXaml.IndexOf(
-                "<ImageIconSource x:Key=\"Chat_IconSource\"", StringComparison.Ordinal), StringComparison.Ordinal)];
-        Assert.Contains("ImageIconSource.ImageSource", chatIconSource);
-        Assert.Contains("SvgImageSource UriSource=\"ms-appx:///Assets/SidebarIcons/Chat.svg\"", chatIconSource);
-        Assert.DoesNotContain("StaticResource", chatIconSource);
         Assert.Contains("<ResourceDictionary x:Key=\"HighContrast\">", resources);
         Assert.Contains("SystemColorWindowColor", resources);
         Assert.Contains("ChatUserBubbleSelectionHighlightBrush", resources);

--- a/tests/OpenClaw.Tray.Tests/AccessibilityThemeResourceSourceTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AccessibilityThemeResourceSourceTests.cs
@@ -1,0 +1,44 @@
+namespace OpenClaw.Tray.Tests;
+
+public sealed class AccessibilityThemeResourceSourceTests
+{
+    [Fact]
+    public void TrayThemeChanges_AreOwnedByXamlResourcesInsteadOfAccessibilitySettings()
+    {
+        var connection = ReadSource("src", "OpenClaw.Tray.WinUI", "Pages", "ConnectionPage.xaml.cs");
+        var connectionXaml = ReadSource("src", "OpenClaw.Tray.WinUI", "Pages", "ConnectionPage.xaml");
+        var hub = ReadSource("src", "OpenClaw.Tray.WinUI", "Windows", "HubWindow.xaml.cs");
+        var hubXaml = ReadSource("src", "OpenClaw.Tray.WinUI", "Windows", "HubWindow.xaml");
+        var timeline = ReadSource("src", "OpenClaw.Tray.WinUI", "Chat", "OpenClawChatTimeline.cs");
+        var resources = ReadSource("src", "OpenClaw.Tray.WinUI", "App.xaml");
+
+        Assert.DoesNotContain("AccessibilitySettings", connection);
+        Assert.DoesNotContain("HighContrastChanged", connection);
+        Assert.DoesNotContain("TrySubscribeAccessibilitySettings", connection);
+        Assert.DoesNotContain("AccessibilitySettings", hub);
+        Assert.DoesNotContain("ApplyHighContrastFallbackIfNeeded", hub);
+        Assert.DoesNotContain("AccessibilitySettings", timeline);
+        Assert.DoesNotContain("TryDetectHighContrast", timeline);
+
+        Assert.Contains("ConnectionCapabilityPillActiveBorderStyle", connection);
+        Assert.Contains("ChatUserBubbleSelectionStyle", timeline);
+        Assert.Contains("ChatToolCardBorderStyle", timeline);
+        Assert.Contains("ConnectionCapabilityPillSuccessBrush", connectionXaml);
+        Assert.Contains("IconSource=\"{ThemeResource Chat_IconSource}\"", hubXaml);
+        Assert.Contains("AgentNavigationIconStyle", hub);
+        Assert.Contains("IconSource\" Value=\"{ThemeResource Agents_IconSource}\"", hubXaml);
+        Assert.Contains("<ResourceDictionary x:Key=\"HighContrast\">", hubXaml);
+        Assert.Contains("FontIconSource x:Key=\"Chat_IconSource\"", hubXaml);
+        Assert.Contains("<ResourceDictionary x:Key=\"HighContrast\">", resources);
+        Assert.Contains("SystemColorWindowColor", resources);
+        Assert.Contains("ChatUserBubbleSelectionHighlightBrush", resources);
+        Assert.Contains("SystemColorHighlightColor", resources);
+        Assert.Contains("<x:Double x:Key=\"ChatAccessibleBorderThickness\">2</x:Double>", resources);
+    }
+
+    private static string ReadSource(params string[] relativePathParts)
+    {
+        var root = TestRepositoryPaths.GetRepositoryRoot();
+        return File.ReadAllText(Path.Combine(new[] { root }.Concat(relativePathParts).ToArray()));
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/AccessibilityThemeResourceSourceTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AccessibilityThemeResourceSourceTests.cs
@@ -30,6 +30,13 @@ public sealed class AccessibilityThemeResourceSourceTests
         Assert.Contains("<ResourceDictionary x:Key=\"HighContrast\">", hubXaml);
         Assert.Contains("SymbolIconSource x:Key=\"Chat_IconSource\"", hubXaml);
         Assert.DoesNotContain("FontIconSource", hubXaml);
+        var chatIconSource = hubXaml[
+            hubXaml.IndexOf("<ImageIconSource x:Key=\"Chat_IconSource\"", StringComparison.Ordinal)
+            ..hubXaml.IndexOf("</ImageIconSource>", hubXaml.IndexOf(
+                "<ImageIconSource x:Key=\"Chat_IconSource\"", StringComparison.Ordinal), StringComparison.Ordinal)];
+        Assert.Contains("ImageIconSource.ImageSource", chatIconSource);
+        Assert.Contains("SvgImageSource UriSource=\"ms-appx:///Assets/SidebarIcons/Chat.svg\"", chatIconSource);
+        Assert.DoesNotContain("StaticResource", chatIconSource);
         Assert.Contains("<ResourceDictionary x:Key=\"HighContrast\">", resources);
         Assert.Contains("SystemColorWindowColor", resources);
         Assert.Contains("ChatUserBubbleSelectionHighlightBrush", resources);

--- a/tests/OpenClaw.Tray.Tests/AccessibilityThemeResourceSourceTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AccessibilityThemeResourceSourceTests.cs
@@ -16,7 +16,7 @@ public sealed class AccessibilityThemeResourceSourceTests
         Assert.DoesNotContain("HighContrastChanged", connection);
         Assert.DoesNotContain("TrySubscribeAccessibilitySettings", connection);
         Assert.DoesNotContain("AccessibilitySettings", hub);
-        Assert.DoesNotContain("ApplyHighContrastFallbackIfNeeded", hub);
+        Assert.DoesNotContain("HighContrastChanged", hub);
         Assert.DoesNotContain("AccessibilitySettings", timeline);
         Assert.DoesNotContain("TryDetectHighContrast", timeline);
 
@@ -27,6 +27,13 @@ public sealed class AccessibilityThemeResourceSourceTests
         Assert.Contains("ImageIcon Source=\"{StaticResource Chat_Icon}\"", hubXaml);
         Assert.Contains("new ImageIcon", hub);
         Assert.Contains("NavView.Resources[\"Agents_Icon\"]", hub);
+        Assert.Contains("ApplyHighContrastFallbackIfNeeded", hub);
+        Assert.Contains("HubNavigationUseHighContrastIcons", hub);
+        Assert.Contains("SwapToFontIcons", hub);
+        Assert.Contains("FluentIconCatalog.Build", hub);
+        Assert.Contains("item == NavAdvanced", hub);
+        Assert.DoesNotContain("content.Equals(\"Advanced\"", hub);
+        Assert.Contains("return FluentIconCatalog.Build(\"\\uE700\", 20);", hub);
         Assert.DoesNotContain("<IconSourceElement", hubXaml);
         Assert.DoesNotContain("FontIconSource", hubXaml);
         var stateIconBlock = connection[
@@ -40,6 +47,7 @@ public sealed class AccessibilityThemeResourceSourceTests
         Assert.Contains("ChatUserBubbleSelectionHighlightBrush", resources);
         Assert.Contains("SystemColorHighlightColor", resources);
         Assert.Contains("<x:Double x:Key=\"ChatAccessibleBorderThickness\">2</x:Double>", resources);
+        Assert.Contains("<x:Boolean x:Key=\"HubNavigationUseHighContrastIcons\">True</x:Boolean>", resources);
     }
 
     private static string ReadSource(params string[] relativePathParts)

--- a/tests/OpenClaw.Tray.Tests/ChatTimelinePresentationTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ChatTimelinePresentationTests.cs
@@ -165,6 +165,25 @@ public sealed class ChatTimelinePresentationTests
     }
 
     [Fact]
+    public void ReactorComposer_LocalizesSettingsTooltipInEveryLocale()
+    {
+        var stringsDirectory = Path.Combine(
+            TestRepositoryPaths.GetRepositoryRoot(),
+            "src",
+            "OpenClaw.Tray.WinUI",
+            "Strings");
+
+        foreach (var resourceFile in Directory.EnumerateFiles(
+                     stringsDirectory,
+                     "Resources.resw",
+                     SearchOption.AllDirectories))
+        {
+            var resources = File.ReadAllText(resourceFile);
+            Assert.Contains("Chat_Composer_Tooltip_Settings", resources);
+        }
+    }
+
+    [Fact]
     public void ReactorRoot_SettlesWelcomeEligibilityBeforeShowingEmptyState()
     {
         var root = File.ReadAllText(Path.Combine(

--- a/tests/OpenClaw.Tray.Tests/ChatTimelinePresentationTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ChatTimelinePresentationTests.cs
@@ -132,6 +132,39 @@ public sealed class ChatTimelinePresentationTests
     }
 
     [Fact]
+    public void ReactorComposer_UsesReactorThemeResourcesWithoutManualThemeObservation()
+    {
+        var root = File.ReadAllText(Path.Combine(
+            TestRepositoryPaths.GetRepositoryRoot(),
+            "src",
+            "OpenClaw.Tray.WinUI",
+            "Chat",
+            "OpenClawReactorChatRoot.cs"));
+        var composer = root[root.IndexOf(
+            "public sealed class ReactorChatComposer",
+            StringComparison.Ordinal)..];
+
+        Assert.Contains("UseColorScheme()", composer);
+        Assert.Contains(".Background(Theme.ControlFill)", composer);
+        Assert.Contains(".BorderBrush(Theme.ControlStroke)", composer);
+        Assert.Contains("Theme.Ref(\"AcrylicBackgroundFillColorDefaultBrush\")", composer);
+        Assert.Contains("Theme.Ref(\"SurfaceStrokeColorFlyoutBrush\")", composer);
+        Assert.Contains("Theme.Ref(\"SubtleFillColorTertiaryBrush\")", composer);
+        Assert.Contains("colorScheme);", composer);
+        Assert.Contains("CreateSlashPopupHost(BuildSlashPopup(", composer);
+
+        Assert.DoesNotContain("AccessibilitySettings", composer);
+        Assert.DoesNotContain("HighContrastChanged", composer);
+        Assert.DoesNotContain("ConditionalWeakTable", composer);
+        Assert.DoesNotContain("ApplyTheme(", composer);
+        Assert.DoesNotContain("ResolveThemeBrush", composer);
+        Assert.DoesNotContain("FindThemedResource", composer);
+        Assert.DoesNotContain("SearchThemeDictionaries", composer);
+        Assert.DoesNotContain("LookupResource", composer);
+        Assert.DoesNotContain("Application.Current.Resources", composer);
+    }
+
+    [Fact]
     public void ReactorRoot_SettlesWelcomeEligibilityBeforeShowingEmptyState()
     {
         var root = File.ReadAllText(Path.Combine(

--- a/tests/OpenClaw.Tray.UITests/ChatTimelineThemeResourceProofTests.cs
+++ b/tests/OpenClaw.Tray.UITests/ChatTimelineThemeResourceProofTests.cs
@@ -1,0 +1,117 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using OpenClaw.Chat;
+using OpenClawTray.Chat;
+using OpenClawTray.FunctionalUI.Hosting;
+using static OpenClawTray.FunctionalUI.Factories;
+using static OpenClaw.Tray.UITests.TestSupport;
+
+namespace OpenClaw.Tray.UITests;
+
+[Collection(UICollection.Name)]
+public sealed class ChatTimelineThemeResourceProofTests
+{
+    private readonly UIThreadFixture _ui;
+
+    public ChatTimelineThemeResourceProofTests(UIThreadFixture ui) => _ui = ui;
+
+    [Fact]
+    public async Task ToolBurst_RendersWithTestHostBorderStyle()
+    {
+        var props = BuildProps(
+        [
+            new ChatTimelineItem("user-1", ChatTimelineItemKind.User, "Check status"),
+            new ChatTimelineItem("assistant-1", ChatTimelineItemKind.Assistant, "Checking."),
+            new ChatTimelineItem(
+                "tool-1",
+                ChatTimelineItemKind.ToolCall,
+                "{}",
+                ToolName: "session_status",
+                ToolResult: ChatToolCallStatus.Success,
+                ToolOutput: "ok"),
+        ]);
+
+        var host = await MountAsync(props);
+
+        await _ui.RunOnUIAsync(() =>
+        {
+            var style = Assert.IsType<Style>(
+                Application.Current.Resources["ChatToolCardBorderStyle"]);
+            Assert.Equal(typeof(Border), style.TargetType);
+            Assert.Contains(
+                FindDescendants<Border>(host),
+                border => ReferenceEquals(border.Style, style));
+            host.Dispose();
+        });
+    }
+
+    [Fact]
+    public async Task CompactionEntry_RendersWithTestHostBorderStyle()
+    {
+        const string entryId = "compaction-1";
+        var metadata = new Dictionary<string, ChatEntryMetadata>(StringComparer.Ordinal)
+        {
+            [entryId] = new(
+                Timestamp: null,
+                Model: null,
+                OpenClawKind: "compaction",
+                CompactionTokensBefore: 42_000,
+                CompactionTokensAfter: 12_000),
+        };
+        var props = BuildProps(
+            [new ChatTimelineItem(entryId, ChatTimelineItemKind.Status, "Context compacted")],
+            metadata);
+
+        var host = await MountAsync(props);
+
+        await _ui.RunOnUIAsync(() =>
+        {
+            var style = Assert.IsType<Style>(
+                Application.Current.Resources["ChatCompactionCardStyle"]);
+            Assert.Equal(typeof(Border), style.TargetType);
+            Assert.Contains(
+                FindDescendants<Border>(host),
+                border => ReferenceEquals(border.Style, style));
+            host.Dispose();
+        });
+    }
+
+    private async Task<FunctionalHostControl> MountAsync(OpenClawChatTimelineProps props)
+    {
+        await _ui.ResetContainerAsync();
+
+        FunctionalHostControl? host = null;
+        await _ui.RunOnUIAsync(() =>
+        {
+            TestApp.EnsureFluentBrushFallbacks(Application.Current.Resources);
+            host = new FunctionalHostControl
+            {
+                Width = 860,
+                Height = 560,
+                SuppressAutoDispose = true,
+            };
+            _ui.Container.Children.Add(host);
+            host.Mount(_ => Component<OpenClawChatTimeline, OpenClawChatTimelineProps>(props));
+        });
+
+        for (var pass = 0; pass < 4; pass++)
+        {
+            await _ui.RunOnUIAsync(() => _ui.Container.UpdateLayout());
+            await _ui.YieldToRenderAsync();
+            await Task.Delay(40);
+        }
+
+        return host!;
+    }
+
+    private static OpenClawChatTimelineProps BuildProps(
+        IReadOnlyList<ChatTimelineItem> entries,
+        IReadOnlyDictionary<string, ChatEntryMetadata>? metadata = null) =>
+        new(
+            SessionId: "theme-resource-proof",
+            Entries: entries,
+            HasMoreHistory: false,
+            OnLoadMoreHistory: null,
+            EntryMetadata: metadata,
+            ShowToolCalls: true);
+}

--- a/tests/OpenClaw.Tray.UITests/TestApp.cs
+++ b/tests/OpenClaw.Tray.UITests/TestApp.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using Microsoft.UI;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Markup;
 using Microsoft.UI.Xaml.Media;
 
@@ -76,6 +77,7 @@ internal sealed class TestApp : Application
             "<Setter Property='Foreground' Value='White' />" +
             "<Setter Property='CornerRadius' Value='4' />" +
             "</Style>");
+        AddChatUserBubbleSelectionStyle(resources);
 
         EnsureFluentBrushFallbacks(resources);
     }
@@ -86,6 +88,8 @@ internal sealed class TestApp : Application
         {
             TryAddBrushResource(resources, key, color);
         }
+
+        AddChatUserBubbleSelectionStyle(resources);
     }
 
     private bool TryGetResources(out ResourceDictionary resources)
@@ -132,5 +136,16 @@ internal sealed class TestApp : Application
         {
             // best-effort; missing key just means renderers fall back.
         }
+    }
+
+    private static void AddChatUserBubbleSelectionStyle(ResourceDictionary resources)
+    {
+        if (resources.ContainsKey("ChatUserBubbleSelectionStyle"))
+            return;
+
+        resources["ChatUserBubbleSelectionStyle"] = new Style
+        {
+            TargetType = typeof(RichTextBlock),
+        };
     }
 }

--- a/tests/OpenClaw.Tray.UITests/TestApp.cs
+++ b/tests/OpenClaw.Tray.UITests/TestApp.cs
@@ -77,8 +77,6 @@ internal sealed class TestApp : Application
             "<Setter Property='Foreground' Value='White' />" +
             "<Setter Property='CornerRadius' Value='4' />" +
             "</Style>");
-        AddChatUserBubbleSelectionStyle(resources);
-
         EnsureFluentBrushFallbacks(resources);
     }
 
@@ -89,7 +87,7 @@ internal sealed class TestApp : Application
             TryAddBrushResource(resources, key, color);
         }
 
-        AddChatUserBubbleSelectionStyle(resources);
+        AddChatTimelineStyles(resources);
     }
 
     private bool TryGetResources(out ResourceDictionary resources)
@@ -138,14 +136,38 @@ internal sealed class TestApp : Application
         }
     }
 
-    private static void AddChatUserBubbleSelectionStyle(ResourceDictionary resources)
+    private static void AddChatTimelineStyles(ResourceDictionary resources)
     {
-        if (resources.ContainsKey("ChatUserBubbleSelectionStyle"))
+        if (!resources.ContainsKey("ChatUserBubbleSelectionStyle"))
+        {
+            resources["ChatUserBubbleSelectionStyle"] = new Style
+            {
+                TargetType = typeof(RichTextBlock),
+            };
+        }
+
+        AddChatBorderStyle(resources, "ChatToolCardBorderStyle");
+        AddChatBorderStyle(resources, "ChatCompactionCardStyle");
+    }
+
+    private static void AddChatBorderStyle(ResourceDictionary resources, string key)
+    {
+        if (resources.ContainsKey(key))
             return;
 
-        resources["ChatUserBubbleSelectionStyle"] = new Style
+        var style = new Style
         {
-            TargetType = typeof(RichTextBlock),
+            TargetType = typeof(Border),
         };
+        style.Setters.Add(new Setter(
+            Border.BackgroundProperty,
+            resources["CardBackgroundFillColorDefaultBrush"]));
+        style.Setters.Add(new Setter(
+            Border.BorderBrushProperty,
+            resources["ControlStrokeColorDefaultBrush"]));
+        style.Setters.Add(new Setter(
+            Border.BorderThicknessProperty,
+            new Thickness(1)));
+        resources[key] = style;
     }
 }


### PR DESCRIPTION
## Summary

- Replace application-owned `Windows.UI.ViewManagement.AccessibilitySettings` and `HighContrastChanged` observation with declarative XAML `ThemeResource` / `ThemeDictionary` resources and Reactor theme bindings.
- Use the `FontIcon`-targeted capability-pill style for the optional Connection status glyph.
- Restore direct `ImageIcon` plus `SvgImageSource` navigation rendering for normal themes.
- Preserve accessible Hub navigation in High Contrast by using an App theme-dictionary boolean to select system-foreground Fluent `FontIcon`s without constructing or subscribing to the legacy accessibility API.
- Add the missing composer settings-tooltip localization in every supported locale.
- Seed the isolated UI test host with the typed chat selection, tool-card, and compaction-card styles required by the production timeline.

## Why `AccessibilitySettings` was removed

This is a reliability fix, not only a cosmetic refactor. Previous DebugView captures on the popout path showed an unhandled `COMException` in the legacy accessibility lifecycle. The replacement keeps theme resolution inside WinUI/Reactor resources.

The maintainer follow-up preserves the former High Contrast navigation contract without restoring that unstable subscription. Normal themes retain the colorful SVG icons. High Contrast resolves to system-foreground Fluent glyphs.

## Validation

Current head: `4b702dcd`

- `git diff --check`
- `.\build.ps1`: all 5 projects passed
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore`: 3,399 passed, 32 skipped
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore`: 2,040 passed
- `dotnet test .\tests\OpenClaw.Tray.UITests\OpenClaw.Tray.UITests.csproj -c Debug -r win-x64 --no-build --filter "Category!=Accessibility"`: 100 passed
- `dotnet test .\tests\OpenClaw.Tray.UITests\OpenClaw.Tray.UITests.csproj -c Debug -r win-x64 --no-build --filter "Category=Accessibility"`: 19 passed
- GitHub CI passed: repo hygiene, shared/tray and UI tests, setup-connect E2E, revocation-recovery E2E, network-recovery E2E, win-x64 build, win-arm64 build, dispatch, Socket checks, and the CodeQL advanced-setup gate.

## Real behavior proof

The patched app was launched with isolated tray data and a dedicated MCP port while Windows High Contrast Black was active. The Hub remained responsive and exposed visible navigation for Connection, Voice & Audio, Permissions, Sandbox, Diagnostics, and Settings. The original custom Windows theme was restored afterward, and the patched process was closed.

```json
{
  "head": "4b702dcd",
  "highContrastEnabled": true,
  "processAlive": true,
  "processResponding": true,
  "connectionStatus": "Disconnected",
  "mcpPort": 8876,
  "visibleNavigationNames": [
    "Connection",
    "Voice & Audio",
    "Permissions",
    "Sandbox",
    "Diagnostics",
    "Settings"
  ]
}
```

Focused WinUI behavior proof also mounts realistic `User -> Assistant -> ToolCall` and compaction rows under the isolated `TestApp`, verifies the exact typed Border styles are applied, and completes without the previous CoreMessagingXP/combase host crash.

## Review

- Initial blind Gemini and Codex reviews independently identified the High Contrast navigation regression and missing test-host styles.
- Runtime probes rejected two false positives: WinUI converts the scalar ThemeResource into a uniform `Thickness`, and WinUI maps semantic success/caution/critical brushes to `SystemColorWindowTextColor` in High Contrast.
- Final post-fix GPT review: `MERGE`, 95% confidence, no actionable findings.
- Final post-fix Gemini review: `MERGE`, 100% confidence, no actionable findings.
- Bundled autoreview was attempted but its Codex engine could not authenticate (`401`), so it produced no review result.

## Scope

This PR starts from `main` and changes chat/tray theme-resource handling, Hub navigation presentation, Connection styling, localization, and focused tests. It does not include chat tail positioning or follow-tail behavior.