### PR TITLE
Add bounded session paging and search

### DIFF
--- a/docs/gateway-protocol-drift-guard.md
+++ b/docs/gateway-protocol-drift-guard.md
@@ -218,12 +218,11 @@ up one level.
 Mitigations:
 
 - The snapshot records `upstreamVerified` (date + the exact `sessions.ts`/`commands.ts`
-  blob SHAs the pin was checked against) so each verification is auditable and
-  reproducible. **Last verified 2026-06-23** against `openclaw/openclaw` main:
-  all enforced request fields / response envelopes / the `sessions.patch` tri-state
-  nullable contract matched exactly; the snapshot is a deliberate subset (see the
-  `upstreamVerified.result` note for the upstream-only `sessions.patch` fields the
-  Windows client does not yet implement).
+  blob SHAs) for the historical full-surface verification from **2026-06-23**.
+  `sessionsListVerified` separately records the released `sessions.list` evolution
+  verified on **2026-08-08**: v2026.5.20 supports `limit`, `search`, and
+  `configuredAgentsOnly`; v2026.5.22 adds `offset`; commit `6df0fb8` adds
+  `archived:boolean`. Each entry links the exact Core commit and source path.
 - Treat a gateway-protocol bump in upstream as a trigger to re-verify and refresh,
   the same way `docs/gateway-node-integration.md` is refreshed.
 - Re-verify by fetching `packages/gateway-protocol/src/schema/{sessions,commands}.ts`

--- a/src/OpenClaw.Shared/GatewayRequestException.cs
+++ b/src/OpenClaw.Shared/GatewayRequestException.cs
@@ -1,0 +1,13 @@
+namespace OpenClaw.Shared;
+
+/// <summary>Structured gateway RPC failure. The message is safe protocol error text, never request data.</summary>
+public sealed class GatewayRequestException : InvalidOperationException
+{
+    public GatewayRequestException(string? code, string message)
+        : base(message)
+    {
+        Code = code;
+    }
+
+    public string? Code { get; }
+}

--- a/src/OpenClaw.Shared/IOperatorGatewayClient.cs
+++ b/src/OpenClaw.Shared/IOperatorGatewayClient.cs
@@ -13,6 +13,10 @@ public interface IOperatorGatewayClient
     event EventHandler<OpenClawNotification>? NotificationReceived;
     event EventHandler<AgentActivity>? ActivityChanged;
     event EventHandler<ChannelHealth[]>? ChannelHealthUpdated;
+    /// <summary>
+    /// Eager compatibility snapshot for existing consumers, bounded to the first
+    /// 100 sessions. Use <see cref="QuerySessionsAsync"/> for deep paging/search.
+    /// </summary>
     event EventHandler<SessionInfo[]>? SessionsUpdated;
     event EventHandler<GatewayUsageInfo>? UsageUpdated;
     event EventHandler<GatewayUsageStatusInfo>? UsageStatusUpdated;
@@ -70,6 +74,18 @@ public interface IOperatorGatewayClient
         => Task.FromException<ChatHistoryInfo>(new NotSupportedException("chat.history is not supported by this gateway client."));
     Task CheckHealthAsync();
     Task RequestSessionsAsync(string? agentId = null);
