### PR TITLE
fix(chat): show checkpoint details for compacted history

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -166,6 +166,10 @@ dotnet_diagnostic.REACTOR_DIALOG_001.severity = none
 [src/OpenClaw.Tray.WinUI/Windows/**/*.cs]
 dotnet_diagnostic.REACTOR_DIALOG_001.severity = none
 
+# Shared XAML/Reactor workflow targets the invoking surface's XamlRoot.
+[src/OpenClaw.Tray.WinUI/Dialogs/SessionCheckpointDialogCoordinator.cs]
+dotnet_diagnostic.REACTOR_DIALOG_001.severity = none
+
 [src/OpenClaw.Tray.WinUI/Chat/ReactorChatHostExtensions.cs]
 dotnet_diagnostic.REACTOR_DIALOG_001.severity = none
 

--- a/src/OpenClaw.Tray.WinUI/Chat/ChatCompactionPresentation.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ChatCompactionPresentation.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using OpenClaw.Chat;
 
 namespace OpenClawTray.Chat;
 
@@ -9,6 +10,29 @@ internal sealed record ChatCompactionPresentation(
 
 internal static class ChatCompactionPresenter
 {
+    public static ChatCompactionPresentation? TryCreateForEntry(
+        ChatTimelineItem entry,
+        IReadOnlyDictionary<string, ChatEntryMetadata>? entryMetadata,
+        string? title = null,
+        string? metricsFormat = null,
+        string? fallbackDetail = null)
+    {
+        if (entry.Kind != ChatTimelineItemKind.Status
+            || entryMetadata?.TryGetValue(entry.Id, out var metadata) != true
+            || metadata is null
+            || !string.Equals(metadata.OpenClawKind, "compaction", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        return Create(
+            metadata.CompactionTokensBefore,
+            metadata.CompactionTokensAfter,
+            title,
+            metricsFormat,
+            fallbackDetail);
+    }
+
     public static ChatCompactionPresentation Create(
         long? tokensBefore,
         long? tokensAfter,

--- a/src/OpenClaw.Tray.WinUI/Chat/ChatCompactionPresentation.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ChatCompactionPresentation.cs
@@ -6,6 +6,7 @@ namespace OpenClawTray.Chat;
 internal sealed record ChatCompactionPresentation(
     string Title,
     string Detail,
+    string ActionLabel,
     string AutomationName);
 
 internal static class ChatCompactionPresenter
@@ -14,8 +15,8 @@ internal static class ChatCompactionPresenter
         ChatTimelineItem entry,
         IReadOnlyDictionary<string, ChatEntryMetadata>? entryMetadata,
         string? title = null,
-        string? metricsFormat = null,
-        string? fallbackDetail = null)
+        string? detail = null,
+        string? actionLabel = null)
     {
         if (entry.Kind != ChatTimelineItemKind.Status
             || entryMetadata?.TryGetValue(entry.Id, out var metadata) != true
@@ -25,12 +26,15 @@ internal static class ChatCompactionPresenter
             return null;
         }
 
-        return Create(
-            metadata.CompactionTokensBefore,
-            metadata.CompactionTokensAfter,
+        title ??= "COMPACTED HISTORY";
+        detail ??= "The compacted transcript is preserved as a checkpoint. " +
+            "Open session checkpoints to branch or restore from that compacted view.";
+        actionLabel ??= "Open checkpoints";
+        return new ChatCompactionPresentation(
             title,
-            metricsFormat,
-            fallbackDetail);
+            detail,
+            actionLabel,
+            $"{title}. {detail}");
     }
 
     public static ChatCompactionPresentation Create(
@@ -38,11 +42,13 @@ internal static class ChatCompactionPresenter
         long? tokensAfter,
         string? title = null,
         string? metricsFormat = null,
-        string? fallbackDetail = null)
+        string? fallbackDetail = null,
+        string? actionLabel = null)
     {
         title ??= "Context compacted";
         var detail = BuildDetail(tokensBefore, tokensAfter, metricsFormat, fallbackDetail);
-        return new ChatCompactionPresentation(title, detail, $"{title}. {detail}");
+        actionLabel ??= "Open checkpoints";
+        return new ChatCompactionPresentation(title, detail, actionLabel, $"{title}. {detail}");
     }
 
     private static string BuildDetail(

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
@@ -118,6 +118,8 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
     private readonly HashSet<string> _historyLoaded = new();              // sessionKey
     private readonly HashSet<string> _historyInFlight = new();            // sessionKey
     private readonly HashSet<string> _authoritativeHistoryReloadPending = new(); // sessionKey
+    private readonly HashSet<string> _replacementHistoryReloadPending = new(); // sessionKey
+    private readonly Dictionary<string, long> _historyReplacementVersions = new(); // sessionKey -> replacement generation
     private CancellationTokenSource _historyGenerationCancellation = new();
     private long _historyConnectionVersion;
     private readonly Dictionary<string, Task> _pendingModelPatches = new(); // sessionKey -> in-flight model set/clear
@@ -1008,17 +1010,52 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
     public Task LoadHistoryAsync(string threadId, bool force = false, CancellationToken cancellationToken = default, bool authoritative = false)
         => LoadHistoryCoreAsync(threadId, force, cancellationToken, expectedConnectionVersion: null, authoritative: authoritative);
 
+    internal Task ReplaceHistoryAfterCheckpointRestoreAsync(
+        string threadId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(threadId);
+
+        ChatDataSnapshot snapshot;
+        lock (_gate)
+        {
+            if (_disposed)
+                return Task.CompletedTask;
+
+            _historyReplacementVersions[threadId] = GetHistoryReplacementVersionLocked(threadId) + 1;
+            _timelines[threadId] = ChatTimelineState.Initial();
+            _entryMeta.Remove(threadId);
+            _historyLoaded.Remove(threadId);
+            _historyRetryCount.Remove(threadId);
+            _authoritativeHistoryReloadPending.Remove(threadId);
+            _replacementHistoryReloadPending.Remove(threadId);
+            snapshot = BuildSnapshotLocked();
+        }
+
+        Publish(snapshot);
+        return LoadHistoryCoreAsync(
+            threadId,
+            force: true,
+            cancellationToken,
+            expectedConnectionVersion: null,
+            authoritative: false,
+            replacementReload: true);
+    }
+
     private async Task LoadHistoryCoreAsync(
         string threadId,
         bool force,
         CancellationToken cancellationToken,
         long? expectedConnectionVersion,
-        bool authoritative = false)
+        long? expectedHistoryReplacementVersion = null,
+        bool authoritative = false,
+        bool replacementReload = false)
     {
         cancellationToken.ThrowIfCancellationRequested();
         if (string.IsNullOrEmpty(threadId)) return;
 
         long requestResetVersion;
+        long requestHistoryReplacementVersion;
         long requestConnectionVersion;
         CancellationToken generationCancellationToken;
         CancellationTokenSource requestCancellation;
@@ -1030,14 +1067,22 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
             {
                 return;
             }
+            if (expectedHistoryReplacementVersion is { } expectedReplacement &&
+                GetHistoryReplacementVersionLocked(threadId) != expectedReplacement)
+            {
+                return;
+            }
             if (!force && _historyLoaded.Contains(threadId)) return;
             if (!_historyInFlight.Add(threadId))
             {
-                if (authoritative)
+                if (replacementReload)
+                    _replacementHistoryReloadPending.Add(threadId);
+                else if (authoritative)
                     _authoritativeHistoryReloadPending.Add(threadId);
                 return;
             }
             requestResetVersion = GetResetVersionLocked(threadId);
+            requestHistoryReplacementVersion = GetHistoryReplacementVersionLocked(threadId);
             requestConnectionVersion = _historyConnectionVersion;
             generationCancellationToken = _historyGenerationCancellation.Token;
             requestCancellation = CancellationTokenSource.CreateLinkedTokenSource(
@@ -1062,7 +1107,8 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
             lock (_gate)
             {
                 if (_historyConnectionVersion != requestConnectionVersion ||
-                    GetResetVersionLocked(threadId) != requestResetVersion)
+                    GetResetVersionLocked(threadId) != requestResetVersion ||
+                    GetHistoryReplacementVersionLocked(threadId) != requestHistoryReplacementVersion)
                 {
                     Logger.Info($"[ChatHistory] Ignoring stale history for thread '{threadId}'");
                     historyOutcome = ChatTelemetryOutcome.Canceled;
@@ -1515,7 +1561,9 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
             bool shouldRetry;
             lock (_gate)
             {
-                if (_disposed || _historyConnectionVersion != requestConnectionVersion)
+                if (_disposed ||
+                    _historyConnectionVersion != requestConnectionVersion ||
+                    GetHistoryReplacementVersionLocked(threadId) != requestHistoryReplacementVersion)
                 {
                     historyOutcome = ChatTelemetryOutcome.Canceled;
                     return;
@@ -1525,7 +1573,7 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
                 historyException = ex;
                 _historyRetryCount.TryGetValue(threadId, out var retries);
                 shouldRetry = _status == ConnectionStatus.Connected
-                              && (authoritative || !_historyLoaded.Contains(threadId))
+                              && (replacementReload || authoritative || !_historyLoaded.Contains(threadId))
                               && retries < MaxHistoryRetries;
                 if (shouldRetry)
                     _historyRetryCount[threadId] = retries + 1;
@@ -1534,7 +1582,9 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
             _historyFailureReservedForTesting?.Invoke();
             lock (_gate)
             {
-                if (_disposed || _historyConnectionVersion != requestConnectionVersion)
+                if (_disposed ||
+                    _historyConnectionVersion != requestConnectionVersion ||
+                    GetHistoryReplacementVersionLocked(threadId) != requestHistoryReplacementVersion)
                 {
                     historyOutcome = ChatTelemetryOutcome.Canceled;
                     historyException = null;
@@ -1549,11 +1599,15 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
                     threadId,
                     LocalizationHelper.GetString("Chat_Notification_LoadHistoryFailed"),
                     ex.Message),
-                requestConnectionVersion);
+                threadId,
+                requestConnectionVersion,
+                requestHistoryReplacementVersion);
 
             lock (_gate)
             {
-                if (_disposed || _historyConnectionVersion != requestConnectionVersion)
+                if (_disposed ||
+                    _historyConnectionVersion != requestConnectionVersion ||
+                    GetHistoryReplacementVersionLocked(threadId) != requestHistoryReplacementVersion)
                 {
                     historyOutcome = ChatTelemetryOutcome.Canceled;
                     historyException = null;
@@ -1576,28 +1630,44 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
                         force: true,
                         CancellationToken.None,
                         expectedConnectionVersion: requestConnectionVersion,
-                        authoritative: authoritative);
+                        expectedHistoryReplacementVersion: requestHistoryReplacementVersion,
+                        authoritative: authoritative,
+                        replacementReload: replacementReload);
                 }));
             }
         }
         finally
         {
+            bool rerunReplacement;
             bool rerunAuthoritative;
             lock (_gate)
             {
                 if (_historyConnectionVersion == requestConnectionVersion)
                 {
                     _historyInFlight.Remove(threadId);
-                    rerunAuthoritative = _authoritativeHistoryReloadPending.Remove(threadId);
+                    rerunReplacement = _replacementHistoryReloadPending.Remove(threadId);
+                    rerunAuthoritative = !rerunReplacement
+                        && _authoritativeHistoryReloadPending.Remove(threadId);
                 }
                 else
                 {
-                    // Generation advance owns clearing pending authoritative state.
+                    // Generation advance owns clearing pending reload state.
+                    rerunReplacement = false;
                     rerunAuthoritative = false;
                 }
             }
             _telemetry.FinishHistoryLoad(historyOperation, historyOutcome, historyException);
-            if (rerunAuthoritative)
+            if (rerunReplacement)
+            {
+                _ = LoadHistoryCoreAsync(
+                    threadId,
+                    force: true,
+                    CancellationToken.None,
+                    expectedConnectionVersion: requestConnectionVersion,
+                    authoritative: false,
+                    replacementReload: true);
+            }
+            else if (rerunAuthoritative)
                 _ = LoadHistoryAsync(threadId, force: true, authoritative: true);
         }
     }
