### PR TITLE
fix(setup): avoid false failure while WSL is still starting

### DIFF
--- a/src/OpenClaw.SetupEngine/SetupSteps.cs
+++ b/src/OpenClaw.SetupEngine/SetupSteps.cs
@@ -740,6 +740,8 @@ public sealed class PreflightPortStep : SetupStep
 
 public sealed class CreateWslInstanceStep : SetupStep
 {
+    private static readonly TimeSpan DistroVersionVerificationTimeout = TimeSpan.FromMinutes(1);
+
     public override string Id => "wsl-create";
     public override string DisplayName => "Create WSL instance";
     public override bool CanRetry => false;
@@ -832,7 +834,11 @@ public sealed class CreateWslInstanceStep : SetupStep
             return StepResult.Fail(environmentIssue != null ? $"{baseMessage} {environmentIssue}" : baseMessage);
         }
 
-        var verbose = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--list", "--verbose"], TimeSpan.FromSeconds(15), ct: ct);
+        var verbose = await ctx.Commands.RunAsync(
+            WslConstants.WslExePath,
+            ["--list", "--verbose"],
+            DistroVersionVerificationTimeout,
+            ct: ct);
         if (verbose.ExitCode != 0 || !WslInstallSupport.TryGetDistroVersion(verbose.Stdout, distro, out var version))
             return StepResult.Fail($"Fresh WSL install registered '{distro}', but setup could not verify it is WSL2.");
 

--- a/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
@@ -1031,6 +1031,37 @@ public class SetupStepsTests : IDisposable
     }
 
     [Fact]
+    public async Task CreateWslInstance_AllowsWslServiceToSettleBeforeVersionVerification()
+    {
+        var installed = false;
+        var commands = new FakeCommandRunner(args =>
+        {
+            if (args.SequenceEqual(["--list", "--quiet"]))
+                return Ok(installed ? "OpenClawGateway\n" : "");
+            if (args.Contains("--install"))
+            {
+                installed = true;
+                return Ok("Installing Ubuntu-24.04\n");
+            }
+            if (args.SequenceEqual(["--list", "--verbose"]))
+                return Ok("  NAME              STATE           VERSION\n* OpenClawGateway   Stopped         2\n");
+            if (args.SequenceEqual(["-d", "OpenClawGateway", "-u", "root", "--", "sh", "-lc", "id -u && test -d / && echo OPENCLAW_FRESH_WSL_READY"]))
+                return Ok("0\nOPENCLAW_FRESH_WSL_READY\n");
+
+            return Fail($"unexpected args: {string.Join(' ', args)}");
+        });
+        var ctx = CreateContext(commands: commands);
+
+        var result = await new CreateWslInstanceStep().ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.True(result.IsSuccess, result.Message);
+        var verboseCall = Assert.Single(
+            commands.TimedCalls,
+            call => call.Arguments.SequenceEqual(["--list", "--verbose"]));
+        Assert.Equal(TimeSpan.FromMinutes(1), verboseCall.Timeout);
+    }
+
+    [Fact]
     public async Task CreateWslInstance_PartialCleanupAvoidsGlobalShutdownWhenUnregisterSucceeds()
     {
         var listCalls = 0;
@@ -3576,6 +3607,7 @@ public class SetupStepsTests : IDisposable
         Func<string, string, TimeSpan, CommandResult>? runInWsl = null) : ICommandRunner
     {
         public List<(string Executable, string[] Arguments)> Calls { get; } = [];
+        public List<(string Executable, string[] Arguments, TimeSpan Timeout)> TimedCalls { get; } = [];
         public List<(string Executable, string[] Arguments, string? StdinInput)> DetailedCalls { get; } = [];
         public List<(string DistroName, string Command, TimeSpan Timeout, string? User, bool InputViaStdin)> WslCalls { get; } = [];
         public List<IReadOnlyDictionary<string, string>?> WslEnvironments { get; } = [];
@@ -3590,6 +3622,7 @@ public class SetupStepsTests : IDisposable
             CancellationToken ct = default)
         {
             Calls.Add((executable, arguments));
+            TimedCalls.Add((executable, arguments, timeout));
             DetailedCalls.Add((executable, arguments, stdinInput));
             return Task.FromResult(run(arguments));
         }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where fresh gateway setup could fail and roll back after WSL installation when the WSL service took more than 15 seconds to report the new distro version. This intermittently failed unrelated pull requests in the revocation-recovery E2E shard.