+    /// <summary>
+    /// Returns a coherent session discovery snapshot, paging up to the query
+    /// safety limit without publishing those deep rows through SessionsUpdated.
+    /// The default keeps external implementers source-compatible.
+    /// </summary>
+    Task<SessionQuerySnapshot> QuerySessionsAsync(
+        SessionQuery query,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult(new SessionQuerySnapshot());
+    /// <summary>Clears server search and restores the coherent recent snapshot.</summary>
+    SessionQuerySnapshot ClearSessionSearch(SessionQuery? query = null)
+        => new();
     Task RequestUsageAsync();
     Task RequestNodesAsync();
     Task RequestUsageStatusAsync();

--- a/src/OpenClaw.Shared/OpenClawGatewayClient.Protocol.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.Protocol.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace OpenClaw.Shared;
@@ -30,6 +31,182 @@ namespace OpenClaw.Shared;
 // ─────────────────────────────────────────────────────────────────────────────
 public partial class OpenClawGatewayClient
 {
+    // ── sessions.list ──
+
+    /// <summary>
+    /// Fetches one typed sessions.list page. Optional fields are negotiated
+    /// progressively per connection from exact INVALID_REQUEST diagnostics.
+    /// </summary>
+    public async Task<SessionListResult> ListSessionsPageAsync(
+        SessionListRequest request,
+        int timeoutMs = 15000,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        await _sessionListCapabilityGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var (connectionGeneration, unsupportedFields) = CaptureSessionListCapability();
+            while (true)
+            {
+                EnsureCurrentSessionListGeneration(connectionGeneration, cancellationToken);
+                try
+                {
+                    var payload = await SendWizardRequestAsync(
+                        "sessions.list",
+                        request.ToParameters(unsupportedFields),
+                        timeoutMs,
+                        cancellationToken).ConfigureAwait(false);
+                    EnsureCurrentSessionListGeneration(connectionGeneration, cancellationToken);
+                    return ParseSessionListResult(
+                        payload,
+                        unsupportedFields & request.RequestedOptionalFields);
+                }
+                catch (GatewayRequestException ex) when (
+                    TryGetRejectedSessionListField(
+                        ex,
+                        request,
+                        unsupportedFields,
+                        out var rejectedField))
+                {
+                    unsupportedFields = RememberUnsupportedSessionListField(
+                        connectionGeneration,
+                        rejectedField,
+                        cancellationToken);
+                    _logger.Warn(
+                        $"sessions.list field '{GetSessionListFieldName(rejectedField)}' unsupported; retrying without it");
+                }
+            }
+        }
+        finally
+        {
+            _sessionListCapabilityGate.Release();
+        }
+    }
+
+    internal static bool TryGetRejectedSessionListField(
+        GatewayRequestException exception,
+        SessionListRequest request,
+        SessionListRequestFields alreadyUnsupported,
+        out SessionListRequestFields rejectedField)
+    {
+        rejectedField = SessionListRequestFields.None;
+        if (!string.Equals(exception.Code, "INVALID_REQUEST", StringComparison.Ordinal))
+            return false;
+
+        var match = Regex.Match(
+            exception.Message,
+            @"\b(?:unexpected\s+property|unknown\s+parameter)\b\s*(?::|=)?\s*[""'`]?(?<field>[A-Za-z][A-Za-z0-9]*)[""'`]?",
+            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+        if (!match.Success)
+            return false;
+
+        rejectedField = match.Groups["field"].Value.ToLowerInvariant() switch
+        {
+            "limit" => SessionListRequestFields.Limit,
+            "offset" => SessionListRequestFields.Offset,
+            "search" => SessionListRequestFields.Search,
+            "configuredagentsonly" => SessionListRequestFields.ConfiguredAgentsOnly,
+            "archived" => SessionListRequestFields.Archived,
+            _ => SessionListRequestFields.None,
+        };
+        return rejectedField != SessionListRequestFields.None &&
+               request.RequestedOptionalFields.HasFlag(rejectedField) &&
+               !alreadyUnsupported.HasFlag(rejectedField);
+    }
+
+    private void EnsureCurrentSessionListGeneration(
+        int connectionGeneration,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        lock (_sessionListCapabilityLock)
+        {
+            if (_sessionListConnectionGeneration != connectionGeneration)
+                throw new OperationCanceledException("sessions.list response belongs to a stale connection generation.");
+        }
+    }
+
+    private (int Generation, SessionListRequestFields UnsupportedFields) CaptureSessionListCapability()
+    {
+        lock (_sessionListCapabilityLock)
+            return (_sessionListConnectionGeneration, _unsupportedSessionListRequestFields);
+    }
+
+    private SessionListRequestFields RememberUnsupportedSessionListField(
+        int connectionGeneration,
+        SessionListRequestFields rejectedField,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        lock (_sessionListCapabilityLock)
+        {
+            if (_sessionListConnectionGeneration != connectionGeneration)
+                throw new OperationCanceledException("sessions.list response belongs to a stale connection generation.");
+            _unsupportedSessionListRequestFields |= rejectedField;
+            return _unsupportedSessionListRequestFields;
+        }
+    }
+
+    private static string GetSessionListFieldName(SessionListRequestFields field) => field switch
+    {
+        SessionListRequestFields.Limit => "limit",
+        SessionListRequestFields.Offset => "offset",
+        SessionListRequestFields.Search => "search",
+        SessionListRequestFields.ConfiguredAgentsOnly => "configuredAgentsOnly",
+        SessionListRequestFields.Archived => "archived",
+        _ => throw new ArgumentOutOfRangeException(nameof(field), field, null),
+    };
+
+    private void ResetSessionListCapability()
+    {
+        lock (_sessionListCapabilityLock)
+        {
+            _sessionListConnectionGeneration++;
+            _unsupportedSessionListRequestFields = SessionListRequestFields.None;
+            _operatorReadScopeUnavailable = false;
+        }
+    }
+
+    internal SessionListResult ParseSessionListResult(
+        JsonElement payload,
+        SessionListRequestFields unsupportedRequestFields = SessionListRequestFields.None)
+    {
+        IReadOnlyList<SessionInfo> sessions = TryGetSessionsPayload(payload, out var sessionsPayload)
+            ? ParseSessionPageRows(
+                sessionsPayload,
+                SessionQueryCoordinator.MaximumMaterializedSessions)
+            : Array.Empty<SessionInfo>();
+        return new SessionListResult
+        {
+            Sessions = sessions,
+            Count = GetInt32OrNull(payload, "count"),
+            TotalCount = GetInt32OrNull(payload, "totalCount"),
+            LimitApplied = GetInt32OrNull(payload, "limitApplied"),
+            Offset = GetInt32OrNull(payload, "offset"),
+            NextOffset = GetInt32OrNull(payload, "nextOffset"),
+            HasMore = payload.ValueKind == JsonValueKind.Object
+                ? GetOptionalBool(payload, "hasMore")
+                : null,
+            UnsupportedRequestFields = unsupportedRequestFields,
+        };
+    }
+
+    private static int? GetInt32OrNull(JsonElement parent, string property)
+    {
+        if (parent.ValueKind != JsonValueKind.Object ||
+            !parent.TryGetProperty(property, out var value) ||
+            value.ValueKind != JsonValueKind.Number)
+        {
+            return null;
+        }
+        if (value.TryGetInt32(out var integer))
+            return integer;
+        if (value.TryGetInt64(out var wide) && wide is >= int.MinValue and <= int.MaxValue)
+            return (int)wide;
+        return null;
+    }
+
     // ── sessions.reset ──
 
     public async Task<SessionResetResult> ResetSessionDetailedAsync(

--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -38,10 +38,15 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
     private GatewayUsageStatusInfo? _usageStatus;
     private GatewayCostUsageInfo? _usageCost;
     private readonly Dictionary<string, string> _pendingRequestMethods = new();
+    private readonly Dictionary<string, int> _pendingRequestConnectionGenerations = new();
     private readonly Dictionary<string, TaskCompletionSource<ChatSendResult>> _pendingChatSendRequests = new();
     private readonly object _pendingRequestLock = new();
     private readonly object _pendingChatSendLock = new();
     private readonly object _sessionsLock = new();
+    private readonly object _sessionListCapabilityLock = new();
+    private readonly SemaphoreSlim _sessionListCapabilityGate = new(1, 1);
+    private readonly SessionQueryCoordinator _sessionQueries;
+    private readonly SessionPublicationCoordinator _sessionPublications;
     private readonly DeviceIdentity _deviceIdentity;
     private readonly string _currentGatewayUrl;
     private string? _mainSessionKey;
@@ -95,6 +100,8 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
     private bool _authFailed;
     private int _handshakeAuthorizationBlocked;
     private int _handshakeChallengeActive;
+    private SessionListRequestFields _unsupportedSessionListRequestFields;
+    private int _sessionListConnectionGeneration;
     private string? _lastSkillsStatusAgentId;
     private readonly bool _tokenIsBootstrapToken;
     private readonly bool _bootstrapPairAsNode;
@@ -141,7 +148,6 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
         _agentsListUnsupported = false;
         _agentFilesListUnsupported = false;
         _agentFileGetUnsupported = false;
-        _operatorReadScopeUnavailable = false;
     }
 
     /// <summary>
@@ -168,6 +174,9 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
         Volatile.Write(ref _handshakeAuthorizationBlocked, 0);
         Volatile.Write(ref _handshakeChallengeActive, 0);
         ResetUnsupportedMethodFlags();
+        ResetSessionListCapability();
+        _sessionQueries.AdvanceConnectionGeneration();
+        _sessionPublications.AdvanceConnectionGeneration();
         RaiseTransportConnected();
         return Task.CompletedTask;
     }
@@ -183,6 +192,9 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
 
     protected override void OnDisconnected()
     {
+        ResetSessionListCapability();
+        _sessionQueries.AdvanceConnectionGeneration();
+        _sessionPublications.AdvanceConnectionGeneration();
         // Invalidate the handshake snapshot — the next hello-ok must
         // re-establish the canonical session key, scopes, etc. Without this,
         // a reconnect-after-server-restart could leave the tray sending to a
@@ -199,6 +211,9 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
 
     protected override void OnDisposing()
     {
+        ResetSessionListCapability();
+        _sessionQueries.Dispose();
+        _sessionPublications.Dispose();
         ClearPendingRequests();
     }
 
@@ -298,12 +313,24 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
         _deviceIdentity.Initialize();
         _connectAuthToken = HasUsableOperatorDeviceToken ? _deviceIdentity.DeviceToken! : (_tokenIsBootstrapToken ? string.Empty : _token);
         _useV2Signature |= _tokenIsBootstrapToken && !HasUsableOperatorDeviceToken;
+        _sessionQueries = new SessionQueryCoordinator(
+            (request, cancellationToken) =>
+                ListSessionsPageAsync(request, cancellationToken: cancellationToken));
+        _sessionPublications = new SessionPublicationCoordinator(
+            (request, cancellationToken) =>
+                ListSessionsPageAsync(request, cancellationToken: cancellationToken),
+            TryCommitSessionPublication,
+            sessions => SessionsUpdated?.Invoke(this, sessions));
     }
 
     public async Task DisconnectAsync()
     {
         if (IsConnected)
         {
+            // Invalidate connection-owned queries before waiting for the close
+            // handshake. A slow gateway response must not keep bootstrap work
+            // alive or publish after the caller has requested disconnect.
+            OnDisconnected();
             try
             {
                 await CloseWebSocketAsync();
@@ -328,14 +355,7 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
 
         try
         {
-            var req = new
-            {
-                type = "req",
-                id = Guid.NewGuid().ToString(),
-                method = "health",
-                @params = new { deep = true }
-            };
-            await SendRawAsync(JsonSerializer.Serialize(req));
+            await SendTrackedRequestAsync("health", new { deep = true });
         }
         catch (Exception ex)
         {
@@ -965,7 +985,28 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
     /// Sends a wizard RPC request and waits for the response payload.
     /// Used for wizard.start, wizard.next, wizard.cancel, wizard.status.
     /// </summary>
-    public async Task<JsonElement> SendWizardRequestAsync(string method, object? parameters = null, int timeoutMs = 30000)
+    public async Task<JsonElement> SendWizardRequestAsync(
+        string method,
+        object? parameters = null,
+        int timeoutMs = 30000)
+    {
+        try
+        {
+            return await SendWizardRequestAsync(
+                method, parameters, timeoutMs, CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (GatewayRequestException ex)
+        {
+            // Preserve the exact public exception contract for existing callers.
+            throw new InvalidOperationException(ex.Message);
+        }
+    }
+
+    public async Task<JsonElement> SendWizardRequestAsync(
+        string method,
+        object? parameters,
+        int timeoutMs,
+        CancellationToken cancellationToken)
     {
         if (!IsConnected)
             throw new InvalidOperationException("Gateway connection is not open");
@@ -974,12 +1015,14 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
         var requestId = Guid.NewGuid().ToString();
         var completion = new TaskCompletionSource<JsonElement>(TaskCreationOptions.RunContinuationsAsynchronously);
         _pendingWizardResponses[requestId] = completion;
-        TrackPendingRequest(requestId, method);
 
         try
         {
+            cancellationToken.ThrowIfCancellationRequested();
             await SendRawAsync(SerializeRequest(requestId, method, parameters));
-            return await completion.Task.WaitAsync(TimeSpan.FromMilliseconds(timeoutMs), CancellationToken);
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(
+                CancellationToken, cancellationToken);
+            return await completion.Task.WaitAsync(TimeSpan.FromMilliseconds(timeoutMs), linked.Token);
         }
         catch (TimeoutException ex)
         {
@@ -988,19 +1031,136 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
         finally
         {
             _pendingWizardResponses.TryRemove(requestId, out _);
-            RemovePendingRequest(requestId);
         }
     }
 
     /// <summary>Request session list from gateway.</summary>
-    public async Task RequestSessionsAsync(string? agentId = null)
+    public Task RequestSessionsAsync(string? agentId = null) =>
+        RequestSessionsAsync(agentId, expectedConnectionGeneration: null);
+
+    private async Task RequestSessionsAsync(
+        string? agentId,
+        int? expectedConnectionGeneration)
     {
-        if (_operatorReadScopeUnavailable) return;
-        if (!string.IsNullOrEmpty(agentId))
-            await SendTrackedRequestAsync("sessions.list", new { agentId });
-        else
-            await SendTrackedRequestAsync("sessions.list");
+        var scopeState = CaptureOperatorReadScopeState();
+        if (expectedConnectionGeneration.HasValue &&
+            expectedConnectionGeneration.Value != scopeState.Generation)
+        {
+            throw new OperationCanceledException(
+                "sessions.list refresh belongs to a stale connection generation.");
+        }
+        if (scopeState.Unavailable) return;
+        try
+        {
+            await _sessionPublications.RequestRefreshAsync(
+                agentId,
+                expectedConnectionGeneration ?? scopeState.Generation).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // The connection generation changed while a bounded refresh was pending.
+        }
+        catch (GatewayRequestException ex) when (IsMissingScopeError(ex.Message, "operator.read"))
+        {
+            MarkOperatorReadScopeUnavailable(scopeState.Generation);
+        }
+        catch (Exception ex)
+        {
+            _logger.Warn($"sessions.list failed: {ex.Message}");
+        }
     }
+
+    public async Task<SessionQuerySnapshot> QuerySessionsAsync(
+        SessionQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        cancellationToken.ThrowIfCancellationRequested();
+        var scopeState = CaptureOperatorReadScopeState();
+        if (scopeState.Unavailable)
+        {
+            var queryGeneration = _sessionQueries.ConnectionGeneration;
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!IsOperatorReadScopeUnavailable(scopeState.Generation))
+            {
+                throw new OperationCanceledException(
+                    "sessions.list query belongs to a stale connection generation.",
+                    cancellationToken);
+            }
+
+            // The query was not executed, so report no paging/search mode while
+            // retaining the requested search identity for upper consumers.
+            return new SessionQuerySnapshot
+            {
+                Search = string.IsNullOrWhiteSpace(query.Search) ? null : query.Search.Trim(),
+                ConnectionGeneration = queryGeneration,
+                Sessions = Array.Empty<SessionInfo>(),
+                MaterializedSessions = Array.Empty<SessionInfo>(),
+            };
+        }
+
+        EnsureCurrentSessionListGeneration(scopeState.Generation, cancellationToken);
+        try
+        {
+            return await (string.IsNullOrWhiteSpace(query.Search)
+                ? _sessionQueries.LoadRecentAsync(
+                    query,
+                    cancellationToken,
+                    scopeState.Generation)
+                : _sessionQueries.SearchAsync(
+                    query,
+                    cancellationToken,
+                    scopeState.Generation)).ConfigureAwait(false);
+        }
+        catch (GatewayRequestException ex) when (IsMissingScopeError(ex.Message, "operator.read"))
+        {
+            if (!MarkOperatorReadScopeUnavailable(scopeState.Generation))
+            {
+                throw new OperationCanceledException(
+                    "sessions.list response belongs to a stale connection generation.",
+                    ex,
+                    cancellationToken);
+            }
+            throw;
+        }
+    }
+
+    private (int Generation, bool Unavailable) CaptureOperatorReadScopeState()
+    {
+        lock (_sessionListCapabilityLock)
+            return (_sessionListConnectionGeneration, _operatorReadScopeUnavailable);
+    }
+
+    private bool IsOperatorReadScopeUnavailable(int connectionGeneration)
+    {
+        lock (_sessionListCapabilityLock)
+        {
+            return _sessionListConnectionGeneration == connectionGeneration &&
+                   _operatorReadScopeUnavailable;
+        }
+    }
+
+    private bool MarkOperatorReadScopeUnavailable(
+        int connectionGeneration,
+        string warning = "Gateway token lacks operator.read; disabling sessions polling")
+    {
+        var shouldLog = false;
+        lock (_sessionListCapabilityLock)
+        {
+            if (_sessionListConnectionGeneration != connectionGeneration)
+                return false;
+            if (_operatorReadScopeUnavailable)
+                return true;
+            _operatorReadScopeUnavailable = true;
+            shouldLog = true;
+        }
+        if (shouldLog)
+            _logger.Warn(warning);
+        return true;
+    }
+
+    public SessionQuerySnapshot ClearSessionSearch(SessionQuery? query = null) =>
+        _sessionQueries.ClearSearch(query);
 
     /// <summary>Subscribe to session change events so the gateway pushes
     /// <c>sessions.changed</c> notifications when sessions are mutated.</summary>
@@ -1013,7 +1173,7 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
     /// <summary>Request usage/context info from gateway (may not be supported on all gateways).</summary>
     public async Task RequestUsageAsync()
     {
-        if (_operatorReadScopeUnavailable) return;
+        if (CaptureOperatorReadScopeState().Unavailable) return;
         if (!IsConnected) return;
         try
         {
@@ -1038,7 +1198,7 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
     /// <summary>Request connected node inventory from gateway.</summary>
     public async Task RequestNodesAsync()
     {
-        if (_operatorReadScopeUnavailable) return;
+        if (CaptureOperatorReadScopeState().Unavailable) return;
         if (_nodeListUnsupported) return;
         await SendTrackedRequestAsync("node.list");
     }
@@ -1950,9 +2110,11 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
 
     private void TrackPendingRequest(string requestId, string method)
     {
+        var connectionGeneration = CaptureOperatorReadScopeState().Generation;
         lock (_pendingRequestLock)
         {
             _pendingRequestMethods[requestId] = method;
+            _pendingRequestConnectionGenerations[requestId] = connectionGeneration;
         }
     }
 
@@ -1961,15 +2123,23 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
         lock (_pendingRequestLock)
         {
             _pendingRequestMethods.Remove(requestId);
+            _pendingRequestConnectionGenerations.Remove(requestId);
         }
     }
 
-    private string? TakePendingRequestMethod(string? requestId)
+    private (string? Method, int? ConnectionGeneration) TakePendingRequest(string? requestId)
     {
-        if (string.IsNullOrWhiteSpace(requestId)) return null;
+        if (string.IsNullOrWhiteSpace(requestId)) return (null, null);
         lock (_pendingRequestLock)
         {
-            return _pendingRequestMethods.Remove(requestId, out var method) ? method : null;
+            if (!_pendingRequestMethods.Remove(requestId, out var method))
+                return (null, null);
+            var generation = _pendingRequestConnectionGenerations.Remove(
+                requestId,
+                out var connectionGeneration)
+                ? connectionGeneration
+                : (int?)null;
+            return (method, generation);
         }
     }
 
@@ -1979,6 +2149,7 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
         lock (_pendingRequestLock)
         {
             _pendingRequestMethods.Clear();
+            _pendingRequestConnectionGenerations.Clear();
         }
 
         lock (_pendingChatSendLock)
@@ -2092,11 +2263,12 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
     private void HandleResponse(JsonElement root)
     {
         string? requestMethod = null;
+        int? requestConnectionGeneration = null;
         string? requestId = null;
         if (root.TryGetProperty("id", out var idProp))
         {
             requestId = idProp.GetString();
-            requestMethod = TakePendingRequestMethod(requestId);
+            (requestMethod, requestConnectionGeneration) = TakePendingRequest(requestId);
         }
 
         var pendingChatSend = TakePendingChatSend(requestId);
@@ -2121,7 +2293,9 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
             if (root.TryGetProperty("ok", out var okWiz) && okWiz.ValueKind == JsonValueKind.False)
             {
                 var message = TryGetErrorMessage(root) ?? "wizard request failed";
-                wizardCompletion.TrySetException(new InvalidOperationException(message));
+                wizardCompletion.TrySetException(new GatewayRequestException(
+                    TryGetErrorTopLevelCode(root),
+                    message));
             }
             else if (root.TryGetProperty("payload", out var wizPayload))
             {
@@ -2159,10 +2333,16 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
             return;
         }
 
+        // Protocol responses are request-owned. Once specialized completion
+        // paths have had first refusal, an id with no tracked owner is stale,
+        // canceled, duplicated, or unsolicited and must not mutate generic state.
+        if (requestId != null && requestMethod is null)
+            return;
+
         if (root.TryGetProperty("ok", out var okProp) &&
             okProp.ValueKind == JsonValueKind.False)
         {
-            HandleRequestError(requestMethod, root);
+            HandleRequestError(requestMethod, requestConnectionGeneration, root);
             return;
         }
 
@@ -2263,17 +2443,8 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
 
             RaiseStatusChanged(ConnectionStatus.Connected);
 
-            // Request initial state after handshake
-            _ = Task.Run(async () =>
-            {
-                await Task.Delay(500);
-                await CheckHealthAsync();
-                await RequestSessionsAsync();
-                await SubscribeSessionEventsAsync();
-                await RequestUsageAsync();
-                await RequestNodesAsync();
-                await RequestAgentsListAsync();
-            });
+            var bootstrapGeneration = CaptureSessionListCapability().Generation;
+            _ = Task.Run(() => RequestInitialStateAsync(bootstrapGeneration));
         }
 
         // Handle health response — channels
@@ -2472,7 +2643,10 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
             _ => null
         };
 
-    private void HandleRequestError(string? method, JsonElement root)
+    private void HandleRequestError(
+        string? method,
+        int? requestConnectionGeneration,
+        JsonElement root)
     {
         var message = TryGetErrorMessage(root) ?? "request failed";
         var detailCode = method == "connect" ? TryGetErrorDetailCode(root) : null;
@@ -2563,12 +2737,12 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
         if (IsMissingScopeError(message, "operator.read") &&
             method is "sessions.list" or "usage.status" or "usage.cost" or "node.list")
         {
-            if (!_operatorReadScopeUnavailable)
+            if (requestConnectionGeneration.HasValue)
             {
-                _logger.Warn("Gateway token lacks operator.read; disabling sessions/usage/nodes polling");
+                MarkOperatorReadScopeUnavailable(
+                    requestConnectionGeneration.Value,
+                    "Gateway token lacks operator.read; disabling sessions/usage/nodes polling");
             }
-
-            _operatorReadScopeUnavailable = true;
             return;
         }
 
@@ -3969,7 +4143,107 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
             if (a.IsMain != b.IsMain) return a.IsMain ? -1 : 1;
             return b.LastSeen.CompareTo(a.LastSeen);
         });
+        if (arr.Length > SessionPublicationCoordinator.MaximumPublishedSessions)
+            Array.Resize(ref arr, SessionPublicationCoordinator.MaximumPublishedSessions);
         return arr;
+    }
+
+    private async Task RequestInitialStateAsync(int connectionGeneration)
+    {
+        Task? sessionCatchUp = null;
+        try
+        {
+            await Task.Delay(500).ConfigureAwait(false);
+            EnsureCurrentSessionListGeneration(connectionGeneration, CancellationToken.None);
+            await CheckHealthAsync().ConfigureAwait(false);
+            EnsureCurrentSessionListGeneration(connectionGeneration, CancellationToken.None);
+
+            // Subscribe before the bounded catch-up. Changes arriving during a
+            // refresh coalesce into a trailing refresh without canceling publication.
+            await SubscribeSessionEventsAsync().ConfigureAwait(false);
+            EnsureCurrentSessionListGeneration(connectionGeneration, CancellationToken.None);
+
+            // Keep the bounded catch-up owned and observed by this bootstrap,
+            // but do not serialize unrelated startup reads behind it.
+            sessionCatchUp = RequestInitialSessionsAsync(connectionGeneration);
+            await RequestUsageAsync().ConfigureAwait(false);
+            EnsureCurrentSessionListGeneration(connectionGeneration, CancellationToken.None);
+            await RequestNodesAsync().ConfigureAwait(false);
+            EnsureCurrentSessionListGeneration(connectionGeneration, CancellationToken.None);
+            await RequestAgentsListAsync().ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // The socket generation changed while bootstrap work was pending.
+        }
+        catch (Exception ex)
+        {
+            _logger.Warn($"Initial gateway state request failed: {ex.Message}");
+        }
+        finally
+        {
+            if (sessionCatchUp is not null)
+                await sessionCatchUp.ConfigureAwait(false);
+        }
+    }
+
+    private async Task RequestInitialSessionsAsync(int connectionGeneration)
+    {
+        try
+        {
+            await RequestSessionsAsync(
+                agentId: null,
+                expectedConnectionGeneration: connectionGeneration).ConfigureAwait(false);
+            EnsureCurrentSessionListGeneration(connectionGeneration, CancellationToken.None);
+        }
+        catch (OperationCanceledException)
+        {
+            // Disconnect/reconnect owns cancellation of this generation's catch-up.
+        }
+        catch (Exception ex)
+        {
+            // Keep this task non-faulting because bootstrap is launched fire-and-forget.
+            _logger.Warn($"Initial sessions catch-up failed: {ex.Message}");
+        }
+    }
+
+    private SessionInfo[] ReplaceCoherentSessions(IReadOnlyList<SessionInfo> sessions)
+    {
+        SessionInfo[] snapshot;
+        lock (_sessionsLock)
+        {
+            var replacement = new Dictionary<string, SessionInfo>(StringComparer.Ordinal);
+            foreach (var incoming in sessions)
+            {
+                if (string.IsNullOrWhiteSpace(incoming.Key))
+                    continue;
+                var session = incoming.Clone();
+                if (_sessions.TryGetValue(session.Key, out var tracked))
+                {
+                    session.CurrentActivity = tracked.CurrentActivity;
+                    if (tracked.LastSeen > session.LastSeen)
+                        session.LastSeen = tracked.LastSeen;
+                }
+                replacement[session.Key] = session;
+            }
+            _sessions.Clear();
+            foreach (var pair in replacement)
+                _sessions[pair.Key] = pair.Value;
+            snapshot = GetSessionListInternal();
+        }
+        return snapshot;
+    }
+
+    private SessionInfo[]? TryCommitSessionPublication(
+        int connectionGeneration,
+        IReadOnlyList<SessionInfo> sessions)
+    {
+        lock (_sessionListCapabilityLock)
+        {
+            if (_sessionListConnectionGeneration != connectionGeneration)
+                return null;
+            return ReplaceCoherentSessions(sessions);
+        }
     }
 
     // --- Parsing helpers ---
@@ -4085,6 +4359,57 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
         }
     }
 
+    private SessionInfo[] ParseSessionPageRows(JsonElement sessions, int maximumRows = int.MaxValue)
+    {
+        var rows = new List<SessionInfo>();
+        if (sessions.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in sessions.EnumerateArray())
+            {
+                if (rows.Count >= maximumRows)
+                    break;
+                if (item.ValueKind != JsonValueKind.Object)
+                    continue;
+                var key = GetString(item, "key");
+                if (string.IsNullOrWhiteSpace(key))
+                    continue;
+                var session = new SessionInfo { Key = key };
+                UpdateSessionMainStatus(session, key, item);
+                PopulateSessionFromObject(session, item);
+                rows.Add(session);
+            }
+        }
+        else if (sessions.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var property in sessions.EnumerateObject())
+            {
+                if (rows.Count >= maximumRows)
+                    break;
+                var key = property.Name;
+                if (key is "recent" or "count" or "path" or "defaults" or "ts")
+                    continue;
+                if (!key.Equals("global", StringComparison.OrdinalIgnoreCase) &&
+                    !key.Contains(':') &&
+                    !key.Contains("agent") &&
+                    !key.Contains("session"))
+                {
+                    continue;
+                }
+
+                var session = new SessionInfo { Key = key };
+                UpdateSessionMainStatus(session, key, property.Value);
+                if (property.Value.ValueKind == JsonValueKind.Object)
+                    PopulateSessionFromObject(session, property.Value);
+                else if (property.Value.ValueKind == JsonValueKind.String)
+                    session.Status = property.Value.GetString() ?? string.Empty;
+                else
+                    continue;
+                rows.Add(session);
+            }
+        }
+        return rows.ToArray();
+    }
+
     private string? ParseSessionItem(JsonElement item)
     {
         var sessionKey = "unknown";
@@ -4170,7 +4495,7 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
         {
             var newModel = model.GetString();
             if (session.Model != newModel)
-                _logger.Info($"[SESSION] {session.Key}: model changed '{session.Model}' → '{newModel}'");
+                _logger.Info($"[SESSION] model changed '{session.Model}' → '{newModel}'");
             session.Model = newModel;
         }
         if (item.TryGetProperty("label", out _)) session.Label = GetString(item, "label");

--- a/src/OpenClaw.Shared/Sessions/SessionListModels.cs
+++ b/src/OpenClaw.Shared/Sessions/SessionListModels.cs
@@ -1,0 +1,154 @@
+using System.Text.Json.Serialization;
+
+namespace OpenClaw.Shared;
+
+[Flags]
+public enum SessionListRequestFields
+{
+    None = 0,
+    Limit = 1 << 0,
+    Offset = 1 << 1,
+    Search = 1 << 2,
+    ConfiguredAgentsOnly = 1 << 3,
+    Archived = 1 << 4,
+}
+
+/// <summary>
+/// Capability-negotiated <c>sessions.list</c> request contract.
+/// Keep this DTO aligned with the pinned protocol snapshot and released Core schemas.
+/// </summary>
+public sealed class SessionListRequest
+{
+    [JsonPropertyName("agentId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? AgentId { get; init; }
+
+    [JsonPropertyName("limit")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? Limit { get; init; }
+
+    [JsonPropertyName("offset")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? Offset { get; init; }
+
+    [JsonPropertyName("search")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Search { get; init; }
+
+    [JsonPropertyName("configuredAgentsOnly")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? ConfiguredAgentsOnly { get; init; }
+
+    [JsonPropertyName("archived")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? Archived { get; init; }
+
+    [JsonIgnore]
+    internal SessionListRequestFields RequestedOptionalFields
+    {
+        get
+        {
+            var fields = SessionListRequestFields.None;
+            if (Limit.HasValue) fields |= SessionListRequestFields.Limit;
+            if (Offset.HasValue) fields |= SessionListRequestFields.Offset;
+            if (!string.IsNullOrWhiteSpace(Search)) fields |= SessionListRequestFields.Search;
+            if (ConfiguredAgentsOnly.HasValue) fields |= SessionListRequestFields.ConfiguredAgentsOnly;
+            if (Archived.HasValue) fields |= SessionListRequestFields.Archived;
+            return fields;
+        }
+    }
+
+    internal Dictionary<string, object?> ToParameters(
+        SessionListRequestFields unsupportedFields = SessionListRequestFields.None)
+    {
+        var parameters = new Dictionary<string, object?>();
+        if (!string.IsNullOrWhiteSpace(AgentId)) parameters["agentId"] = AgentId;
+        if (Limit.HasValue && !unsupportedFields.HasFlag(SessionListRequestFields.Limit))
+            parameters["limit"] = Limit.Value;
+        if (Offset.HasValue && !unsupportedFields.HasFlag(SessionListRequestFields.Offset))
+            parameters["offset"] = Offset.Value;
+        if (!string.IsNullOrWhiteSpace(Search) &&
+            !unsupportedFields.HasFlag(SessionListRequestFields.Search))
+        {
+            parameters["search"] = Search;
+        }
+        if (ConfiguredAgentsOnly.HasValue &&
+            !unsupportedFields.HasFlag(SessionListRequestFields.ConfiguredAgentsOnly))
+        {
+            parameters["configuredAgentsOnly"] = ConfiguredAgentsOnly.Value;
+        }
+        if (Archived.HasValue && !unsupportedFields.HasFlag(SessionListRequestFields.Archived))
+            parameters["archived"] = Archived.Value;
+        return parameters;
+    }
+}
+
+/// <summary>
+/// Stable <c>sessions.list</c> response contract.
+/// Nullable metadata deliberately tolerates older and additive gateway shapes.
+/// </summary>
+public sealed class SessionListResult
+{
+    [JsonPropertyName("sessions")]
+    public IReadOnlyList<SessionInfo> Sessions { get; init; } = Array.Empty<SessionInfo>();
+
+    [JsonPropertyName("count")]
+    public int? Count { get; init; }
+
+    [JsonPropertyName("totalCount")]
+    public int? TotalCount { get; init; }
+
+    [JsonPropertyName("limitApplied")]
+    public int? LimitApplied { get; init; }
+
+    [JsonPropertyName("offset")]
+    public int? Offset { get; init; }
+
+    [JsonPropertyName("nextOffset")]
+    public int? NextOffset { get; init; }
+
+    [JsonPropertyName("hasMore")]
+    public bool? HasMore { get; init; }
+
+    [JsonIgnore]
+    public SessionListRequestFields UnsupportedRequestFields { get; init; }
+
+    [JsonIgnore]
+    public bool UsedCompatibilityFallback =>
+        UnsupportedRequestFields != SessionListRequestFields.None;
+}
+
+/// <summary>UI-neutral query accepted by the session discovery boundary.</summary>
+public sealed class SessionQuery
+{
+    public string? AgentId { get; init; }
+    public string? Search { get; init; }
+    public bool ConfiguredAgentsOnly { get; init; }
+    public bool? Archived { get; init; }
+    public bool IncludeBackground { get; init; }
+    public IReadOnlyList<SessionInfo> PinnedSessions { get; init; } = Array.Empty<SessionInfo>();
+}
+
+public enum SessionSearchExecutionMode
+{
+    None,
+    Server,
+    LegacyLocal,
+}
+
+/// <summary>One coherent, bounded session discovery snapshot.</summary>
+public sealed class SessionQuerySnapshot
+{
+    public IReadOnlyList<SessionInfo> Sessions { get; init; } = Array.Empty<SessionInfo>();
+    public string? Search { get; init; }
+    public int ConnectionGeneration { get; init; }
+    public int PagesRead { get; init; }
+    public SessionListRequestFields UnsupportedRequestFields { get; init; }
+    public SessionSearchExecutionMode SearchExecutionMode { get; init; }
+
+    public bool UsedCompatibilityFallback =>
+        UnsupportedRequestFields != SessionListRequestFields.None;
+
+    internal IReadOnlyList<SessionInfo> MaterializedSessions { get; init; } = Array.Empty<SessionInfo>();
+    internal long RequestIdentity { get; init; }
+}

--- a/src/OpenClaw.Shared/Sessions/SessionPublicationCoordinator.cs
+++ b/src/OpenClaw.Shared/Sessions/SessionPublicationCoordinator.cs
@@ -1,0 +1,251 @@
+namespace OpenClaw.Shared;
+
+/// <summary>
+/// Coalesces eager session refreshes while preserving the historical one-page
+/// publication bound used by existing SessionsUpdated consumers.
+/// </summary>
+internal sealed class SessionPublicationCoordinator : IDisposable
+{
+    public const int MaximumPublishedSessions = 100;
+
+    private readonly Func<SessionListRequest, CancellationToken, Task<SessionListResult>> _fetchPage;
+    private readonly Func<
+        int,
+        IReadOnlyList<SessionInfo>,
+        SessionInfo[]?> _tryCommit;
+    private readonly Action<SessionInfo[]> _publish;
+    private readonly object _gate = new();
+    private CancellationTokenSource _generationCancellation = new();
+    private PublicationBatch? _pending;
+    private int _generation;
+    private bool _workerRunning;
+    private bool _disposed;
+
+    public SessionPublicationCoordinator(
+        Func<SessionListRequest, CancellationToken, Task<SessionListResult>> fetchPage,
+        Func<int, IReadOnlyList<SessionInfo>, SessionInfo[]?> tryCommit,
+        Action<SessionInfo[]> publish)
+    {
+        _fetchPage = fetchPage ?? throw new ArgumentNullException(nameof(fetchPage));
+        _tryCommit = tryCommit ?? throw new ArgumentNullException(nameof(tryCommit));
+        _publish = publish ?? throw new ArgumentNullException(nameof(publish));
+    }
+
+    public Task RequestRefreshAsync(
+        string? agentId = null,
+        int? expectedConnectionGeneration = null)
+    {
+        var normalizedAgentId = string.IsNullOrWhiteSpace(agentId) ? null : agentId.Trim();
+        var waiter = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var startWorker = false;
+        lock (_gate)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (expectedConnectionGeneration.HasValue &&
+                expectedConnectionGeneration.Value != _generation)
+            {
+                throw new OperationCanceledException(
+                    "Session publication request belongs to a stale connection generation.");
+            }
+            if (_pending is null || _pending.Generation != _generation)
+            {
+                _pending = new PublicationBatch(_generation, normalizedAgentId);
+            }
+            else
+            {
+                // One queued trailing batch is enough for any burst. Use the latest
+                // requested scope while completing every coalesced caller together.
+                _pending.AgentId = normalizedAgentId;
+            }
+
+            _pending.Waiters.Add(waiter);
+            if (!_workerRunning)
+            {
+                _workerRunning = true;
+                startWorker = true;
+            }
+        }
+
+        if (startWorker)
+            _ = RunAsync();
+        return waiter.Task;
+    }
+
+    public void AdvanceConnectionGeneration()
+    {
+        CancellationTokenSource oldGeneration;
+        CancellationToken oldToken;
+        PublicationBatch? canceled;
+        lock (_gate)
+        {
+            if (_disposed) return;
+            _generation++;
+            oldGeneration = _generationCancellation;
+            oldToken = oldGeneration.Token;
+            _generationCancellation = new CancellationTokenSource();
+            canceled = _pending;
+            _pending = null;
+        }
+
+        CancelAndDispose(oldGeneration);
+        if (canceled is not null)
+            CancelBatch(canceled, oldToken);
+    }
+
+    private async Task RunAsync()
+    {
+        while (true)
+        {
+            PublicationBatch? batch;
+            CancellationToken generationToken;
+            lock (_gate)
+            {
+                if (_pending is null)
+                {
+                    _workerRunning = false;
+                    return;
+                }
+
+                batch = _pending;
+                _pending = null;
+                generationToken = _generationCancellation.Token;
+            }
+
+            if (batch.Generation != GetGeneration())
+            {
+                CancelBatch(batch, generationToken);
+                continue;
+            }
+
+            try
+            {
+                var page = await _fetchPage(
+                    new SessionListRequest
+                    {
+                        AgentId = batch.AgentId,
+                        Limit = MaximumPublishedSessions,
+                    },
+                    generationToken).ConfigureAwait(false);
+                generationToken.ThrowIfCancellationRequested();
+                var rows = BuildBoundedRows(page.Sessions);
+
+                // This lock is the publication linearization point: generation
+                // changes ordered before it suppress the callback, while changes
+                // ordered after it cancel completion of the old batch. Never invoke
+                // the external callback while holding the coordinator lock.
+                lock (_gate)
+                {
+                    if (_disposed || batch.Generation != _generation)
+                        throw new OperationCanceledException(generationToken);
+                }
+                var publication = _tryCommit(batch.Generation, rows);
+                if (publication is null || !IsCurrent(batch.Generation))
+                {
+                    CancelBatch(batch, generationToken);
+                    continue;
+                }
+                _publish(publication);
+
+                if (IsCurrent(batch.Generation))
+                {
+                    foreach (var waiter in batch.Waiters)
+                        waiter.TrySetResult();
+                }
+                else
+                {
+                    CancelBatch(batch, generationToken);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                CancelBatch(batch, generationToken);
+            }
+            catch (Exception ex)
+            {
+                if (IsCurrent(batch.Generation))
+                {
+                    foreach (var waiter in batch.Waiters)
+                        waiter.TrySetException(ex);
+                }
+                else
+                {
+                    CancelBatch(batch, generationToken);
+                }
+            }
+        }
+    }
+
+    private bool IsCurrent(int generation)
+    {
+        lock (_gate)
+            return !_disposed && generation == _generation;
+    }
+
+    private int GetGeneration()
+    {
+        lock (_gate)
+            return _generation;
+    }
+
+    private static IReadOnlyList<SessionInfo> BuildBoundedRows(
+        IReadOnlyList<SessionInfo> sessions)
+    {
+        var rows = new List<SessionInfo>(
+            Math.Min(MaximumPublishedSessions, sessions.Count));
+        var indicesByKey = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var session in sessions)
+        {
+            if (string.IsNullOrWhiteSpace(session.Key))
+                continue;
+            if (indicesByKey.TryGetValue(session.Key, out var index))
+            {
+                rows[index] = session.Clone();
+            }
+            else if (rows.Count < MaximumPublishedSessions)
+            {
+                indicesByKey[session.Key] = rows.Count;
+                rows.Add(session.Clone());
+            }
+        }
+        return rows;
+    }
+
+    private static void CancelBatch(PublicationBatch batch, CancellationToken token)
+    {
+        foreach (var waiter in batch.Waiters)
+            waiter.TrySetCanceled(token);
+    }
+
+    private static void CancelAndDispose(CancellationTokenSource cancellation)
+    {
+        try { cancellation.Cancel(); }
+        finally { cancellation.Dispose(); }
+    }
+
+    public void Dispose()
+    {
+        CancellationTokenSource generation;
+        CancellationToken generationToken;
+        PublicationBatch? canceled;
+        lock (_gate)
+        {
+            if (_disposed) return;
+            _disposed = true;
+            generation = _generationCancellation;
+            generationToken = generation.Token;
+            canceled = _pending;
+            _pending = null;
+        }
+
+        CancelAndDispose(generation);
+        if (canceled is not null)
+            CancelBatch(canceled, generationToken);
+    }
+
+    private sealed class PublicationBatch(int generation, string? agentId)
+    {
+        public int Generation { get; } = generation;
+        public string? AgentId { get; set; } = agentId;
+        public List<TaskCompletionSource> Waiters { get; } = [];
+    }
+}

--- a/src/OpenClaw.Shared/Sessions/SessionQueryCoordinator.cs
+++ b/src/OpenClaw.Shared/Sessions/SessionQueryCoordinator.cs
@@ -1,0 +1,446 @@
+namespace OpenClaw.Shared;
+
+/// <summary>
+/// Owns bounded sessions.list paging, search debounce, and connection-generation
+/// cancellation. It returns only complete accumulated snapshots.
+/// </summary>
+internal sealed class SessionQueryCoordinator : IDisposable
+{
+    public const int PageSize = 100;
+    public const int MaximumPages = 20;
+    public const int MaximumMaterializedSessions = 2000;
+    public static readonly TimeSpan DefaultSearchDebounce = TimeSpan.FromMilliseconds(250);
+
+    private readonly Func<SessionListRequest, CancellationToken, Task<SessionListResult>> _fetchPage;
+    private readonly TimeSpan _searchDebounce;
+    private readonly object _gate = new();
+    private CancellationTokenSource _generationCancellation = new();
+    private CancellationTokenSource? _recentCancellation;
+    private CancellationTokenSource? _searchCancellation;
+    private SessionQuerySnapshot? _recent;
+    private RecentServerQueryIdentity? _recentQueryIdentity;
+    private int _generation;
+    private long _recentIdentity;
+    private long _searchIdentity;
+    private bool _disposed;
+
+    public SessionQueryCoordinator(
+        Func<SessionListRequest, CancellationToken, Task<SessionListResult>> fetchPage,
+        TimeSpan? searchDebounce = null)
+    {
+        _fetchPage = fetchPage ?? throw new ArgumentNullException(nameof(fetchPage));
+        _searchDebounce = searchDebounce ?? DefaultSearchDebounce;
+    }
+
+    public int ConnectionGeneration
+    {
+        get { lock (_gate) return _generation; }
+    }
+
+    public void AdvanceConnectionGeneration()
+    {
+        CancellationTokenSource oldGeneration;
+        lock (_gate)
+        {
+            if (_disposed) return;
+            _generation++;
+            _recent = null;
+            _recentQueryIdentity = null;
+            _searchIdentity++;
+            _recentIdentity++;
+            oldGeneration = _generationCancellation;
+            _generationCancellation = new CancellationTokenSource();
+            _recentCancellation = null;
+            _searchCancellation = null;
+        }
+        CancelAndDispose(oldGeneration);
+    }
+
+    public Task<SessionQuerySnapshot> LoadRecentAsync(
+        SessionQuery? query = null,
+        CancellationToken cancellationToken = default,
+        int? expectedConnectionGeneration = null)
+    {
+        query ??= new SessionQuery();
+        return LoadAndRememberRecentAsync(
+            query,
+            cancellationToken,
+            expectedConnectionGeneration);
+    }
+
+    public async Task<SessionQuerySnapshot> SearchAsync(
+        SessionQuery query,
+        CancellationToken cancellationToken = default,
+        int? expectedConnectionGeneration = null)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        var normalized = query.Search?.Trim();
+        if (string.IsNullOrEmpty(normalized))
+            return ClearSearch(query);
+
+        CancellationTokenSource searchCancellation;
+        CancellationToken generationToken;
+        int generation;
+        long identity;
+        CancellationTokenSource? oldSearch;
+        lock (_gate)
+        {
+            ThrowIfDisposed();
+            ThrowIfUnexpectedGeneration(expectedConnectionGeneration);
+            generation = _generation;
+            generationToken = _generationCancellation.Token;
+            identity = ++_searchIdentity;
+            oldSearch = _searchCancellation;
+            searchCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+                generationToken, cancellationToken);
+            _searchCancellation = searchCancellation;
+        }
+        Cancel(oldSearch);
+
+        try
+        {
+            await Task.Delay(_searchDebounce, searchCancellation.Token).ConfigureAwait(false);
+            var normalizedQuery = new SessionQuery
+            {
+                AgentId = query.AgentId,
+                Search = normalized,
+                ConfiguredAgentsOnly = query.ConfiguredAgentsOnly,
+                Archived = query.Archived,
+                IncludeBackground = query.IncludeBackground,
+                PinnedSessions = query.PinnedSessions,
+            };
+            var snapshot = await LoadCoreAsync(
+                normalizedQuery, generation, 0, searchCancellation.Token).ConfigureAwait(false);
+            lock (_gate)
+            {
+                ThrowIfStale(generation, identity);
+            }
+            return snapshot;
+        }
+        finally
+        {
+            lock (_gate)
+            {
+                if (ReferenceEquals(_searchCancellation, searchCancellation))
+                    _searchCancellation = null;
+            }
+            searchCancellation.Dispose();
+        }
+    }
+
+    public SessionQuerySnapshot ClearSearch(SessionQuery? query = null)
+    {
+        query ??= new SessionQuery();
+        CancellationTokenSource? oldSearch;
+        SessionQuerySnapshot? recent;
+        RecentServerQueryIdentity? recentQueryIdentity;
+        int generation;
+        lock (_gate)
+        {
+            ThrowIfDisposed();
+            _searchIdentity++;
+            oldSearch = _searchCancellation;
+            _searchCancellation = null;
+            recent = _recent;
+            recentQueryIdentity = _recentQueryIdentity;
+            generation = _generation;
+        }
+        Cancel(oldSearch);
+
+        var requestedIdentity = RecentServerQueryIdentity.Create(query);
+        if (recent is null || recentQueryIdentity != requestedIdentity)
+        {
+            return new SessionQuerySnapshot
+            {
+                ConnectionGeneration = generation,
+                Sessions = PinAndFilter(Array.Empty<SessionInfo>(), query),
+                MaterializedSessions = Array.Empty<SessionInfo>(),
+            };
+        }
+
+        return new SessionQuerySnapshot
+        {
+            Search = recent.Search,
+            ConnectionGeneration = recent.ConnectionGeneration,
+            PagesRead = recent.PagesRead,
+            UnsupportedRequestFields = recent.UnsupportedRequestFields,
+            SearchExecutionMode = recent.SearchExecutionMode,
+            Sessions = PinAndFilter(recent.MaterializedSessions, query),
+            MaterializedSessions = recent.MaterializedSessions,
+            RequestIdentity = recent.RequestIdentity,
+        };
+    }
+
+    private async Task<SessionQuerySnapshot> LoadAndRememberRecentAsync(
+        SessionQuery query,
+        CancellationToken cancellationToken,
+        int? expectedConnectionGeneration)
+    {
+        CancellationTokenSource recentCancellation;
+        CancellationTokenSource? oldRecent;
+        int generation;
+        long identity;
+        lock (_gate)
+        {
+            ThrowIfDisposed();
+            ThrowIfUnexpectedGeneration(expectedConnectionGeneration);
+            generation = _generation;
+            identity = ++_recentIdentity;
+            oldRecent = _recentCancellation;
+            recentCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+                _generationCancellation.Token, cancellationToken);
+            _recentCancellation = recentCancellation;
+        }
+        Cancel(oldRecent);
+        try
+        {
+            var recentQuery = new SessionQuery
+            {
+                AgentId = query.AgentId,
+                ConfiguredAgentsOnly = query.ConfiguredAgentsOnly,
+                Archived = query.Archived,
+                IncludeBackground = query.IncludeBackground,
+                PinnedSessions = query.PinnedSessions,
+            };
+            var snapshot = await LoadCoreAsync(
+                recentQuery, generation, identity, recentCancellation.Token).ConfigureAwait(false);
+            lock (_gate)
+            {
+                if (_generation != generation || _recentIdentity != identity || _disposed)
+                    throw new OperationCanceledException("Session query response is stale.");
+                _recent = snapshot;
+                _recentQueryIdentity = RecentServerQueryIdentity.Create(recentQuery);
+            }
+            return snapshot;
+        }
+        finally
+        {
+            lock (_gate)
+            {
+                if (ReferenceEquals(_recentCancellation, recentCancellation))
+                    _recentCancellation = null;
+            }
+            recentCancellation.Dispose();
+        }
+    }
+
+    private async Task<SessionQuerySnapshot> LoadCoreAsync(
+        SessionQuery query,
+        int generation,
+        long requestIdentity,
+        CancellationToken cancellationToken)
+    {
+        var materialized = new List<SessionInfo>(PageSize);
+        var indicesByKey = new Dictionary<string, int>(StringComparer.Ordinal);
+        var seenOffsets = new HashSet<int>();
+        var offset = 0;
+        var pagesRead = 0;
+        var unsupportedFields = SessionListRequestFields.None;
+
+        while (pagesRead < MaximumPages &&
+               materialized.Count < MaximumMaterializedSessions &&
+               seenOffsets.Add(offset))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var page = await _fetchPage(new SessionListRequest
+            {
+                AgentId = query.AgentId,
+                Limit = PageSize,
+                Offset = offset,
+                Search = string.IsNullOrWhiteSpace(query.Search) ? null : query.Search,
+                ConfiguredAgentsOnly = query.ConfiguredAgentsOnly ? true : null,
+                Archived = query.Archived,
+            }, cancellationToken).ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+            EnsureCurrentGeneration(generation);
+
+            pagesRead++;
+            unsupportedFields |= page.UnsupportedRequestFields;
+            foreach (var session in page.Sessions)
+            {
+                if (string.IsNullOrWhiteSpace(session.Key))
+                    continue;
+                if (indicesByKey.TryGetValue(session.Key, out var index))
+                {
+                    materialized[index] = session;
+                }
+                else if (materialized.Count < MaximumMaterializedSessions)
+                {
+                    indicesByKey[session.Key] = materialized.Count;
+                    materialized.Add(session);
+                }
+            }
+
+            if (unsupportedFields.HasFlag(SessionListRequestFields.Offset) ||
+                materialized.Count >= MaximumMaterializedSessions)
+                break;
+
+            var nextOffset = ResolveNextOffset(page, offset);
+            if (!nextOffset.HasValue || nextOffset.Value <= offset || seenOffsets.Contains(nextOffset.Value))
+                break;
+            offset = nextOffset.Value;
+        }
+
+        var all = materialized.Select(static session => session.Clone()).ToArray();
+        var normalizedSearch = string.IsNullOrWhiteSpace(query.Search) ? null : query.Search.Trim();
+        var searchExecutionMode = normalizedSearch is null
+            ? SessionSearchExecutionMode.None
+            : unsupportedFields.HasFlag(SessionListRequestFields.Search)
+                ? SessionSearchExecutionMode.LegacyLocal
+                : SessionSearchExecutionMode.Server;
+        IReadOnlyList<SessionInfo> resultRows =
+            normalizedSearch is not null &&
+            unsupportedFields.HasFlag(SessionListRequestFields.Search)
+            ? all.Where(session => MatchesLocalSearch(session, normalizedSearch)).ToArray()
+            : all;
+        return new SessionQuerySnapshot
+        {
+            Search = normalizedSearch,
+            ConnectionGeneration = generation,
+            PagesRead = pagesRead,
+            UnsupportedRequestFields = unsupportedFields,
+            SearchExecutionMode = searchExecutionMode,
+            Sessions = PinAndFilter(resultRows, query),
+            MaterializedSessions = resultRows,
+            RequestIdentity = requestIdentity,
+        };
+    }
+
+    private static int? ResolveNextOffset(SessionListResult page, int currentOffset)
+    {
+        if (page.HasMore == false)
+            return null;
+        if (page.NextOffset.HasValue)
+            return page.NextOffset.Value;
+        if (page.HasMore == true)
+            return null;
+        if (page.Sessions.Count < PageSize)
+            return null;
+        var next = (long)currentOffset + page.Sessions.Count;
+        return next <= int.MaxValue ? (int)next : null;
+    }
+
+    private static IReadOnlyList<SessionInfo> PinAndFilter(
+        IReadOnlyList<SessionInfo> sessions,
+        SessionQuery query)
+    {
+        var result = new List<SessionInfo>(sessions.Count + query.PinnedSessions.Count);
+        var keys = new HashSet<string>(StringComparer.Ordinal);
+        var pinsByKey = new Dictionary<string, SessionInfo>(StringComparer.Ordinal);
+        var pinOrder = new List<string>(query.PinnedSessions.Count);
+        foreach (var pinned in query.PinnedSessions)
+        {
+            if (string.IsNullOrWhiteSpace(pinned.Key))
+                continue;
+            if (!pinsByKey.ContainsKey(pinned.Key))
+                pinOrder.Add(pinned.Key);
+            pinsByKey[pinned.Key] = pinned;
+        }
+
+        foreach (var session in sessions)
+        {
+            if (pinsByKey.TryGetValue(session.Key, out var current))
+            {
+                if (keys.Add(session.Key))
+                    result.Add(current.Clone());
+                continue;
+            }
+            if (!query.IncludeBackground && SessionDisplayResolver.IsBackground(session))
+                continue;
+            if (keys.Add(session.Key))
+                result.Add(session.Clone());
+        }
+        foreach (var key in pinOrder)
+        {
+            if (keys.Add(key))
+                result.Add(pinsByKey[key].Clone());
+        }
+        return result;
+    }
+
+    private static bool MatchesLocalSearch(SessionInfo session, string search)
+    {
+        var display = SessionDisplayResolver.Resolve(session);
+        return Contains(display.Title, search) ||
+               Contains(display.Subtitle, search);
+    }
+
+    private static bool Contains(string? value, string search) =>
+        !string.IsNullOrWhiteSpace(value) &&
+        value.Contains(search, StringComparison.OrdinalIgnoreCase);
+
+    private readonly record struct RecentServerQueryIdentity(
+        string? AgentId,
+        bool ConfiguredAgentsOnly,
+        bool? Archived,
+        int PageSize,
+        int MaximumPages,
+        int MaximumMaterializedSessions)
+    {
+        public static RecentServerQueryIdentity Create(SessionQuery query) => new(
+            string.IsNullOrWhiteSpace(query.AgentId) ? null : query.AgentId,
+            query.ConfiguredAgentsOnly,
+            query.Archived,
+            SessionQueryCoordinator.PageSize,
+            SessionQueryCoordinator.MaximumPages,
+            SessionQueryCoordinator.MaximumMaterializedSessions);
+    }
+
+    private void EnsureCurrentGeneration(int generation)
+    {
+        lock (_gate)
+        {
+            if (_disposed || _generation != generation)
+                throw new OperationCanceledException("Session query belongs to a stale connection generation.");
+        }
+    }
+
+    private void ThrowIfStale(int generation, long identity)
+    {
+        if (_disposed || _generation != generation || _searchIdentity != identity)
+            throw new OperationCanceledException("Session search response is stale.");
+    }
+
+    private void ThrowIfUnexpectedGeneration(int? expectedConnectionGeneration)
+    {
+        if (expectedConnectionGeneration.HasValue &&
+            expectedConnectionGeneration.Value != _generation)
+        {
+            throw new OperationCanceledException(
+                "Session query request belongs to a stale connection generation.");
+        }
+    }
+
+    private void ThrowIfDisposed() => ObjectDisposedException.ThrowIf(_disposed, this);
+
+    private static void CancelAndDispose(CancellationTokenSource? cancellation)
+    {
+        if (cancellation is null) return;
+        try { cancellation.Cancel(); }
+        finally { cancellation.Dispose(); }
+    }
+
+    private static void Cancel(CancellationTokenSource? cancellation)
+    {
+        if (cancellation is null) return;
+        try { cancellation.Cancel(); }
+        catch (ObjectDisposedException)
+        {
+            // The superseded query completed and disposed its own CTS first.
+        }
+    }
+
+    public void Dispose()
+    {
+        CancellationTokenSource generation;
+        lock (_gate)
+        {
+            if (_disposed) return;
+            _disposed = true;
+            generation = _generationCancellation;
+            _recentCancellation = null;
+            _searchCancellation = null;
+        }
+        CancelAndDispose(generation);
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Chat/IChatGatewayBridge.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/IChatGatewayBridge.cs
@@ -70,6 +70,20 @@ public interface IChatGatewayBridge : IDisposable
             Error = "Response-aware sessions.compact is not supported by this chat bridge."
         });
     Task RequestSessionsAsync() => Task.CompletedTask;
+    /// <summary>
+    /// Typed deep session discovery API for picker consumers. Results do not fan
+    /// out through the eager, first-page <see cref="SessionsUpdated"/> event.
+    /// </summary>
+    Task<SessionQuerySnapshot> QuerySessionsAsync(
+        SessionQuery query,
+        CancellationToken cancellationToken = default) =>
+        Task.FromResult(new SessionQuerySnapshot
+        {
+            Sessions = GetSessionList(),
+        });
+    /// <summary>Restores the last coherent recent snapshot without another RPC.</summary>
+    SessionQuerySnapshot ClearSessionSearch(SessionQuery? query = null) =>
+        new() { Sessions = GetSessionList() };
     Task PatchSessionModelAsync(string sessionKey, string model);
     /// <summary>
     /// Clears the session's model override (tri-state <c>sessions.patch</c> with
@@ -84,6 +98,7 @@ public interface IChatGatewayBridge : IDisposable
     Task ResolveExecApprovalAsync(string approvalId, string decision);
 
     event EventHandler<ConnectionStatus>? StatusChanged;
+    /// <summary>Compatibility event bounded to the first 100 sessions.</summary>
     event EventHandler<SessionInfo[]>? SessionsUpdated;
     event EventHandler<SessionCommandResult>? SessionCommandCompleted;
     event EventHandler<ChatMessageInfo>? ChatMessageReceived;
@@ -234,6 +249,14 @@ public sealed class GatewayClientChatBridge : IChatGatewayBridge
 
     public Task RequestSessionsAsync() =>
         _client.RequestSessionsAsync();
+
+    public Task<SessionQuerySnapshot> QuerySessionsAsync(
+        SessionQuery query,
+        CancellationToken cancellationToken = default) =>
+        _client.QuerySessionsAsync(query, cancellationToken);
+
+    public SessionQuerySnapshot ClearSessionSearch(SessionQuery? query = null) =>
+        _client.ClearSessionSearch(query);
 
     public Task<ChatHistoryInfo> RequestChatHistoryAsync(string? sessionKey) =>
         _client.RequestChatHistoryAsync(sessionKey);

--- a/tests/OpenClaw.Shared.Tests/GatewayProtocolLiveRoundTripTests.cs
+++ b/tests/OpenClaw.Shared.Tests/GatewayProtocolLiveRoundTripTests.cs
@@ -126,6 +126,48 @@ public sealed class GatewayProtocolLiveRoundTripTests : IDisposable
     }
 
     [Fact]
+    public async Task CheckHealth_TrackedResponse_PublishesHealthAndPreservesDeepRequest()
+    {
+        using var server = new LoopbackGatewayServer();
+        server.OnMethod("health", _ => new
+        {
+            uptimeMs = 1234,
+            channels = new
+            {
+                telegram = new { status = "ready", configured = true },
+            },
+        });
+        var client = new OpenClawGatewayClient(
+            server.WebSocketUrl, "test-token", new TestLogger(),
+            identityPath: _identityDir);
+        var channelHealth = new TaskCompletionSource<ChannelHealth[]>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var gatewaySelf = new TaskCompletionSource<GatewaySelfInfo>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        client.ChannelHealthUpdated += (_, health) => channelHealth.TrySetResult(health);
+        client.GatewaySelfUpdated += (_, self) => gatewaySelf.TrySetResult(self);
+
+        try
+        {
+            await ConnectAndWaitAsync(client, server);
+
+            await client.CheckHealthAsync();
+
+            var channels = await channelHealth.Task.WaitAsync(TimeSpan.FromSeconds(20));
+            var self = await gatewaySelf.Task.WaitAsync(TimeSpan.FromSeconds(20));
+            var frame = await server.WaitFrameAsync("health", occurrence: 0, timeoutMs: 20000);
+            using var document = JsonDocument.Parse(frame);
+            Assert.True(document.RootElement.GetProperty("params").GetProperty("deep").GetBoolean());
+            Assert.Equal("telegram", Assert.Single(channels).Name);
+            Assert.Equal(1234, self.UptimeMs);
+        }
+        finally
+        {
+            await client.DisconnectAsync();
+        }
+    }
+
+    [Fact]
     public async Task CronRunDetailed_FallsBackToLegacyIdPayload_WhenJobIdPayloadIsRejected()
     {
         using var server = new LoopbackGatewayServer();
@@ -212,6 +254,990 @@ public sealed class GatewayProtocolLiveRoundTripTests : IDisposable
         {
             await client.DisconnectAsync();
         }
+    }
+
+    [Fact]
+    public async Task SessionsList_BoundedEventStaysAtOneHundred_WhileQueryPagesOneThousand()
+    {
+        using var server = new LoopbackGatewayServer();
+        server.OnMethod("sessions.list", parameters =>
+        {
+            var offset = parameters.TryGetProperty("offset", out var offsetProperty)
+                ? offsetProperty.GetInt32()
+                : 0;
+            var limit = parameters.GetProperty("limit").GetInt32();
+            var search = parameters.TryGetProperty("search", out var searchProperty)
+                ? searchProperty.GetString()
+                : null;
+            if (!string.IsNullOrEmpty(search))
+            {
+                return new
+                {
+                    sessions = new[] { new { key = "agent:main:900", label = "Session 900" } },
+                    count = 1,
+                    totalCount = 1,
+                    limitApplied = limit,
+                    offset,
+                    nextOffset = (int?)null,
+                    hasMore = false,
+                };
+            }
+
+            var rows = Enumerable.Range(offset, Math.Min(limit, 1000 - offset))
+                .Select(index => new { key = $"agent:main:{index}", label = $"Session {index}" })
+                .ToArray();
+            var hasMore = offset + rows.Length < 1000;
+            return new
+            {
+                sessions = rows,
+                count = rows.Length,
+                totalCount = 1000,
+                limitApplied = limit,
+                offset,
+                nextOffset = hasMore ? offset + rows.Length : (int?)null,
+                hasMore,
+            };
+        });
+        var logger = new TestLogger();
+        var client = new OpenClawGatewayClient(
+            server.WebSocketUrl, "test-token", logger,
+            identityPath: _identityDir);
+        var published = new TaskCompletionSource<SessionInfo[]>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        client.SessionsUpdated += (_, sessions) => published.TrySetResult(sessions);
+
+        try
+        {
+            await ConnectAndWaitAsync(client, server);
+
+            await client.RequestSessionsAsync();
+            var visible = await published.Task.WaitAsync(TimeSpan.FromSeconds(20));
+            var recent = await client.QuerySessionsAsync(new SessionQuery { IncludeBackground = true });
+            var search = await client.QuerySessionsAsync(new SessionQuery
+            {
+                Search = "Session 900",
+                IncludeBackground = true,
+            });
+
+            Assert.Equal(SessionPublicationCoordinator.MaximumPublishedSessions, visible.Length);
+            Assert.Equal(1000, recent.Sessions.Count);
+            Assert.Equal(10, recent.PagesRead);
+            Assert.Equal("agent:main:900", Assert.Single(search.Sessions).Key);
+            using var publicationFrame = JsonDocument.Parse(server.FrameFor("sessions.list", 0));
+            var publicationParameters = publicationFrame.RootElement.GetProperty("params");
+            Assert.Equal(["limit"], publicationParameters.EnumerateObject().Select(p => p.Name).ToArray());
+            Assert.Equal(
+                SessionPublicationCoordinator.MaximumPublishedSessions,
+                publicationParameters.GetProperty("limit").GetInt32());
+            using var queryFrame = JsonDocument.Parse(server.FrameFor("sessions.list", 1));
+            var queryParameters = queryFrame.RootElement.GetProperty("params");
+            Assert.Equal(["limit", "offset"], queryParameters.EnumerateObject().Select(p => p.Name).ToArray());
+            Assert.Equal(100, queryParameters.GetProperty("limit").GetInt32());
+            Assert.Equal(0, queryParameters.GetProperty("offset").GetInt32());
+            Assert.DoesNotContain("agent:main:900", logger.Logs);
+        }
+        finally
+        {
+            await client.DisconnectAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Bootstrap_SubscribesBeforeBoundedRefresh_AndChangedEventQueuesTrailingRefresh()
+    {
+        using var server = new LoopbackGatewayServer
+        {
+            SendChallengeOnConnect = true,
+            ProcessRequestsConcurrently = true,
+        };
+        var firstPageStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirstPage = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var listCalls = 0;
+        server.OnMethod("connect", _ => new
+        {
+            type = "hello-ok",
+            protocol = 3,
+            server = new { version = "test" },
+        });
+        server.OnMethod("health", _ => new { ok = true });
+        server.OnMethodAsync("sessions.list", async parameters =>
+        {
+            var call = Interlocked.Increment(ref listCalls);
+            var offset = parameters.TryGetProperty("offset", out var offsetProperty)
+                ? offsetProperty.GetInt32()
+                : 0;
+            if (call == 1)
+            {
+                firstPageStarted.TrySetResult();
+                await releaseFirstPage.Task;
+                return SessionPage(
+                    Enumerable.Range(0, 100)
+                        .Select(index => new { key = $"agent:main:{index}", label = "Stale" })
+                        .ToArray(),
+                    offset: 0,
+                    nextOffset: 100,
+                    hasMore: true);
+            }
+
+            return SessionPage(
+                Enumerable.Range(0, 100)
+                    .Select(index => new
+                    {
+                        key = $"agent:main:{index}",
+                        label = index == 0 ? "Changed during refresh" : $"Session {index}",
+                    })
+                    .ToArray(),
+                offset: 0,
+                nextOffset: 100,
+                hasMore: true);
+        });
+        var logger = new TestLogger();
+        var client = new OpenClawGatewayClient(
+            server.WebSocketUrl, "test-token", logger,
+            identityPath: _identityDir);
+        var publications = new ConcurrentQueue<SessionInfo[]>();
+        var changedPublished = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        client.SessionsUpdated += (_, sessions) =>
+        {
+            publications.Enqueue(sessions);
+            if (sessions.Any(session => session.Label == "Changed during refresh"))
+                changedPublished.TrySetResult();
+        };
+
+        try
+        {
+            await ConnectAndWaitAsync(client, server);
+            await firstPageStarted.Task.WaitAsync(TimeSpan.FromSeconds(20));
+            await WaitUntilAsync(
+                () =>
+                {
+                    var startupMethods = server.AllMethods.ToArray();
+                    return startupMethods.Contains("usage.status")
+                           && startupMethods.Contains("node.list")
+                           && startupMethods.Contains("agents.list");
+                },
+                TimeSpan.FromSeconds(20));
+
+            var methods = server.AllMethods.ToArray();
+            var healthIndex = Array.IndexOf(methods, "health");
+            var subscribeIndex = Array.IndexOf(methods, "sessions.subscribe");
+            var listIndex = Array.IndexOf(methods, "sessions.list");
+            Assert.True(healthIndex >= 0, "health was not sent.");
+            Assert.True(subscribeIndex >= 0, "sessions.subscribe was not sent.");
+            Assert.True(listIndex >= 0, "sessions.list was not sent.");
+            Assert.True(healthIndex < subscribeIndex, "health must precede sessions.subscribe.");
+            Assert.True(subscribeIndex < listIndex, "sessions.subscribe must precede sessions.list.");
+            Assert.Contains("usage.status", methods);
+            Assert.Contains("node.list", methods);
+            Assert.Contains("agents.list", methods);
+
+            await server.SendEventAsync("sessions.changed", new { });
+            await WaitUntilAsync(
+                () => logger.Logs.Any(log =>
+                    log.Contains("sessions.changed received", StringComparison.Ordinal)),
+                TimeSpan.FromSeconds(20));
+            releaseFirstPage.TrySetResult();
+            await changedPublished.Task.WaitAsync(TimeSpan.FromSeconds(20));
+
+            Assert.Equal(2, publications.Count);
+            Assert.All(
+                publications,
+                publication => Assert.Equal(
+                    SessionPublicationCoordinator.MaximumPublishedSessions,
+                    publication.Length));
+            var publication = publications.Last();
+            Assert.Equal(
+                "Changed during refresh",
+                Assert.Single(publication, session => session.Key == "agent:main:0").Label);
+            Assert.Equal(2, listCalls);
+        }
+        finally
+        {
+            releaseFirstPage.TrySetResult();
+            await client.DisconnectAsync();
+        }
+    }
+
+    [Fact]
+    public async Task SessionsChanged_SustainedBurstCannotStarveBoundedPublication()
+    {
+        using var server = new LoopbackGatewayServer();
+        var firstRequestStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var calls = 0;
+        server.OnMethodAsync("sessions.list", async _ =>
+        {
+            var call = Interlocked.Increment(ref calls);
+            firstRequestStarted.TrySetResult();
+            await Task.Delay(40);
+            return SessionPage(
+                Enumerable.Range(0, 100)
+                    .Select(index => new
+                    {
+                        key = $"agent:main:{index}",
+                        label = $"Refresh {call}",
+                    })
+                    .ToArray(),
+                offset: 0,
+                nextOffset: 100,
+                hasMore: true);
+        });
+        var client = new OpenClawGatewayClient(
+            server.WebSocketUrl, "test-token", new TestLogger(),
+            identityPath: _identityDir);
+        var firstPublication = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var publicationCount = 0;
+        client.SessionsUpdated += (_, sessions) =>
+        {
+            Assert.Equal(
+                SessionPublicationCoordinator.MaximumPublishedSessions,
+                sessions.Length);
+            if (Interlocked.Increment(ref publicationCount) == 1)
+                firstPublication.TrySetResult();
+        };
+
+        try
+        {
+            await ConnectAndWaitAsync(client, server);
+            await server.SendEventAsync("sessions.changed", new { });
+            await firstRequestStarted.Task.WaitAsync(TimeSpan.FromSeconds(20));
+            var burst = Task.Run(async () =>
+            {
+                for (var index = 0; index < 80; index++)
+                {
+                    await server.SendEventAsync("sessions.changed", new { });
+                    await Task.Delay(5);
+                }
+            });
+
+            await firstPublication.Task.WaitAsync(TimeSpan.FromSeconds(20));
+            Assert.False(burst.IsCompleted);
+            await burst;
+            await WaitUntilAsync(
+                () => Volatile.Read(ref publicationCount) >= 2,
+                TimeSpan.FromSeconds(20));
+
+            Assert.InRange(calls, 2, 40);
+            Assert.InRange(publicationCount, 2, calls);
+        }
+        finally
+        {
+            await client.DisconnectAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Bootstrap_DisconnectCancelsSlowRefreshWithoutLatePublication()
+    {
+        using var server = new LoopbackGatewayServer
+        {
+            SendChallengeOnConnect = true,
+            ProcessRequestsConcurrently = true,
+        };
+        var firstPageStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirstPage = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var listCalls = 0;
+        server.OnMethod("connect", _ => new
+        {
+            type = "hello-ok",
+            protocol = 3,
+            server = new { version = "test" },
+        });
+        server.OnMethod("health", _ => new { ok = true });
+        server.OnMethodAsync("sessions.list", async _ =>
+        {
+            Interlocked.Increment(ref listCalls);
+            firstPageStarted.TrySetResult();
+            await releaseFirstPage.Task;
+            return SessionPage(
+                Enumerable.Range(0, 100)
+                    .Select(index => new { key = $"agent:main:{index}", label = "Late stale row" })
+                    .ToArray(),
+                offset: 0,
+                nextOffset: 100,
+                hasMore: true);
+        });
+        var client = new OpenClawGatewayClient(
+            server.WebSocketUrl, "test-token", new TestLogger(),
+            identityPath: _identityDir);
+        var publications = new ConcurrentQueue<SessionInfo[]>();
+        client.SessionsUpdated += (_, sessions) => publications.Enqueue(sessions);
+
+        try
+        {
+            await ConnectAndWaitAsync(client, server);
+            await firstPageStarted.Task.WaitAsync(TimeSpan.FromSeconds(20));
+            Assert.Contains("sessions.subscribe", server.AllMethods);
+            await WaitUntilAsync(
+                () =>
+                {
+                    var startupMethods = server.AllMethods.ToArray();
+                    return startupMethods.Contains("usage.status")
+                           && startupMethods.Contains("node.list")
+                           && startupMethods.Contains("agents.list");
+                },
+                TimeSpan.FromSeconds(20));
+
+            var disconnect = client.DisconnectAsync();
+            Assert.False(client.HasHandshakeSnapshot);
+            releaseFirstPage.TrySetResult();
+            await disconnect.WaitAsync(TimeSpan.FromSeconds(20));
+            await Task.Delay(100);
+
+            Assert.Empty(publications);
+            Assert.Equal(1, listCalls);
+            var methods = server.AllMethods.ToArray();
+            Assert.Contains("usage.status", methods);
+            Assert.Contains("node.list", methods);
+            Assert.Contains("agents.list", methods);
+        }
+        finally
+        {
+            releaseFirstPage.TrySetResult();
+            client.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task Bootstrap_SlowBoundedCatchUp_DoesNotBlockUnrelatedStartupReads()
+    {
+        using var server = new LoopbackGatewayServer
+        {
+            SendChallengeOnConnect = true,
+            ProcessRequestsConcurrently = true,
+        };
+        var refreshStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseRefresh = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var listCalls = 0;
+        server.OnMethod("connect", _ => new
+        {
+            type = "hello-ok",
+            protocol = 3,
+            server = new { version = "test" },
+        });
+        server.OnMethod("health", _ => new { ok = true });
+        server.OnMethodAsync("sessions.list", async parameters =>
+        {
+            Interlocked.Increment(ref listCalls);
+            var offset = parameters.TryGetProperty("offset", out var offsetProperty)
+                ? offsetProperty.GetInt32()
+                : 0;
+            refreshStarted.TrySetResult();
+            await releaseRefresh.Task;
+            return SessionPage(
+                Enumerable.Range(offset, 100)
+                    .Select(index => new { key = $"agent:main:{index}", label = $"Session {index}" })
+                    .ToArray(),
+                offset,
+                nextOffset: offset < 1900 ? offset + 100 : null,
+                hasMore: offset < 1900);
+        });
+        var client = new OpenClawGatewayClient(
+            server.WebSocketUrl, "test-token", new TestLogger(),
+            identityPath: _identityDir);
+        var published = new TaskCompletionSource<SessionInfo[]>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        client.SessionsUpdated += (_, sessions) =>
+        {
+            if (sessions.Length == SessionPublicationCoordinator.MaximumPublishedSessions)
+                published.TrySetResult(sessions);
+        };
+
+        try
+        {
+            await ConnectAndWaitAsync(client, server);
+            await refreshStarted.Task.WaitAsync(TimeSpan.FromSeconds(20));
+            await WaitUntilAsync(
+                () =>
+                {
+                    var startupMethods = server.AllMethods.ToArray();
+                    return startupMethods.Contains("usage.status")
+                           && startupMethods.Contains("node.list")
+                           && startupMethods.Contains("agents.list");
+                },
+                TimeSpan.FromSeconds(20));
+
+            var methods = server.AllMethods.ToArray();
+            Assert.True(
+                Array.IndexOf(methods, "health") < Array.IndexOf(methods, "sessions.subscribe"),
+                "health must precede sessions.subscribe.");
+            Assert.True(
+                Array.IndexOf(methods, "sessions.subscribe") < Array.IndexOf(methods, "sessions.list"),
+                "sessions.subscribe must precede sessions.list.");
+            Assert.DoesNotContain("models.list", methods);
+            Assert.Equal(1, listCalls);
+
+            releaseRefresh.TrySetResult();
+            Assert.Equal(
+                SessionPublicationCoordinator.MaximumPublishedSessions,
+                (await published.Task.WaitAsync(TimeSpan.FromSeconds(20))).Length);
+            Assert.Equal(1, listCalls);
+        }
+        finally
+        {
+            releaseRefresh.TrySetResult();
+            await client.DisconnectAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Bootstrap_SessionPagingFailure_DoesNotBlockUnrelatedStartupReads()
+    {
+        using var server = new LoopbackGatewayServer { SendChallengeOnConnect = true };
+        server.OnMethod("connect", _ => new
+        {
+            type = "hello-ok",
+            protocol = 3,
+            server = new { version = "test" },
+        });
+        server.OnMethod("health", _ => new { ok = true });
+        server.OnMethod(
+            "sessions.list",
+            _ => LoopbackResponse.Fail(new { code = "SERVER_ERROR", message = "paging failed" }));
+        var logger = new TestLogger();
+        var client = new OpenClawGatewayClient(
+            server.WebSocketUrl, "test-token", logger,
+            identityPath: _identityDir);
+
+        try
+        {
+            await ConnectAndWaitAsync(client, server);
+            await WaitUntilAsync(
+                () =>
+                {
+                    var methods = server.AllMethods.ToArray();
+                    return methods.Contains("usage.status")
+                           && methods.Contains("node.list")
+                           && methods.Contains("agents.list")
+                           && logger.Logs.Any(log =>
+                               log.Contains("sessions.list failed: paging failed", StringComparison.Ordinal));
+                },
+                TimeSpan.FromSeconds(20));
+
+            var methods = server.AllMethods.ToArray();
+            Assert.True(
+                Array.IndexOf(methods, "sessions.subscribe") < Array.IndexOf(methods, "sessions.list"),
+                "sessions.subscribe must precede sessions.list.");
+        }
+        finally
+        {
+            await client.DisconnectAsync();
+        }
+    }
+
+    [Fact]
+    public async Task SessionsList_OffsetRejectionPreservesSupportedFieldsAndCachesCapability()
+    {
+        using var server = new LoopbackGatewayServer();
+        var calls = 0;
+        server.OnMethod("sessions.list", parameters =>
+        {
+            calls++;
+            if (parameters.TryGetProperty("offset", out _))
+            {
+                return LoopbackResponse.Fail(new
+                {
+                    code = "INVALID_REQUEST",
+                    message = "invalid sessions.list params: at root: unexpected property 'offset'",
+                });
+            }
+            Assert.True(parameters.TryGetProperty("limit", out _));
+            Assert.True(parameters.TryGetProperty("search", out _));
+            Assert.True(parameters.TryGetProperty("configuredAgentsOnly", out _));
+            return new
+            {
+                sessions = new[]
+                {
+                    new { key = "agent:main:900", label = "Needle outside newest 100" },
+                },
+            };
+        });
+        var client = new OpenClawGatewayClient(
+            server.WebSocketUrl, "test-token", new TestLogger(),
+            identityPath: _identityDir);
+
+        try
+        {
+            await ConnectAndWaitAsync(client, server);
+            var first = await client.ListSessionsPageAsync(new SessionListRequest
+            {
+                AgentId = "main",
+                Limit = 100,
+                Offset = 0,
+                Search = "needle",
+                ConfiguredAgentsOnly = true,
+            });
+            var second = await client.ListSessionsPageAsync(new SessionListRequest
+            {
+                AgentId = "main",
+                Limit = 100,
+                Offset = 100,
+                Search = "again",
+                ConfiguredAgentsOnly = true,
+            });
+
+            Assert.Equal(SessionListRequestFields.Offset, first.UnsupportedRequestFields);
+            Assert.Equal(SessionListRequestFields.Offset, second.UnsupportedRequestFields);
+            Assert.Equal("agent:main:900", Assert.Single(first.Sessions).Key);
+            Assert.Equal(3, calls);
+            using var expandedFrame = JsonDocument.Parse(server.FrameFor("sessions.list", 0));
+            Assert.Equal(
+                ["agentId", "limit", "offset", "search", "configuredAgentsOnly"],
+                expandedFrame.RootElement.GetProperty("params").EnumerateObject().Select(p => p.Name).ToArray());
+            foreach (var occurrence in new[] { 1, 2 })
+            {
+                using var compatibleFrame = JsonDocument.Parse(server.FrameFor("sessions.list", occurrence));
+                var compatibleParameters = compatibleFrame.RootElement.GetProperty("params");
+                Assert.Equal(
+                    ["agentId", "limit", "search", "configuredAgentsOnly"],
+                    compatibleParameters.EnumerateObject().Select(p => p.Name).ToArray());
+            }
+        }
+        finally
+        {
+            await client.DisconnectAsync();
+        }
+    }
+
+    [Fact]
+    public async Task SessionsList_MultipleRejectedFieldsAreRemovedProgressively()
+    {
+        using var server = new LoopbackGatewayServer();
+        var calls = 0;
+        server.OnMethod("sessions.list", parameters =>
+        {
+            calls++;
+            if (parameters.TryGetProperty("archived", out _))
+            {
+                return LoopbackResponse.Fail(new
+                {
+                    code = "INVALID_REQUEST",
+                    message = "invalid sessions.list params: at root: unexpected property 'archived'",
+                });
+            }
+            if (parameters.TryGetProperty("offset", out _))
+            {
+                return LoopbackResponse.Fail(new
+                {
+                    code = "INVALID_REQUEST",
+                    message = "invalid sessions.list params: at root: unexpected property 'offset'",
+                });
+            }
+            return new { sessions = Array.Empty<object>() };
+        });
+        var client = new OpenClawGatewayClient(
+            server.WebSocketUrl, "test-token", new TestLogger(),
+            identityPath: _identityDir);
+
+        try
+        {
+            await ConnectAndWaitAsync(client, server);
+            var request = new SessionListRequest
+            {
+                Limit = 100,
+                Offset = 0,
+                Search = "needle",
+                ConfiguredAgentsOnly = true,
+                Archived = false,
+            };
+
+            var first = await client.ListSessionsPageAsync(request);
+            var second = await client.ListSessionsPageAsync(request);
+
+            Assert.Equal(
+                SessionListRequestFields.Offset | SessionListRequestFields.Archived,
+                first.UnsupportedRequestFields);
+            Assert.Equal(first.UnsupportedRequestFields, second.UnsupportedRequestFields);
+            Assert.Equal(4, calls);
+            using var finalFrame = JsonDocument.Parse(server.FrameFor("sessions.list", 3));
+            Assert.Equal(
+                ["limit", "search", "configuredAgentsOnly"],
+                finalFrame.RootElement.GetProperty("params").EnumerateObject().Select(p => p.Name).ToArray());
+        }
+        finally
+        {
+            await client.DisconnectAsync();
+        }
+    }
+
+    [Fact]
+    public async Task QuerySessions_SearchRejectionFallsBackLocallyAcrossDeepPages()
+    {
+        using var server = new LoopbackGatewayServer();
+        var calls = 0;
+        server.OnMethod("sessions.list", parameters =>
+        {
+            calls++;
+            if (parameters.TryGetProperty("search", out _))
+            {
+                return LoopbackResponse.Fail(new
+                {
+                    code = "INVALID_REQUEST",
+                    message = "invalid sessions.list params: at root: unexpected property 'search'",
+                });
+            }
+
+            var offset = parameters.GetProperty("offset").GetInt32();
+            var rows = Enumerable.Range(offset, 100)
+                .Select(index => new
+                {
+                    key = $"agent:main:{index}",
+                    label = index == 900 ? "Needle outside newest 100" : $"Session {index}",
+                })
+                .ToArray();
+            return SessionPage(
+                rows,
+                offset,
+                nextOffset: offset < 900 ? offset + 100 : null,
+                hasMore: offset < 900);
+        });
+        var client = new OpenClawGatewayClient(
+            server.WebSocketUrl, "test-token", new TestLogger(),
+            identityPath: _identityDir);
+
+        try
+        {
+            await ConnectAndWaitAsync(client, server);
+
+            var result = await client.QuerySessionsAsync(new SessionQuery
+            {
+                Search = "needle",
+                IncludeBackground = true,
+            });
+
+            Assert.Equal(11, calls);
+            Assert.Equal(10, result.PagesRead);
+            Assert.Equal(SessionSearchExecutionMode.LegacyLocal, result.SearchExecutionMode);
+            Assert.Equal(SessionListRequestFields.Search, result.UnsupportedRequestFields);
+            Assert.Equal("agent:main:900", Assert.Single(result.Sessions).Key);
+            using var retryFrame = JsonDocument.Parse(server.FrameFor("sessions.list", 1));
+            Assert.Equal(
+                ["limit", "offset"],
+                retryFrame.RootElement.GetProperty("params").EnumerateObject().Select(p => p.Name).ToArray());
+        }
+        finally
+        {
+            await client.DisconnectAsync();
+        }
+    }
+
+    [Fact]
+    public async Task SessionsList_ConnectionGenerationAdvance_RejectsLateNegotiationResponse()
+    {
+        using var server = new LoopbackGatewayServer();
+        var firstRequestReceived = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirstResponse = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var calls = 0;
+        server.OnMethodAsync("sessions.list", async parameters =>
+        {
+            if (Interlocked.Increment(ref calls) == 1)
+            {
+                firstRequestReceived.TrySetResult();
+                await releaseFirstResponse.Task;
+                return LoopbackResponse.Fail(new
+                {
+                    code = "INVALID_REQUEST",
+                    message = "unexpected property limit",
+                });
+            }
+
+            Assert.True(parameters.TryGetProperty("limit", out _));
+            Assert.True(parameters.TryGetProperty("offset", out _));
+            return new { sessions = Array.Empty<object>() };
+        });
+        var client = new OpenClawGatewayClient(
+            server.WebSocketUrl, "test-token", new TestLogger(),
+            identityPath: _identityDir);
+
+        try
+        {
+            await ConnectAndWaitAsync(client, server);
+            var stale = client.ListSessionsPageAsync(
+                new SessionListRequest { Limit = 100, Offset = 0 },
+                timeoutMs: 20000);
+            await firstRequestReceived.Task.WaitAsync(TimeSpan.FromSeconds(20));
+
+            var resetCapability = typeof(OpenClawGatewayClient).GetMethod(
+                "ResetSessionListCapability",
+                System.Reflection.BindingFlags.NonPublic |
+                System.Reflection.BindingFlags.Instance);
+            resetCapability!.Invoke(client, null);
+            releaseFirstResponse.TrySetResult();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => stale);
+            var current = await client.ListSessionsPageAsync(
+                new SessionListRequest { Limit = 100, Offset = 0 },
+                timeoutMs: 20000);
+
+            Assert.Equal(
+                SessionListRequestFields.None,
+                current.UnsupportedRequestFields);
+            Assert.Equal(2, calls);
+        }
+        finally
+        {
+            releaseFirstResponse.TrySetResult();
+            await client.DisconnectAsync();
+        }
+    }
+
+    [Theory]
+    [InlineData("AUTH_REQUIRED", "unexpected property limit")]
+    [InlineData("SERVER_ERROR", "unexpected property limit")]
+    [InlineData("INVALID_REQUEST", "validation failed")]
+    [InlineData("INVALID_REQUEST", "unknown parameter archived")]
+    [InlineData("INVALID_REQUEST", "unknown parameter value for search")]
+    public async Task SessionsList_DoesNotBroadlyFallback(string code, string message)
+    {
+        using var server = new LoopbackGatewayServer();
+        var calls = 0;
+        server.OnMethod("sessions.list", _ =>
+        {
+            calls++;
+            return LoopbackResponse.Fail(new { code, message });
+        });
+        var client = new OpenClawGatewayClient(
+            server.WebSocketUrl, "test-token", new TestLogger(),
+            identityPath: _identityDir);
+
+        try
+        {
+            await ConnectAndWaitAsync(client, server);
+
+            var error = await Assert.ThrowsAsync<GatewayRequestException>(() =>
+                client.ListSessionsPageAsync(new SessionListRequest { Limit = 100, Offset = 0 }));
+
+            Assert.Equal(code, error.Code);
+            Assert.Equal(1, calls);
+        }
+        finally
+        {
+            await client.DisconnectAsync();
+        }
+    }
+
+    [Fact]
+    public async Task QuerySessions_MissingOperatorRead_SuppressesDirectQueriesUntilReconnect()
+    {
+        using var server = new LoopbackGatewayServer();
+        var calls = 0;
+        server.OnMethod("sessions.list", _ =>
+        {
+            if (Interlocked.Increment(ref calls) == 1)
+            {
+                return LoopbackResponse.Fail(new
+                {
+                    code = "INVALID_REQUEST",
+                    message = "missing scope: operator.read",
+                });
+            }
+            return SessionPage(
+                new[] { new { key = "agent:main:after-reconnect", label = "Current" } },
+                offset: 0,
+                nextOffset: (int?)null,
+                hasMore: false);
+        });
+        var client = new OpenClawGatewayClient(
+            server.WebSocketUrl, "test-token", new TestLogger(),
+            identityPath: _identityDir);
+
+        try
+        {
+            await ConnectAndWaitAsync(client, server);
+            await Assert.ThrowsAsync<GatewayRequestException>(() =>
+                client.QuerySessionsAsync(new SessionQuery { IncludeBackground = true }));
+            Assert.Equal(1, calls);
+
+            var recent = await client.QuerySessionsAsync(
+                new SessionQuery { IncludeBackground = true });
+            var search = await client.QuerySessionsAsync(new SessionQuery
+            {
+                Search = "needle",
+                IncludeBackground = true,
+            });
+            using var canceled = new CancellationTokenSource();
+            canceled.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                client.QuerySessionsAsync(
+                    new SessionQuery { Search = "canceled", IncludeBackground = true },
+                    canceled.Token));
+
+            Assert.Empty(recent.Sessions);
+            Assert.Empty(search.Sessions);
+            Assert.Equal("needle", search.Search);
+            Assert.Equal(SessionSearchExecutionMode.None, search.SearchExecutionMode);
+            Assert.Equal(0, recent.PagesRead);
+            Assert.Equal(recent.ConnectionGeneration, search.ConnectionGeneration);
+            Assert.Equal(GetSessionListConnectionGeneration(client), recent.ConnectionGeneration);
+            Assert.Equal(GetSessionQueryConnectionGeneration(client), recent.ConnectionGeneration);
+            Assert.Equal(1, calls);
+
+            await client.DisconnectAsync();
+            await ConnectAndWaitAsync(client, server);
+            var afterReconnect = await client.QuerySessionsAsync(
+                new SessionQuery { IncludeBackground = true });
+
+            Assert.Equal("agent:main:after-reconnect", Assert.Single(afterReconnect.Sessions).Key);
+            Assert.True(afterReconnect.ConnectionGeneration > recent.ConnectionGeneration);
+            Assert.Equal(2, calls);
+        }
+        finally
+        {
+            await client.DisconnectAsync();
+        }
+    }
+
+    [Fact]
+    public async Task QuerySessions_LateMissingScopeFromOldConnection_DoesNotSuppressReconnectedQuery()
+    {
+        using var server = new LoopbackGatewayServer
+        {
+            ProcessRequestsConcurrently = true,
+        };
+        var firstRequestReceived = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirstResponse = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var calls = 0;
+        server.OnMethodAsync("sessions.list", async _ =>
+        {
+            if (Interlocked.Increment(ref calls) == 1)
+            {
+                firstRequestReceived.TrySetResult();
+                await releaseFirstResponse.Task;
+                return LoopbackResponse.Fail(new
+                {
+                    code = "INVALID_REQUEST",
+                    message = "missing scope: operator.read",
+                });
+            }
+
+            return SessionPage(
+                new[] { new { key = "agent:main:new-connection", label = "Current" } },
+                offset: 0,
+                nextOffset: (int?)null,
+                hasMore: false);
+        });
+        var client = new OpenClawGatewayClient(
+            server.WebSocketUrl, "test-token", new TestLogger(),
+            identityPath: _identityDir);
+
+        try
+        {
+            await ConnectAndWaitAsync(client, server);
+            var oldGeneration = GetSessionListConnectionGeneration(client);
+            var stale = client.QuerySessionsAsync(
+                new SessionQuery { IncludeBackground = true });
+            await firstRequestReceived.Task.WaitAsync(TimeSpan.FromSeconds(20));
+
+            await client.DisconnectAsync();
+            await ConnectAndWaitAsync(client, server);
+            Assert.True(GetSessionListConnectionGeneration(client) > oldGeneration);
+
+            releaseFirstResponse.TrySetResult();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => stale);
+
+            // Deterministically exercise the old continuation after reconnect.
+            Assert.False(MarkOperatorReadScopeUnavailable(client, oldGeneration));
+
+            var current = await client.QuerySessionsAsync(
+                new SessionQuery { IncludeBackground = true });
+
+            Assert.Equal("agent:main:new-connection", Assert.Single(current.Sessions).Key);
+            Assert.Equal(GetSessionQueryConnectionGeneration(client), current.ConnectionGeneration);
+            Assert.Equal(2, calls);
+        }
+        finally
+        {
+            releaseFirstResponse.TrySetResult();
+            await client.DisconnectAsync();
+        }
+    }
+
+    [Fact]
+    public async Task QuerySessions_UnrelatedGatewayErrorsPropagateWithoutSuppressingNextQuery()
+    {
+        using var server = new LoopbackGatewayServer();
+        var calls = 0;
+        server.OnMethod("sessions.list", _ =>
+        {
+            Interlocked.Increment(ref calls);
+            return LoopbackResponse.Fail(new
+            {
+                code = "SERVER_ERROR",
+                message = "unrelated failure",
+            });
+        });
+        var client = new OpenClawGatewayClient(
+            server.WebSocketUrl, "test-token", new TestLogger(),
+            identityPath: _identityDir);
+
+        try
+        {
+            await ConnectAndWaitAsync(client, server);
+
+            var first = await Assert.ThrowsAsync<GatewayRequestException>(() =>
+                client.QuerySessionsAsync(new SessionQuery { IncludeBackground = true }));
+            var second = await Assert.ThrowsAsync<GatewayRequestException>(() =>
+                client.QuerySessionsAsync(new SessionQuery
+                {
+                    Search = "still queries",
+                    IncludeBackground = true,
+                }));
+
+            Assert.Equal("SERVER_ERROR", first.Code);
+            Assert.Equal("SERVER_ERROR", second.Code);
+            Assert.Equal(2, calls);
+        }
+        finally
+        {
+            await client.DisconnectAsync();
+        }
+    }
+
+    private static int GetSessionListConnectionGeneration(OpenClawGatewayClient client)
+    {
+        var field = typeof(OpenClawGatewayClient).GetField(
+            "_sessionListConnectionGeneration",
+            System.Reflection.BindingFlags.NonPublic |
+            System.Reflection.BindingFlags.Instance);
+        return (int)field!.GetValue(client)!;
+    }
+
+    private static int GetSessionQueryConnectionGeneration(OpenClawGatewayClient client)
+    {
+        var field = typeof(OpenClawGatewayClient).GetField(
+            "_sessionQueries",
+            System.Reflection.BindingFlags.NonPublic |
+            System.Reflection.BindingFlags.Instance);
+        return ((SessionQueryCoordinator)field!.GetValue(client)!).ConnectionGeneration;
+    }
+
+    private static bool MarkOperatorReadScopeUnavailable(
+        OpenClawGatewayClient client,
+        int connectionGeneration)
+    {
+        var method = typeof(OpenClawGatewayClient).GetMethod(
+            "MarkOperatorReadScopeUnavailable",
+            System.Reflection.BindingFlags.NonPublic |
+            System.Reflection.BindingFlags.Instance);
+        return (bool)method!.Invoke(
+            client,
+            new object[]
+            {
+                connectionGeneration,
+                "stale test continuation",
+            })!;
     }
 
     private static void ConfigureResponders(LoopbackGatewayServer server)
@@ -335,6 +1361,29 @@ public sealed class GatewayProtocolLiveRoundTripTests : IDisposable
         }
     }
 
+    private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (!condition() && DateTime.UtcNow < deadline)
+            await Task.Delay(25);
+        Assert.True(condition(), "Condition was not satisfied before timeout.");
+    }
+
+    private static object SessionPage<T>(
+        T[] sessions,
+        int offset,
+        int? nextOffset,
+        bool hasMore) => new
+    {
+        sessions,
+        count = sessions.Length,
+        totalCount = 101,
+        limitApplied = 100,
+        offset,
+        nextOffset,
+        hasMore,
+    };
+
     private void PrintProof(LoopbackGatewayServer server)
     {
         _output.WriteLine("===== Gateway protocol live round-trip: captured request frames =====");
@@ -357,11 +1406,15 @@ public sealed class GatewayProtocolLiveRoundTripTests : IDisposable
         private readonly HttpListener _listener;
         private readonly CancellationTokenSource _cts = new();
         private readonly Task _loop;
-        private readonly Dictionary<string, Func<JsonElement, object>> _responders = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, Func<JsonElement, Task<object>>> _responders = new(StringComparer.Ordinal);
         private readonly ConcurrentQueue<(string Method, string Frame)> _frames = new();
+        private readonly SemaphoreSlim _sendGate = new(1, 1);
+        private WebSocket? _activeSocket;
 
         public int Port { get; }
         public string WebSocketUrl => $"ws://127.0.0.1:{Port}/";
+        public bool SendChallengeOnConnect { get; init; }
+        public bool ProcessRequestsConcurrently { get; init; }
 
         public LoopbackGatewayServer()
         {
@@ -391,7 +1444,11 @@ public sealed class GatewayProtocolLiveRoundTripTests : IDisposable
             throw new InvalidOperationException("Could not bind a loopback HttpListener after multiple attempts", last);
         }
 
-        public void OnMethod(string method, Func<JsonElement, object> responder) => _responders[method] = responder;
+        public void OnMethod(string method, Func<JsonElement, object> responder) =>
+            _responders[method] = parameters => Task.FromResult(responder(parameters));
+
+        public void OnMethodAsync(string method, Func<JsonElement, Task<object>> responder) =>
+            _responders[method] = responder;
 
         public IEnumerable<string> AllFrames
         {
@@ -399,6 +1456,21 @@ public sealed class GatewayProtocolLiveRoundTripTests : IDisposable
             {
                 foreach (var f in _frames) yield return f.Frame;
             }
+        }
+
+        public IEnumerable<string> AllMethods => _frames.Select(frame => frame.Method);
+
+        public async Task SendEventAsync(string eventName, object payload)
+        {
+            var socket = Volatile.Read(ref _activeSocket);
+            if (socket is null || socket.State != WebSocketState.Open)
+                throw new InvalidOperationException("No active gateway socket.");
+            await SendTextAsync(socket, JsonSerializer.Serialize(new
+            {
+                type = "event",
+                @event = eventName,
+                payload,
+            }));
         }
 
         /// <summary>Returns the captured request frame for the Nth occurrence of a method.</summary>
@@ -461,11 +1533,26 @@ public sealed class GatewayProtocolLiveRoundTripTests : IDisposable
             catch { return; }
 
             var socket = wsCtx.WebSocket;
+            Volatile.Write(ref _activeSocket, socket);
             var buffer = new byte[16 * 1024];
             var sb = new StringBuilder();
 
             try
             {
+                if (SendChallengeOnConnect)
+                {
+                    await SendTextAsync(socket, JsonSerializer.Serialize(new
+                    {
+                        type = "event",
+                        @event = "connect.challenge",
+                        payload = new
+                        {
+                            nonce = "loopback-challenge",
+                            ts = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                        },
+                    }));
+                }
+
                 while (socket.State == WebSocketState.Open && !_cts.IsCancellationRequested)
                 {
                     sb.Clear();
@@ -482,11 +1569,25 @@ public sealed class GatewayProtocolLiveRoundTripTests : IDisposable
                     }
                     while (!result.EndOfMessage);
 
-                    await HandleFrameAsync(socket, sb.ToString());
+                    var frame = sb.ToString();
+                    if (ProcessRequestsConcurrently)
+                        _ = HandleFrameSafelyAsync(socket, frame);
+                    else
+                        await HandleFrameAsync(socket, frame);
                 }
             }
             catch (OperationCanceledException) { /* shutting down */ }
             catch { /* client closed */ }
+            finally
+            {
+                Interlocked.CompareExchange(ref _activeSocket, null, socket);
+            }
+        }
+
+        private async Task HandleFrameSafelyAsync(WebSocket socket, string frame)
+        {
+            try { await HandleFrameAsync(socket, frame); }
+            catch { /* client closed or test shutting down */ }
         }
 
         private async Task HandleFrameAsync(WebSocket socket, string frame)
@@ -509,7 +1610,7 @@ public sealed class GatewayProtocolLiveRoundTripTests : IDisposable
             _frames.Enqueue((method, frame));
 
             object payload = _responders.TryGetValue(method, out var responder)
-                ? responder(parameters)
+                ? await responder(parameters)
                 : new { };
 
             var response = payload is LoopbackResponse loopbackResponse
@@ -517,8 +1618,25 @@ public sealed class GatewayProtocolLiveRoundTripTests : IDisposable
                     ? JsonSerializer.Serialize(new { type = "res", id, ok = true, payload = loopbackResponse.Payload })
                     : JsonSerializer.Serialize(new { type = "res", id, ok = false, error = loopbackResponse.Error })
                 : JsonSerializer.Serialize(new { type = "res", id, ok = true, payload });
-            var bytes = Encoding.UTF8.GetBytes(response);
-            await socket.SendAsync(new ArraySegment<byte>(bytes), WebSocketMessageType.Text, endOfMessage: true, CancellationToken.None);
+            await SendTextAsync(socket, response);
+        }
+
+        private async Task SendTextAsync(WebSocket socket, string text)
+        {
+            await _sendGate.WaitAsync(_cts.Token);
+            try
+            {
+                var bytes = Encoding.UTF8.GetBytes(text);
+                await socket.SendAsync(
+                    new ArraySegment<byte>(bytes),
+                    WebSocketMessageType.Text,
+                    endOfMessage: true,
+                    CancellationToken.None);
+            }
+            finally
+            {
+                _sendGate.Release();
+            }
         }
 
         private static int FindFreePort()
@@ -536,12 +1654,13 @@ public sealed class GatewayProtocolLiveRoundTripTests : IDisposable
             try { _listener.Stop(); } catch { }
             try { _listener.Close(); } catch { }
             try { _loop.Wait(TimeSpan.FromSeconds(2)); } catch { }
+            _sendGate.Dispose();
             _cts.Dispose();
         }
     }
 
-    private sealed record LoopbackResponse(bool Ok, object? Payload = null, string? Error = null)
+    private sealed record LoopbackResponse(bool Ok, object? Payload = null, object? Error = null)
     {
-        public static LoopbackResponse Fail(string error) => new(false, Error: error);
+        public static LoopbackResponse Fail(object error) => new(false, Error: error);
     }
 }