@@ -1660,7 +1730,9 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
 
     private void RaiseHistoryNotificationIfCurrent(
         ChatProviderNotification notification,
-        long requestConnectionVersion)
+        string threadId,
+        long requestConnectionVersion,
+        long requestHistoryReplacementVersion)
     {
         var args = new ChatProviderNotificationEventArgs(notification);
 
@@ -1668,7 +1740,9 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         {
             lock (_gate)
             {
-                if (_disposed || _historyConnectionVersion != requestConnectionVersion)
+                if (_disposed ||
+                    _historyConnectionVersion != requestConnectionVersion ||
+                    GetHistoryReplacementVersionLocked(threadId) != requestHistoryReplacementVersion)
                     return;
             }
 
@@ -2175,6 +2249,7 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         _historyInFlight.Clear();
         _historyRetryCount.Clear();
         _authoritativeHistoryReloadPending.Clear();
+        _replacementHistoryReloadPending.Clear();
         if (clearLoaded)
             _historyLoaded.Clear();
         return previousCancellation;
@@ -5215,6 +5290,9 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
 
     private long GetResetVersionLocked(string threadId) =>
         _resetVersions.TryGetValue(threadId, out var version) ? version : 0;
+
+    private long GetHistoryReplacementVersionLocked(string threadId) =>
+        _historyReplacementVersions.TryGetValue(threadId, out var version) ? version : 0;
 
     private long GetHistoryRevisionLocked(string threadId) =>
         _historyRevisions.TryGetValue(threadId, out var revision) ? revision : 0;

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawReactorChatRoot.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawReactorChatRoot.cs
@@ -715,7 +715,7 @@ public sealed class ReactorChatComposer : Component<ReactorChatComposerProps>
             .FirstOrDefault(value => value is not null);
     }
 
-    private static bool IsHighContrast()
+    internal static bool IsHighContrast()
     {
         return AccessibilitySettings?.HighContrast ?? false;
     }

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawReactorChatRoot.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawReactorChatRoot.cs
@@ -29,6 +29,7 @@ public sealed record OpenClawReactorChatRootProps(
     Func<CancellationToken, Action?, Task<string?>>? OnVoiceRequest = null,
     Action? OnAttachClick = null,
     Action? OnSettingsClick = null,
+    Action<string>? OnOpenCheckpoints = null,
     Action<bool>? OnSpeakerMuteChanged = null,
     Func<string, string?, Task<bool>>? ConfirmResetAsync = null,
     bool InitialMuted = false,
@@ -318,6 +319,7 @@ public sealed class OpenClawReactorChatRoot : Component<OpenClawReactorChatRootP
             timelineProps,
             onSuggestionPicked,
             firstSendInFlight,
+            OnOpenCheckpoints: props.OnOpenCheckpoints,
             HistoryRevision: historyRevision));
         var composerElement = effectiveThread is null
             ? Empty()

--- a/src/OpenClaw.Tray.WinUI/Chat/ReactorChatHostExtensions.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ReactorChatHostExtensions.cs
@@ -36,6 +36,7 @@ public static class ReactorChatHostExtensions
         Func<CancellationToken, Action?, Task<string?>>? onVoiceRequest = null,
         Action? onAttachClick = null,
         Action? onSettingsClick = null,
+        Action<string>? onOpenCheckpoints = null,
         Action<bool>? onSpeakerMuteChanged = null,
         bool initialMuted = false,
         bool isCompact = false)
@@ -81,6 +82,7 @@ public static class ReactorChatHostExtensions
             onVoiceRequest,
             onAttachClick,
             onSettingsClick,
+            onOpenCheckpoints,
             onSpeakerMuteChanged,
             ConfirmResetAsync,
             initialMuted,

--- a/src/OpenClaw.Tray.WinUI/Chat/ReactorChatTimeline.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ReactorChatTimeline.cs
@@ -31,6 +31,7 @@ public sealed record ReactorChatTimelineProps(
     Action<string>? OnSuggestionPicked = null,
     bool SuggestionsDisabled = false,
     ReactorChatIdentity? AssistantIdentity = null,
+    Action<string>? OnOpenCheckpoints = null,
     long HistoryRevision = 0);
 
 public sealed record ReactorChatIdentity(
@@ -927,14 +928,15 @@ public sealed class ReactorChatTimeline : Component<ReactorChatTimelineProps>
         var presentation = ChatCompactionPresenter.TryCreateForEntry(
             entry,
             row.Props.Timeline.EntryMetadata,
-            LocalizedOrDefault("Chat_Compaction_Title", "Context compacted"),
-            LocalizedOrDefault("Chat_Compaction_MetricsFormat", "{0} → {1} tokens · {2} saved"),
+            LocalizedOrDefault("Chat_Compaction_Title", "COMPACTED HISTORY"),
             LocalizedOrDefault(
                 "Chat_Compaction_FallbackDetail",
-                "Earlier context was summarized into a checkpoint."));
+                "The compacted transcript is preserved as a checkpoint. " +
+                "Open session checkpoints to branch or restore from that compacted view."),
+            LocalizedOrDefault("Chat_Compaction_OpenCheckpoints", "Open checkpoints"));
         return presentation is null
             ? BuildGenericStatus(entry)
-            : BuildCompaction(presentation);
+            : BuildCompaction(row, presentation);
     }
 
     private static Element BuildGenericStatus(ChatTimelineItem entry)
@@ -961,16 +963,31 @@ public sealed class ReactorChatTimeline : Component<ReactorChatTimelineProps>
                     isError ? (byte)0x32 : (byte)0x80)));
     }
 
-    private static Element BuildCompaction(ChatCompactionPresentation presentation)
+    private static Element BuildCompaction(
+        ReactorTimelineRow row,
+        ChatCompactionPresentation presentation)
     {
+        var sessionKey = row.Props.Timeline.SessionId;
+        var canOpenCheckpoints = !string.IsNullOrWhiteSpace(sessionKey)
+            && row.Props.OnOpenCheckpoints is not null;
         return Border(
                 VStack(
-                    3,
+                    8,
                     Text(presentation.Title, 13, FontWeights.SemiBold)
                         .HAlign(HorizontalAlignment.Center),
                     Text(presentation.Detail, 12, FontWeights.Normal, "TextFillColorSecondaryBrush")
                         .Set(text => text.TextAlignment = TextAlignment.Center)
-                        .HAlign(HorizontalAlignment.Center)))
+                        .HAlign(HorizontalAlignment.Center),
+                    Button(
+                            presentation.ActionLabel,
+                            () =>
+                            {
+                                if (canOpenCheckpoints)
+                                    row.Props.OnOpenCheckpoints!(sessionKey!);
+                            })
+                        .IsEnabled(canOpenCheckpoints)
+                        .HAlign(HorizontalAlignment.Center)
+                        .AutomationName(presentation.ActionLabel)))
             .Margin(36, 8, 24, 8)
             .Padding(16, 10)
             .HAlign(HorizontalAlignment.Stretch)

--- a/src/OpenClaw.Tray.WinUI/Chat/ReactorChatTimeline.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ReactorChatTimeline.cs
@@ -412,8 +412,8 @@ public sealed class ReactorChatTimeline : Component<ReactorChatTimelineProps>
         ChatTimelineItemKind.ToolCall => BuildTool(row, entry),
         ChatTimelineItemKind.Reasoning => BuildReasoning(entry),
         ChatTimelineItemKind.PermissionRequest => BuildPermission(row, entry),
-        ChatTimelineItemKind.Status => BuildStatus(entry),
-        _ => BuildStatus(entry),
+        ChatTimelineItemKind.Status => BuildStatus(row, entry),
+        _ => BuildGenericStatus(entry),
     };
 
     private static Element BuildUser(
@@ -922,7 +922,22 @@ public sealed class ReactorChatTimeline : Component<ReactorChatTimelineProps>
             .BorderThickness(1));
     }
 
-    private static Element BuildStatus(ChatTimelineItem entry)
+    private static Element BuildStatus(ReactorTimelineRow row, ChatTimelineItem entry)
+    {
+        var presentation = ChatCompactionPresenter.TryCreateForEntry(
+            entry,
+            row.Props.Timeline.EntryMetadata,
+            LocalizedOrDefault("Chat_Compaction_Title", "Context compacted"),
+            LocalizedOrDefault("Chat_Compaction_MetricsFormat", "{0} → {1} tokens · {2} saved"),
+            LocalizedOrDefault(
+                "Chat_Compaction_FallbackDetail",
+                "Earlier context was summarized into a checkpoint."));
+        return presentation is null
+            ? BuildGenericStatus(entry)
+            : BuildCompaction(presentation);
+    }
+
+    private static Element BuildGenericStatus(ChatTimelineItem entry)
     {
         var isError = entry.Tone == ChatTone.Error;
         return Border(Text(
@@ -944,6 +959,26 @@ public sealed class ReactorChatTimeline : Component<ReactorChatTimelineProps>
                     isError ? (byte)0xC8 : (byte)0x80,
                     isError ? (byte)0x32 : (byte)0x80,
                     isError ? (byte)0x32 : (byte)0x80)));
