### PR TITLE
fix(chat): stabilize bottom anchoring

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Chat/ReactorChatTimeline.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ReactorChatTimeline.cs
@@ -38,11 +38,6 @@ public sealed record ReactorChatIdentity(
     string? Avatar = null,
     string? Emoji = null);
 
-internal sealed record ReactorStreamingTailState(
-    string EntryId,
-    int TextLength,
-    bool IsStreaming);
-
 /// <summary>
 /// Reactor-owned production timeline. Reactor's keyed ItemsView handles row
 /// reconciliation, container realization, scrolling, and virtualization.
@@ -105,7 +100,7 @@ public sealed class ReactorChatTimeline : Component<ReactorChatTimelineProps>
         var rows = BuildRows(props);
         var initialTailRequestKey =
             $"{props.Timeline.SessionId ?? "none"}|{props.Timeline.TimelineGeneration}|{props.HistoryRevision}|{props.Timeline.ScrollToBottomToken}";
-        var streamingTailState = GetStreamingTailState(props.Timeline.Entries);
+        var displayedTailKey = rows.Count > 0 ? rows[^1].Key : null;
         void SetEntryHovered(string entryId, bool isHovered)
         {
             if (isHovered)
@@ -166,7 +161,7 @@ public sealed class ReactorChatTimeline : Component<ReactorChatTimelineProps>
                     annotatedScrollBarRef,
                     rows.Count - 1,
                     initialTailRequestKey,
-                    streamingTailState)
+                    displayedTailKey)
                 .Grid(column: 0)
                 .AutomationName("Chat messages")
                 .HAlign(HorizontalAlignment.Stretch)
@@ -185,15 +180,6 @@ public sealed class ReactorChatTimeline : Component<ReactorChatTimelineProps>
 
     public static string SyntheticRowKey(OpenClawChatTimelineProps props, string id, ChatTimelineItemKind kind) =>
         $"thread:{props.SessionId ?? "none"}|generation:{props.TimelineGeneration}|kind:{kind}|synthetic:{id}";
-
-    private static ReactorStreamingTailState? GetStreamingTailState(
-        IReadOnlyList<ChatTimelineItem> entries)
-    {
-        if (entries.LastOrDefault() is not { Kind: ChatTimelineItemKind.Assistant } entry)
-            return null;
-
-        return new ReactorStreamingTailState(entry.Id, entry.Text.Length, entry.IsStreaming);
-    }
 
     private static IReadOnlyList<ReactorTimelineRow> BuildRows(ReactorChatTimelineProps props)
     {

--- a/src/OpenClaw.Tray.WinUI/Chat/ReactorChatTimeline.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ReactorChatTimeline.cs
@@ -160,6 +160,7 @@ public sealed class ReactorChatTimeline : Component<ReactorChatTimelineProps>
                 .BindVerticalScrollController(
                     annotatedScrollBarRef,
                     rows.Count - 1,
+                    rows.Count,
                     initialTailRequestKey,
                     displayedTailKey)
                 .Grid(column: 0)

--- a/src/OpenClaw.Tray.WinUI/Chat/ReactorChatTimeline.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ReactorChatTimeline.cs
@@ -38,6 +38,11 @@ public sealed record ReactorChatIdentity(
     string? Avatar = null,
     string? Emoji = null);
 
+internal sealed record ReactorStreamingTailState(
+    string EntryId,
+    int TextLength,
+    bool IsStreaming);
+
 /// <summary>
 /// Reactor-owned production timeline. Reactor's keyed ItemsView handles row
 /// reconciliation, container realization, scrolling, and virtualization.
@@ -100,6 +105,7 @@ public sealed class ReactorChatTimeline : Component<ReactorChatTimelineProps>
         var rows = BuildRows(props);
         var initialTailRequestKey =
             $"{props.Timeline.SessionId ?? "none"}|{props.Timeline.TimelineGeneration}|{props.HistoryRevision}|{props.Timeline.ScrollToBottomToken}";
+        var streamingTailState = GetStreamingTailState(props.Timeline.Entries);
         void SetEntryHovered(string entryId, bool isHovered)
         {
             if (isHovered)
@@ -159,7 +165,8 @@ public sealed class ReactorChatTimeline : Component<ReactorChatTimelineProps>
                 .BindVerticalScrollController(
                     annotatedScrollBarRef,
                     rows.Count - 1,
-                    initialTailRequestKey)
+                    initialTailRequestKey,
+                    streamingTailState)
                 .Grid(column: 0)
                 .AutomationName("Chat messages")
                 .HAlign(HorizontalAlignment.Stretch)
@@ -178,6 +185,15 @@ public sealed class ReactorChatTimeline : Component<ReactorChatTimelineProps>
 
     public static string SyntheticRowKey(OpenClawChatTimelineProps props, string id, ChatTimelineItemKind kind) =>
         $"thread:{props.SessionId ?? "none"}|generation:{props.TimelineGeneration}|kind:{kind}|synthetic:{id}";
+
+    private static ReactorStreamingTailState? GetStreamingTailState(
+        IReadOnlyList<ChatTimelineItem> entries)
+    {
+        if (entries.LastOrDefault() is not { Kind: ChatTimelineItemKind.Assistant } entry)
+            return null;
+
+        return new ReactorStreamingTailState(entry.Id, entry.Text.Length, entry.IsStreaming);
+    }
 
     private static IReadOnlyList<ReactorTimelineRow> BuildRows(ReactorChatTimelineProps props)
     {

--- a/src/OpenClaw.Tray.WinUI/Chat/ReactorItemsViewScrollController.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ReactorItemsViewScrollController.cs
@@ -6,7 +6,6 @@ using Microsoft.UI.Xaml;
 using System.Runtime.CompilerServices;
 using WinUIAnnotatedScrollBar = Microsoft.UI.Xaml.Controls.AnnotatedScrollBar;
 using WinUIItemsView = Microsoft.UI.Xaml.Controls.ItemsView;
-using WinUIScrollingInteractionState = Microsoft.UI.Xaml.Controls.ScrollingInteractionState;
 using WinUIScrollView = Microsoft.UI.Xaml.Controls.ScrollView;
 
 namespace OpenClawTray.Chat;
@@ -16,7 +15,7 @@ file sealed record ItemsViewVerticalScrollControllerElement(
     ElementRef<WinUIAnnotatedScrollBar> ScrollBarRef,
     int InitialTailIndex,
     string InitialTailRequestKey,
-    ReactorStreamingTailState? StreamingTailState) : Element
+    string? DisplayedTailKey) : Element
 {
     static ItemsViewVerticalScrollControllerElement() =>
         ControlRegistry.RegisterDecorator<ItemsViewVerticalScrollControllerElement>(
@@ -40,7 +39,10 @@ file sealed class ItemsViewVerticalScrollControllerHandler
                 ((WinUIItemsView)value).VerticalScrollController = scrollBar?.ScrollController);
         var positioner = new InitialTailPositioner(itemsView);
         Positioners.Add(itemsView, positioner);
-        positioner.Request(element.InitialTailIndex, element.InitialTailRequestKey);
+        positioner.Request(
+            element.InitialTailIndex,
+            element.InitialTailRequestKey,
+            element.DisplayedTailKey);
         return itemsView;
     }
 
@@ -55,12 +57,14 @@ file sealed class ItemsViewVerticalScrollControllerHandler
             throw new InvalidOperationException("ItemsView scroll controller binding requires an ItemsView child.");
         if (!string.Equals(oldElement.InitialTailRequestKey, newElement.InitialTailRequestKey, StringComparison.Ordinal)
             && Positioners.TryGetValue(itemsView, out var positioner))
-            positioner.Request(newElement.InitialTailIndex, newElement.InitialTailRequestKey);
-        else if (Positioners.TryGetValue(itemsView, out var existingPositioner))
-            existingPositioner.UpdateTailIndex(
+            positioner.Request(
                 newElement.InitialTailIndex,
-                oldElement.StreamingTailState,
-                newElement.StreamingTailState);
+                newElement.InitialTailRequestKey,
+                newElement.DisplayedTailKey);
+        else if (Positioners.TryGetValue(itemsView, out var existingPositioner))
+            existingPositioner.UpdateTail(
+                newElement.InitialTailIndex,
+                newElement.DisplayedTailKey);
         return itemsView;
     }
 