## Why This Change Was Made

The failing run showed `wsl.exe --install` completing successfully and `wsl.exe --list --quiet` finding the new distro, followed by `wsl.exe --list --verbose` timing out at 15.013 seconds. The post-install version verification now allows up to one minute for WSL to settle. Other WSL command timeouts and setup behavior are unchanged.

## User Impact

Gateway setup is less likely to report a false failure and remove a valid newly installed distro on slower Windows hosts or hosted runners.

## Evidence

- Failing hosted artifact: fresh WSL installation completed, then version discovery timed out at exactly 15 seconds and setup rolled back the distro.
- Regression coverage asserts that post-install version verification receives the one-minute settling allowance.
- The exact real-gateway revocation-recovery E2E test passed from commit `cb329a76`.
- Focused code review found no significant issues.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs or instructions
- [x] Tests or validation
- [ ] Security hardening
- [ ] Chore or infrastructure

## Scope

- [ ] Tray or WinUI UX
- [ ] Windows node capability
- [ ] Local MCP or `winnode`
- [ ] Gateway, connection, or pairing
- [x] Setup or onboarding
- [ ] Permissions, privacy, or security
- [x] Tests, CI, or docs

## Validation

- `./build.ps1`: passed
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj`: 3,399 passed, 32 skipped
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj`: 2,053 passed
- `dotnet test ./tests/OpenClaw.SetupEngine.Tests/OpenClaw.SetupEngine.Tests.csproj`: 704 passed
- `dotnet build ./tests/OpenClaw.E2ETests/OpenClaw.E2ETests.csproj -c Debug -r win-x64`: passed
- `dotnet test ./tests/OpenClaw.E2ETests/OpenClaw.E2ETests.csproj --no-build -c Debug -r win-x64 --filter "FullyQualifiedName~OpenClaw.E2ETests.Setup.RevocationAndRecoveryTests"`: 1 passed

The fresh worktree initially lacked NuGet assets for `--no-restore` test invocations. The test projects were rerun with restore and executed the non-zero counts above.

## Real Behavior Proof

- Environment tested: Windows 11, WSL2, isolated E2E distro, real published gateway
- PR head or commit tested: `cb329a76`
- Exact steps or command run: built `OpenClaw.E2ETests`, set `OPENCLAW_RUN_E2E=1`, then ran `FullyQualifiedName~OpenClaw.E2ETests.Setup.RevocationAndRecoveryTests`
- Evidence after fix: `RealGateway_DeviceRemoval_RecoversThroughSharedTokenReconnect` passed
- Observed result: 1 test executed, 1 passed, 0 failed in approximately 4.76 minutes
- Screenshot or artifact links verified? (`Yes`/`No`/`N/A`): N/A
- Not verified or blocked: none

## Security Impact

- New permissions or capabilities? (`Yes`/`No`): No
- Secrets or tokens handling changed? (`Yes`/`No`): No
- New or changed network calls? (`Yes`/`No`): No
- Command or tool execution surface changed? (`Yes`/`No`): No
- Data access scope changed? (`Yes`/`No`): No
- If any answer is `Yes`, explain the risk and mitigation: N/A

## Compatibility and Migration

- Backward compatible? (`Yes`/`No`): Yes
- Config or environment changes? (`Yes`/`No`): No
- Migration needed? (`Yes`/`No`): No
- If yes, list the exact upgrade steps: N/A

## Review Conversations

- [ ] I replied to or resolved every bot review conversation addressed by this PR.
- [ ] I left unresolved only conversations that still need maintainer judgment.