+    }
+
+    private static Element BuildCompaction(ChatCompactionPresentation presentation)
+    {
+        return Border(
+                VStack(
+                    3,
+                    Text(presentation.Title, 13, FontWeights.SemiBold)
+                        .HAlign(HorizontalAlignment.Center),
+                    Text(presentation.Detail, 12, FontWeights.Normal, "TextFillColorSecondaryBrush")
+                        .Set(text => text.TextAlignment = TextAlignment.Center)
+                        .HAlign(HorizontalAlignment.Center)))
+            .Margin(36, 8, 24, 8)
+            .Padding(16, 10)
+            .HAlign(HorizontalAlignment.Stretch)
+            .CornerRadius(8)
+            .Background(Theme.Ref("CardBackgroundFillColorDefaultBrush"))
+            .BorderBrush(Theme.Ref("ControlStrokeColorDefaultBrush"))
+            .BorderThickness(ReactorChatComposer.IsHighContrast() ? 2 : 1)
+            .AutomationName(presentation.AutomationName);
     }
 
     private static Element Footer(

--- a/src/OpenClaw.Tray.WinUI/Dialogs/SessionCheckpointDialogCoordinator.cs
+++ b/src/OpenClaw.Tray.WinUI/Dialogs/SessionCheckpointDialogCoordinator.cs
@@ -1,0 +1,445 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using OpenClaw.Shared;
+using OpenClaw.Shared.Sessions;
+using OpenClawTray.Helpers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace OpenClawTray.Dialogs;
+
+internal sealed class SessionCheckpointDialogCoordinator
+{
+    private static App CurrentApp => (App)Application.Current!;
+    private static readonly ConditionalWeakTable<XamlRoot, SemaphoreSlim> DialogGates = new();
+
+    private readonly XamlRoot _xamlRoot;
+    private readonly Func<bool> _isHostAvailable;
+    private readonly Func<string, string, InfoBarSeverity, Task>? _showStatusAsync;
+
+    private SessionCheckpointDialogCoordinator(
+        XamlRoot xamlRoot,
+        Func<bool> isHostAvailable,
+        Func<string, string, InfoBarSeverity, Task>? showStatusAsync)
+    {
+        _xamlRoot = xamlRoot;
+        _isHostAvailable = isHostAvailable;
+        _showStatusAsync = showStatusAsync;
+    }
+    public static async Task ShowAsync(
+        XamlRoot? xamlRoot,
+        string sessionKey,
+        Func<bool>? isHostAvailable = null,
+        Func<string, string, InfoBarSeverity, Task>? showStatusAsync = null,
+        string? displayName = null,
+        bool? rowIsMain = null)
+    {
+        if (xamlRoot is null || string.IsNullOrWhiteSpace(sessionKey))
+            return;
+
+        var gate = DialogGates.GetValue(xamlRoot, static _ => new SemaphoreSlim(1, 1));
+        if (!await gate.WaitAsync(0))
+            return;
+
+        try
+        {
+            var coordinator = new SessionCheckpointDialogCoordinator(
+                xamlRoot,
+                isHostAvailable ?? (() => true),
+                showStatusAsync);
+            await coordinator.ShowCoreAsync(sessionKey, displayName, rowIsMain);
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    private async Task ShowCoreAsync(string key, string? displayName, bool? rowIsMain)
+    {
+        var client = CurrentApp.GatewayClient;
+        if (client is null)
+        {
+            await ShowStatusAsync(
+                LocalizationHelper.GetString("SessionsPage_GatewayDisconnected.Title"),
+                LocalizationHelper.GetString("SessionsPage_GatewayDisconnected.Message"),
+                InfoBarSeverity.Warning);
+            return;
+        }
+
+        var session = CurrentApp.AppState?.Sessions?
+            .FirstOrDefault(candidate => string.Equals(candidate.Key, key, StringComparison.Ordinal));
+        var name = SessionActionPlanner.Describe(key, displayName ?? session?.DisplayName);
+        var isMainState = ResolveMainState(key, rowIsMain ?? session?.IsMain);
+        var isMain = isMainState == SessionMainState.Main;
+
+        SessionCompactionCheckpointList list;
+        try
+        {
+            list = await client.ListCompactionCheckpointsAsync(key);
+        }
+        catch (Exception ex)
+        {
+            await ShowStatusAsync("Couldn't load checkpoints", ex.Message, InfoBarSeverity.Error);
+            return;
+        }
+
+        if (!list.IsSupported)
+        {
+            await ShowStatusAsync(
+                "Not supported",
+                "This gateway doesn't support session compaction checkpoints. Update the gateway to use this.",
+                InfoBarSeverity.Informational);
+            return;
+        }
+
+        if (!_isHostAvailable())
+            return;
+
+        var checkpoints = list.Checkpoints
+            .OrderByDescending(checkpoint => checkpoint.CreatedAt ?? DateTime.MinValue)
+            .ToList();
+        var branchTarget = checkpoints.FirstOrDefault(checkpoint => !string.IsNullOrWhiteSpace(checkpoint.Id));
+        var restoreTarget = SessionCheckpointSelection.ResolveUnambiguousLatest(checkpoints);
+        var canRestore = restoreTarget is not null
+            && SessionActionPlanner.IsAllowed(SessionActionKind.Restore, isMainState, out _);
+
+        var body = BuildDialogBody(
+            checkpoints,
+            branchTarget,
+            restoreTarget,
+            canRestore,
+            isMainState);
+        var dialog = new ContentDialog
+        {
+            Title = $"Checkpoints: {name}",
+            Content = body,
+            PrimaryButtonText = branchTarget is not null
+                ? (restoreTarget is not null ? "Branch from latest" : "Branch from latest targetable")
+                : "",
+            SecondaryButtonText = canRestore ? "Restore latest" : "",
+            CloseButtonText = "Close",
+            DefaultButton = ContentDialogButton.Close,
+            XamlRoot = _xamlRoot,
+        };
+
+        var result = await dialog.ShowAsync();
+        if (result == ContentDialogResult.Primary && branchTarget is not null)
+            await BranchCheckpointAsync(key, branchTarget.Id);
+        else if (result == ContentDialogResult.Secondary && restoreTarget is not null)
+            await RestoreCheckpointAsync(key, name, isMain, restoreTarget.Id);
+    }
+
+    private static StackPanel BuildDialogBody(
+        IReadOnlyCollection<SessionCompactionCheckpoint> checkpoints,
+        SessionCompactionCheckpoint? branchTarget,
+        SessionCompactionCheckpoint? restoreTarget,
+        bool canRestore,
+        SessionMainState mainState)
+    {
+        var body = new StackPanel { Spacing = 12 };
+        if (checkpoints.Count == 0)
+        {
+            body.Children.Add(new TextBlock
+            {
+                Text = "No compaction checkpoints yet. Compacting this session creates one you can branch from or restore to.",
+                TextWrapping = TextWrapping.Wrap,
+            });
+            return body;
+        }
+
+        body.Children.Add(new TextBlock
+        {
+            Text = $"{checkpoints.Count} checkpoint{(checkpoints.Count == 1 ? "" : "s")} \u00B7 newest first",
+            Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+        });
+
+        var listPanel = new StackPanel { Spacing = 4 };
+        foreach (var checkpoint in checkpoints)
+        {
+            listPanel.Children.Add(new TextBlock
+            {
+                Text = "\u2022 " + DescribeCheckpoint(checkpoint),
+                TextWrapping = TextWrapping.Wrap,
+            });
+        }
+        body.Children.Add(listPanel);
+        body.Children.Add(new TextBlock
+        {
+            Text = BuildCheckpointActionHint(
+                checkpoints.Count,
+                branchTarget,
+                restoreTarget,
+                canRestore,
+                mainState),
+            Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+            Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"],
+            TextWrapping = TextWrapping.Wrap,
+        });
+        return body;
+    }
+
+    private static string DescribeCheckpoint(SessionCompactionCheckpoint checkpoint)
+    {
+        var parts = new List<string>(3);
+        if (checkpoint.CreatedAt is { } timestamp)
+            parts.Add(timestamp.ToLocalTime().ToString("g"));
+        if (!string.IsNullOrWhiteSpace(checkpoint.Reason))
+            parts.Add(checkpoint.Reason!);
+        if (checkpoint.TokensBefore is { } tokensBefore && checkpoint.TokensAfter is { } tokensAfter)
+            parts.Add($"{tokensBefore:n0}\u2192{tokensAfter:n0} tokens");
+
+        var description = parts.Count > 0
+            ? string.Join(" \u00B7 ", parts)
+            : (string.IsNullOrEmpty(checkpoint.Id) ? "checkpoint" : checkpoint.Id);
+        if (!string.IsNullOrWhiteSpace(checkpoint.Summary))
+            description += $" - {checkpoint.Summary}";
+        return description;
+    }
+
+    private static string BuildCheckpointActionHint(
+        int checkpointCount,
+        SessionCompactionCheckpoint? branchTarget,
+        SessionCompactionCheckpoint? restoreTarget,
+        bool canRestore,
+        SessionMainState mainState)
+    {
+        if (checkpointCount <= 0)
+            return "";
+
+        if (canRestore)
+        {
+            return "Actions apply to the most recent checkpoint (top of the list). " +
+                   "Branch starts a new session from it; Restore rolls this session back to it.";
+        }
+
+        var reason = mainState == SessionMainState.Main
+            ? "Restore is unavailable for the main session."
+            : restoreTarget is null
+                ? "Restore is unavailable because the latest checkpoint can't be determined safely."
+                : "Restore is unavailable for this session.";
+        var branchText = branchTarget is null
+            ? "Branch is unavailable because no checkpoint has a checkpoint id."
+            : "Branch starts a new session from the latest targetable checkpoint.";
+        return branchText + " " + reason;
+    }
+
+    private async Task BranchCheckpointAsync(string key, string checkpointId)
+    {
+        if (string.IsNullOrWhiteSpace(checkpointId))
+        {
+            await ShowStatusAsync(
+                "Action unavailable",
+                "This checkpoint can't be branched because it has no checkpoint id.",
+                InfoBarSeverity.Informational);
+            return;
+        }
+
+        var client = CurrentApp.GatewayClient;
+        if (client is null)
+        {
+            await ShowStatusAsync(
+                LocalizationHelper.GetString("SessionsPage_GatewayDisconnected.Title"),
+                LocalizationHelper.GetString("SessionsPage_GatewayDisconnected.Message"),
+                InfoBarSeverity.Warning);
+            return;
+        }
+
+        SessionCompactionMutationResult result;
+        try
+        {
+            result = await client.BranchCompactionCheckpointAsync(key, checkpointId);
+        }
+        catch (Exception ex)
+        {
+            await ShowStatusAsync("Branch failed", ex.Message, InfoBarSeverity.Error);
+            return;
+        }
+
+        if (!result.IsSupported)
+        {
+            await ShowStatusAsync(
+                "Not supported",
+                "This gateway doesn't support branching from a checkpoint. Update the gateway to use this.",
+                InfoBarSeverity.Informational);
+        }
+        else if (result.Ok)
+        {
+            await ShowStatusAsync(
+                "Branched",
+                result.ResultSessionKey is { Length: > 0 } newKey
+                    ? $"Created session {newKey}."
+                    : "Created a new session from the checkpoint.",
+                InfoBarSeverity.Success);
+            _ = client.RequestSessionsAsync();
+        }
+        else
+        {
+            await ShowStatusAsync(
+                "Branch failed",
+                result.Error ?? "Could not branch from the checkpoint.",
+                InfoBarSeverity.Error);
+        }
+    }
+
+    private async Task RestoreCheckpointAsync(string key, string name, bool wasMain, string checkpointId)
+    {
+        var mainState = ResolveMainState(key);
+        if (wasMain && mainState == SessionMainState.NotMain)
+            mainState = SessionMainState.Main;
+
+        if (!SessionActionPlanner.IsAllowed(SessionActionKind.Restore, mainState, out var blockedReason))
+        {
+            await ShowStatusAsync(
+                "Action unavailable",
+                blockedReason ?? "Restore isn't available for this session.",
+                InfoBarSeverity.Informational);
+            return;
+        }
+
+        var prompt = SessionActionPlanner.BuildPrompt(
+            SessionActionKind.Restore,
+            key,
+            name,
+            mainState == SessionMainState.Main);
+        if (prompt is not null && !await ConfirmAsync(prompt))
+            return;
+
+        var client = CurrentApp.GatewayClient;
+        if (client is null)
+        {
+            await ShowStatusAsync(
+                LocalizationHelper.GetString("SessionsPage_GatewayDisconnected.Title"),
+                LocalizationHelper.GetString("SessionsPage_GatewayDisconnected.Message"),
+                InfoBarSeverity.Warning);
+            return;
+        }
+
+        mainState = ResolveMainState(key);
+        if (wasMain && mainState == SessionMainState.NotMain)
+            mainState = SessionMainState.Main;
+        if (!SessionActionPlanner.IsAllowed(SessionActionKind.Restore, mainState, out blockedReason))
+        {
+            await ShowStatusAsync(
+                "Action unavailable",
+                blockedReason ?? "Restore isn't available for this session.",
+                InfoBarSeverity.Informational);
+            return;
+        }
+
+        try
+        {
+            var fresh = await client.ListCompactionCheckpointsAsync(key);
+            if (!fresh.IsSupported)
+            {
+                await ShowStatusAsync(
+                    "Not supported",
+                    "This gateway doesn't support restoring a checkpoint. Update the gateway to use this.",
+                    InfoBarSeverity.Informational);
+                return;
+            }
+
+            var freshLatest = SessionCheckpointSelection.ResolveUnambiguousLatest(fresh.Checkpoints);
+            if (freshLatest is null || !string.Equals(freshLatest.Id, checkpointId, StringComparison.Ordinal))
+            {
+                await ShowStatusAsync(
+                    "Checkpoints changed",
+                    "The latest checkpoint changed since you opened this. Reopen Checkpoints and try again.",
+                    InfoBarSeverity.Warning);
+                return;
+            }
+        }
+        catch (Exception ex)
+        {
+            await ShowStatusAsync("Restore failed", ex.Message, InfoBarSeverity.Error);
+            return;
+        }
+
+        SessionCompactionMutationResult result;
+        try
+        {
+            result = await client.RestoreCompactionCheckpointAsync(key, checkpointId);
+        }
+        catch (Exception ex)
+        {
+            await ShowStatusAsync("Restore failed", ex.Message, InfoBarSeverity.Error);
+            return;
+        }
+
+        if (!result.IsSupported)
+        {
+            await ShowStatusAsync(
+                "Not supported",
+                "This gateway doesn't support restoring a checkpoint. Update the gateway to use this.",
+                InfoBarSeverity.Informational);
+        }
+        else if (result.Ok)
+        {
+            await ShowStatusAsync(
+                "Restored",
+                "Rolled the session back to the checkpoint.",
+                InfoBarSeverity.Success);
+            _ = client.RequestSessionsAsync();
+        }
+        else
+        {
+            await ShowStatusAsync(
+                "Restore failed",
+                result.Error ?? "Could not restore the checkpoint.",
+                InfoBarSeverity.Error);
+        }
+    }
+
+    private SessionMainState ResolveMainState(string key, bool? rowIsMain = null)
+        => SessionActionPlanner.ResolveMainState(
+            key,
+            rowIsMain,
+            CurrentApp.GatewayClient?.MainSessionKey,
+            CurrentApp.AppState?.Sessions);
+
+    private async Task<bool> ConfirmAsync(SessionActionPrompt prompt)
+    {
+        if (!_isHostAvailable())
+            return false;
+
+        var localizedPrompt = SessionActionPromptLocalizer.Localize(prompt);
+        var dialog = new ContentDialog
+        {
+            Title = localizedPrompt.Title,
+            Content = localizedPrompt.Body,
+            PrimaryButtonText = localizedPrompt.ConfirmLabel,
+            CloseButtonText = LocalizationHelper.GetString("SessionActionPrompt_CancelLabel"),
+            DefaultButton = ContentDialogButton.None,
+            XamlRoot = _xamlRoot,
+        };
+        if (localizedPrompt.IsDestructive)
+            dialog.PrimaryButtonStyle = (Style)Application.Current.Resources["AccentButtonStyle"];
+        return await dialog.ShowAsync() == ContentDialogResult.Primary;
+    }
+
+    private async Task ShowStatusAsync(string title, string message, InfoBarSeverity severity)
+    {
+        if (!_isHostAvailable())
+            return;
+
+        if (_showStatusAsync is not null)
+        {
+            await _showStatusAsync(title, message, severity);
+            return;
+        }
+
+        var dialog = new ContentDialog
+        {
+            Title = title,
+            Content = message,
+            CloseButtonText = "Close",
+            DefaultButton = ContentDialogButton.Close,
+            XamlRoot = _xamlRoot,
+        };
+        await dialog.ShowAsync();
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Dialogs/SessionCheckpointDialogCoordinator.cs
+++ b/src/OpenClaw.Tray.WinUI/Dialogs/SessionCheckpointDialogCoordinator.cs
@@ -3,6 +3,7 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using OpenClaw.Shared;
 using OpenClaw.Shared.Sessions;
+using OpenClawTray.Chat;
 using OpenClawTray.Helpers;
 using System;
 using System.Collections.Generic;
@@ -379,6 +380,9 @@ internal sealed class SessionCheckpointDialogCoordinator
         }
         else if (result.Ok)
         {
+            if (CurrentApp.ChatProvider is { } chatProvider)
+                await chatProvider.ReplaceHistoryAfterCheckpointRestoreAsync(key);
+
             await ShowStatusAsync(
                 "Restored",
                 "Rolled the session back to the checkpoint.",

--- a/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml.cs
@@ -5,6 +5,7 @@ using OpenClaw.Chat;
 using OpenClaw.Shared;
 using OpenClaw.Shared.Capabilities;
 using OpenClawTray.Chat;
+using OpenClawTray.Dialogs;
 using OpenClawTray.Helpers;
 using OpenClawTray.Services;
 using OpenClawTray.Windows;
@@ -297,6 +298,7 @@ public sealed partial class ChatPage : Page
             onVoiceRequest: VoiceTranscribeAsync,
             onAttachClick: OnAttachClicked,
             onSettingsClick: () => _hub?.NavigateTo("voice"),
+            onOpenCheckpoints: OpenSessionCheckpoints,
             onSpeakerMuteChanged: muted => _ = OnSpeakerMuteChangedAsync(muted),
             initialMuted: ShouldStartSpeakerMuted(CurrentApp.Settings));
         _mountedProvider = provider;
@@ -315,6 +317,15 @@ public sealed partial class ChatPage : Page
             });
         }
     }
+
+    private void OpenSessionCheckpoints(string sessionKey) =>
+        AsyncEventHandlerGuard.Run(
+            () => SessionCheckpointDialogCoordinator.ShowAsync(
+                XamlRoot,
+                sessionKey,
+                isHostAvailable: () => _pageActive && XamlRoot is not null),
+            new OpenClawTray.AppLogger(),
+            nameof(OpenSessionCheckpoints));
 
     private IChatDataProvider? ResolveChatProvider(App? app)
     {

--- a/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
@@ -4,6 +4,7 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using OpenClaw.Shared;
 using OpenClaw.Shared.Sessions;
+using OpenClawTray.Dialogs;
 using OpenClawTray.Helpers;
 using OpenClawTray.Services;
 using OpenClawTray.Windows;
@@ -558,253 +559,26 @@ public sealed partial class SessionsPage : Page
     {
         var vm = ResolveSessionVm(sender);
         var key = vm?.Key ?? ResolveSessionKey(sender);
-        if (string.IsNullOrEmpty(key)) return;
-        if (XamlRoot == null) return;
+        if (string.IsNullOrEmpty(key))
+            return;
 
-        var client = CurrentApp.GatewayClient;
-        if (client == null) { ShowDisconnected(); return; }
-
-        var name = SessionActionPlanner.Describe(key, vm?.DisplayName);
-        var isMainState = ResolveMainState(key, vm);
-        var isMain = isMainState == SessionMainState.Main;
-
-        SessionCompactionCheckpointList list;
-        try
+        if (CurrentApp.GatewayClient is null)
         {
-            list = await client.ListCompactionCheckpointsAsync(key);
-        }
-        catch (Exception ex)
-        {
-            ShowActionFailure("Couldn't load checkpoints", ex);
+            ShowDisconnected();
             return;
         }
 
-        if (!list.IsSupported)
-        {
-            ShowActionInfo("Not supported", "This gateway doesn't support session compaction checkpoints. Update the gateway to use this.", InfoBarSeverity.Informational);
-            return;
-        }
-
-        if (_unloaded || XamlRoot == null)
-            return;
-
-        var checkpoints = list.Checkpoints
-            .OrderByDescending(c => c.CreatedAt ?? DateTime.MinValue)
-            .ToList();
-
-        var branchTarget = checkpoints.FirstOrDefault(c => !string.IsNullOrWhiteSpace(c.Id));
-        var restoreTarget = SessionCheckpointSelection.ResolveUnambiguousLatest(checkpoints);
-        var canRestore = restoreTarget is not null
-            && SessionActionPlanner.IsAllowed(SessionActionKind.Restore, isMainState, out _);
-        var actionHint = BuildCheckpointActionHint(checkpoints.Count, branchTarget, restoreTarget, canRestore, isMainState);
-
-        var body = new StackPanel { Spacing = 12 };
-
-        if (checkpoints.Count == 0)
-        {
-            body.Children.Add(new TextBlock
+        await SessionCheckpointDialogCoordinator.ShowAsync(
+            XamlRoot,
+            key,
+            isHostAvailable: () => !_unloaded && XamlRoot is not null,
+            showStatusAsync: (title, message, severity) =>
             {
-                Text = "No compaction checkpoints yet. Compacting this session creates one you can branch from or restore to.",
-                TextWrapping = TextWrapping.Wrap,
-            });
-        }
-        else
-        {
-            body.Children.Add(new TextBlock
-            {
-                Text = $"{checkpoints.Count} checkpoint{(checkpoints.Count == 1 ? "" : "s")} \u00B7 newest first",
-                Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
-            });
-
-            var listPanel = new StackPanel { Spacing = 4 };
-            foreach (var cp in checkpoints)
-            {
-                listPanel.Children.Add(new TextBlock
-                {
-                    Text = "\u2022 " + DescribeCheckpoint(cp),
-                    TextWrapping = TextWrapping.Wrap,
-                });
-            }
-            body.Children.Add(listPanel);
-
-            body.Children.Add(new TextBlock
-            {
-                Text = actionHint,
-                Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
-                Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"],
-                TextWrapping = TextWrapping.Wrap,
-            });
-        }
-
-        var dialog = new ContentDialog
-        {
-            Title = $"Checkpoints \u2014 {name}",
-            Content = body,
-            PrimaryButtonText = branchTarget is not null
-                ? (restoreTarget is not null ? "Branch from latest" : "Branch from latest targetable")
-                : "",
-            SecondaryButtonText = canRestore ? "Restore latest" : "",
-            CloseButtonText = "Close",
-            DefaultButton = ContentDialogButton.Close,
-            XamlRoot = XamlRoot,
-        };
-
-        var result = await dialog.ShowAsync();
-        if (result == ContentDialogResult.Primary && branchTarget is not null)
-            await BranchCheckpointAsync(key, branchTarget.Id);
-        else if (result == ContentDialogResult.Secondary && restoreTarget is not null)
-            await RestoreCheckpointAsync(key, name, isMain, restoreTarget.Id);
-    }
-
-    private static string DescribeCheckpoint(SessionCompactionCheckpoint cp)
-    {
-        var parts = new List<string>(3);
-        if (cp.CreatedAt is { } ts) parts.Add(ts.ToLocalTime().ToString("g"));
-        if (!string.IsNullOrWhiteSpace(cp.Reason)) parts.Add(cp.Reason!);
-        if (cp.TokensBefore is { } tb && cp.TokensAfter is { } ta) parts.Add($"{tb:n0}\u2192{ta:n0} tokens");
-
-        var head = parts.Count > 0
-            ? string.Join(" \u00B7 ", parts)
-            : (string.IsNullOrEmpty(cp.Id) ? "checkpoint" : cp.Id);
-
-        if (!string.IsNullOrWhiteSpace(cp.Summary))
-            head += $" \u2014 {cp.Summary}";
-        return head;
-    }
-
-    private static string BuildCheckpointActionHint(
-        int checkpointCount,
-        SessionCompactionCheckpoint? branchTarget,
-        SessionCompactionCheckpoint? restoreTarget,
-        bool canRestore,
-        SessionMainState mainState)
-    {
-        if (checkpointCount <= 0)
-            return "";
-
-        if (canRestore)
-        {
-            return "Actions apply to the most recent checkpoint (top of the list). " +
-                   "Branch starts a new session from it; Restore rolls this session back to it.";
-        }
-
-        var reason = mainState == SessionMainState.Main
-            ? "Restore is unavailable for the main session."
-            : restoreTarget is null
-                ? "Restore is unavailable because the latest checkpoint can't be determined safely."
-                : "Restore is unavailable for this session.";
-
-        var branchText = branchTarget is null
-            ? "Branch is unavailable because no checkpoint has a checkpoint id."
-            : "Branch starts a new session from the latest targetable checkpoint.";
-        return branchText + " " + reason;
-    }
-
-    private async Task BranchCheckpointAsync(string key, string checkpointId)
-    {
-        if (string.IsNullOrWhiteSpace(checkpointId))
-        {
-            ShowActionInfo("Action unavailable", "This checkpoint can't be branched because it has no checkpoint id.", InfoBarSeverity.Informational);
-            return;
-        }
-
-        var client = CurrentApp.GatewayClient;
-        if (client == null) { ShowDisconnected(); return; }
-
-        SessionCompactionMutationResult result;
-        try
-        {
-            result = await client.BranchCompactionCheckpointAsync(key, checkpointId);
-        }
-        catch (Exception ex)
-        {
-            ShowActionFailure("Branch failed", ex);
-            return;
-        }
-
-        if (!result.IsSupported)
-            ShowActionInfo("Not supported", "This gateway doesn't support branching from a checkpoint. Update the gateway to use this.", InfoBarSeverity.Informational);
-        else if (result.Ok)
-        {
-            ShowActionInfo("Branched", result.ResultSessionKey is { Length: > 0 } nk ? $"Created session {nk}." : "Created a new session from the checkpoint.", InfoBarSeverity.Success);
-            _ = client.RequestSessionsAsync();
-        }
-        else
-            ShowActionInfo("Branch failed", result.Error ?? "Could not branch from the checkpoint.", InfoBarSeverity.Error);
-    }
-
-    private async Task RestoreCheckpointAsync(string key, string name, bool isMain, string checkpointId)
-    {
-        var mainState = ResolveMainState(key, null);
-        if (isMain && mainState == SessionMainState.NotMain)
-            mainState = SessionMainState.Main;
-
-        if (!SessionActionPlanner.IsAllowed(SessionActionKind.Restore, mainState, out var blockedReason))
-        {
-            ShowActionInfo("Action unavailable", blockedReason ?? "Restore isn't available for this session.", InfoBarSeverity.Informational);
-            return;
-        }
-
-        var prompt = SessionActionPlanner.BuildPrompt(SessionActionKind.Restore, key, name, mainState == SessionMainState.Main);
-        if (prompt is not null && !await ConfirmAsync(prompt))
-            return;
-
-        var client = CurrentApp.GatewayClient;
-        if (client == null) { ShowDisconnected(); return; }
-
-        mainState = ResolveMainState(key, null);
-        if (isMain && mainState == SessionMainState.NotMain)
-            mainState = SessionMainState.Main;
-        if (!SessionActionPlanner.IsAllowed(SessionActionKind.Restore, mainState, out blockedReason))
-        {
-            ShowActionInfo("Action unavailable", blockedReason ?? "Restore isn't available for this session.", InfoBarSeverity.Informational);
-            return;
-        }
-
-        // Re-check before restore so a concurrent compaction cannot make the
-        // confirmed "latest" checkpoint stale.
-        try
-        {
-            var fresh = await client.ListCompactionCheckpointsAsync(key);
-            if (!fresh.IsSupported)
-            {
-                ShowActionInfo("Not supported", "This gateway doesn't support restoring a checkpoint. Update the gateway to use this.", InfoBarSeverity.Informational);
-                return;
-            }
-
-            var freshLatest = SessionCheckpointSelection.ResolveUnambiguousLatest(fresh.Checkpoints);
-            if (freshLatest is null || !string.Equals(freshLatest.Id, checkpointId, StringComparison.Ordinal))
-            {
-                ShowActionInfo("Checkpoints changed", "The latest checkpoint changed since you opened this. Reopen Checkpoints and try again.", InfoBarSeverity.Warning);
-                return;
-            }
-        }
-        catch (Exception ex)
-        {
-            ShowActionFailure("Restore failed", ex);
-            return;
-        }
-
-        SessionCompactionMutationResult result;
-        try
-        {
-            result = await client.RestoreCompactionCheckpointAsync(key, checkpointId);
-        }
-        catch (Exception ex)
-        {
-            ShowActionFailure("Restore failed", ex);
-            return;
-        }
-
-        if (!result.IsSupported)
-            ShowActionInfo("Not supported", "This gateway doesn't support restoring a checkpoint. Update the gateway to use this.", InfoBarSeverity.Informational);
-        else if (result.Ok)
-        {
-            ShowActionInfo("Restored", "Rolled the session back to the checkpoint.", InfoBarSeverity.Success);
-            _ = client.RequestSessionsAsync();
-        }
-        else
-            ShowActionInfo("Restore failed", result.Error ?? "Could not restore the checkpoint.", InfoBarSeverity.Error);
+                ShowActionInfo(title, message, severity);
+                return Task.CompletedTask;
+            },
+            displayName: vm?.DisplayName,
+            rowIsMain: vm?.IsMain);
     }
 
     private async Task<bool> ConfirmAsync(SessionActionPrompt prompt)

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -2889,13 +2889,16 @@ Use one of these options:
     <value>Done</value>
   </data>
   <data name="Chat_Compaction_Title" xml:space="preserve">
-    <value>Context compacted</value>
+    <value>COMPACTED HISTORY</value>
   </data>
   <data name="Chat_Compaction_MetricsFormat" xml:space="preserve">
     <value>{0} → {1} tokens · {2} saved</value>
   </data>
   <data name="Chat_Compaction_FallbackDetail" xml:space="preserve">
-    <value>Earlier context was summarized into a checkpoint.</value>
+    <value>The compacted transcript is preserved as a checkpoint. Open session checkpoints to branch or restore from that compacted view.</value>
+  </data>
+  <data name="Chat_Compaction_OpenCheckpoints" xml:space="preserve">
+    <value>Open checkpoints</value>
   </data>
   <data name="Chat_PendingNewSessionTitle" xml:space="preserve">
     <value>New session</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -2842,13 +2842,16 @@ Utilisez l'une de ces options :
     <value>Terminé</value>
   </data>
   <data name="Chat_Compaction_Title" xml:space="preserve">
-    <value>Contexte compacté</value>
+    <value>HISTORIQUE COMPACTÉ</value>
   </data>
   <data name="Chat_Compaction_MetricsFormat" xml:space="preserve">
     <value>{0} → {1} jetons · {2} économisés</value>
   </data>
   <data name="Chat_Compaction_FallbackDetail" xml:space="preserve">
-    <value>Le contexte antérieur a été résumé dans un point de contrôle.</value>
+    <value>La transcription compactée est conservée en tant que point de contrôle. Ouvrez les points de contrôle de la session pour créer une branche ou restaurer cette vue compactée.</value>
+  </data>
+  <data name="Chat_Compaction_OpenCheckpoints" xml:space="preserve">
+    <value>Ouvrir les points de contrôle</value>
   </data>
   <data name="Chat_PendingNewSessionTitle" xml:space="preserve">
     <value>Nouvelle session</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -2843,13 +2843,16 @@ Gebruik een van deze opties:
     <value>Voltooid</value>
   </data>
   <data name="Chat_Compaction_Title" xml:space="preserve">
-    <value>Context gecomprimeerd</value>
+    <value>GECOMPRIMEERDE GESCHIEDENIS</value>
   </data>
   <data name="Chat_Compaction_MetricsFormat" xml:space="preserve">
     <value>{0} → {1} tokens · {2} bespaard</value>
   </data>
   <data name="Chat_Compaction_FallbackDetail" xml:space="preserve">
-    <value>Eerdere context is samengevat in een controlepunt.</value>
+    <value>Het gecomprimeerde transcript wordt bewaard als controlepunt. Open de sessiecontrolepunten om vanaf die gecomprimeerde weergave een vertakking te maken of deze te herstellen.</value>
+  </data>
+  <data name="Chat_Compaction_OpenCheckpoints" xml:space="preserve">
+    <value>Controlepunten openen</value>
   </data>
   <data name="Chat_PendingNewSessionTitle" xml:space="preserve">
     <value>Nieuwe sessie</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -2842,13 +2842,16 @@
     <value>完成</value>
   </data>
   <data name="Chat_Compaction_Title" xml:space="preserve">
-    <value>上下文已压缩</value>
+    <value>已压缩的历史记录</value>
   </data>
   <data name="Chat_Compaction_MetricsFormat" xml:space="preserve">
     <value>{0} → {1} 个令牌 · 节省 {2}</value>
   </data>
   <data name="Chat_Compaction_FallbackDetail" xml:space="preserve">
-    <value>较早的上下文已汇总到检查点中。</value>
+    <value>压缩后的对话记录会保留为检查点。打开会话检查点，以便从该压缩视图创建分支或进行还原。</value>
+  </data>
+  <data name="Chat_Compaction_OpenCheckpoints" xml:space="preserve">
+    <value>打开检查点</value>
   </data>
   <data name="Chat_PendingNewSessionTitle" xml:space="preserve">
     <value>新会话</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -2842,13 +2842,16 @@
     <value>完成</value>
   </data>
   <data name="Chat_Compaction_Title" xml:space="preserve">
-    <value>內容已壓縮</value>
+    <value>已壓縮的歷程記錄</value>
   </data>
   <data name="Chat_Compaction_MetricsFormat" xml:space="preserve">
     <value>{0} → {1} 個權杖 · 節省 {2}</value>
   </data>
   <data name="Chat_Compaction_FallbackDetail" xml:space="preserve">
-    <value>較早的內容已摘要至檢查點。</value>
+    <value>壓縮後的對話記錄會保留為檢查點。開啟工作階段檢查點，以便從該壓縮檢視建立分支或還原。</value>
+  </data>
+  <data name="Chat_Compaction_OpenCheckpoints" xml:space="preserve">
+    <value>開啟檢查點</value>
   </data>
   <data name="Chat_PendingNewSessionTitle" xml:space="preserve">
     <value>新工作階段</value>

--- a/src/OpenClaw.Tray.WinUI/Windows/ChatWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/ChatWindow.xaml.cs
@@ -6,6 +6,7 @@ using Microsoft.UI.Xaml.Media;
 using Microsoft.Web.WebView2.Core;
 using OpenClaw.Shared;
 using OpenClawTray.Chat;
+using OpenClawTray.Dialogs;
 using OpenClawTray.Helpers;
 using OpenClawTray.Services;
 using System;
@@ -435,12 +436,22 @@ public sealed partial class ChatWindow : WindowEx
             onVoiceRequest: VoiceTranscribeAsync,
             onAttachClick: OnAttachClicked,
             onSettingsClick: () => appInstance?.ShowHub("voice"),
+            onOpenCheckpoints: OpenSessionCheckpoints,
             onSpeakerMuteChanged: muted => _ = OnSpeakerMuteChangedAsync(muted),
             initialMuted: ShouldStartSpeakerMuted(appInstance?.Settings),
             isCompact: true);
         _mountedProvider = provider;
         UpdateNativeChatSurfaceActive();
     }