@@ -78,22 +82,18 @@ file sealed class ItemsViewVerticalScrollControllerHandler
 file sealed class InitialTailPositioner : IDisposable
 {
     private const double FollowThreshold = 60;
-    private const int StreamingTailFollowIntervalMs = 125;
 
     private readonly WinUIItemsView itemsView;
     private string? _requestKey;
+    private string? _displayedTailKey;
     private int _tailIndex;
     private int _version;
     private bool _valid;
     private bool _awaitingLayout;
     private WinUIScrollView? _awaitingScrollView;
     private WinUIScrollView? _scrollView;
-    private DispatcherTimer? _streamingTailFollowTimer;
-    private ReactorStreamingTailState? _pendingStreamingTail;
     private bool _following;
     private bool _tailRequestQueued;
-    private bool _streamingTailFollowPending;
-    private bool _userInteractionObserved;
     private bool _disposed;
 
     public InitialTailPositioner(WinUIItemsView itemsView)
@@ -103,7 +103,7 @@ file sealed class InitialTailPositioner : IDisposable
         itemsView.Unloaded += OnUnloaded;
     }
 
-    public void Request(int tailIndex, string requestKey)
+    public void Request(int tailIndex, string requestKey, string? displayedTailKey)
     {
         if (_disposed || string.Equals(_requestKey, requestKey, StringComparison.Ordinal))
             return;
@@ -111,33 +111,26 @@ file sealed class InitialTailPositioner : IDisposable
         _requestKey = requestKey;
         _version++;
         DetachLayout();
-        StopStreamingTailFollow();
         _valid = tailIndex >= 0;
         if (!_valid)
             return;
 
         _tailIndex = tailIndex;
+        _displayedTailKey = displayedTailKey;
         _following = true;
         if (itemsView.IsLoaded)
             AwaitLayout();
     }
 
-    public void UpdateTailIndex(
-        int tailIndex,
-        ReactorStreamingTailState? previousStreamingTail,
-        ReactorStreamingTailState? currentStreamingTail)
+    public void UpdateTail(int tailIndex, string? displayedTailKey)
     {
-        var changed = _tailIndex != tailIndex;
+        var changed = !string.Equals(_displayedTailKey, displayedTailKey, StringComparison.Ordinal);
         _tailIndex = tailIndex;
-        if (changed && _following && tailIndex >= 0 && itemsView.IsLoaded)
+        _displayedTailKey = displayedTailKey;
+        if (changed && _following && tailIndex >= 0 && itemsView.IsLoaded && displayedTailKey is not null)
         {
-            StopStreamingTailFollow();
             QueueTailRequest(_version);
-            return;
         }
-
-        if (_following && IsStreamingTailUpdate(previousStreamingTail, currentStreamingTail))
-            RequestStreamingTailFollow(currentStreamingTail!);
     }
 
     private void OnLoaded(object sender, RoutedEventArgs args)
@@ -206,24 +199,15 @@ file sealed class InitialTailPositioner : IDisposable
         DetachScrollView();
         _scrollView = nextScrollView;
         if (_scrollView is not null)
+        {
+            _scrollView.VerticalAnchorRatio = 1.0;
             _scrollView.ViewChanged += OnViewChanged;
+        }
     }
 
     private void OnViewChanged(WinUIScrollView sender, object args)
     {
-        if (sender.State == WinUIScrollingInteractionState.Interaction)
-        {
-            _following = false;
-            _userInteractionObserved = true;
-            StopStreamingTailFollow();
-            return;
-        }
-
-        if (_userInteractionObserved)
-        {
-            _userInteractionObserved = false;
-            _following = IsNearBottom(sender);
-        }
+        _following = IsNearBottom(sender);
     }
 
     private void QueueTailRequest(int version)
@@ -252,7 +236,6 @@ file sealed class InitialTailPositioner : IDisposable
     {
         if (itemsView.ScrollView is not { IsLoaded: true })
             return;
-
         _following = true;
         itemsView.StartBringItemIntoView(index, new BringIntoViewOptions
         {
@@ -261,67 +244,13 @@ file sealed class InitialTailPositioner : IDisposable
         });
     }
 
-    private void RequestStreamingTailFollow(ReactorStreamingTailState streamingTail)
-    {
-        _pendingStreamingTail = streamingTail;
-        _streamingTailFollowPending = true;
-        _streamingTailFollowTimer ??= CreateStreamingTailFollowTimer();
-        if (!_streamingTailFollowTimer.IsEnabled)
-            _streamingTailFollowTimer.Start();
-    }
-
-    private DispatcherTimer CreateStreamingTailFollowTimer()
-    {
-        var timer = new DispatcherTimer
-        {
-            Interval = TimeSpan.FromMilliseconds(StreamingTailFollowIntervalMs),
-        };
-        timer.Tick += OnStreamingTailFollowTick;
-        return timer;
-    }
-
-    private void OnStreamingTailFollowTick(object? sender, object args)
-    {
-        _streamingTailFollowTimer?.Stop();
-        if (_disposed
-            || !_valid
-            || !_following
-            || !_streamingTailFollowPending
-            || !itemsView.IsLoaded
-            || _scrollView is not { IsLoaded: true, State: not WinUIScrollingInteractionState.Interaction })
-        {
-            StopStreamingTailFollow();
-            return;
-        }
-
-        _streamingTailFollowPending = false;
-        var streamingTail = _pendingStreamingTail;
-        _pendingStreamingTail = null;
-        StartTailRequest(_tailIndex);
-        if (streamingTail is { IsStreaming: true } && _following)
-            return;
-
-        StopStreamingTailFollow();
-    }
-
     private static bool IsNearBottom(WinUIScrollView scrollView) =>
         scrollView.ScrollableHeight - scrollView.VerticalOffset <= FollowThreshold;
