### PR TITLE
fix(chat): preserve persisted tool activity details

### DIFF
--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -756,12 +756,14 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
 
                 var itemSemanticCallId = ReadFirstString(
                     item,
+                    "callId",
                     "tool_call_id",
                     "toolCallId",
                     "tool_use_id",
                     "toolUseId");
                 var messageSemanticCallId = ReadFirstString(
                     message,
+                    "callId",
                     "tool_call_id",
                     "toolCallId",
                     "tool_use_id",
@@ -770,6 +772,7 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
                     ? ReadFirstString(
                         item,
                         "id",
+                        "callId",
                         "tool_call_id",
                         "toolCallId",
                         "tool_use_id",
@@ -791,7 +794,8 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
                     Text = kind == ChatToolContentKind.Result
                         ? ExtractToolContentText(item)
                         : null,
-                    IsError = ReadBoolean(item, "isError", "is_error"),
+                    IsError = ReadNullableBoolean(item, "isError", "is_error")
+                        ?? ReadBoolean(message, "isError", "is_error"),
                 });
             }
         }
@@ -809,6 +813,7 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
                 Kind = ChatToolContentKind.Result,
                 CallId = ReadFirstString(
                     message,
+                    "callId",
                     "tool_call_id",
                     "toolCallId",
                     "tool_use_id",
@@ -1141,6 +1146,9 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
     }
 
     private static bool ReadBoolean(JsonElement value, params string[] propertyNames)
+        => ReadNullableBoolean(value, propertyNames) ?? false;
+
+    private static bool? ReadNullableBoolean(JsonElement value, params string[] propertyNames)
     {
         foreach (var propertyName in propertyNames)
         {
@@ -1151,7 +1159,7 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
             }
         }
 
-        return false;
+        return null;
     }
 
     private static string? ExtractToolContentText(JsonElement item)

--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -769,14 +769,8 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
                     "tool_use_id",
                     "toolUseId");
                 var callId = kind == ChatToolContentKind.Call
-                    ? ReadFirstString(
-                        item,
-                        "id",
-                        "callId",
-                        "tool_call_id",
-                        "toolCallId",
-                        "tool_use_id",
-                        "toolUseId")
+                    ? ReadFirstString(item, "id")
+                        ?? itemSemanticCallId
                         ?? messageSemanticCallId
                     : itemSemanticCallId
                         ?? messageSemanticCallId