+
+    private void OpenSessionCheckpoints(string sessionKey) =>
+        AsyncEventHandlerGuard.Run(
+            () => SessionCheckpointDialogCoordinator.ShowAsync(
+                Content?.XamlRoot,
+                sessionKey,
+                isHostAvailable: () => !IsClosed && _shownNearTray && Content?.XamlRoot is not null),
+            new OpenClawTray.AppLogger(),
+            nameof(OpenSessionCheckpoints));
 
     private void DisposeReactorHost()
     {

--- a/tests/OpenClaw.Tray.Tests/ChatTimelinePresentationTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ChatTimelinePresentationTests.cs
@@ -169,4 +169,23 @@ public sealed class ChatTimelinePresentationTests
         Assert.Contains("ChatTimelineAssistantRuns.Describe(orderedEntries)", timeline);
         Assert.Contains("includeMetadata: row.IsAssistantRunEnd", timeline);
     }
+
+    [Fact]
+    public void ReactorTimeline_RendersStructuredCompactionCard()
+    {
+        var timeline = File.ReadAllText(Path.Combine(
+            TestRepositoryPaths.GetRepositoryRoot(),
+            "src",
+            "OpenClaw.Tray.WinUI",
+            "Chat",
+            "ReactorChatTimeline.cs"));
+
+        Assert.Contains("ChatTimelineItemKind.Status => BuildStatus(row, entry)", timeline);
+        Assert.Contains("ChatCompactionPresenter.TryCreateForEntry(", timeline);
+        Assert.Contains("Chat_Compaction_Title", timeline);
+        Assert.Contains("Chat_Compaction_MetricsFormat", timeline);
+        Assert.Contains("Chat_Compaction_FallbackDetail", timeline);
+        Assert.Contains(".BorderThickness(ReactorChatComposer.IsHighContrast() ? 2 : 1)", timeline);
+        Assert.Contains(".AutomationName(presentation.AutomationName)", timeline);
+    }
 }