--- a/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
@@ -545,6 +545,7 @@ public class OpenClawGatewayClientTests
         var responseTask = client.SendWizardRequestAsync("wizard.start", timeoutMs: 10_000);
         var request = await server.ReceiveTextAsync().WaitAsync(TimeSpan.FromSeconds(2));
         var requestId = ReadRequestId(request);
+        Assert.Equal((1, 0), helper.GetPendingRequestCounts());
 
         await server.SendTextAsync(
             JsonSerializer.Serialize(new
@@ -561,6 +562,72 @@ public class OpenClawGatewayClientTests
         Assert.Equal((0, 0), helper.GetPendingRequestCounts());
 
         client.Dispose();
+        Assert.Equal((0, 0), helper.GetPendingRequestCounts());
+    }
+
+    [Fact]
+    public async Task SessionsList_LateTypedResponseAfterTimeout_DoesNotPublish_AndCurrentRequestReturnsPage()
+    {
+        using var server = new LoopbackWebSocketServer();
+        using var identity = new TempDirectory("sessions-list-late-");
+        await server.StartAsync();
+        var helper = new GatewayClientTestHelper(
+            gatewayUrl: server.WebSocketUrl,
+            identityPath: identity.Path);
+        using var client = helper.Client;
+        await client.ConnectAsync();
+        var updateCount = 0;
+        client.SessionsUpdated += (_, _) => updateCount++;
+
+        var staleTask = client.ListSessionsPageAsync(
+            new SessionListRequest { Limit = 100, Offset = 0 },
+            timeoutMs: 250);
+        var staleRequest = await server.ReceiveTextAsync().WaitAsync(TimeSpan.FromSeconds(2));
+        var staleRequestId = ReadRequestId(staleRequest);
+        await Assert.ThrowsAsync<TimeoutException>(async () => await staleTask);
+        Assert.Equal((0, 0), helper.GetPendingRequestCounts());
+
+        await server.SendTextAsync(JsonSerializer.Serialize(new
+        {
+            type = "res",
+            id = staleRequestId,
+            ok = true,
+            payload = new
+            {
+                sessions = new[] { new { key = "agent:main:stale", label = "Stale" } },
+                count = 1,
+                totalCount = 1,
+                limitApplied = 100,
+                offset = 0,
+                hasMore = false,
+            },
+        }));
+
+        var currentTask = client.ListSessionsPageAsync(
+            new SessionListRequest { Limit = 100, Offset = 0 },
+            timeoutMs: 10_000);
+        var currentRequest = await server.ReceiveTextAsync().WaitAsync(TimeSpan.FromSeconds(2));
+        var currentRequestId = ReadRequestId(currentRequest);
+        await server.SendTextAsync(JsonSerializer.Serialize(new
+        {
+            type = "res",
+            id = currentRequestId,
+            ok = true,
+            payload = new
+            {
+                sessions = new[] { new { key = "agent:main:current", label = "Current" } },
+                count = 1,
+                totalCount = 1,
+                limitApplied = 100,
+                offset = 0,
+                hasMore = false,
+            },
+        }));
+
+        var current = await currentTask.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.Equal("agent:main:current", Assert.Single(current.Sessions).Key);
+        Assert.Equal(0, updateCount);
+        Assert.Empty(client.GetSessionList());
         Assert.Equal((0, 0), helper.GetPendingRequestCounts());
     }
 
@@ -696,6 +763,7 @@ public class OpenClawGatewayClientTests
             identityPath: identity.Path);
         using var client = helper.Client;
         await client.ConnectAsync();