-
-    private static bool IsStreamingTailUpdate(
-        ReactorStreamingTailState? previous,
-        ReactorStreamingTailState? current) =>
-        previous is not null
-        && current is not null
-        && string.Equals(previous.EntryId, current.EntryId, StringComparison.Ordinal)
-        && ((current.IsStreaming
-             && (!previous.IsStreaming || previous.TextLength != current.TextLength))
-            || (previous.IsStreaming && !current.IsStreaming));
 
     private void OnUnloaded(object sender, RoutedEventArgs args)
     {
         _version++;
         DetachLayout();
-        StopStreamingTailFollow();
         DetachScrollView();
     }
 
@@ -343,16 +272,12 @@ file sealed class InitialTailPositioner : IDisposable
     private void DetachScrollView()
     {
         if (_scrollView is not null)
+        {
+            _scrollView.VerticalAnchorRatio = double.NaN;
             _scrollView.ViewChanged -= OnViewChanged;
+        }
 
         _scrollView = null;
-    }
-
-    private void StopStreamingTailFollow()
-    {
-        _streamingTailFollowTimer?.Stop();
-        _pendingStreamingTail = null;
-        _streamingTailFollowPending = false;
     }
 
     public void Dispose()
@@ -363,12 +288,6 @@ file sealed class InitialTailPositioner : IDisposable
         _disposed = true;
         _version++;
         DetachLayout();
-        StopStreamingTailFollow();
-        if (_streamingTailFollowTimer is not null)
-        {
-            _streamingTailFollowTimer.Tick -= OnStreamingTailFollowTick;
-            _streamingTailFollowTimer = null;
-        }
         DetachScrollView();
         itemsView.Loaded -= OnLoaded;
         itemsView.Unloaded -= OnUnloaded;
@@ -382,11 +301,11 @@ internal static class ItemsViewScrollControllerExtensions
         ElementRef<WinUIAnnotatedScrollBar> scrollBarRef,
         int initialTailIndex,
         string initialTailRequestKey,
-        ReactorStreamingTailState? streamingTailState) =>
+        string? displayedTailKey) =>
         new ItemsViewVerticalScrollControllerElement(
             itemsView,
             scrollBarRef,
             initialTailIndex,
             initialTailRequestKey,
-            streamingTailState);
+            displayedTailKey);
 }

--- a/src/OpenClaw.Tray.WinUI/Chat/ReactorItemsViewScrollController.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ReactorItemsViewScrollController.cs
@@ -1,12 +1,12 @@
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;
 using Microsoft.UI.Reactor.Core.V1Protocol;
-using Microsoft.UI.Reactor.Hooks;
 using Microsoft.UI.Reactor.Input;
 using Microsoft.UI.Xaml;
 using System.Runtime.CompilerServices;
 using WinUIAnnotatedScrollBar = Microsoft.UI.Xaml.Controls.AnnotatedScrollBar;
 using WinUIItemsView = Microsoft.UI.Xaml.Controls.ItemsView;
+using WinUIScrollingInteractionState = Microsoft.UI.Xaml.Controls.ScrollingInteractionState;
 using WinUIScrollView = Microsoft.UI.Xaml.Controls.ScrollView;
 
 namespace OpenClawTray.Chat;
@@ -15,7 +15,8 @@ file sealed record ItemsViewVerticalScrollControllerElement(
     Element Child,
     ElementRef<WinUIAnnotatedScrollBar> ScrollBarRef,
     int InitialTailIndex,
-    string InitialTailRequestKey) : Element
+    string InitialTailRequestKey,
+    ReactorStreamingTailState? StreamingTailState) : Element
 {
     static ItemsViewVerticalScrollControllerElement() =>
         ControlRegistry.RegisterDecorator<ItemsViewVerticalScrollControllerElement>(
@@ -56,7 +57,10 @@ file sealed class ItemsViewVerticalScrollControllerHandler
             && Positioners.TryGetValue(itemsView, out var positioner))
             positioner.Request(newElement.InitialTailIndex, newElement.InitialTailRequestKey);
         else if (Positioners.TryGetValue(itemsView, out var existingPositioner))
-            existingPositioner.UpdateTailIndex(newElement.InitialTailIndex);
+            existingPositioner.UpdateTailIndex(
+                newElement.InitialTailIndex,
+                oldElement.StreamingTailState,
+                newElement.StreamingTailState);
         return itemsView;
     }
 
@@ -73,6 +77,9 @@ file sealed class ItemsViewVerticalScrollControllerHandler
 
 file sealed class InitialTailPositioner : IDisposable
 {
+    private const double FollowThreshold = 60;
+    private const int StreamingTailFollowIntervalMs = 125;
+
     private readonly WinUIItemsView itemsView;
     private string? _requestKey;
     private int _tailIndex;
@@ -81,7 +88,12 @@ file sealed class InitialTailPositioner : IDisposable
     private bool _awaitingLayout;
     private WinUIScrollView? _awaitingScrollView;
     private WinUIScrollView? _scrollView;
+    private DispatcherTimer? _streamingTailFollowTimer;
+    private ReactorStreamingTailState? _pendingStreamingTail;
     private bool _following;
+    private bool _tailRequestQueued;
+    private bool _streamingTailFollowPending;
+    private bool _userInteractionObserved;
     private bool _disposed;
 
     public InitialTailPositioner(WinUIItemsView itemsView)
@@ -95,42 +107,66 @@ file sealed class InitialTailPositioner : IDisposable
     {
         if (_disposed || string.Equals(_requestKey, requestKey, StringComparison.Ordinal))
             return;
+
         _requestKey = requestKey;
         _version++;
         DetachLayout();
+        StopStreamingTailFollow();
         _valid = tailIndex >= 0;
-        if (!_valid) return;
+        if (!_valid)
+            return;
+
         _tailIndex = tailIndex;
-        SetFollowing(true);
-        if (itemsView.IsLoaded) AwaitLayout();
+        _following = true;
+        if (itemsView.IsLoaded)
+            AwaitLayout();
     }
 
-    public void UpdateTailIndex(int tailIndex)
+    public void UpdateTailIndex(
+        int tailIndex,
+        ReactorStreamingTailState? previousStreamingTail,
+        ReactorStreamingTailState? currentStreamingTail)
     {
+        var changed = _tailIndex != tailIndex;
         _tailIndex = tailIndex;
+        if (changed && _following && tailIndex >= 0 && itemsView.IsLoaded)
+        {
+            StopStreamingTailFollow();
+            QueueTailRequest(_version);
+            return;
+        }
+
+        if (_following && IsStreamingTailUpdate(previousStreamingTail, currentStreamingTail))
+            RequestStreamingTailFollow(currentStreamingTail!);
     }
 
     private void OnLoaded(object sender, RoutedEventArgs args)
     {
-        if (_valid) AwaitLayout();
+        if (_valid)
+            AwaitLayout();
     }
 
     private void AwaitLayout()
     {
-        if (_disposed || !_valid || !itemsView.IsLoaded || _awaitingLayout) return;
+        if (_disposed || !_valid || !itemsView.IsLoaded || _awaitingLayout)
+            return;
+
         if (itemsView.ScrollView is { IsLoaded: false } scrollView)
         {
             _awaitingScrollView = scrollView;
             scrollView.Loaded += OnScrollViewLoaded;
             return;
         }
+
         _awaitingLayout = true;
         itemsView.LayoutUpdated += OnLayoutUpdated;
     }
 
     private void OnScrollViewLoaded(object sender, RoutedEventArgs args)
     {
-        if (sender is WinUIScrollView scrollView) scrollView.Loaded -= OnScrollViewLoaded;
+        if (sender is WinUIScrollView scrollView)
+            scrollView.Loaded -= OnScrollViewLoaded;
+
         _awaitingScrollView = null;
         AwaitLayout();
     }
@@ -143,6 +179,7 @@ file sealed class InitialTailPositioner : IDisposable
             AwaitLayout();
             return;
         }