--- a/tests/OpenClaw.Tray.Tests/ChatTimelinePresentationTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ChatTimelinePresentationTests.cs
@@ -183,8 +183,9 @@ public sealed class ChatTimelinePresentationTests
         Assert.Contains("ChatTimelineItemKind.Status => BuildStatus(row, entry)", timeline);
         Assert.Contains("ChatCompactionPresenter.TryCreateForEntry(", timeline);
         Assert.Contains("Chat_Compaction_Title", timeline);
-        Assert.Contains("Chat_Compaction_MetricsFormat", timeline);
         Assert.Contains("Chat_Compaction_FallbackDetail", timeline);
+        Assert.Contains("Chat_Compaction_OpenCheckpoints", timeline);
+        Assert.Contains("row.Props.OnOpenCheckpoints!(sessionKey!)", timeline);
         Assert.Contains(".BorderThickness(ReactorChatComposer.IsHighContrast() ? 2 : 1)", timeline);
         Assert.Contains(".AutomationName(presentation.AutomationName)", timeline);
     }

--- a/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
@@ -314,6 +314,44 @@ public class OpenClawChatDataProviderTests
         Assert.Contains(presentation.Title, presentation.AutomationName);
     }
 
+    [Fact]
+    public void CompactionPresenter_CreatesPresentationForStructuredStatusEntry()
+    {
+        var entry = new ChatTimelineItem("compaction-1", ChatTimelineItemKind.Status, "Compacted");
+        var metadata = new Dictionary<string, ChatEntryMetadata>
+        {
+            [entry.Id] = new(
+                Timestamp: null,
+                Model: null,
+                OpenClawKind: "compaction",
+                CompactionTokensBefore: 42000,
+                CompactionTokensAfter: 12000),
+        };
+
+        var presentation = ChatCompactionPresenter.TryCreateForEntry(entry, metadata);
+
+        Assert.NotNull(presentation);
+        Assert.Contains("42", presentation.Detail);
+        Assert.Contains("12", presentation.Detail);
+        Assert.Contains("30", presentation.Detail);
+    }
+
+    [Theory]
+    [InlineData(ChatTimelineItemKind.Status, "status")]
+    [InlineData(ChatTimelineItemKind.Assistant, "compaction")]
+    public void CompactionPresenter_RejectsEntriesOutsideStructuredCompactionContract(
+        ChatTimelineItemKind kind,
+        string openClawKind)
+    {
+        var entry = new ChatTimelineItem("entry-1", kind, "Text");
+        var metadata = new Dictionary<string, ChatEntryMetadata>
+        {
+            [entry.Id] = new(Timestamp: null, Model: null, OpenClawKind: openClawKind),
+        };
+
+        Assert.Null(ChatCompactionPresenter.TryCreateForEntry(entry, metadata));
+    }
+
     [Theory]
     [InlineData("/new worktree", false)]
     [InlineData("/reset model", false)]