+        helper.TrackPendingRequest("req-hello-restart", "connect");
         helper.ProcessRawMessage("""
         {
             "type": "res",
@@ -894,6 +962,7 @@ public class OpenClawGatewayClientTests
             identityPath: CreateTempIdentityPath());
         helper.SetDeviceTokenForTest(null);
 
+        helper.TrackPendingRequest("req-hello-node", "connect");
         helper.ProcessRawMessage("""
         {
           "type": "res",
@@ -922,6 +991,7 @@ public class OpenClawGatewayClientTests
             identityPath: CreateTempIdentityPath());
         helper.SetDeviceTokenForTest(null);
 
+        helper.TrackPendingRequest("req-hello-node", "connect");
         helper.ProcessRawMessage("""
         {
           "type": "res",
@@ -1100,6 +1170,7 @@ public class OpenClawGatewayClientTests
             identityPath: CreateTempIdentityPath());
         helper.SetDeviceTokenForTest(null);
 
+        helper.TrackPendingRequest("req-hello-operator", "connect");
         helper.ProcessRawMessage("""
         {
           "type": "res",
@@ -1144,6 +1215,7 @@ public class OpenClawGatewayClientTests
             FileAccess.Read,
             FileShare.Read))
         {
+            helper.TrackPendingRequest("req-hello-operator", "connect");
             helper.ProcessRawMessage("""
             {
               "type": "res",
@@ -2422,6 +2494,32 @@ public class OpenClawGatewayClientTests
     }
 
     [Fact]
+    public void ParseSessions_CompatibilitySnapshotIsBoundedToOneHundredUniqueRows()
+    {
+        var helper = new GatewayClientTestHelper();
+        var rows = Enumerable.Range(0, 150)
+            .Select(index => new
+            {
+                key = $"agent:main:{index}",
+                label = $"Session {index}",
+                updatedAt = index,
+            });
+        SessionInfo[]? publication = null;
+        helper.Client.SessionsUpdated += (_, sessions) => publication = sessions;
+
+        helper.ParseSessionsPayload(JsonSerializer.Serialize(rows));
+
+        Assert.NotNull(publication);
+        Assert.Equal(SessionPublicationCoordinator.MaximumPublishedSessions, publication.Length);
+        Assert.Equal(
+            publication.Length,
+            publication.Select(session => session.Key).Distinct(StringComparer.Ordinal).Count());
+        Assert.Equal(
+            SessionPublicationCoordinator.MaximumPublishedSessions,
+            helper.GetSessionList().Length);
+    }
+
+    [Fact]
     public void ParseSessions_UsesHandshakeMainSessionKeyInsteadOfKeyShapeGuessing()
     {
         var helper = new GatewayClientTestHelper();
@@ -2642,6 +2740,79 @@ public class OpenClawGatewayClientTests
         Assert.Equal("failed", session.Status);
         Assert.Equal(false, session.HasActiveRun);
         Assert.Equal("Current task", session.DisplayName);
+    }
+
+    [Fact]
+    public void SessionsList_DuplicateLateResponse_DoesNotReplaceCurrentSnapshot()
+    {
+        var helper = new GatewayClientTestHelper();
+        helper.TrackPendingRequest("session-page", "sessions.list");
+        helper.ProcessRawMessage("""
+            {
+              "type": "res",
+              "id": "session-page",
+              "ok": true,
+              "payload": { "sessions": [{ "key": "agent:main:current", "label": "Current" }] }
+            }
+            """);
+        helper.ProcessRawMessage("""
+            {
+              "type": "res",
+              "id": "session-page",
+              "ok": true,
+              "payload": { "sessions": [{ "key": "agent:main:stale", "label": "Stale" }] }
+            }
+            """);
+
+        var session = Assert.Single(helper.GetSessionList());
+        Assert.Equal("agent:main:current", session.Key);
+    }
+
+    [Fact]
+    public void SessionsList_UnknownResponseId_DoesNotPublishOrMutateSessions()
+    {
+        var helper = new GatewayClientTestHelper();
+        var updateCount = 0;
+        helper.Client.SessionsUpdated += (_, _) => updateCount++;
+
+        helper.ProcessRawMessage("""
+            {
+              "type": "res",
+              "id": "never-owned",
+              "ok": true,
+              "payload": { "sessions": [{ "key": "agent:main:stale", "label": "Stale" }] }
+            }
+            """);
+
+        Assert.Empty(helper.GetSessionList());
+        Assert.Equal(0, updateCount);
+    }
+
+    [Fact]
+    public void Health_UnknownResponseId_DoesNotPublishHealth()
+    {
+        var helper = new GatewayClientTestHelper();
+        var channelUpdateCount = 0;
+        var selfUpdateCount = 0;
+        helper.Client.ChannelHealthUpdated += (_, _) => channelUpdateCount++;
+        helper.Client.GatewaySelfUpdated += (_, _) => selfUpdateCount++;
+
+        helper.ProcessRawMessage("""
+            {
+              "type": "res",
+              "id": "never-owned-health",
+              "ok": true,
+              "payload": {
+                "uptimeMs": 1234,
+                "channels": {
+                  "telegram": { "status": "ready", "configured": true }
+                }
+              }
+            }
+            """);
+
+        Assert.Equal(0, channelUpdateCount);
+        Assert.Equal(0, selfUpdateCount);
     }
 
     [Fact]
@@ -4400,6 +4571,7 @@ public class OpenClawGatewayClientTests
         Assert.True(helper.GetAuthFailedFlag());
 
         // Now receive hello-ok — flag must be cleared
+        helper.TrackPendingRequest("req-hello-1", "connect");
         helper.ProcessRawMessage("""
         {
             "type": "res",

--- a/tests/OpenClaw.Shared.Tests/Protocol/GatewayProtocolDriftTests.cs
+++ b/tests/OpenClaw.Shared.Tests/Protocol/GatewayProtocolDriftTests.cs
@@ -156,6 +156,27 @@ public class GatewayProtocolDriftTests
         }
     }
 
+    [Fact]
+    public void SessionsList_responseMetadataDto_matches_snapshot()
+    {
+        var snapshot = LoadSnapshot();
+        var protocol = LoadProtocolSource();
+        var pinned = snapshot.Methods.Single(m => m.Method == "sessions.list")
+            .ResponseMetadataFields
+            .ToHashSet(StringComparer.Ordinal);
+        var region = ExtractMethodBody(protocol, "public sealed class SessionListResult");
+        Assert.NotNull(region);
+        var dtoFields = Regex.Matches(
+                region!.Code,
+                "\\[JsonPropertyName\\(\\s*\"([A-Za-z_][A-Za-z0-9_]*)\"\\s*\\)\\]")
+            .Select(match => match.Groups[1].Value)
+            .ToHashSet(StringComparer.Ordinal);
+
+        Assert.Equal(
+            pinned.OrderBy(value => value, StringComparer.Ordinal),
+            dtoFields.OrderBy(value => value, StringComparer.Ordinal));
+    }
+
     /// <summary>
     /// Guard C — request shapes, scoped and <b>bidirectional</b>. For each
     /// <c>used</c> request method, the set of wire keys the client actually
@@ -819,7 +840,9 @@ public class GatewayProtocolDriftTests
     /// <summary>The client surface plus the DTO/payload builders (GatewayProtocolModels.cs).</summary>
     private static Source LoadProtocolSource() =>
         ConcatSources(
-            f => FileNameMatches(f.Path, "OpenClawGatewayClient", ".cs") || EndsWith(f.Path, "GatewayProtocolModels.cs"),
+            f => FileNameMatches(f.Path, "OpenClawGatewayClient", ".cs") ||
+                 EndsWith(f.Path, "GatewayProtocolModels.cs") ||
+                 EndsWith(f.Path, "SessionListModels.cs"),
             "Could not locate the gateway protocol source under src/.");
 
     private static Source ConcatSources(Func<SourceFileSnapshot, bool> predicate, string notFound)
@@ -875,6 +898,7 @@ public class GatewayProtocolDriftTests
                 RequestFields: ReadStringArray(m, "requestFields"),
                 AllowedExtraRequestFields: ReadStringArray(m, "allowedExtraRequestFields"),
                 ResponseFields: ReadStringArray(m, "responseFields"),
+                ResponseMetadataFields: ReadStringArray(m, "responseMetadataFields"),
                 ResponseEnvelope: ReadStringArray(m, "responseEnvelope"),
                 RequestFieldsSource: m.TryGetProperty("requestFieldsSource", out var s) && s.ValueKind == JsonValueKind.String ? s.GetString() : null,
                 ResponseEnvelopeSource: m.TryGetProperty("responseEnvelopeSource", out var es) && es.ValueKind == JsonValueKind.String ? es.GetString() : null,
@@ -938,6 +962,7 @@ public class GatewayProtocolDriftTests
         IReadOnlyList<string> RequestFields,
         IReadOnlyList<string> AllowedExtraRequestFields,
         IReadOnlyList<string> ResponseFields,
+        IReadOnlyList<string> ResponseMetadataFields,
         IReadOnlyList<string> ResponseEnvelope,
         string? RequestFieldsSource,
         string? ResponseEnvelopeSource,

--- a/tests/OpenClaw.Shared.Tests/Protocol/gateway-protocol-snapshot.json
+++ b/tests/OpenClaw.Shared.Tests/Protocol/gateway-protocol-snapshot.json
@@ -51,20 +51,33 @@
     "date": "2026-06-23",
     "sessionsTsBlobSha": "d938f80f68cb285719e20801e83f74893aa04332",
     "commandsTsBlobSha": "a24972162dfbe4f95e05bf19211097707d30f9bb",
-    "result": "All enforced request fields, response envelopes, and the sessions.patch tri-state nullable (Union([value, Null])) contract match upstream main exactly. The snapshot is a deliberate SUBSET: the Windows client does not yet implement these upstream sessions.patch fields — label, agentId, spawnedBy, spawnedWorkspaceDir, spawnedCwd, spawnDepth, subagentRole, subagentControlScope, inheritedToolAllow, inheritedToolDeny (spawn/subagent orchestration); nor the compaction checkpoint preCompaction/postCompaction references. These are upstream fields the client does not implement yet, not drift."
+    "result": "Historical full-surface verification for request fields, response envelopes, and the sessions.patch tri-state nullable contract. sessions.list evolution after this date is verified separately in sessionsListVerified. The snapshot is a deliberate SUBSET: the Windows client does not yet implement upstream sessions.patch spawn/subagent orchestration fields or compaction checkpoint preCompaction/postCompaction references."
+  },
+  "sessionsListVerified": {
+    "date": "2026-08-08",
+    "v2026.5.20": "https://github.com/openclaw/openclaw/blob/e510042870cf248c0e0461b6f8d427326266141d/src/gateway/protocol/schema/sessions.ts",
+    "v2026.5.22": "https://github.com/openclaw/openclaw/blob/a374c3a5bfd5225ce319bce3865aab6216309c4f/src/gateway/protocol/schema/sessions.ts",
+    "archivedBoolean": "https://github.com/openclaw/openclaw/blob/6df0fb818d67032c71eb885ac36febd540fbd10f/packages/gateway-protocol/src/schema/sessions.ts",
+    "result": "v2026.5.20 supports limit, search, and configuredAgentsOnly but rejects offset and archived. v2026.5.22 adds offset. Commit 6df0fb8 adds archived:boolean. Windows negotiates these optional fields independently."
   },
   "clientFoundationCommit": "2cae69ba",
   "_clientFoundationCommitNote": "The commit on main that introduced the typed gateway protocol client (OpenClawGatewayClient.Protocol.cs + GatewayProtocolModels.cs) this guard cross-checks.",
-  "snapshotUpdated": "2026-07-13",
+  "snapshotUpdated": "2026-08-08",
   "scopePrefixes": ["sessions.", "agents.files.", "commands."],
   "methods": [
     {
       "method": "sessions.list",
       "kind": "request",
       "windowsUsage": "used",
-      "requestFields": ["agentId"],
+      "protocolVersion": "v2026.5.20 plus negotiated additions",
+      "protocolProvenance": "limit/search/configuredAgentsOnly: openclaw/openclaw v2026.5.20 commit e510042870cf248c0e0461b6f8d427326266141d src/gateway/protocol/schema/sessions.ts; offset: v2026.5.22 commit a374c3a5bfd5225ce319bce3865aab6216309c4f at the same path; archived:boolean: commit 6df0fb818d67032c71eb885ac36febd540fbd10f packages/gateway-protocol/src/schema/sessions.ts",
+      "requestFields": ["agentId", "limit", "offset", "search", "configuredAgentsOnly", "archived"],
+      "requestFieldsSource": "internal Dictionary<string, object?> ToParameters(",
       "responseEnvelope": ["sessions"],
       "responseEnvelopeSource": "TryGetSessionsPayload(JsonElement payload",
+      "responseMetadataFields": [
+        "sessions", "count", "totalCount", "limitApplied", "offset", "nextOffset", "hasMore"
+      ],
       "responseFields": [
         "key", "isMain", "status", "hasActiveRun", "model", "label", "channel", "displayName",
         "derivedTitle", "modelProvider", "provider", "subject", "groupChannel", "room",

--- a/tests/OpenClaw.Shared.Tests/SessionListProtocolTests.cs
+++ b/tests/OpenClaw.Shared.Tests/SessionListProtocolTests.cs
@@ -1,0 +1,235 @@
+using System.Text.Json;
+using OpenClaw.Shared;
+using OpenClaw.TestSupport;
+using Xunit;
+
+namespace OpenClaw.Shared.Tests;
+
+public sealed class SessionListProtocolTests
+{
+    [Fact]
+    public void RequestDto_UsesExactStableWireNames_AndOmitsAbsentFields()
+    {
+        var request = new SessionListRequest
+        {
+            AgentId = "main",
+            Limit = 100,
+            Offset = 200,
+            Search = "needle",
+            ConfiguredAgentsOnly = true,
+            Archived = false,
+        };
+
+        using var document = JsonDocument.Parse(JsonSerializer.Serialize(request));
+        var names = document.RootElement.EnumerateObject().Select(property => property.Name).ToArray();
+
+        Assert.Equal(
+            ["agentId", "limit", "offset", "search", "configuredAgentsOnly", "archived"],
+            names);
+        Assert.Equal(["limit"], JsonDocument.Parse(
+            JsonSerializer.Serialize(new SessionListRequest { Limit = 100 }))
+            .RootElement.EnumerateObject().Select(property => property.Name).ToArray());
+        Assert.Equal(
+            ["agentId", "limit", "search", "configuredAgentsOnly"],
+            request.ToParameters(
+                    SessionListRequestFields.Offset |
+                    SessionListRequestFields.Archived)
+                .Keys);
+    }
+
+    [Fact]
+    public void ResultDto_UsesExactStableMetadataWireNames()
+    {
+        var result = new SessionListResult
+        {
+            Sessions = [new SessionInfo { Key = "agent:main:1" }],
+            Count = 1,
+            TotalCount = 2,
+            LimitApplied = 100,
+            Offset = 0,
+            NextOffset = 1,
+            HasMore = true,
+        };
+
+        using var document = JsonDocument.Parse(JsonSerializer.Serialize(result));
+        var names = document.RootElement.EnumerateObject().Select(property => property.Name).ToArray();
+
+        Assert.Equal(
+            ["sessions", "count", "totalCount", "limitApplied", "offset", "nextOffset", "hasMore"],
+            names);
+    }
+
+    [Fact]
+    public void ResultParser_ToleratesAbsentAndAdditiveMetadata()
+    {
+        using var identity = new TempDirectory("session-list-parser-");
+        var client = new OpenClawGatewayClient(
+            "ws://localhost:18789",
+            "token",
+            identityPath: identity.Path);
+        using var document = JsonDocument.Parse("""
+            {
+              "sessions": [{ "key": "agent:main:1", "label": "One" }],
+              "count": 1,
+              "futureMetadata": { "ignored": true }
+            }
+            """);
+
+        var result = client.ParseSessionListResult(document.RootElement);
+
+        Assert.Equal(1, result.Count);
+        Assert.Null(result.TotalCount);
+        Assert.Null(result.NextOffset);
+        Assert.Equal("One", Assert.Single(result.Sessions).Label);
+        client.Dispose();
+    }
+
+    [Fact]
+    public void ResultParser_CapsUnboundedRowsAtTwoThousand()
+    {
+        using var identity = new TempDirectory("session-list-legacy-cap-");
+        var client = new OpenClawGatewayClient(
+            "ws://localhost:18789",
+            "token",
+            identityPath: identity.Path);
+        var rows = Enumerable.Range(0, 2001)
+            .Select(index => new { key = $"agent:main:{index}" })
+            .ToArray();
+        using var document = JsonDocument.Parse(JsonSerializer.Serialize(new { sessions = rows }));
+
+        var result = client.ParseSessionListResult(document.RootElement);
+
+        Assert.Equal(SessionQueryCoordinator.MaximumMaterializedSessions, result.Sessions.Count);
+        client.Dispose();
+    }
+
+    [Fact]
+    public void ArrayResultParser_StopsBeforeMalformedRowBeyondCap()
+    {
+        using var identity = new TempDirectory("session-list-legacy-array-cap-");
+        var client = new OpenClawGatewayClient(
+            "ws://localhost:18789",
+            "token",
+            identityPath: identity.Path);
+        var rows = Enumerable.Range(0, SessionQueryCoordinator.MaximumMaterializedSessions)
+            .Select(index => (object)new { key = $"agent:main:{index}", label = $"Session {index}" })
+            .ToList();
+        rows.Add(new { key = "agent:main:after-cap", model = 123 });
+        using var document = JsonDocument.Parse(JsonSerializer.Serialize(new { sessions = rows }));
+
+        var result = client.ParseSessionListResult(document.RootElement);
+
+        Assert.Equal(SessionQueryCoordinator.MaximumMaterializedSessions, result.Sessions.Count);
+        Assert.DoesNotContain(result.Sessions, session => session.Key == "agent:main:after-cap");
+        client.Dispose();
+    }
+
+    [Fact]
+    public void ObjectResultParser_StopsBeforeMalformedRowBeyondCap()
+    {
+        using var identity = new TempDirectory("session-list-legacy-object-cap-");
+        var client = new OpenClawGatewayClient(
+            "ws://localhost:18789",
+            "token",
+            identityPath: identity.Path);
+        var rows = Enumerable.Range(0, SessionQueryCoordinator.MaximumMaterializedSessions)
+            .ToDictionary(
+                index => $"agent:main:{index}",
+                index => (object)new { label = $"Session {index}" });
+        rows.Add("agent:main:after-cap", new { model = 123 });
+        using var document = JsonDocument.Parse(JsonSerializer.Serialize(new { sessions = rows }));
+
+        var result = client.ParseSessionListResult(document.RootElement);
+
+        Assert.Equal(SessionQueryCoordinator.MaximumMaterializedSessions, result.Sessions.Count);
+        Assert.DoesNotContain(result.Sessions, session => session.Key == "agent:main:after-cap");
+        client.Dispose();
+    }
+
+    [Fact]
+    public void ExpandedResultParser_IsStillCappedDefensively()
+    {
+        using var identity = new TempDirectory("session-list-expanded-cap-");
+        var client = new OpenClawGatewayClient(
+            "ws://localhost:18789",
+            "token",
+            identityPath: identity.Path);
+        var rows = Enumerable.Range(0, SessionQueryCoordinator.MaximumMaterializedSessions + 1)
+            .Select(index => new { key = $"agent:main:{index}", label = $"Session {index}" });
+        using var document = JsonDocument.Parse(JsonSerializer.Serialize(new { sessions = rows }));
+
+        var result = client.ParseSessionListResult(document.RootElement);
+
+        Assert.Equal(SessionQueryCoordinator.MaximumMaterializedSessions, result.Sessions.Count);
+        client.Dispose();
+    }
+
+    [Theory]
+    [InlineData(
+        "invalid sessions.list params: unexpected property limit",
+        SessionListRequestFields.Limit)]
+    [InlineData(
+        "invalid sessions.list params: at root: unexpected property 'offset'",
+        SessionListRequestFields.Offset)]
+    [InlineData("Unexpected property 'search'.", SessionListRequestFields.Search)]
+    [InlineData(
+        "unknown parameter `configuredAgentsOnly`",
+        SessionListRequestFields.ConfiguredAgentsOnly)]
+    [InlineData("unknown parameter archived", SessionListRequestFields.Archived)]
+    public void RejectedFieldMatcher_AcceptsExactSentOptionalField(
+        string message,
+        SessionListRequestFields expected)
+    {
+        var request = new SessionListRequest
+        {
+            Limit = 100,
+            Offset = 0,
+            Search = "needle",
+            ConfiguredAgentsOnly = true,
+            Archived = false,
+        };
+
+        Assert.True(OpenClawGatewayClient.TryGetRejectedSessionListField(
+            new GatewayRequestException("INVALID_REQUEST", message),
+            request,
+            SessionListRequestFields.None,
+            out var rejected));
+        Assert.Equal(expected, rejected);
+    }
+
+    [Theory]
+    [InlineData("unknown parameter value for search")]
+    [InlineData("unknown parameter archived")]
+    [InlineData("unexpected property searchValue")]
+    [InlineData("validation failed for unexpected search property")]
+    public void RejectedFieldMatcher_RejectsNonFieldDiagnostics(string message)
+    {
+        var request = new SessionListRequest { Search = "needle" };
+
+        Assert.False(OpenClawGatewayClient.TryGetRejectedSessionListField(
+            new GatewayRequestException("INVALID_REQUEST", message),
+            request,
+            SessionListRequestFields.None,
+            out _));
+    }
+
+    [Fact]
+    public void RejectedFieldMatcher_RejectsOptionalFieldThatWasNotSent()
+    {
+        Assert.False(OpenClawGatewayClient.TryGetRejectedSessionListField(
+            new GatewayRequestException("INVALID_REQUEST", "unexpected property search"),
+            new SessionListRequest { Limit = 100 },
+            SessionListRequestFields.None,
+            out _));
+    }
+
+    [Fact]
+    public void RejectedFieldMatcher_RejectsAlreadyDisabledField()
+    {
+        Assert.False(OpenClawGatewayClient.TryGetRejectedSessionListField(
+            new GatewayRequestException("INVALID_REQUEST", "unexpected property offset"),
+            new SessionListRequest { Limit = 100, Offset = 0 },
+            SessionListRequestFields.Offset,
+            out _));
+    }
+}

--- a/tests/OpenClaw.Shared.Tests/SessionPublicationCoordinatorTests.cs
+++ b/tests/OpenClaw.Shared.Tests/SessionPublicationCoordinatorTests.cs
@@ -1,0 +1,188 @@
+using OpenClaw.Shared;
+using Xunit;
+
+namespace OpenClaw.Shared.Tests;
+
+public sealed class SessionPublicationCoordinatorTests
+{
+    [Fact]
+    public async Task RefreshBurst_DoesNotCancelFirstPublication_AndCoalescesOneTrailingRefresh()
+    {
+        var firstStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirst = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var calls = 0;
+        var publications = new List<IReadOnlyList<SessionInfo>>();
+        using var coordinator = new SessionPublicationCoordinator(
+            async (_, _) =>
+            {
+                var call = Interlocked.Increment(ref calls);
+                if (call == 1)
+                {
+                    firstStarted.TrySetResult();
+                    await releaseFirst.Task;
+                }
+                return Result(new SessionInfo
+                {
+                    Key = "agent:main:current",
+                    Label = call == 1 ? "First publication" : "Trailing publication",
+                });
+            },
+            (_, sessions) => sessions.ToArray(),
+            sessions => publications.Add(sessions));
+
+        var first = coordinator.RequestRefreshAsync();
+        await firstStarted.Task;
+        var burst = Enumerable.Range(0, 100)
+            .Select(_ => coordinator.RequestRefreshAsync())
+            .ToArray();
+
+        releaseFirst.TrySetResult();
+        await first;
+        await Task.WhenAll(burst);
+
+        Assert.Equal(2, calls);
+        Assert.Equal(2, publications.Count);
+        Assert.Equal("First publication", Assert.Single(publications[0]).Label);
+        Assert.Equal("Trailing publication", Assert.Single(publications[1]).Label);
+    }
+
+    [Fact]
+    public async Task Publication_IsBounded_Deduplicated_AndKeepsLaterMutation()
+    {
+        var rows = Enumerable.Range(0, 150)
+            .Select(index => new SessionInfo { Key = $"agent:main:{index}", Label = $"Session {index}" })
+            .Append(new SessionInfo { Key = "agent:main:0", Label = "Mutated" })
+            .ToArray();
+        IReadOnlyList<SessionInfo>? publication = null;
+        using var coordinator = new SessionPublicationCoordinator(
+            (_, _) => Task.FromResult(new SessionListResult { Sessions = rows }),
+            (_, sessions) => sessions.ToArray(),
+            sessions => publication = sessions);
+
+        await coordinator.RequestRefreshAsync();
+
+        Assert.NotNull(publication);
+        Assert.Equal(SessionPublicationCoordinator.MaximumPublishedSessions, publication.Count);
+        Assert.Equal(
+            publication.Count,
+            publication.Select(session => session.Key).Distinct(StringComparer.Ordinal).Count());
+        Assert.Equal("Mutated", Assert.Single(publication, session => session.Key == "agent:main:0").Label);
+        Assert.DoesNotContain(publication, session => session.Key == "agent:main:149");
+    }
+
+    [Fact]
+    public async Task AdvanceConnectionGeneration_CancelsLatePublication_AndAllowsCurrentRefresh()
+    {
+        var staleResponse = new TaskCompletionSource<SessionListResult>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var calls = 0;
+        var publications = new List<IReadOnlyList<SessionInfo>>();
+        using var coordinator = new SessionPublicationCoordinator(
+            (_, _) => Interlocked.Increment(ref calls) == 1
+                ? staleResponse.Task
+                : Task.FromResult(Result(new SessionInfo
+                {
+                    Key = "agent:main:current",
+                    Label = "Current",
+                })),
+            (_, sessions) => sessions.ToArray(),
+            sessions => publications.Add(sessions));
+        var stale = coordinator.RequestRefreshAsync();
+
+        coordinator.AdvanceConnectionGeneration();
+        staleResponse.TrySetResult(Result(new SessionInfo
+        {
+            Key = "agent:main:stale",
+            Label = "Stale",
+        }));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => stale);
+        await coordinator.RequestRefreshAsync();
+
+        Assert.Equal(2, calls);
+        Assert.Equal("agent:main:current", Assert.Single(Assert.Single(publications)).Key);
+    }
+
+    [Fact]
+    public async Task StaleExpectedGeneration_IsRejectedBeforeFetchEnrollment()
+    {
+        var calls = 0;
+        using var coordinator = new SessionPublicationCoordinator(
+            (_, _) =>
+            {
+                Interlocked.Increment(ref calls);
+                return Task.FromResult(Result());
+            },
+            (_, sessions) => sessions.ToArray(),
+            _ => { });
+        coordinator.AdvanceConnectionGeneration();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            coordinator.RequestRefreshAsync(expectedConnectionGeneration: 0));
+
+        Assert.Equal(0, calls);
+    }
+
+    [Fact]
+    public async Task PublicationCallback_DoesNotHoldCoordinatorLock_AndGenerationAdvanceCancelsCompletion()
+    {
+        SessionPublicationCoordinator coordinator = null!;
+        var publicationCount = 0;
+        coordinator = new SessionPublicationCoordinator(
+            (_, _) => Task.FromResult(Result(new SessionInfo { Key = "agent:main:first" })),
+            (_, sessions) => sessions.ToArray(),
+            _ =>
+            {
+                if (Interlocked.Increment(ref publicationCount) != 1)
+                    return;
+                var advance = Task.Run(coordinator.AdvanceConnectionGeneration);
+                if (!advance.Wait(TimeSpan.FromSeconds(2)))
+                    throw new TimeoutException("Generation advance blocked behind the publication callback.");
+            });
+        using (coordinator)
+        {
+            var stale = coordinator.RequestRefreshAsync();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => stale);
+            await coordinator.RequestRefreshAsync();
+        }
+
+        Assert.Equal(2, publicationCount);
+    }
+
+    [Fact]
+    public async Task AlternatingScopeBurst_CoalescesToOneTrailingRefreshUsingLatestScope()
+    {
+        var firstStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirst = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var requestedAgents = new List<string?>();
+        using var coordinator = new SessionPublicationCoordinator(
+            async (request, _) =>
+            {
+                requestedAgents.Add(request.AgentId);
+                if (requestedAgents.Count == 1)
+                {
+                    firstStarted.TrySetResult();
+                    await releaseFirst.Task;
+                }
+                return Result(new SessionInfo { Key = $"agent:{request.AgentId}:session" });
+            },
+            (_, sessions) => sessions.ToArray(),
+            _ => { });
+
+        var first = coordinator.RequestRefreshAsync("first");
+        await firstStarted.Task;
+        var burst = Enumerable.Range(0, 100)
+            .Select(index => coordinator.RequestRefreshAsync(index % 2 == 0 ? "even" : "odd"))
+            .ToArray();
+
+        releaseFirst.TrySetResult();
+        await first;
+        await Task.WhenAll(burst);
+
+        Assert.Equal(["first", "odd"], requestedAgents);
+    }
+
+    private static SessionListResult Result(params SessionInfo[] sessions) =>
+        new() { Sessions = sessions };
+}

--- a/tests/OpenClaw.Shared.Tests/SessionQueryCoordinatorTests.cs
+++ b/tests/OpenClaw.Shared.Tests/SessionQueryCoordinatorTests.cs
@@ -1,0 +1,725 @@
+using OpenClaw.Shared;
+using Xunit;
+
+namespace OpenClaw.Shared.Tests;
+
+public sealed class SessionQueryCoordinatorTests
+{
+    [Theory]
+    [InlineData(1000, 10)]
+    [InlineData(2000, 20)]
+    public async Task RecentLoad_PagesInHundreds_ToBoundedMaximum(int total, int expectedPages)
+    {
+        var offsets = new List<int>();
+        using var coordinator = new SessionQueryCoordinator((request, _) =>
+        {
+            var offset = request.Offset ?? 0;
+            offsets.Add(offset);
+            var count = Math.Min(SessionQueryCoordinator.PageSize, total - offset);
+            return Task.FromResult(Page(
+                Enumerable.Range(offset, count).Select(Session),
+                offset,
+                offset + count < total ? offset + count : null,
+                offset + count < total));
+        }, TimeSpan.Zero);
+
+        var snapshot = await coordinator.LoadRecentAsync(new SessionQuery { IncludeBackground = true });
+
+        Assert.Equal(total, snapshot.Sessions.Count);
+        Assert.Equal(expectedPages, snapshot.PagesRead);
+        Assert.Equal(Enumerable.Range(0, expectedPages).Select(i => i * 100), offsets);
+    }
+
+    [Fact]
+    public async Task Paging_DeduplicatesKeys_AndKeepsLaterMutation()
+    {
+        using var coordinator = new SessionQueryCoordinator((request, _) =>
+        {
+            if (request.Offset == 0)
+            {
+                return Task.FromResult(Page(
+                    Enumerable.Range(0, 100).Select(Session),
+                    0, 100, true));
+            }
+            var rows = Enumerable.Range(100, 99).Select(Session).Prepend(
+                new SessionInfo { Key = "agent:main:0", Label = "mutated" });
+            return Task.FromResult(Page(rows, 100, null, false));
+        }, TimeSpan.Zero);
+
+        var snapshot = await coordinator.LoadRecentAsync(new SessionQuery { IncludeBackground = true });
+
+        Assert.Equal(199, snapshot.Sessions.Count);
+        Assert.Equal("mutated", Assert.Single(snapshot.Sessions, s => s.Key == "agent:main:0").Label);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public async Task Paging_StopsOnMalformedOrStalledNextOffset(int nextOffset)
+    {
+        var calls = 0;
+        using var coordinator = new SessionQueryCoordinator((request, _) =>
+        {
+            calls++;
+            return Task.FromResult(Page(
+                Enumerable.Range(0, 100).Select(Session),
+                request.Offset ?? 0,
+                nextOffset,
+                true));
+        }, TimeSpan.Zero);
+
+        var snapshot = await coordinator.LoadRecentAsync();
+
+        Assert.Equal(1, calls);
+        Assert.Equal(1, snapshot.PagesRead);
+    }
+
+    [Fact]
+    public async Task Paging_StopsWhenNextOffsetRepeatsSeenCursor()
+    {
+        var calls = 0;
+        using var coordinator = new SessionQueryCoordinator((request, _) =>
+        {
+            calls++;
+            var offset = request.Offset ?? 0;
+            return Task.FromResult(Page(
+                Enumerable.Range(offset, 100).Select(Session),
+                offset,
+                offset == 0 ? 100 : 0,
+                true));
+        }, TimeSpan.Zero);
+
+        var snapshot = await coordinator.LoadRecentAsync();
+
+        Assert.Equal(2, calls);
+        Assert.Equal(2, snapshot.PagesRead);
+    }
+
+    [Fact]
+    public async Task HiddenOnlyPage_DoesNotStopRawPaging()
+    {
+        using var coordinator = new SessionQueryCoordinator((request, _) =>
+        {
+            if (request.Offset == 0)
+            {
+                var hidden = Enumerable.Range(0, 100).Select(i => new SessionInfo
+                {
+                    Key = $"agent:main:subagent:{i}",
+                    Label = "Background",
+                    Classification = "subagent",
+                    IsBackground = true,
+                });
+                return Task.FromResult(Page(hidden, 0, 100, true));
+            }
+            return Task.FromResult(Page([new SessionInfo { Key = "agent:main:visible" }], 100, null, false));
+        }, TimeSpan.Zero);
+
+        var snapshot = await coordinator.LoadRecentAsync();
+
+        Assert.Equal(2, snapshot.PagesRead);
+        Assert.Equal("agent:main:visible", Assert.Single(snapshot.Sessions).Key);
+    }
+
+    [Fact]
+    public async Task AdvanceConnectionGeneration_CancelsInFlightAndRejectsLateResponse()
+    {
+        var response = new TaskCompletionSource<SessionListResult>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        using var coordinator = new SessionQueryCoordinator((_, _) => response.Task, TimeSpan.Zero);
+        var query = coordinator.LoadRecentAsync();
+
+        coordinator.AdvanceConnectionGeneration();
+        response.TrySetResult(Page([Session(1)], 0, null, false));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => query);
+        Assert.Empty(coordinator.ClearSearch().Sessions);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task StaleExpectedGeneration_IsRejectedBeforeQueryEnrollment(bool search)
+    {
+        var calls = 0;
+        using var coordinator = new SessionQueryCoordinator(
+            (_, _) =>
+            {
+                Interlocked.Increment(ref calls);
+                return Task.FromResult(Page([], 0, null, false));
+            },
+            TimeSpan.Zero);
+        coordinator.AdvanceConnectionGeneration();
+
+        var query = new SessionQuery { Search = search ? "needle" : null };
+        var operation = search
+            ? coordinator.SearchAsync(
+                query,
+                expectedConnectionGeneration: 0)
+            : coordinator.LoadRecentAsync(
+                query,
+                expectedConnectionGeneration: 0);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => operation);
+        Assert.Equal(0, calls);
+    }
+
+    [Fact]
+    public async Task ConcurrentRecentLoads_LatestIdentityWins()
+    {
+        var firstResponse = new TaskCompletionSource<SessionListResult>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var call = 0;
+        using var coordinator = new SessionQueryCoordinator((_, _) =>
+        {
+            call++;
+            return call == 1
+                ? firstResponse.Task
+                : Task.FromResult(Page([new SessionInfo { Key = "agent:main:latest" }], 0, null, false));
+        }, TimeSpan.Zero);
+        var first = coordinator.LoadRecentAsync();
+        var latest = await coordinator.LoadRecentAsync();
+        firstResponse.TrySetResult(Page([new SessionInfo { Key = "agent:main:stale" }], 0, null, false));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => first);
+        Assert.Equal("agent:main:latest", Assert.Single(latest.Sessions).Key);
+        Assert.Equal(
+            latest.Sessions.Select(session => session.Key),
+            coordinator.ClearSearch().Sessions.Select(session => session.Key));
+    }
+
+    [Fact]
+    public async Task ConcurrentRecentCompletionAndSupersession_DoesNotRaceCtsDisposal()
+    {
+        for (var iteration = 0; iteration < 250; iteration++)
+        {
+            var firstResponse = new TaskCompletionSource<SessionListResult>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var start = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var call = 0;
+            using var coordinator = new SessionQueryCoordinator((_, _) =>
+            {
+                return Interlocked.Increment(ref call) == 1
+                    ? firstResponse.Task
+                    : Task.FromResult(Page([Session(2)], 0, null, false));
+            }, TimeSpan.Zero);
+            var first = coordinator.LoadRecentAsync();
+
+            var complete = Task.Run(async () =>
+            {
+                await start.Task;
+                firstResponse.TrySetResult(Page([Session(1)], 0, null, false));
+            });
+            var supersede = Task.Run(async () =>
+            {
+                await start.Task;
+                return await coordinator.LoadRecentAsync();
+            });
+
+            start.TrySetResult();
+            await complete;
+            _ = await supersede;
+            var firstException = await Record.ExceptionAsync(() => first);
+            Assert.True(
+                firstException is null or OperationCanceledException,
+                $"Unexpected supersession exception: {firstException}");
+        }
+    }
+
+    [Fact]
+    public async Task Dispose_CancelsClientOwnedQuery()
+    {
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var coordinator = new SessionQueryCoordinator(async (_, cancellationToken) =>
+        {
+            started.TrySetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            return Page([], 0, null, false);
+        }, TimeSpan.Zero);
+        var query = coordinator.LoadRecentAsync();
+        await started.Task;
+
+        coordinator.Dispose();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => query);
+    }
+
+    [Fact]
+    public async Task Search_FindsOnlyRowReturnedOnNinthPage()
+    {
+        using var coordinator = new SessionQueryCoordinator((request, _) =>
+        {
+            var offset = request.Offset ?? 0;
+            var rows = offset == 800
+                ? new[] { new SessionInfo { Key = "agent:main:900", Label = "needle" } }
+                : Array.Empty<SessionInfo>();
+            return Task.FromResult(Page(rows, offset, offset < 800 ? offset + 100 : null, offset < 800));
+        }, TimeSpan.Zero);
+
+        var snapshot = await coordinator.SearchAsync(new SessionQuery { Search = "needle" });
+
+        Assert.Equal(9, snapshot.PagesRead);
+        Assert.Equal("agent:main:900", Assert.Single(snapshot.Sessions).Key);
+    }
+
+    [Fact]
+    public async Task Search_WhenServerRejectsSearch_PagesAndFindsRowOutsideNewestHundred()
+    {
+        using var coordinator = new SessionQueryCoordinator((request, _) =>
+        {
+            var offset = request.Offset ?? 0;
+            var rows = Enumerable.Range(offset, 100)
+                .Select(index => new SessionInfo
+                {
+                    Key = $"agent:main:{index}",
+                    Label = index == 900 ? "Needle outside first page" : $"Session {index}",
+                });
+            return Task.FromResult(Page(
+                rows,
+                offset,
+                offset < 900 ? offset + 100 : null,
+                offset < 900,
+                SessionListRequestFields.Search));
+        }, TimeSpan.Zero);
+
+        var snapshot = await coordinator.SearchAsync(new SessionQuery
+        {
+            Search = "needle",
+            IncludeBackground = true,
+        });
+
+        Assert.Equal(10, snapshot.PagesRead);
+        Assert.Equal(SessionSearchExecutionMode.LegacyLocal, snapshot.SearchExecutionMode);
+        Assert.Equal(SessionListRequestFields.Search, snapshot.UnsupportedRequestFields);
+        Assert.Equal("agent:main:900", Assert.Single(snapshot.Sessions).Key);
+    }
+
+    [Fact]
+    public async Task Search_DebounceCancelsOldQuery_AndLatestWins()
+    {
+        var requests = new List<string?>();
+        using var coordinator = new SessionQueryCoordinator((request, _) =>
+        {
+            lock (requests) requests.Add(request.Search);
+            return Task.FromResult(Page(
+                [new SessionInfo { Key = $"agent:main:{request.Search}" }],
+                0, null, false));
+        }, TimeSpan.FromMilliseconds(50));
+
+        var old = coordinator.SearchAsync(new SessionQuery { Search = "old" });
+        var latest = coordinator.SearchAsync(new SessionQuery { Search = "latest" });
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => old);
+        var snapshot = await latest;
+        Assert.Equal("agent:main:latest", Assert.Single(snapshot.Sessions).Key);
+        Assert.Equal(["latest"], requests);
+    }
+
+    [Fact]
+    public async Task Search_PinsSelectedLocalSession_WhenServerOmitsIt()
+    {
+        using var coordinator = new SessionQueryCoordinator(
+            (_, _) => Task.FromResult(Page([Session(1)], 0, null, false)),
+            TimeSpan.Zero);
+
+        var snapshot = await coordinator.SearchAsync(new SessionQuery
+        {
+            Search = "one",
+            IncludeBackground = true,
+            PinnedSessions = [new SessionInfo { Key = "agent:main:selected", Label = "Selected" }],
+        });
+
+        Assert.Contains(snapshot.Sessions, s => s.Key == "agent:main:selected");
+    }
+
+    [Fact]
+    public async Task ClearSearch_RestoresCoherentRecentSnapshotMetadata()
+    {
+        using var coordinator = new SessionQueryCoordinator(
+            (_, _) => Task.FromResult(Page([Session(1)], 0, null, false)),
+            TimeSpan.Zero);
+        var recent = await coordinator.LoadRecentAsync();
+        _ = await coordinator.SearchAsync(new SessionQuery { Search = "other" });
+
+        var restored = coordinator.ClearSearch();
+
+        Assert.NotSame(recent, restored);
+        Assert.Equal(recent.Sessions.Select(session => session.Key), restored.Sessions.Select(session => session.Key));
+        Assert.Equal(recent.PagesRead, restored.PagesRead);
+        Assert.Equal(recent.UnsupportedRequestFields, restored.UnsupportedRequestFields);
+    }
+
+    [Fact]
+    public async Task ClearSearch_UsesServerIdentityAndReprojectsClientOnlyState()
+    {
+        using var coordinator = new SessionQueryCoordinator((request, _) =>
+            Task.FromResult(Page(
+                [
+                    new SessionInfo
+                    {
+                        Key = $"agent:{request.AgentId}:recent",
+                        Label = request.ConfiguredAgentsOnly == true ? "Configured" : "All",
+                    },
+                    new SessionInfo
+                    {
+                        Key = $"agent:{request.AgentId}:background",
+                        Classification = "subagent",
+                        IsBackground = true,
+                    },
+                ],
+                0, null, false)),
+            TimeSpan.Zero);
+        var pinned = new SessionInfo { Key = "agent:a:pinned", Label = "Pinned" };
+        var recentQuery = new SessionQuery
+        {
+            AgentId = "a",
+            ConfiguredAgentsOnly = true,
+            Archived = false,
+            IncludeBackground = true,
+            PinnedSessions = [pinned],
+        };
+        var recent = await coordinator.LoadRecentAsync(recentQuery);
+        _ = await coordinator.SearchAsync(new SessionQuery
+        {
+            AgentId = "a",
+            Search = "other",
+            ConfiguredAgentsOnly = true,
+            Archived = false,
+            IncludeBackground = true,
+            PinnedSessions = [pinned],
+        });
+
+        Assert.Equal(
+            recent.Sessions.Select(session => session.Key),
+            coordinator.ClearSearch(recentQuery).Sessions.Select(session => session.Key));
+        Assert.Empty(coordinator.ClearSearch(new SessionQuery
+        {
+            AgentId = "b",
+            ConfiguredAgentsOnly = true,
+            Archived = false,
+            IncludeBackground = true,
+            PinnedSessions = [],
+        }).Sessions);
+        Assert.Empty(coordinator.ClearSearch(new SessionQuery
+        {
+            AgentId = "a",
+            ConfiguredAgentsOnly = false,
+            Archived = false,
+            IncludeBackground = true,
+            PinnedSessions = [],
+        }).Sessions);
+        Assert.Empty(coordinator.ClearSearch(new SessionQuery
+        {
+            AgentId = "a",
+            ConfiguredAgentsOnly = true,
+            Archived = true,
+            IncludeBackground = true,
+            PinnedSessions = [],
+        }).Sessions);
+        var foregroundOnly = coordinator.ClearSearch(new SessionQuery
+        {
+            AgentId = "a",
+            ConfiguredAgentsOnly = true,
+            Archived = false,
+            IncludeBackground = false,
+            PinnedSessions = [],
+        });
+        Assert.Equal("agent:a:recent", Assert.Single(foregroundOnly.Sessions).Key);
+        var withoutPin = coordinator.ClearSearch(new SessionQuery
+        {
+            AgentId = "a",
+            ConfiguredAgentsOnly = true,
+            Archived = false,
+            IncludeBackground = true,
+            PinnedSessions = [],
+        });
+        Assert.Equal(
+            ["agent:a:recent", "agent:a:background"],
+            withoutPin.Sessions.Select(session => session.Key));
+        var replacementPin = new SessionInfo { Key = "agent:a:replacement", Label = "Replacement" };
+        var withReplacementPin = coordinator.ClearSearch(new SessionQuery
+        {
+            AgentId = "a",
+            ConfiguredAgentsOnly = true,
+            Archived = false,
+            IncludeBackground = true,
+            PinnedSessions = [replacementPin],
+        });
+        Assert.Equal(
+            ["agent:a:recent", "agent:a:background", replacementPin.Key],
+            withReplacementPin.Sessions.Select(session => session.Key));
+    }
+
+    [Fact]
+    public async Task ClearSearch_ReprojectsChangedSameKeyCurrentPin()
+    {
+        var selectedKey = "agent:main:selected";
+        using var coordinator = new SessionQueryCoordinator(
+            (_, _) => Task.FromResult(Page(
+                [
+                    new SessionInfo { Key = "agent:main:before", Label = "Before" },
+                    new SessionInfo
+                    {
+                        Key = selectedKey,
+                        Label = "Stale server label",
+                        CurrentActivity = "Stale server activity",
+                        DerivedTitle = "Stale server title",
+                    },
+                    new SessionInfo { Key = "agent:main:after", Label = "After" },
+                ],
+                0,
+                null,
+                false)),
+            TimeSpan.Zero);
+        var oldPin = new SessionInfo
+        {
+            Key = selectedKey,
+            Label = "Old label",
+            CurrentActivity = "Old activity",
+            DerivedTitle = "Old title",
+        };
+        _ = await coordinator.LoadRecentAsync(new SessionQuery
+        {
+            IncludeBackground = true,
+            PinnedSessions = [oldPin],
+        });
+        var currentPin = new SessionInfo
+        {
+            Key = oldPin.Key,
+            Label = "Current label",
+            CurrentActivity = "Current activity",
+            DerivedTitle = "Current title",
+        };
+
+        var restored = coordinator.ClearSearch(new SessionQuery
+        {
+            IncludeBackground = true,
+            PinnedSessions = [currentPin],
+        });
+
+        var selected = Assert.Single(restored.Sessions, session => session.Key == currentPin.Key);
+        Assert.Equal(
+            ["agent:main:before", selectedKey, "agent:main:after"],
+            restored.Sessions.Select(session => session.Key));
+        Assert.Equal("Current label", selected.Label);
+        Assert.Equal("Current activity", selected.CurrentActivity);
+        Assert.Equal("Current title", selected.DerivedTitle);
+    }
+
+    [Fact]
+    public async Task LegacySearch_FiltersSafeDisplayFieldsWithoutMatchingRawKeys()
+    {
+        using var coordinator = new SessionQueryCoordinator(
+            (_, _) => Task.FromResult(new SessionListResult
+            {
+                Sessions =
+                [
+                    new SessionInfo
+                    {
+                        Key = "agent:main:telegram:main:direct:needle",
+                        Label = "Unrelated",
+                    },
+                    new SessionInfo { Key = "agent:main:label", Label = "Project Needle" },
+                    new SessionInfo
+                    {
+                        Key = "agent:main:presentation",
+                        DerivedTitle = "Needle discussion",
+                    },
+                    new SessionInfo { Key = "agent:main:miss", DisplayName = "Different" },
+                ],
+                UnsupportedRequestFields = SessionListRequestFields.Search |
+                                           SessionListRequestFields.Offset,
+            }),
+            TimeSpan.Zero);
+
+        var snapshot = await coordinator.SearchAsync(new SessionQuery
+        {
+            Search = "  needle ",
+            IncludeBackground = true,
+        });
+
+        Assert.Equal(SessionSearchExecutionMode.LegacyLocal, snapshot.SearchExecutionMode);
+        Assert.Equal(
+            ["agent:main:label", "agent:main:presentation"],
+            snapshot.Sessions.Select(session => session.Key));
+        Assert.DoesNotContain(
+            snapshot.Sessions,
+            session => session.Key == "agent:main:telegram:main:direct:needle");
+    }
+
+    [Fact]
+    public async Task CompatibilitySearch_UsesCurrentSessionDisplayResolverWithoutUnsafeFields()
+    {
+        const string opaqueId = "01234567-89ab-cdef-0123-456789abcdef";
+        using var coordinator = new SessionQueryCoordinator(
+            (_, _) => Task.FromResult(new SessionListResult
+            {
+                Sessions =
+                [
+                    new SessionInfo
+                    {
+                        Key = $"agent:main:tui-{opaqueId}",
+                        DisplayName = $"Terminal:{opaqueId}",
+                    },
+                    new SessionInfo { Key = "global" },
+                    new SessionInfo { Key = "agent:ops:tui-safe", ExecNode = "buildbox" },
+                    new SessionInfo
+                    {
+                        Key = "agent:main:explicit:safe",
+                        SessionId = "secretneedle",
+                        ParentSessionKey = "secretneedle",
+                    },
+                    new SessionInfo
+                    {
+                        Key = "agent:main:tui-duplicate",
+                        Label = "Terminal session",
+                    },
+                    new SessionInfo
+                    {
+                        Key = "agent:main:explicit:visible",
+                        Label = "Visible title",
+                        Subject = "hiddenneedle",
+                        Room = "hiddenneedle",
+                        Space = "hiddenneedle",
+                        OriginLabel = "hiddenneedle",
+                    },
+                ],
+                UnsupportedRequestFields = SessionListRequestFields.Search |
+                                           SessionListRequestFields.Offset,
+            }),
+            TimeSpan.Zero);
+
+        var terminal = await coordinator.SearchAsync(new SessionQuery
+        {
+            Search = "terminal session",
+            IncludeBackground = true,
+        });
+        var globalTitle = SessionDisplayResolver.Resolve(new SessionInfo { Key = "global" }).Title;
+        var global = await coordinator.SearchAsync(new SessionQuery
+        {
+            Search = globalTitle,
+            IncludeBackground = true,
+        });
+        var subtitle = await coordinator.SearchAsync(new SessionQuery
+        {
+            Search = "node buildbox",
+            IncludeBackground = true,
+        });
+        var opaque = await coordinator.SearchAsync(new SessionQuery
+        {
+            Search = opaqueId,
+            IncludeBackground = true,
+        });
+        var unsafeFields = await coordinator.SearchAsync(new SessionQuery
+        {
+            Search = "secretneedle",
+            IncludeBackground = true,
+        });
+        var hiddenRawFields = await coordinator.SearchAsync(new SessionQuery
+        {
+            Search = "hiddenneedle",
+            IncludeBackground = true,
+        });
+
+        Assert.Equal(3, terminal.Sessions.Count);
+        Assert.Equal(
+            terminal.Sessions.Count,
+            terminal.Sessions.Select(session => session.Key).Distinct(StringComparer.Ordinal).Count());
+        Assert.Equal("global", Assert.Single(global.Sessions).Key);
+        Assert.Equal("agent:ops:tui-safe", Assert.Single(subtitle.Sessions).Key);
+        Assert.Empty(opaque.Sessions);
+        Assert.Empty(unsafeFields.Sessions);
+        Assert.Empty(hiddenRawFields.Sessions);
+    }
+
+    [Fact]
+    public async Task LegacySearch_IsCappedPinsSelectionAndClearRestoresRecent()
+    {
+        var rows = Enumerable.Range(0, 2500)
+            .Select(index => new SessionInfo
+            {
+                Key = $"agent:main:{index}",
+                DisplayName = index % 2 == 0 ? "Needle" : "Other",
+            })
+            .ToArray();
+        using var coordinator = new SessionQueryCoordinator(
+            (_, _) => Task.FromResult(new SessionListResult
+            {
+                Sessions = rows,
+                UnsupportedRequestFields = SessionListRequestFields.Search |
+                                           SessionListRequestFields.Offset,
+            }),
+            TimeSpan.Zero);
+        var recentQuery = new SessionQuery { IncludeBackground = true };
+        var recent = await coordinator.LoadRecentAsync(recentQuery);
+        var pinned = new SessionInfo { Key = "agent:main:selected", Label = "Selected" };
+
+        var search = await coordinator.SearchAsync(new SessionQuery
+        {
+            Search = "needle",
+            IncludeBackground = true,
+            PinnedSessions = [pinned],
+        });
+        var restored = coordinator.ClearSearch(recentQuery);
+
+        Assert.Equal(SessionQueryCoordinator.MaximumMaterializedSessions, recent.Sessions.Count);
+        Assert.Equal(1001, search.Sessions.Count);
+        Assert.Contains(search.Sessions, session => session.Key == pinned.Key);
+        Assert.Equal(
+            recent.Sessions.Select(session => session.Key),
+            restored.Sessions.Select(session => session.Key));
+        Assert.Equal(SessionSearchExecutionMode.None, restored.SearchExecutionMode);
+    }
+
+    [Fact]
+    public async Task ServerSearch_ReportsServerExecutionMode()
+    {
+        using var coordinator = new SessionQueryCoordinator(
+            (_, _) => Task.FromResult(Page([Session(1)], 0, null, false)),
+            TimeSpan.Zero);
+
+        var snapshot = await coordinator.SearchAsync(new SessionQuery { Search = "one" });
+
+        Assert.Equal(SessionSearchExecutionMode.Server, snapshot.SearchExecutionMode);
+    }
+
+    [Fact]
+    public async Task LegacyUnboundedResponse_IsCappedDefensively()
+    {
+        using var coordinator = new SessionQueryCoordinator(
+            (_, _) => Task.FromResult(new SessionListResult
+            {
+                Sessions = Enumerable.Range(0, 2500).Select(Session).ToArray(),
+                UnsupportedRequestFields = SessionListRequestFields.Offset,
+            }),
+            TimeSpan.Zero);
+
+        var snapshot = await coordinator.LoadRecentAsync(new SessionQuery { IncludeBackground = true });
+
+        Assert.Equal(SessionQueryCoordinator.MaximumMaterializedSessions, snapshot.Sessions.Count);
+        Assert.Equal(1, snapshot.PagesRead);
+        Assert.True(snapshot.UsedCompatibilityFallback);
+    }
+
+    private static SessionInfo Session(int index) => new() { Key = $"agent:main:{index}" };
+
+    private static SessionListResult Page(
+        IEnumerable<SessionInfo> sessions,
+        int offset,
+        int? nextOffset,
+        bool hasMore,
+        SessionListRequestFields unsupportedRequestFields = SessionListRequestFields.None)
+    {
+        var rows = sessions.ToArray();
+        return new SessionListResult
+        {
+            Sessions = rows,
+            Count = rows.Length,
+            TotalCount = 2000,
+            LimitApplied = 100,
+            Offset = offset,
+            NextOffset = nextOffset,
+            HasMore = hasMore,
+            UnsupportedRequestFields = unsupportedRequestFields,
+        };
+    }
+}