+
         var version = _version;
         var index = _tailIndex;
         itemsView.DispatcherQueue.TryEnqueue(() =>
@@ -150,61 +187,142 @@ file sealed class InitialTailPositioner : IDisposable
             if (_disposed || !_valid || !itemsView.IsLoaded || version != _version
                 || itemsView.ScrollView is not { IsLoaded: true })
             {
-                if (!_disposed && _valid) AwaitLayout();
+                if (!_disposed && _valid)
+                    AwaitLayout();
                 return;
             }
-            itemsView.StartBringItemIntoView(index, new BringIntoViewOptions
-            {
-                AnimationDesired = false,
-                VerticalAlignmentRatio = 1.0,
-            });
+
             AttachScrollView();
-            ApplyFollowAnchor();
+            StartTailRequest(index);
         });
     }
 
     private void AttachScrollView()
     {
-        if (ReferenceEquals(_scrollView, itemsView.ScrollView))
+        var nextScrollView = itemsView.ScrollView;
+        if (ReferenceEquals(_scrollView, nextScrollView))
             return;
 
-        if (_scrollView is not null)
-            _scrollView.ViewChanged -= OnViewChanged;
-        _scrollView = itemsView.ScrollView;
+        DetachScrollView();
+        _scrollView = nextScrollView;
         if (_scrollView is not null)
             _scrollView.ViewChanged += OnViewChanged;
     }
 
     private void OnViewChanged(WinUIScrollView sender, object args)
     {
-        if (_tailIndex < 0
-            || !itemsView.TryGetItemIndex(0.5, 1.0, out var bottomIndex))
+        if (sender.State == WinUIScrollingInteractionState.Interaction)
         {
+            _following = false;
+            _userInteractionObserved = true;
+            StopStreamingTailFollow();
             return;
         }
 
-        SetFollowing(bottomIndex >= _tailIndex);
+        if (_userInteractionObserved)
+        {
+            _userInteractionObserved = false;
+            _following = IsNearBottom(sender);
+        }
     }
 
-    private void SetFollowing(bool following)
+    private void QueueTailRequest(int version)
     {
-        if (_following == following)
+        if (_tailRequestQueued)
             return;
 
-        _following = following;
-        ApplyFollowAnchor();
+        _tailRequestQueued = true;
+        if (!itemsView.DispatcherQueue.TryEnqueue(() =>
+        {
+            _tailRequestQueued = false;
+            if (_disposed || !_valid || !itemsView.IsLoaded || version != _version || !_following)
+            {
+                return;
+            }
+
+            StartTailRequest(_tailIndex);
+        }))
+        {
+            _tailRequestQueued = false;
+            _following = false;
+        }
     }
 
-    private void ApplyFollowAnchor()
+    private void StartTailRequest(int index)
     {
-        if (itemsView.ScrollView is { IsLoaded: true } scrollView)
-            scrollView.VerticalAnchorRatio = _following ? 1.0 : double.NaN;
+        if (itemsView.ScrollView is not { IsLoaded: true })
+            return;
+
+        _following = true;
+        itemsView.StartBringItemIntoView(index, new BringIntoViewOptions
+        {
+            AnimationDesired = false,
+            VerticalAlignmentRatio = 1.0,
+        });
     }
+
+    private void RequestStreamingTailFollow(ReactorStreamingTailState streamingTail)
+    {
+        _pendingStreamingTail = streamingTail;
+        _streamingTailFollowPending = true;
+        _streamingTailFollowTimer ??= CreateStreamingTailFollowTimer();
+        if (!_streamingTailFollowTimer.IsEnabled)
+            _streamingTailFollowTimer.Start();
+    }
+
+    private DispatcherTimer CreateStreamingTailFollowTimer()
+    {
+        var timer = new DispatcherTimer
+        {
+            Interval = TimeSpan.FromMilliseconds(StreamingTailFollowIntervalMs),
+        };
+        timer.Tick += OnStreamingTailFollowTick;
+        return timer;
+    }
+
+    private void OnStreamingTailFollowTick(object? sender, object args)
+    {
+        _streamingTailFollowTimer?.Stop();
+        if (_disposed
+            || !_valid
+            || !_following
+            || !_streamingTailFollowPending
+            || !itemsView.IsLoaded
+            || _scrollView is not { IsLoaded: true, State: not WinUIScrollingInteractionState.Interaction })
+        {
+            StopStreamingTailFollow();
+            return;
+        }
+
+        _streamingTailFollowPending = false;
+        var streamingTail = _pendingStreamingTail;
+        _pendingStreamingTail = null;
+        StartTailRequest(_tailIndex);
+        if (streamingTail is { IsStreaming: true } && _following)
+            return;
+
+        StopStreamingTailFollow();
+    }
+
+    private static bool IsNearBottom(WinUIScrollView scrollView) =>
+        scrollView.ScrollableHeight - scrollView.VerticalOffset <= FollowThreshold;
+
+    private static bool IsStreamingTailUpdate(
+        ReactorStreamingTailState? previous,
+        ReactorStreamingTailState? current) =>
+        previous is not null
+        && current is not null
+        && string.Equals(previous.EntryId, current.EntryId, StringComparison.Ordinal)
+        && ((current.IsStreaming
+             && (!previous.IsStreaming || previous.TextLength != current.TextLength))
+            || (previous.IsStreaming && !current.IsStreaming));
 
     private void OnUnloaded(object sender, RoutedEventArgs args)
     {
         _version++;
         DetachLayout();
+        StopStreamingTailFollow();
+        DetachScrollView();
     }
 
     private void DetachLayout()
@@ -214,6 +332,7 @@ file sealed class InitialTailPositioner : IDisposable
             scrollView.Loaded -= OnScrollViewLoaded;
             _awaitingScrollView = null;
         }