--- a/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
@@ -331,9 +331,14 @@ public class OpenClawChatDataProviderTests
         var presentation = ChatCompactionPresenter.TryCreateForEntry(entry, metadata);
 
         Assert.NotNull(presentation);
-        Assert.Contains("42", presentation.Detail);
-        Assert.Contains("12", presentation.Detail);
-        Assert.Contains("30", presentation.Detail);
+        Assert.Equal("COMPACTED HISTORY", presentation.Title);
+        Assert.Equal(
+            "The compacted transcript is preserved as a checkpoint. " +
+            "Open session checkpoints to branch or restore from that compacted view.",
+            presentation.Detail);
+        Assert.Equal("Open checkpoints", presentation.ActionLabel);
+        Assert.DoesNotContain("42", presentation.Detail);
+        Assert.DoesNotContain(presentation.ActionLabel, presentation.AutomationName);
     }
 
     [Theory]

--- a/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
@@ -244,15 +244,17 @@ public class OpenClawChatDataProviderTests
             string? lastChatStatePath = null,
             TimeSpan? lastChatStateSaveDelay = null,
             Func<TimeSpan, CancellationToken, Func<Task>, Task>? historyRetryScheduler = null,
-            Action? historyFailureReservedForTesting = null)
+            Action? historyFailureReservedForTesting = null,
+            Action<Action>? post = null)
     {
         var bridge = new FakeBridge { Sessions = initial ?? Array.Empty<SessionInfo>() };
         var provider = toolMetaCachePath is null && attachmentMetaCachePath is null && lastChatStatePath is null &&
-            lastChatStateSaveDelay is null && historyRetryScheduler is null && historyFailureReservedForTesting is null
+            lastChatStateSaveDelay is null && historyRetryScheduler is null && historyFailureReservedForTesting is null &&
+            post is null
             ? new OpenClawChatDataProvider(bridge)
             : new OpenClawChatDataProvider(
                 bridge,
-                post: null,
+                post,
                 toolMetaCacheFilePath: toolMetaCachePath ?? Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"), "tool-metadata.json"),
                 attachmentMetaCacheFilePath: attachmentMetaCachePath,
                 lastChatStateFilePath: lastChatStatePath,
@@ -458,6 +460,193 @@ public class OpenClawChatDataProviderTests
                 OpenClawSeq: 9),
             maxHistorySequence: 10,
             requestStartedAt));