### PR DESCRIPTION
Related to #953

Stack: 1 of 2. This PR is the protocol/query/publication foundation. The virtualized searchable picker will follow as a dependent Part 2 PR.

## Root cause

Windows sent an `agentId`-only `sessions.list` request, consumed the bounded first page, and discarded paging metadata. Users with large session stores could not discover rows beyond the newest 100.

## What changed

- Added typed `sessions.list` request/result models for `agentId`, `limit`, `offset`, `search`, `configuredAgentsOnly`, `archived`, and returned paging metadata.
- Preserved the compatibility surface: `SessionsUpdated` and `GetSessionList()` publish at most 100 unique rows and never deep-page into existing nonvirtualized consumers.
- Added `QuerySessionsAsync` for coherent deep discovery in 100-row pages, capped at 20 pages and 2,000 materialized sessions.
- Added exact per-field `INVALID_REQUEST` negotiation. Only the rejected optional field is disabled for the connection; every supported field survives subsequent retries. Local search is used only when `search` itself is rejected.
- Added key dedupe, cursor progress guards, current-session pins, debounced latest-query ownership, clear-search reprojection, and stale-generation cancellation.
- Added a single-owner publication queue with at most one in-flight and one trailing refresh. State commit is generation-checked; external `SessionsUpdated` callbacks run after locks are released.
- Kept `IncludeBackground` as a client-only projection option outside server query identity.
- Uses current `SessionDisplayResolver` and `SessionRunState` ownership; no deleted presentation resolver was restored.