+
         if (_awaitingLayout)
         {
             itemsView.LayoutUpdated -= OnLayoutUpdated;
@@ -221,15 +340,36 @@ file sealed class InitialTailPositioner : IDisposable
         }
     }
 
+    private void DetachScrollView()
+    {
+        if (_scrollView is not null)
+            _scrollView.ViewChanged -= OnViewChanged;
+
+        _scrollView = null;
+    }
+
+    private void StopStreamingTailFollow()
+    {
+        _streamingTailFollowTimer?.Stop();
+        _pendingStreamingTail = null;
+        _streamingTailFollowPending = false;
+    }
+
     public void Dispose()
     {
-        if (_disposed) return;
+        if (_disposed)
+            return;
+
         _disposed = true;
         _version++;
         DetachLayout();
-        if (_scrollView is not null)
-            _scrollView.ViewChanged -= OnViewChanged;
-        _scrollView = null;
+        StopStreamingTailFollow();
+        if (_streamingTailFollowTimer is not null)
+        {
+            _streamingTailFollowTimer.Tick -= OnStreamingTailFollowTick;
+            _streamingTailFollowTimer = null;
+        }
+        DetachScrollView();
         itemsView.Loaded -= OnLoaded;
         itemsView.Unloaded -= OnUnloaded;
     }
@@ -241,6 +381,12 @@ internal static class ItemsViewScrollControllerExtensions
         this ItemsViewElement<T> itemsView,
         ElementRef<WinUIAnnotatedScrollBar> scrollBarRef,
         int initialTailIndex,
-        string initialTailRequestKey) =>
-        new ItemsViewVerticalScrollControllerElement(itemsView, scrollBarRef, initialTailIndex, initialTailRequestKey);
+        string initialTailRequestKey,
+        ReactorStreamingTailState? streamingTailState) =>
+        new ItemsViewVerticalScrollControllerElement(
+            itemsView,
+            scrollBarRef,
+            initialTailIndex,
+            initialTailRequestKey,
+            streamingTailState);
 }

--- a/src/OpenClaw.Tray.WinUI/Chat/ReactorItemsViewScrollController.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ReactorItemsViewScrollController.cs
@@ -14,6 +14,7 @@ file sealed record ItemsViewVerticalScrollControllerElement(
     Element Child,
     ElementRef<WinUIAnnotatedScrollBar> ScrollBarRef,
     int InitialTailIndex,
+    int ItemCount,
     string InitialTailRequestKey,
     string? DisplayedTailKey) : Element
 {
@@ -41,6 +42,7 @@ file sealed class ItemsViewVerticalScrollControllerHandler
         Positioners.Add(itemsView, positioner);
         positioner.Request(
             element.InitialTailIndex,
+            element.ItemCount,
             element.InitialTailRequestKey,
             element.DisplayedTailKey);
         return itemsView;
@@ -59,11 +61,13 @@ file sealed class ItemsViewVerticalScrollControllerHandler
             && Positioners.TryGetValue(itemsView, out var positioner))
             positioner.Request(
                 newElement.InitialTailIndex,
+                newElement.ItemCount,
                 newElement.InitialTailRequestKey,
                 newElement.DisplayedTailKey);
         else if (Positioners.TryGetValue(itemsView, out var existingPositioner))
             existingPositioner.UpdateTail(
                 newElement.InitialTailIndex,
+                newElement.ItemCount,
                 newElement.DisplayedTailKey);
         return itemsView;
     }
@@ -87,13 +91,14 @@ file sealed class InitialTailPositioner : IDisposable
     private string? _requestKey;
     private string? _displayedTailKey;
     private int _tailIndex;
+    private int _itemCount;
     private int _version;
     private bool _valid;
     private bool _awaitingLayout;
     private WinUIScrollView? _awaitingScrollView;
     private WinUIScrollView? _scrollView;
     private bool _following;
-    private bool _tailRequestQueued;
+    private readonly TailNavigationQueue _tailNavigationQueue = new();
     private bool _disposed;
 
     public InitialTailPositioner(WinUIItemsView itemsView)
@@ -103,7 +108,7 @@ file sealed class InitialTailPositioner : IDisposable
         itemsView.Unloaded += OnUnloaded;
     }
 
-    public void Request(int tailIndex, string requestKey, string? displayedTailKey)
+    public void Request(int tailIndex, int itemCount, string requestKey, string? displayedTailKey)
     {
         if (_disposed || string.Equals(_requestKey, requestKey, StringComparison.Ordinal))
             return;
@@ -111,25 +116,34 @@ file sealed class InitialTailPositioner : IDisposable
         _requestKey = requestKey;
         _version++;
         DetachLayout();
-        _valid = tailIndex >= 0;
+        _tailIndex = tailIndex;
+        _itemCount = itemCount;
+        _displayedTailKey = displayedTailKey;
+        _following = true;
+        _valid = TailNavigationPolicy.TryCapture(tailIndex, displayedTailKey, itemCount, out _);
         if (!_valid)
             return;
 
-        _tailIndex = tailIndex;
-        _displayedTailKey = displayedTailKey;
-        _following = true;
         if (itemsView.IsLoaded)
             AwaitLayout();
     }
 
-    public void UpdateTail(int tailIndex, string? displayedTailKey)
+    public void UpdateTail(int tailIndex, int itemCount, string? displayedTailKey)
     {
         var changed = !string.Equals(_displayedTailKey, displayedTailKey, StringComparison.Ordinal);
         _tailIndex = tailIndex;
+        _itemCount = itemCount;
         _displayedTailKey = displayedTailKey;
-        if (changed && _following && tailIndex >= 0 && itemsView.IsLoaded && displayedTailKey is not null)
+        _valid = TailNavigationPolicy.TryCapture(tailIndex, displayedTailKey, itemCount, out var request);
+        if (!_valid)
         {
-            QueueTailRequest(_version);
+            _tailNavigationQueue.Clear();
+            return;
+        }
+
+        if (changed && _following && itemsView.IsLoaded)
+        {
+            QueueTailRequest(_version, request);
         }
     }
 
@@ -174,7 +188,9 @@ file sealed class InitialTailPositioner : IDisposable
         }
 
         var version = _version;
-        var index = _tailIndex;
+        if (!TailNavigationPolicy.TryCapture(_tailIndex, _displayedTailKey, _itemCount, out var request))
+            return;
+
         itemsView.DispatcherQueue.TryEnqueue(() =>
         {
             if (_disposed || !_valid || !itemsView.IsLoaded || version != _version
@@ -186,7 +202,8 @@ file sealed class InitialTailPositioner : IDisposable
             }
 
             AttachScrollView();
-            StartTailRequest(index);
+            if (!StartTailRequest(request) && !_disposed && _valid)
+                AwaitLayout();
         });
     }
 
@@ -210,38 +227,51 @@ file sealed class InitialTailPositioner : IDisposable
         _following = IsNearBottom(sender);
     }
 