--- a/src/OpenClaw.Tray.WinUI/Chat/ChatHistoryReplayProjection.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ChatHistoryReplayProjection.cs
@@ -13,10 +13,30 @@ internal sealed record ChatHistoryReplayPart(
 
 internal static class ChatHistoryReplayProjection
 {
-    internal static JsonObject? ProjectToolArgs(JsonElement? value) =>
-        value is { ValueKind: JsonValueKind.Object } args
-            ? NativeToolProjector.ExtractSafeToolDisplayArgs(args)
-            : null;
+    internal static JsonObject? ProjectToolArgs(JsonElement? value)
+    {
+        if (value is { ValueKind: JsonValueKind.Object } args)
+            return NativeToolProjector.ExtractSafeToolDisplayArgs(args);
+
+        if (value is not { ValueKind: JsonValueKind.String } encoded)
+            return null;
+
+        var json = encoded.GetString();
+        if (string.IsNullOrWhiteSpace(json))
+            return null;
+
+        try
+        {
+            using var document = JsonDocument.Parse(json);
+            return document.RootElement.ValueKind == JsonValueKind.Object
+                ? NativeToolProjector.ExtractSafeToolDisplayArgs(document.RootElement)
+                : null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
 
     internal static string ToolLabel(string toolName, JsonObject? args)
     {

--- a/src/OpenClaw.Tray.WinUI/Chat/ChatHistoryReplayProjection.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ChatHistoryReplayProjection.cs
@@ -14,7 +14,7 @@ internal sealed record ChatHistoryReplayPart(
 internal static class ChatHistoryReplayProjection
 {
     internal static JsonObject? ProjectToolArgs(JsonElement? value) =>
-        NativeToolProjector.ExtractSafeToolDisplayArgsValue(value);
+        NativeToolProjector.ExtractSafePersistedToolDisplayArgs(value);
 
     internal static string ToolLabel(string toolName, JsonObject? args)
     {

--- a/src/OpenClaw.Tray.WinUI/Chat/ChatHistoryReplayProjection.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ChatHistoryReplayProjection.cs
@@ -13,30 +13,8 @@ internal sealed record ChatHistoryReplayPart(
 
 internal static class ChatHistoryReplayProjection
 {
-    internal static JsonObject? ProjectToolArgs(JsonElement? value)
-    {
-        if (value is { ValueKind: JsonValueKind.Object } args)
-            return NativeToolProjector.ExtractSafeToolDisplayArgs(args);
-
-        if (value is not { ValueKind: JsonValueKind.String } encoded)
-            return null;
-
-        var json = encoded.GetString();
-        if (string.IsNullOrWhiteSpace(json))
-            return null;
-
-        try
-        {
-            using var document = JsonDocument.Parse(json);
-            return document.RootElement.ValueKind == JsonValueKind.Object
-                ? NativeToolProjector.ExtractSafeToolDisplayArgs(document.RootElement)
-                : null;
-        }
-        catch (JsonException)
-        {
-            return null;
-        }
-    }
+    internal static JsonObject? ProjectToolArgs(JsonElement? value) =>
+        NativeToolProjector.ExtractSafeToolDisplayArgsValue(value);
 
     internal static string ToolLabel(string toolName, JsonObject? args)
     {

--- a/src/OpenClaw.Tray.WinUI/Chat/ChatToolActivityPresentation.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ChatToolActivityPresentation.cs
@@ -65,9 +65,21 @@ public static class ChatToolActivityPresentation
                 continue;
             }
 
+            if (entry.ToolResult == ChatToolCallStatus.Error)
+            {
+                if (showToolCalls)
+                    rows.Add(Standalone(entry, sessionId, timelineGeneration));
+                index++;
+                continue;
+            }
+
             var end = index + 1;
-            while (end < entries.Count && entries[end].Kind == ChatTimelineItemKind.ToolCall)
+            while (end < entries.Count
+                && entries[end].Kind == ChatTimelineItemKind.ToolCall
+                && entries[end].ToolResult != ChatToolCallStatus.Error)
+            {
                 end++;
+            }
 
             if (!showToolCalls)
             {

--- a/src/OpenClaw.Tray.WinUI/Chat/NativeToolProjector.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/NativeToolProjector.cs
@@ -21,6 +21,7 @@ internal static class NativeToolProjector
         ["command", "path", "file_path", "query", "url", "pattern"];
 
     internal const int MaxDisplayValueChars = 240;
+    internal const int MaxPersistedToolArgumentsChars = 64 * 1024;
     private const int MaxIdentityChars = 80;
     private const int ToolOutputMaxChars = 4000;
 
@@ -181,8 +182,11 @@ internal static class NativeToolProjector
             return null;
 
         var json = encoded.GetString();
-        if (string.IsNullOrWhiteSpace(json))
+        if (string.IsNullOrWhiteSpace(json)
+            || json.Length > MaxPersistedToolArgumentsChars)
+        {
             return null;
+        }
 
         try
         {

--- a/src/OpenClaw.Tray.WinUI/Chat/NativeToolProjector.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/NativeToolProjector.cs
@@ -172,7 +172,7 @@ internal static class NativeToolProjector
         return displayArgs.Count == 0 ? null : displayArgs;
     }
 
-    internal static JsonObject? ExtractSafeToolDisplayArgsValue(JsonElement? value)
+    internal static JsonObject? ExtractSafePersistedToolDisplayArgs(JsonElement? value)
     {
         if (value is { ValueKind: JsonValueKind.Object } data)
             return ExtractSafeToolDisplayArgs(data);

--- a/src/OpenClaw.Tray.WinUI/Chat/NativeToolProjector.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/NativeToolProjector.cs
@@ -172,6 +172,31 @@ internal static class NativeToolProjector
         return displayArgs.Count == 0 ? null : displayArgs;
     }
 
+    internal static JsonObject? ExtractSafeToolDisplayArgsValue(JsonElement? value)
+    {
+        if (value is { ValueKind: JsonValueKind.Object } data)
+            return ExtractSafeToolDisplayArgs(data);
+
+        if (value is not { ValueKind: JsonValueKind.String } encoded)
+            return null;
+
+        var json = encoded.GetString();
+        if (string.IsNullOrWhiteSpace(json))
+            return null;
+
+        try
+        {
+            using var document = JsonDocument.Parse(json);
+            return document.RootElement.ValueKind == JsonValueKind.Object
+                ? ExtractSafeToolDisplayArgs(document.RootElement)
+                : null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
     internal static string SanitizeToolDisplayValue(string? value)
     {
         if (string.IsNullOrWhiteSpace(value))

--- a/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
@@ -1873,6 +1873,36 @@ public class OpenClawGatewayClientTests
         Assert.Equal("call-1", Assert.Single(history.Messages[0].ToolContent).CallId);
     }
 
+    [Fact]
+    public void ParseChatHistoryPayload_ToolResult_UsesCallIdAndMessageErrorFallback()
+    {
+        var helper = new GatewayClientTestHelper();
+
+        var history = helper.ParseChatHistoryPayload("""
+        {
+          "messages": [
+            {
+              "role": "toolResult",
+              "isError": true,
+              "content": [
+                {
+                  "type": "tool_result",
+                  "callId": "call-1",
+                  "name": "exec",
+                  "content": "access denied"
+                }
+              ],
+              "timestamp": 2
+            }
+          ]
+        }
+        """);
+
+        var result = Assert.Single(Assert.Single(history.Messages).ToolContent);
+        Assert.Equal("call-1", result.CallId);
+        Assert.True(result.IsError);
+    }
+
     [Theory]
     [InlineData("toolResult")]
     [InlineData("tool_result")]

--- a/tests/OpenClaw.Tray.Tests/ChatToolActivityPresentationTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ChatToolActivityPresentationTests.cs
@@ -87,6 +87,28 @@ public sealed class ChatToolActivityPresentationTests
         Assert.Equal(standalone.Key, grouped.Key);
     }
 
+    [Fact]
+    public void Project_KeepsFailedToolsVisibleOutsideActivityGroups()
+    {
+        var rows = ChatToolActivityPresentation.Project(
+            [
+                Tool("success-1", "read_file"),
+                Tool("success-2", "write_file"),
+                Tool("failed", "powershell", result: ChatToolCallStatus.Error),
+                Tool("success-3", "web_fetch"),
+                Tool("success-4", "grep"),
+            ],
+            "session",
+            9);
+
+        Assert.Equal(3, rows.Count);
+        Assert.True(rows[0].IsActivityGroup);
+        Assert.False(rows[1].IsActivityGroup);
+        Assert.Equal("failed", rows[1].Entry?.Id);
+        Assert.Equal(ChatToolCallStatus.Error, rows[1].Entry?.ToolResult);
+        Assert.True(rows[2].IsActivityGroup);
+    }
+
     [Theory]
     [InlineData("powershell", ChatToolActivityCategory.Command)]
     [InlineData("system.run", ChatToolActivityCategory.Command)]

--- a/tests/OpenClaw.Tray.Tests/NativeToolProjectorTests.cs
+++ b/tests/OpenClaw.Tray.Tests/NativeToolProjectorTests.cs
@@ -131,4 +131,16 @@ public class NativeToolProjectorTests
 
         Assert.Empty(matches);
     }
+
+    [Fact]
+    public void ExtractSafeToolDisplayArgsValue_DecodesStringAndPreservesSafeProjection()
+    {
+        var value = JsonSerializer.SerializeToElement(
+            """{"command":"pwd","workdir":"C:\\private"}""");
+
+        var args = NativeToolProjector.ExtractSafeToolDisplayArgsValue(value)!;
+
+        Assert.Equal("pwd", args["command"]!.GetValue<string>());
+        Assert.False(args.ContainsKey("workdir"));
+    }
 }

--- a/tests/OpenClaw.Tray.Tests/NativeToolProjectorTests.cs
+++ b/tests/OpenClaw.Tray.Tests/NativeToolProjectorTests.cs
@@ -69,6 +69,45 @@ public class NativeToolProjectorTests
     }
 
     [Fact]
+    public void ExtractSafePersistedToolDisplayArgs_DecodesAllowlistedRedactedInput()
+    {
+        var value = JsonSerializer.SerializeToElement(
+            """{"command":"curl https://example.test --token abcdef1234567890ghij","workdir":"C:\\private","content":"must-not-render"}""");
+
+        var args = NativeToolProjector.ExtractSafePersistedToolDisplayArgs(value)!;
+
+        Assert.DoesNotContain(
+            "abcdef1234567890ghij",
+            args["command"]!.GetValue<string>(),
+            StringComparison.Ordinal);
+        Assert.False(args.ContainsKey("workdir"));
+        Assert.False(args.ContainsKey("content"));
+        Assert.DoesNotContain("must-not-render", args.ToJsonString(), StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not-json")]
+    [InlineData("[]")]
+    [InlineData("null")]
+    public void ExtractSafePersistedToolDisplayArgs_RejectsMalformedOrNonObjectInput(
+        string encoded)
+    {
+        var value = JsonSerializer.SerializeToElement(encoded);
+
+        Assert.Null(NativeToolProjector.ExtractSafePersistedToolDisplayArgs(value));
+    }
+
+    [Fact]
+    public void ExtractSafePersistedToolDisplayArgs_RejectsOversizedInputBeforeParsing()
+    {
+        var value = JsonSerializer.SerializeToElement(
+            new string('x', NativeToolProjector.MaxPersistedToolArgumentsChars + 1));
+
+        Assert.Null(NativeToolProjector.ExtractSafePersistedToolDisplayArgs(value));
+    }
+
+    [Fact]
     public void ExtractToolCorrelationId_ExplicitToolCallIdIsOpaqueAndWins()
     {
         using var payload = JsonDocument.Parse(
@@ -131,5 +170,4 @@ public class NativeToolProjectorTests
 
         Assert.Empty(matches);
     }
-
 }

--- a/tests/OpenClaw.Tray.Tests/NativeToolProjectorTests.cs
+++ b/tests/OpenClaw.Tray.Tests/NativeToolProjectorTests.cs
@@ -132,15 +132,4 @@ public class NativeToolProjectorTests
         Assert.Empty(matches);
     }
 
-    [Fact]
-    public void ExtractSafeToolDisplayArgsValue_DecodesStringAndPreservesSafeProjection()
-    {
-        var value = JsonSerializer.SerializeToElement(
-            """{"command":"pwd","workdir":"C:\\private"}""");
-
-        var args = NativeToolProjector.ExtractSafeToolDisplayArgsValue(value)!;
-
-        Assert.Equal("pwd", args["command"]!.GetValue<string>());
-        Assert.False(args.ContainsKey("workdir"));
-    }
 }

--- a/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
@@ -7326,6 +7326,42 @@ public class OpenClawChatDataProviderTests
         Assert.Equal("/workspace", entry.ToolOutput);
     }
 
+    [Fact]
+    public async Task LoadHistoryAsync_StringEncodedToolArguments_PreservesSafeInput()
+    {
+        var (bridge, provider, snapshots, _) = CreateProvider(new[] { MainSession() });
+        bridge.HistoryBehavior = _ => Task.FromResult(new ChatHistoryInfo
+        {
+            SessionKey = "main",
+            Messages =
+            [
+                new ChatMessageInfo
+                {
+                    Role = "assistant",
+                    State = "final",
+                    Ts = 1,
+                    ToolContent =
+                    [
+                        new ChatToolContentInfo
+                        {
+                            Kind = ChatToolContentKind.Call,
+                            CallId = "call-1",
+                            ToolName = "exec",
+                            Args = JsonSerializer.SerializeToElement(
+                                """{"command":"pwd","workdir":"/workspace"}"""),
+                        },
+                    ],
+                },
+            ],
+        });
+
+        await provider.LoadHistoryAsync("main");
+
+        var entry = Assert.Single(snapshots[^1].Timelines["main"].Entries);
+        Assert.Equal("pwd", entry.ToolArgs?["command"]?.GetValue<string>());
+        Assert.False(entry.ToolArgs?.ContainsKey("workdir"));
+    }
+
     [Theory]
     [InlineData("toolResult")]
     [InlineData("tool_result")]

--- a/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
@@ -7362,6 +7362,61 @@ public class OpenClawChatDataProviderTests
         Assert.False(entry.ToolArgs?.ContainsKey("workdir"));
     }
 
+    [Fact]
+    public async Task LoadHistoryAsync_AfterRestart_ReplaysSanitizedArgumentsWithoutLocalPersistence()
+    {
+        using var tempDir = new TempDirectory();
+        var cachePath = Path.Combine(tempDir.DirectoryPath, "tool-metadata.json");
+        static ChatHistoryInfo History() => new()
+        {
+            SessionKey = "main",
+            Messages =
+            [
+                new ChatMessageInfo
+                {
+                    Role = "assistant",
+                    State = "final",
+                    Ts = 1,
+                    ToolContent =
+                    [
+                        new ChatToolContentInfo
+                        {
+                            Kind = ChatToolContentKind.Call,
+                            CallId = "call-1",
+                            ToolName = "exec",
+                            Args = JsonSerializer.SerializeToElement(
+                                """{"command":"curl https://example.test --token abcdef1234567890ghij","workdir":"C:\\private"}"""),
+                        },
+                    ],
+                },
+            ],
+        };
+
+        var first = CreateProvider(
+            new[] { MainSession() },
+            toolMetaCachePath: cachePath);
+        first.bridge.HistoryBehavior = _ => Task.FromResult(History());
+        await first.provider.LoadHistoryAsync("main");
+        await first.provider.DisposeAsync();
+
+        var second = CreateProvider(
+            new[] { MainSession() },
+            toolMetaCachePath: cachePath);
+        second.bridge.HistoryBehavior = _ => Task.FromResult(History());
+        await second.provider.LoadHistoryAsync("main");
+
+        var entry = Assert.Single(second.snapshots[^1].Timelines["main"].Entries);
+        var command = entry.ToolArgs?["command"]?.GetValue<string>();
+        Assert.NotNull(command);
+        Assert.DoesNotContain(
+            "abcdef1234567890ghij",
+            command,
+            StringComparison.Ordinal);
+        Assert.False(entry.ToolArgs?.ContainsKey("workdir"));
+        Assert.False(File.Exists(cachePath));
+        await second.provider.DisposeAsync();
+    }
+
     [Theory]
     [InlineData("toolResult")]
     [InlineData("tool_result")]


### PR DESCRIPTION
Related: #1092

## What Problem This Solves

Fixes an issue where users reopening persisted chat history could lose important tool activity details: failed tool calls could be hidden inside a successful activity group, tool results using `callId` could lose their correlation, message-level errors could be ignored, and JSON-string-encoded tool arguments could render without their safe display fields.

## Why This Change Was Made

The history parser now accepts the persisted aliases and shapes already emitted by the Gateway, while the existing `NativeToolProjector` remains authoritative for decoding and safe argument projection. Failed tools remain individually visible; only neighboring successful tools are compacted into activity groups. This is a narrow follow-up to the compact tool activity work in #1092.

## User Impact

Users can reopen older conversations and still inspect failed tools, correlated results, and safe command arguments without losing the compact presentation for successful activity.

## Evidence

- Failed-first regressions reproduce and cover persisted `callId`, message-level errors, JSON-string arguments, result correlation, and failure presentation.
- Fresh exact-head build passed for Shared, CLI, WinNodeCLI, SetupEngine, and WinUI.
- Fresh exact-head Shared suite: 3,632 passed, 0 failed, 32 environment-only skips.
- Fresh exact-head Tray suite: 2,250 passed, 0 failed.
- All required GitHub test, build, E2E, hygiene, and CodeQL gates are green on the current head.
- Exact-head persisted Gateway-to-WinUI replay was exercised twice: initially and again after terminating/relaunching the disposable app without rewriting history.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs or instructions
- [x] Tests or validation
- [ ] Security hardening
- [ ] Chore or infrastructure

## Scope

- [x] Tray or WinUI UX
- [ ] Windows node capability
- [ ] Local MCP or `winnode`
- [x] Gateway, connection, or pairing
- [ ] Setup or onboarding
- [ ] Permissions, privacy, or security
- [x] Tests, CI, or docs

## Validation

- `./build.ps1` - passed all 5 projects on exact head `e05d86c5151bae9e6aa286231975c99616c577ce`
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` - 3,632 passed, 0 failed, 32 skipped
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` - 2,250 passed, 0 failed
- Exact-head side-by-side Dev executable SHA-256: `6CFA0FC0616FF77956461B71B6CAB4C83F3C88A8A495F9217F4D81E91CC95691`
- `git diff --check` - passed; source worktree remained clean
- Current required GitHub checks - green, including setup-connect, network-recovery, revocation-recovery, win-x64, win-arm64, repository hygiene, and CodeQL gate

## Real Behavior Proof

- Environment tested: Windows 11 host, exact-head side-by-side Dev WinUI, and a disposable OpenClaw Core Gateway `2026.7.2-beta.6` profile in WSL
- PR head or commit tested: `e05d86c5151bae9e6aa286231975c99616c577ce`
- Isolation: Gateway bound only to WSL loopback with an ephemeral token and disposable paired device; production Gateway state, sessions, identities, models, providers, and credentials were not used
- Persisted fixture: six canonical `chat.history` messages containing a JSON-string `read` call and success result, plus an object-form `exec` call and error result
- Initial exact-head WinUI result: `Connected`; `read · Done` with safe `path: proof/success.txt`; `exec · Error` with safe `command: proof-command`; correlated success/error result text visible
- Post-reopen result: after terminating and relaunching the disposable app against the same isolated data directory without rewriting the transcript, the same six-message history and expanded success/error cards were reproduced
- Redacted evidence SHA-256: initial `9551A52E5D2A953E76C0BC99E5276AE718E1D847B1095E9402707F9B23BE2B91`; post-reopen `AD787822369BAD8A9FD352F08A181286B633FB5B745055E79C33FE39B996D72C`
- Proof level: `runtime_proven` for current-head persisted Gateway-to-WinUI replay and post-reopen persistence; not claimed as provider or real tool-execution proof
- Cleanup: disposable app and Gateway stopped; the pre-existing production Companion process remained running unchanged
- Screenshot or artifact links verified? (`Yes`/`No`/`N/A`): accessibility/live diagnostic evidence is copied into the PR discussion; no token, endpoint, device/request identifier, private transcript, or raw filesystem path is included

## Security Impact

- New permissions or capabilities? (`Yes`/`No`): No
- Secrets or tokens handling changed? (`Yes`/`No`): No
- New or changed network calls? (`Yes`/`No`): No
- Command or tool execution surface changed? (`Yes`/`No`): No
- Data access scope changed? (`Yes`/`No`): No
- If any answer is `Yes`, explain the risk and mitigation: N/A

## Compatibility and Migration

- Backward compatible? (`Yes`/`No`): Yes
- Config or environment changes? (`Yes`/`No`): No
- Migration needed? (`Yes`/`No`): No
- If yes, list the exact upgrade steps: N/A

## Review Conversations

- [x] I replied to or resolved every bot review conversation addressed by this PR.
- [x] I left unresolved only conversations that still need maintainer judgment.