## Core protocol provenance

The optional request fields were introduced across released Core schemas and are negotiated independently:

- v2026.5.20 commit [`e5100428`](https://github.com/openclaw/openclaw/blob/e510042870cf248c0e0461b6f8d427326266141d/src/gateway/protocol/schema/sessions.ts) supports `limit`, `search`, and `configuredAgentsOnly`, but not `offset` or `archived`.
- v2026.5.22 commit [`a374c3a5`](https://github.com/openclaw/openclaw/blob/a374c3a5bfd5225ce319bce3865aab6216309c4f/src/gateway/protocol/schema/sessions.ts) adds `offset` at the same historical source path.
- Commit [`6df0fb8`](https://github.com/openclaw/openclaw/blob/6df0fb818d67032c71eb885ac36febd540fbd10f/packages/gateway-protocol/src/schema/sessions.ts) adds `archived:boolean` at the later packages path.
- Current Core accepts `archived:boolean|"all"`; Windows intentionally sends only the boolean subset.

## Scope

This is the lower protocol/query/publication foundation only. It contains no picker UI, Reactor, localization, copy, or design changes.

Current head: [`389f8d31`](https://github.com/bkudiess/openclaw-windows-node/commit/389f8d319398dd3a27270c9ec68f7ec70bad3889), with validated parent [`77141d27`](https://github.com/openclaw/openclaw-windows-node/commit/77141d27ee69728da6c3509fb116de63bd176da4) (the latest main when this head was committed). The target `main` branch subsequently advanced to [`4712e227`](https://github.com/openclaw/openclaw-windows-node/commit/4712e227d110746400e93107c60616544d68f7b4); GitHub currently reports the PR mergeable and runs checks against the current target.

## Validation

```powershell
$env:OPENCLAW_REPO_ROOT = (Get-Location).Path
.\build.ps1
dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore
dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore
```

| Validation | Result |
|---|---:|
| Full repository build | Passed: Shared, CLI, WinNode CLI, SetupEngine, WinUI; 46 docs checked |
| Shared | 3,705 passed, 32 skipped, 0 failed |
| Tray | 2,246 passed, 0 skipped, 0 failed |
| Focused protocol/query/publication/live WebSocket set | 72 passed |
| Service-restart response ownership | 1 passed |
| Coordinator burst/cancellation stress | 25 iterations, 75 tests passed |
| Live WebSocket burst/cancellation stress | 10 iterations, 30 tests passed |
| `git diff --check` | Passed |

## Real behavior proof

Credential-free loopback WebSocket tests exercise the real `OpenClawGatewayClient` request/response path and prove:

- eager `RequestSessionsAsync` publishes 100 rows while `QuerySessionsAsync` returns a 1,000-row snapshot in 10 pages;
- a v2026.5.20-shaped Gateway rejects only `offset`, retains server-side `search`, and finds a match outside the newest 100 rows;
- exact rejection of `limit`, `offset`, `search`, `configuredAgentsOnly`, and `archived` removes only the named field and caches that connection capability;
- search rejection falls back locally across bounded deep pages, while supported server search remains server-owned;
- sustained change bursts publish the in-flight snapshot and a coalesced trailing snapshot without starvation or a lost final refresh;
- disconnect/reconnect and generation changes reject stale query, negotiation, bootstrap, and publication work;
- paging bounds, key dedupe, current-session pins, clear-search projection, and service-restart response ownership remain intact.

The earlier 1,000-session Gateway comment was captured at old head `48d55f6c`. It is historical evidence for deep query behavior only; the current bounded compatibility path intentionally does not publish 1,000 bootstrap rows.

No historical v2026.5.20/v2026.5.22 Gateway binary was run for this head. Compatibility evidence is bounded to exact released source contracts plus deterministic live fake-WebSocket negotiation tests.

## Review closure

- GPT-5.6 Sol/high rubber-duck final follow-up found no high-signal issue and independently ran 82 targeted protocol/coordinator/race/integration tests.
- Independent GPT-5.6 Sol/high code review found three generation/publication races: cross-generation admission, stale bootstrap generation recapture, and post-check/pre-publication state commit. All three were repaired with deterministic coverage.
- Final GPT-5.6 Sol/high closure review found no significant issue.

## Part 2 dependency

Part 2 can stack on this exact head and consume the UI-neutral `QuerySessionsAsync(SessionQuery, CancellationToken)` and `ClearSessionSearch(SessionQuery?)` bridge seams. It will own virtualization/search picker UI; this PR deliberately does not.