-    private void QueueTailRequest(int version)
+    private void QueueTailRequest(int version, TailNavigationRequest request)
     {
-        if (_tailRequestQueued)
+        if (!_tailNavigationQueue.Enqueue(version, request))
             return;
 
-        _tailRequestQueued = true;
         if (!itemsView.DispatcherQueue.TryEnqueue(() =>
         {
-            _tailRequestQueued = false;
-            if (_disposed || !_valid || !itemsView.IsLoaded || version != _version || !_following)
+            if (!_tailNavigationQueue.TryDequeue(_version, out var queuedRequest)
+                || _disposed
+                || !_valid
+                || !itemsView.IsLoaded
+                || !_following)
             {
                 return;
             }
 
-            StartTailRequest(_tailIndex);
+            StartTailRequest(queuedRequest);
         }))
         {
-            _tailRequestQueued = false;
+            _tailNavigationQueue.SchedulingFailed();
             _following = false;
         }
     }
 
-    private void StartTailRequest(int index)
+    private bool StartTailRequest(TailNavigationRequest request)
     {
         if (itemsView.ScrollView is not { IsLoaded: true })
-            return;
+            return false;
+
+        if (!TailNavigationPolicy.CanExecute(
+                request,
+                _tailIndex,
+                _displayedTailKey,
+                _itemCount))
+        {
+            return false;
+        }
+
         _following = true;
-        itemsView.StartBringItemIntoView(index, new BringIntoViewOptions
+        itemsView.StartBringItemIntoView(request.Index, new BringIntoViewOptions
         {
             AnimationDesired = false,
             VerticalAlignmentRatio = 1.0,
         });
+        return true;
     }
 
     private static bool IsNearBottom(WinUIScrollView scrollView) =>
@@ -250,6 +280,7 @@ file sealed class InitialTailPositioner : IDisposable
     private void OnUnloaded(object sender, RoutedEventArgs args)
     {
         _version++;
+        _tailNavigationQueue.Clear();
         DetachLayout();
         DetachScrollView();
     }
@@ -287,6 +318,7 @@ file sealed class InitialTailPositioner : IDisposable
 
         _disposed = true;
         _version++;
+        _tailNavigationQueue.Clear();
         DetachLayout();
         DetachScrollView();
         itemsView.Loaded -= OnLoaded;
@@ -300,12 +332,14 @@ internal static class ItemsViewScrollControllerExtensions
         this ItemsViewElement<T> itemsView,
         ElementRef<WinUIAnnotatedScrollBar> scrollBarRef,
         int initialTailIndex,
+        int itemCount,
         string initialTailRequestKey,
         string? displayedTailKey) =>
         new ItemsViewVerticalScrollControllerElement(
             itemsView,
             scrollBarRef,
             initialTailIndex,
+            itemCount,
             initialTailRequestKey,
             displayedTailKey);
 }

--- a/src/OpenClaw.Tray.WinUI/Chat/TailNavigationPolicy.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/TailNavigationPolicy.cs
@@ -1,0 +1,75 @@
+namespace OpenClawTray.Chat;
+
+internal readonly record struct TailNavigationRequest(int Index, string DisplayedTailKey);
+
+internal static class TailNavigationPolicy
+{
+    public static bool TryCapture(
+        int tailIndex,
+        string? displayedTailKey,
+        int itemCount,
+        out TailNavigationRequest request)
+    {
+        if (tailIndex < 0 || tailIndex >= itemCount || string.IsNullOrEmpty(displayedTailKey))
+        {
+            request = default;
+            return false;
+        }
+
+        request = new TailNavigationRequest(tailIndex, displayedTailKey);
+        return true;
+    }
+
+    public static bool CanExecute(
+        TailNavigationRequest request,
+        int currentTailIndex,
+        string? currentDisplayedTailKey,
+        int itemCount) =>
+        request.Index >= 0
+        && request.Index < itemCount
+        && request.Index == currentTailIndex
+        && string.Equals(
+            request.DisplayedTailKey,
+            currentDisplayedTailKey,
+            StringComparison.Ordinal);
+}
+
+internal sealed class TailNavigationQueue
+{
+    private (int Version, TailNavigationRequest Request)? _pending;
+
+    public bool Enqueue(int version, TailNavigationRequest request)
+    {
+        _pending = (version, request);
+        if (IsScheduled)
+            return false;
+
+        IsScheduled = true;
+        return true;
+    }
+
+    public bool TryDequeue(int currentVersion, out TailNavigationRequest request)
+    {
+        IsScheduled = false;
+        var pending = _pending;
+        _pending = null;
+        if (pending is not { } value || value.Version != currentVersion)
+        {
+            request = default;
+            return false;
+        }
+
+        request = value.Request;
+        return true;
+    }
+
+    public void Clear() => _pending = null;
+
+    public void SchedulingFailed()
+    {
+        IsScheduled = false;
+        _pending = null;
+    }
+
+    public bool IsScheduled { get; private set; }
+}

--- a/tests/OpenClaw.Tray.Tests/ChatTimelinePresentationTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ChatTimelinePresentationTests.cs
@@ -30,6 +30,7 @@ public sealed class ChatTimelinePresentationTests
         Assert.Contains("annotatedScrollBarRef,", timeline);
         Assert.Contains("rows.Count - 1", timeline);
         Assert.Contains("initialTailRequestKey", timeline);
+        Assert.Contains("var displayedTailKey = rows.Count > 0 ? rows[^1].Key : null", timeline);
         Assert.DoesNotContain("ItemsRepeater(", timeline);
         Assert.DoesNotContain("ScrollView(", timeline);
     }
@@ -50,7 +51,7 @@ public sealed class ChatTimelinePresentationTests
     }
 
     [Fact]