+    }
+
+    [Fact]
+    public async Task CheckpointRestoreReplacement_DropsArchivedEntriesFromLoadedTimeline()
+    {
+        var (bridge, provider, _, _) = CreateProvider([MainSession()]);
+        var historyCall = 0;
+        bridge.HistoryBehavior = key =>
+        {
+            historyCall++;
+            return Task.FromResult(new ChatHistoryInfo
+            {
+                SessionKey = key ?? "",
+                Messages = historyCall == 1
+                    ?
+                    [
+                        new ChatMessageInfo
+                        {
+                            SessionKey = key ?? "",
+                            Role = "user",
+                            Text = "Before checkpoint",
+                            OpenClawSeq = 1,
+                        },
+                        new ChatMessageInfo
+                        {
+                            SessionKey = key ?? "",
+                            Role = "assistant",
+                            Text = "Archived after restore",
+                            OpenClawSeq = 2,
+                        },
+                    ]
+                    :
+                    [
+                        new ChatMessageInfo
+                        {
+                            SessionKey = key ?? "",
+                            Role = "user",
+                            Text = "Before checkpoint",
+                            OpenClawSeq = 1,
+                        },
+                    ],
+            });
+        };
+
+        await using (provider)
+        {
+            bridge.RaiseStatus(ConnectionStatus.Connected);
+            await provider.LoadHistoryAsync("main", force: true);
+            Assert.Contains(
+                (await provider.LoadAsync()).Timelines["main"].Entries,
+                entry => entry.Text == "Archived after restore");
+
+            await provider.ReplaceHistoryAfterCheckpointRestoreAsync("main");
+
+            var timeline = (await provider.LoadAsync()).Timelines["main"];
+            Assert.Contains(timeline.Entries, entry => entry.Text == "Before checkpoint");
+            Assert.DoesNotContain(timeline.Entries, entry => entry.Text == "Archived after restore");
+            Assert.Equal(2, bridge.RequestedHistoryKeys.Count);
+        }
+    }
+
+    [Fact]
+    public async Task CheckpointRestoreReplacement_InvalidatesInflightHistoryAndPreservesNewLiveEntry()
+    {
+        var (bridge, provider, snapshots, _) = CreateProvider([MainSession()]);
+        var staleHistory = new TaskCompletionSource<ChatHistoryInfo>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var restoredHistory = new TaskCompletionSource<ChatHistoryInfo>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        bridge.HistoryBehavior = _ =>
+            bridge.RequestedHistoryKeys.Count == 1
+                ? staleHistory.Task
+                : restoredHistory.Task;
+
+        await using (provider)
+        {
+            bridge.RaiseStatus(ConnectionStatus.Connected);
+            var staleLoad = provider.LoadHistoryAsync("main", force: true);
+
+            await provider.ReplaceHistoryAfterCheckpointRestoreAsync("main");
+            Assert.Single(bridge.RequestedHistoryKeys);
+
+            bridge.RaiseChat(new ChatMessageInfo
+            {
+                SessionKey = "main",
+                Role = "user",
+                Text = "New after restore",
+                OpenClawSeq = 3,
+            });
+            staleHistory.SetResult(new ChatHistoryInfo
+            {
+                SessionKey = "main",
+                Messages =
+                [
+                    new ChatMessageInfo
+                    {
+                        SessionKey = "main",
+                        Role = "user",
+                        Text = "Before checkpoint",
+                        OpenClawSeq = 1,
+                    },
+                    new ChatMessageInfo
+                    {
+                        SessionKey = "main",
+                        Role = "assistant",
+                        Text = "Archived after restore",
+                        OpenClawSeq = 2,
+                    },
+                ],
+            });
+            await staleLoad;
+            await WaitForConditionAsync(() => bridge.RequestedHistoryKeys.Count == 2);
+
+            restoredHistory.SetResult(new ChatHistoryInfo
+            {
+                SessionKey = "main",
+                Messages =
+                [
+                    new ChatMessageInfo
+                    {
+                        SessionKey = "main",
+                        Role = "user",
+                        Text = "Before checkpoint",
+                        OpenClawSeq = 1,
+                    },
+                ],
+            });
+            await WaitForConditionAsync(() =>
+                snapshots.Count > 0 &&
+                snapshots[^1].Timelines["main"].HistoryLoaded);
+
+            var timeline = snapshots[^1].Timelines["main"];
+            Assert.Contains(timeline.Entries, entry => entry.Text == "Before checkpoint");
+            Assert.Contains(timeline.Entries, entry => entry.Text == "New after restore");
+            Assert.DoesNotContain(timeline.Entries, entry => entry.Text == "Archived after restore");
+        }
+    }
+
+    [Fact]
+    public async Task CheckpointRestoreReplacement_SuppressesStaleFailureNotificationAndRetry()
+    {
+        var posted = new Queue<Action>();
+        Func<Task>? scheduledRetry = null;
+        var (bridge, provider, _, notifications) = CreateProvider(
+            [MainSession()],
+            historyRetryScheduler: (_, _, retry) =>
+            {
+                scheduledRetry = retry;
+                return Task.CompletedTask;
+            },
+            post: posted.Enqueue);
+        bridge.HistoryBehavior = key =>
+            bridge.RequestedHistoryKeys.Count == 1
+                ? Task.FromException<ChatHistoryInfo>(new IOException("stale failure"))
+                : Task.FromResult(new ChatHistoryInfo
+                {
+                    SessionKey = key ?? "",
+                    Messages =
+                    [
+                        new ChatMessageInfo
+                        {
+                            SessionKey = key ?? "",
+                            Role = "user",
+                            Text = "Before checkpoint",
+                            OpenClawSeq = 1,
+                        },
+                    ],
+                });
+
+        await using (provider)
+        {
+            bridge.RaiseStatus(ConnectionStatus.Connected);
+            posted.Clear();
+
+            await provider.LoadHistoryAsync("main", force: true);
+            var staleNotification = Assert.Single(posted);
+            Assert.NotNull(scheduledRetry);
+
+            await provider.ReplaceHistoryAfterCheckpointRestoreAsync("main");
+            Assert.Equal(2, bridge.RequestedHistoryKeys.Count);
+
+            staleNotification();
+            Assert.Empty(notifications);
+
+            await scheduledRetry!();
+            Assert.Equal(2, bridge.RequestedHistoryKeys.Count);
+        }
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/SessionActionsWiringTests.cs
+++ b/tests/OpenClaw.Tray.Tests/SessionActionsWiringTests.cs
@@ -51,6 +51,7 @@ public sealed class SessionActionsWiringTests
         Assert.Contains("ListCompactionCheckpointsAsync", checkpoints);
         Assert.Contains("BranchCompactionCheckpointAsync", checkpoints);
         Assert.Contains("RestoreCompactionCheckpointAsync", checkpoints);
+        Assert.Contains("ReplaceHistoryAfterCheckpointRestoreAsync", checkpoints);
         // Unsupported gateways are surfaced via the typed IsSupported flag.
         Assert.Contains("IsSupported", checkpoints);
     }