-    public void ReactorTimeline_ThrottlesStreamingAssistantTailWithoutPersistentAnchoring()
+    public void ReactorTimeline_UsesStableBottomAnchoringAndDiscreteTailRequests()
     {
         var binding = File.ReadAllText(Path.Combine(
             TestRepositoryPaths.GetRepositoryRoot(),
@@ -64,12 +65,11 @@ public sealed class ChatTimelinePresentationTests
         Assert.Contains("itemsView.DispatcherQueue.TryEnqueue", binding);
         Assert.Contains("itemsView.StartBringItemIntoView(", binding);
         Assert.Contains("VerticalAlignmentRatio = 1.0", binding);
-        Assert.Contains("var changed = _tailIndex != tailIndex", binding);
-        Assert.Contains("IsStreamingTailUpdate(previousStreamingTail, currentStreamingTail)", binding);
-        Assert.Contains("RequestStreamingTailFollow(currentStreamingTail!)", binding);
-        Assert.Contains("StreamingTailFollowIntervalMs = 125", binding);
-        Assert.Contains("OnStreamingTailFollowTick", binding);
-        Assert.Contains("StopStreamingTailFollow()", binding);
+        Assert.Contains("!string.Equals(_displayedTailKey, displayedTailKey, StringComparison.Ordinal)", binding);
+        Assert.Contains("_following = IsNearBottom(sender)", binding);
+        Assert.Contains("displayedTailKey is not null", binding);
+        Assert.Contains("_scrollView.VerticalAnchorRatio = 1.0", binding);
+        Assert.Contains("_scrollView.VerticalAnchorRatio = double.NaN", binding);
         Assert.Contains("if (_tailRequestQueued)", binding);
         Assert.Contains("_valid = tailIndex >= 0", binding);
         Assert.Contains("itemsView.Unloaded += OnUnloaded", binding);
@@ -77,10 +77,20 @@ public sealed class ChatTimelinePresentationTests
         Assert.Contains("itemsView.LayoutUpdated -= OnLayoutUpdated", binding);
         Assert.DoesNotContain("ChangeView", binding);
         Assert.DoesNotContain("UpdateLayout", binding);
-        Assert.DoesNotContain("VerticalAnchorRatio =", binding);
         Assert.DoesNotContain("TailSettle", binding);
         Assert.DoesNotContain("ScrollTo(", binding);
         Assert.DoesNotContain("ScrollCompleted", binding);
+        Assert.DoesNotContain("DispatcherTimer", binding);
+        Assert.DoesNotContain("TextLength != current.TextLength", binding);
+        Assert.DoesNotContain("ReactorStreamingTailState", binding);
+        Assert.DoesNotContain("QueueBottomAnchoringUpdate", binding);
+        Assert.DoesNotContain("ApplyBottomAnchoring", binding);
+
+        var viewChangedStart = binding.IndexOf("private void OnViewChanged", StringComparison.Ordinal);
+        var tailRequestStart = binding.IndexOf("private void QueueTailRequest", viewChangedStart, StringComparison.Ordinal);
+        var viewChanged = binding[viewChangedStart..tailRequestStart];
+        Assert.DoesNotContain("VerticalAnchorRatio", viewChanged);
+        Assert.DoesNotContain("StartBringItemIntoView", viewChanged);
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/ChatTimelinePresentationTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ChatTimelinePresentationTests.cs
@@ -1,3 +1,5 @@
+using OpenClawTray.Chat;
+
 namespace OpenClaw.Tray.Tests;
 
 public sealed class ChatTimelinePresentationTests
@@ -29,6 +31,7 @@ public sealed class ChatTimelinePresentationTests
         Assert.Contains(".BindVerticalScrollController(", timeline);
         Assert.Contains("annotatedScrollBarRef,", timeline);
         Assert.Contains("rows.Count - 1", timeline);
+        Assert.Contains("rows.Count,", timeline);
         Assert.Contains("initialTailRequestKey", timeline);
         Assert.Contains("var displayedTailKey = rows.Count > 0 ? rows[^1].Key : null", timeline);
         Assert.DoesNotContain("ItemsRepeater(", timeline);
@@ -67,11 +70,13 @@ public sealed class ChatTimelinePresentationTests
         Assert.Contains("VerticalAlignmentRatio = 1.0", binding);
         Assert.Contains("!string.Equals(_displayedTailKey, displayedTailKey, StringComparison.Ordinal)", binding);
         Assert.Contains("_following = IsNearBottom(sender)", binding);
-        Assert.Contains("displayedTailKey is not null", binding);
         Assert.Contains("_scrollView.VerticalAnchorRatio = 1.0", binding);
         Assert.Contains("_scrollView.VerticalAnchorRatio = double.NaN", binding);
-        Assert.Contains("if (_tailRequestQueued)", binding);
-        Assert.Contains("_valid = tailIndex >= 0", binding);
+        Assert.Contains("_tailNavigationQueue.Enqueue(version, request)", binding);
+        Assert.Contains("_tailNavigationQueue.TryDequeue(_version, out var queuedRequest)", binding);
+        Assert.Contains("_valid = TailNavigationPolicy.TryCapture", binding);
+        Assert.Contains("_itemCount = itemCount", binding);
+        Assert.Contains("TailNavigationPolicy.CanExecute(", binding);
         Assert.Contains("itemsView.Unloaded += OnUnloaded", binding);
         Assert.Contains("itemsView.Loaded -= OnLoaded", binding);
         Assert.Contains("itemsView.LayoutUpdated -= OnLayoutUpdated", binding);
@@ -91,6 +96,77 @@ public sealed class ChatTimelinePresentationTests
         var viewChanged = binding[viewChangedStart..tailRequestStart];
         Assert.DoesNotContain("VerticalAnchorRatio", viewChanged);
         Assert.DoesNotContain("StartBringItemIntoView", viewChanged);
+    }
+
+    [Fact]
+    public void TailNavigationPolicy_RejectsQueuedRequestAfterValidTailBecomesEmpty()
+    {
+        Assert.True(TailNavigationPolicy.TryCapture(2, "assistant-3", 3, out var queued));
+        Assert.False(TailNavigationPolicy.TryCapture(-1, null, 0, out _));
+
+        Assert.False(TailNavigationPolicy.CanExecute(
+            queued,
+            currentTailIndex: -1,
+            currentDisplayedTailKey: null,
+            itemCount: 0));
+    }
+
+    [Fact]
+    public void TailNavigationPolicy_AllowsNewRequestAfterEmptyTailBecomesValid()
+    {
+        Assert.False(TailNavigationPolicy.TryCapture(-1, null, 0, out _));
+        Assert.True(TailNavigationPolicy.TryCapture(0, "assistant-1", 1, out var queued));
+
+        Assert.True(TailNavigationPolicy.CanExecute(
+            queued,
+            currentTailIndex: 0,
+            currentDisplayedTailKey: "assistant-1",
+            itemCount: 1));
+    }
+
+    [Fact]
+    public void TailNavigationPolicy_RejectsStaleIdentityAndOutOfRangeIndex()
+    {
+        Assert.True(TailNavigationPolicy.TryCapture(1, "assistant-2", 2, out var queued));
+
+        Assert.False(TailNavigationPolicy.CanExecute(
+            queued,
+            currentTailIndex: 1,
+            currentDisplayedTailKey: "assistant-3",
+            itemCount: 2));
+        Assert.False(TailNavigationPolicy.CanExecute(
+            queued,
+            currentTailIndex: 1,
+            currentDisplayedTailKey: "assistant-2",
+            itemCount: 1));
+    }
+
+    [Fact]
+    public void TailNavigationQueue_OldCallbackConsumesNewestMatchingGeneration()
+    {
+        var queue = new TailNavigationQueue();
+        var first = new TailNavigationRequest(1, "assistant-2");
+        var replacement = new TailNavigationRequest(0, "assistant-1");
+
+        Assert.True(queue.Enqueue(version: 1, first));
+        queue.Clear();
+        Assert.False(queue.Enqueue(version: 2, replacement));
+
+        Assert.True(queue.TryDequeue(currentVersion: 2, out var dequeued));
+        Assert.Equal(replacement, dequeued);
+        Assert.False(queue.IsScheduled);
+    }
+
+    [Fact]
+    public void TailNavigationQueue_RejectsPendingRequestFromStaleGeneration()
+    {
+        var queue = new TailNavigationQueue();
+        Assert.True(queue.Enqueue(
+            version: 1,
+            new TailNavigationRequest(1, "assistant-2")));
+
+        Assert.False(queue.TryDequeue(currentVersion: 2, out _));
+        Assert.False(queue.IsScheduled);
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/ChatTimelinePresentationTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ChatTimelinePresentationTests.cs
@@ -50,7 +50,7 @@ public sealed class ChatTimelinePresentationTests
     }
 
     [Fact]
-    public void ReactorTimeline_QueuesInitialTailAfterLoadedLayoutAndCleansUp()
+    public void ReactorTimeline_ThrottlesStreamingAssistantTailWithoutPersistentAnchoring()
     {
         var binding = File.ReadAllText(Path.Combine(
             TestRepositoryPaths.GetRepositoryRoot(),
@@ -64,13 +64,23 @@ public sealed class ChatTimelinePresentationTests
         Assert.Contains("itemsView.DispatcherQueue.TryEnqueue", binding);
         Assert.Contains("itemsView.StartBringItemIntoView(", binding);
         Assert.Contains("VerticalAlignmentRatio = 1.0", binding);
+        Assert.Contains("var changed = _tailIndex != tailIndex", binding);
+        Assert.Contains("IsStreamingTailUpdate(previousStreamingTail, currentStreamingTail)", binding);
+        Assert.Contains("RequestStreamingTailFollow(currentStreamingTail!)", binding);
+        Assert.Contains("StreamingTailFollowIntervalMs = 125", binding);
+        Assert.Contains("OnStreamingTailFollowTick", binding);
+        Assert.Contains("StopStreamingTailFollow()", binding);
+        Assert.Contains("if (_tailRequestQueued)", binding);
         Assert.Contains("_valid = tailIndex >= 0", binding);
         Assert.Contains("itemsView.Unloaded += OnUnloaded", binding);
         Assert.Contains("itemsView.Loaded -= OnLoaded", binding);
         Assert.Contains("itemsView.LayoutUpdated -= OnLayoutUpdated", binding);
         Assert.DoesNotContain("ChangeView", binding);
         Assert.DoesNotContain("UpdateLayout", binding);
-        Assert.Contains("scrollView.VerticalAnchorRatio = _following ? 1.0 : double.NaN", binding);
+        Assert.DoesNotContain("VerticalAnchorRatio =", binding);
+        Assert.DoesNotContain("TailSettle", binding);
+        Assert.DoesNotContain("ScrollTo(", binding);
+        Assert.DoesNotContain("ScrollCompleted", binding);
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -44,6 +44,7 @@
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Chat\ChatLifecycleCommandDispatcher.cs" Link="Chat\ChatLifecycleCommandDispatcher.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Chat\ChatComposerSubmissionPolicy.cs" Link="Chat\ChatComposerSubmissionPolicy.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Chat\ChatCompactionPresentation.cs" Link="Chat\ChatCompactionPresentation.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Chat\TailNavigationPolicy.cs" Link="Chat\TailNavigationPolicy.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Chat\ReactorSlashCommandController.cs" Link="Chat\ReactorSlashCommandController.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Chat\OpenClawChatDataProvider.cs" Link="Chat\OpenClawChatDataProvider.cs" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

This PR stabilizes the Reactor chat follow-tail path and hardens queued native navigation against stale reconciled state.

- Establishes native bottom anchoring once when the inner `ScrollView` attaches.
- Keeps `ViewChanged` observation-only.
- Stops issuing native navigation as streamed text grows in place.
- Uses stable row keys to distinguish streamed growth from a genuinely new tail row.
- Captures immutable tail requests and revalidates index, identity, item count, and generation immediately before `StartBringItemIntoView`.
- Clears invalid pending work on empty-tail transitions, unload, and disposal while preserving empty-to-valid follow behavior.
- Synchronizes the branch with current `main`, including #1084 theme-resource changes, without conflicts.

## Tail navigation contract

`TailNavigationPolicy.TryCapture` rejects empty or out-of-range tail state before work is queued. `TailNavigationQueue` coalesces to the newest generation while retaining one dispatcher callback. `TailNavigationPolicy.CanExecute` then rejects stale identity, count, generation, or bounds immediately before native navigation.

The design intentionally has no synthetic sentinel row, custom layout, extent calculation, `TryGetItemIndex`, `ChangeView`, `UpdateLayout`, streamed text-length trigger, settle loop, or timer. `ItemsView` owns virtualization, `ScrollView` owns scrolling and anchoring, and `ViewChanged` remains observation-only.

## Validation

Current synchronized head: `12bc6d2c`

- `git diff --check`
- `.\build.ps1`: passed
- Shared: 3,399 passed, 32 skipped
- Tray: 2,045 passed
- Focused chat timeline and tail-policy tests: 15 passed
- WinUI non-accessibility: 100 passed
- WinUI accessibility: 19 passed
- The synchronized diff against current `main` remains limited to the intended five files.
- Fresh GitHub CI passed: repository hygiene, shared/tray and UI tests, setup-connect E2E, revocation-recovery E2E, network-recovery E2E, win-x64 build, win-arm64 build, dispatch, and the CodeQL advanced-setup gate.

## Real behavior proof

The maintainer accepts the contributor's manual proof for `be07589d`, the functional commit immediately below the synchronization merge:

- Clean debugger-free ARM64 DevBuild with isolated tray data.
- 25 full-range scroll/remount passes.
- 15 additional remount passes with 2,846 tool-card expand/collapse operations.
- A 14,077-character assistant response streamed to completion while 12 alternating Home/End passes and a Chat remount ran.
- The app remained responsive.
- Signed DebugView and application logs contained no `LayoutCycleException`, `Element is already the child of another element`, COM failure, or unhandled exception.

The synchronization commit only incorporates current `main` and merged cleanly. Exact synchronized-head build, Tray, Shared, focused timeline, WinUI, accessibility, x64, ARM64, and E2E validation all pass.

The earlier reviewer-observed exception on `96f0e9ec` remains classified as an intermittent negative-reproduction concern rather than a current known code defect. It did not reproduce in clean isolation passes or the contributor's current-head stress runs.

## Review

- The confirmed stale queued-tail race was fixed in `be07589d`.
- ClawSweeper found no remaining actionable code findings on that functional head.
- Final synchronized-diff GPT review found no actionable findings and returned `MERGE` at 88% confidence.
- Final synchronized-diff Gemini review found no significant issues and returned `MERGE` at 100% confidence.
- Maintainer accepts the manual proof. Combined merge confidence is above the repository's 90% threshold.

## Scope

This PR changes only Reactor chat tail positioning and its focused policy/tests. Theme and navigation resources are supplied by current `main` through #1084.