--- a/tests/OpenClaw.Tray.Tests/SessionActionsWiringTests.cs
+++ b/tests/OpenClaw.Tray.Tests/SessionActionsWiringTests.cs
@@ -35,6 +35,11 @@ public sealed class SessionActionsWiringTests
     public void SessionsPage_ExposesExportAndCheckpointActions()
     {
         var source = ReadSource("src", "OpenClaw.Tray.WinUI", "Pages", "SessionsPage.xaml.cs");
+        var checkpoints = ReadSource(
+            "src",
+            "OpenClaw.Tray.WinUI",
+            "Dialogs",
+            "SessionCheckpointDialogCoordinator.cs");
 
         // Export uses transcript fetch + formatter + file picker.
         Assert.Contains("RequestChatHistoryAsync", source);
@@ -42,24 +47,59 @@ public sealed class SessionActionsWiringTests
         Assert.Contains("FileSavePicker", source);
 
         // Checkpoints use the gateway's compaction-checkpoint protocol APIs.
-        Assert.Contains("ListCompactionCheckpointsAsync", source);
-        Assert.Contains("BranchCompactionCheckpointAsync", source);
-        Assert.Contains("RestoreCompactionCheckpointAsync", source);
+        Assert.Contains("SessionCheckpointDialogCoordinator.ShowAsync", source);
+        Assert.Contains("ListCompactionCheckpointsAsync", checkpoints);
+        Assert.Contains("BranchCompactionCheckpointAsync", checkpoints);
+        Assert.Contains("RestoreCompactionCheckpointAsync", checkpoints);
         // Unsupported gateways are surfaced via the typed IsSupported flag.
-        Assert.Contains("IsSupported", source);
+        Assert.Contains("IsSupported", checkpoints);
+    }
+
+    [Fact]
+    public void ChatCompactionAction_OpensTheCurrentSessionsCheckpoints()
+    {
+        var root = ReadSource("src", "OpenClaw.Tray.WinUI", "Chat", "OpenClawReactorChatRoot.cs");
+        var host = ReadSource("src", "OpenClaw.Tray.WinUI", "Chat", "ReactorChatHostExtensions.cs");
+        var timeline = ReadSource("src", "OpenClaw.Tray.WinUI", "Chat", "ReactorChatTimeline.cs");
+        var chatPage = ReadSource("src", "OpenClaw.Tray.WinUI", "Pages", "ChatPage.xaml.cs");
+        var chatWindow = ReadSource("src", "OpenClaw.Tray.WinUI", "Windows", "ChatWindow.xaml.cs");
+        var sessions = ReadSource("src", "OpenClaw.Tray.WinUI", "Pages", "SessionsPage.xaml.cs");
+        var checkpoints = ReadSource(
+            "src",
+            "OpenClaw.Tray.WinUI",
+            "Dialogs",
+            "SessionCheckpointDialogCoordinator.cs");
+
+        Assert.Contains("Action<string>? OnOpenCheckpoints", root);
+        Assert.Contains("Action<string>? onOpenCheckpoints", host);
+        Assert.Contains("row.Props.OnOpenCheckpoints!(sessionKey!)", timeline);
+        Assert.Contains("onOpenCheckpoints: OpenSessionCheckpoints", chatPage);
+        Assert.Contains("onOpenCheckpoints: OpenSessionCheckpoints", chatWindow);
+        Assert.Contains("SessionCheckpointDialogCoordinator.ShowAsync", chatPage);
+        Assert.Contains("SessionCheckpointDialogCoordinator.ShowAsync", chatWindow);
+        Assert.Contains("SessionCheckpointDialogCoordinator.ShowAsync", sessions);
+        Assert.Contains("XamlRoot = _xamlRoot", checkpoints);
+        Assert.DoesNotContain("ShowHub(\"sessions\")", chatWindow);
     }
 
     [Fact]
     public void SessionsPage_HardensDestructiveActions()
     {
         var source = ReadSource("src", "OpenClaw.Tray.WinUI", "Pages", "SessionsPage.xaml.cs");
+        var checkpoints = ReadSource(
+            "src",
+            "OpenClaw.Tray.WinUI",
+            "Dialogs",
+            "SessionCheckpointDialogCoordinator.cs");
 
         // Main-session gating uses an authoritative resolver, not a VM-only default.
-        Assert.Contains("ResolveMainState", source);
+        Assert.Contains("ResolveMainState", checkpoints);
         // Restore only acts on a provably-latest checkpoint and re-validates fresh.
-        Assert.Contains("ResolveUnambiguousLatest", source);
+        Assert.Contains("ResolveUnambiguousLatest", checkpoints);
         // ID-less checkpoints are preserved for restore safety, but can't be used as branch targets.
-        Assert.Contains("FirstOrDefault(c => !string.IsNullOrWhiteSpace(c.Id))", source);
+        Assert.Contains(
+            "FirstOrDefault(checkpoint => !string.IsNullOrWhiteSpace(checkpoint.Id))",
+            checkpoints);
         // Destructive send failures are surfaced, not swallowed.
         Assert.Contains("\"The gateway didn't accept the request. Try again.\"", source);
     }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users viewing a compaction event in Chat would see a generic status instead of checkpoint-focused compacted-history details. It also avoids taking users to the Sessions page just to display the checkpoint dialog.

## Why This Change Was Made

The Reactor timeline now renders structured compaction events with the web-parity checkpoint explanation and an **Open checkpoints** action. A shared checkpoint dialog coordinator hosts the existing list, branch, and restore workflow on the invoking Chat surface while remaining reusable from Sessions.

A maintainer patch also makes successful restores replace the active Chat transcript with fresh gateway history. It invalidates pre-restore history responses, preserves genuinely new post-restore events, and suppresses stale failure notifications and retries.

## User Impact

Users can see that compacted history is preserved as a checkpoint and open that session's checkpoints directly over Chat without losing their place. After restoring a checkpoint, Chat no longer shows messages that the gateway archived.

## Evidence

- UI automation at `2a85a0d3` verified the localized compacted-history card, checkpoint explanation, and **Open checkpoints** action.
- Invoking the action opened the checkpoint dialog over Chat while Chat remained selected and Sessions remained unselected.
- Three deterministic restore-replacement tests verify stale-entry removal, in-flight response invalidation, post-restore live-entry preservation, and stale notification/retry suppression.
- Focused Chat and checkpoint coverage: 313 passed, 0 skipped, 0 failed.
- Shared suite: 3,399 passed, 32 skipped, 0 failed.
- Tray suite: 2,053 passed, 0 skipped, 0 failed.
- Full repository build succeeded for Windows x64.
- Conflict-boundary WinUI theme proof: 2 passed, 0 skipped, 0 failed.
- Independent Opus and Codex adversarial reviews found no actionable issues in the maintainer patch or the conflict-resolved `5fdba1d0` head. Latest `main` merged without conflicts and was validated at `6093c50a`.

### UI screenshots from the visual change

<img width="1702" height="289" alt="Screenshot 2026-08-04 162114" src="https://github.com/user-attachments/assets/2e44364f-84bc-466e-82b4-6622c7afe230" />
<img width="1720" height="914" alt="Screenshot 2026-08-04 162124" src="https://github.com/user-attachments/assets/df6c84d1-7d7a-4d9b-888c-87623e6711af" />

## Change Type

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs or instructions
- [x] Tests or validation
- [ ] Security hardening
- [ ] Chore or infrastructure

## Scope

- [x] Tray or WinUI UX
- [ ] Windows node capability
- [ ] Local MCP or `winnode`
- [ ] Gateway, connection, or pairing
- [ ] Setup or onboarding
- [ ] Permissions, privacy, or security
- [x] Tests, CI, or docs

## Validation

- `.\build.ps1` - passed.
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore` - 3,399 passed, 32 skipped, 0 failed.
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore` - 2,053 passed, 0 skipped, 0 failed.
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore --filter "FullyQualifiedName~SessionActionsWiringTests|FullyQualifiedName~ChatTimelinePresentationTests|FullyQualifiedName~OpenClawChatDataProviderTests"` - 313 passed, 0 skipped, 0 failed.
- `dotnet test .\tests\OpenClaw.Tray.UITests\OpenClaw.Tray.UITests.csproj -c Debug -r win-x64 --filter "FullyQualifiedName~ChatTimelineThemeResourceProofTests"` - 2 passed, 0 skipped, 0 failed.

## Real Behavior Proof

- Environment tested: original visual proof on Windows ARM64; maintainer patch and merged-head validation on Windows x64 with .NET 10 SDK.
- PR head or commit tested: `6093c50a`.
- Exact steps or command run: launched the Debug ARM64 package at the visual-change head, inspected Chat through UI Automation, invoked **Open checkpoints**, and inspected the resulting dialog and navigation state. On merged head, ran the restore-replacement provider tests and the conflict-boundary WinUI theme proof listed above.
- Evidence after fix: the card displayed **COMPACTED HISTORY**, the checkpoint-preservation explanation, and **Open checkpoints**. The checkpoint dialog opened over the same Chat page. Restore tests prove the cached transcript is cleared and rebuilt from fresh history while post-restore live entries remain.
- Observed result: Chat remained selected, Sessions remained unselected, and the card and dialog had no visible clipping, overlap, or dark-theme issues. Restore reconciliation removed archived messages and rejected stale pre-restore completions, notifications, and retries.
- Screenshot or artifact links verified? (`Yes`/`No`/`N/A`): Yes. Both GitHub-hosted screenshots return valid PNG content and show the visual portion of the change.
- Not verified or blocked: A live gateway checkpoint restore was not repeated on merged head `6093c50a`. The restore aftermath is covered by deterministic provider tests. The maintainer patch changed state reconciliation, not visual composition.

## Security Impact

- New permissions or capabilities? (`Yes`/`No`): No.
- Secrets or tokens handling changed? (`Yes`/`No`): No.
- New or changed network calls? (`Yes`/`No`): Yes. The Chat action invokes the existing typed checkpoint list, branch, and restore APIs already used by Sessions. After a successful restore, it also refreshes `chat.history` so the local transcript matches gateway state.
- Command or tool execution surface changed? (`Yes`/`No`): No.
- Data access scope changed? (`Yes`/`No`): No.
- If any answer is `Yes`, explain the risk and mitigation: The action only exposes existing current-session checkpoint workflows on another trusted app surface. The added history refresh reads the same selected session after restore and adds no endpoint, permission, credential handling, or broader data access.

## Compatibility and Migration

- Backward compatible? (`Yes`/`No`): Yes.
- Config or environment changes? (`Yes`/`No`): No.
- Migration needed? (`Yes`/`No`): No.
- If yes, list the exact upgrade steps: N/A.

## Review Conversations

- [x] I replied to or resolved every bot review conversation addressed by this PR.
- [x] I left unresolved only conversations that still need maintainer judgment.