### PR TITLE
fix(chat): repeated image paste and right-click menu failures

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Chat/ChatComposerContextMenuState.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ChatComposerContextMenuState.cs
@@ -1,0 +1,34 @@
+namespace OpenClawTray.Chat;
+
+internal readonly record struct ChatComposerContextMenuState(
+    bool ShowUndo,
+    bool ShowRedo,
+    bool ShowCut,
+    bool ShowCopy,
+    bool ShowPaste,
+    bool ShowSelectAll,
+    bool ShowEditSeparator,
+    bool ShowSelectAllSeparator)
+{
+    public static ChatComposerContextMenuState Project(
+        bool canUndo,
+        bool canRedo,
+        bool hasSelection,
+        bool canPaste,
+        bool hasText)
+    {
+        var showEditSeparator = (canUndo || canRedo) && (hasSelection || canPaste);
+        var showSelectAllSeparator =
+            hasText && (canUndo || canRedo || hasSelection || canPaste);
+
+        return new ChatComposerContextMenuState(
+            ShowUndo: canUndo,
+            ShowRedo: canRedo,
+            ShowCut: hasSelection,
+            ShowCopy: hasSelection,
+            ShowPaste: canPaste,
+            ShowSelectAll: hasText,
+            ShowEditSeparator: showEditSeparator,
+            ShowSelectAllSeparator: showSelectAllSeparator);
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawReactorChatRoot.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawReactorChatRoot.cs
@@ -599,7 +599,36 @@ public sealed class ReactorChatComposer : Component<ReactorChatComposerProps>
         var voiceCancellation = UseRef<CancellationTokenSource?>(null);
         var voiceOperation = UseRef(0);
         var voiceStopOperation = UseRef(0);
-        var pasteHooked = UseRef(false);
+        var onAttachmentPasted = UseRef<Action<ChatAttachment>>(props.OnAttachmentPasted);
+        onAttachmentPasted.Current = props.OnAttachmentPasted;
+        var pasteHandler = UseRef<TextControlPasteEventHandler>(async (_, args) =>
+        {
+            var clipboardContent = global::Windows.ApplicationModel.DataTransfer.Clipboard.GetContent();
+            if (clipboardContent is null
+                || !clipboardContent.Contains(
+                    global::Windows.ApplicationModel.DataTransfer.StandardDataFormats.Bitmap))
+            {
+                return;
+            }
+
+            // Paste is a synchronous routed event. Suppress the default text paste
+            // before awaiting bitmap extraction so a multi-format clipboard cannot
+            // insert text alongside the image attachment.
+            args.Handled = true;
+            try
+            {
+                var attachment = await TryReadImageFromClipboardAsync(clipboardContent);
+                if (attachment is null)
+                    return;
+
+                onAttachmentPasted.Current(attachment);
+            }
+            catch (Exception ex)
+            {
+                OpenClawTray.Services.Logger.Debug(
+                    $"Reactor chat composer: clipboard image paste failed: {ex.Message}");
+            }
+        });
         var inputText = UseRef(text);
         var inputControl = UseRef<TextBox?>(null);
         var slashPopup = UseRef<Microsoft.UI.Xaml.Controls.Primitives.Popup?>(null);
@@ -1110,39 +1139,9 @@ public sealed class ReactorChatComposer : Component<ReactorChatComposerProps>
                 control.Resources["TextControlBorderBrush"] = transparent;
                 control.Resources["TextControlBorderBrushFocused"] = transparent;
                 control.Resources["TextControlBorderBrushPointerOver"] = transparent;
-                if (!pasteHooked.Current)
-                {
-                    pasteHooked.Current = true;
-                    control.Paste += async (_, args) =>
-                    {
-                        var clipboardContent = global::Windows.ApplicationModel.DataTransfer.Clipboard.GetContent();
-                        if (clipboardContent is null
-                            || !clipboardContent.Contains(
-                                global::Windows.ApplicationModel.DataTransfer.StandardDataFormats.Bitmap))
-                        {
-                            return;
-                        }
-
-                        // Paste is a synchronous routed event. Suppress the default text paste
-                        // before awaiting bitmap extraction so a multi-format clipboard cannot
-                        // insert text alongside the image attachment.
-                        args.Handled = true;
-                        try
-                        {
-                            var attachment = await TryReadImageFromClipboardAsync(clipboardContent);
-                            if (attachment is null)
-                                return;
-
-                            props.OnAttachmentPasted(attachment);
-                        }
-                        catch (Exception ex)
-                        {
-                            OpenClawTray.Services.Logger.Debug(
-                                $"Reactor chat composer: clipboard image paste failed: {ex.Message}");
-                        }
-                    };
-                }
-            });
+            })
+            .OnMount(control => ((TextBox)control).Paste += pasteHandler.Current)
+            .OnUnmount(control => ((TextBox)control).Paste -= pasteHandler.Current);
         UseEffect((Func<Action>)(() =>
         {
             if (inputControl.Current is { } anchor)

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawReactorChatRoot.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawReactorChatRoot.cs
@@ -603,31 +603,14 @@ public sealed class ReactorChatComposer : Component<ReactorChatComposerProps>
         onAttachmentPasted.Current = props.OnAttachmentPasted;
         var pasteHandler = UseRef<TextControlPasteEventHandler>(async (_, args) =>
         {
-            var clipboardContent = global::Windows.ApplicationModel.DataTransfer.Clipboard.GetContent();
-            if (clipboardContent is null
-                || !clipboardContent.Contains(
-                    global::Windows.ApplicationModel.DataTransfer.StandardDataFormats.Bitmap))
-            {
+            if (GetBitmapClipboardContent() is not { } clipboardContent)
                 return;
-            }
 
             // Paste is a synchronous routed event. Suppress the default text paste
             // before awaiting bitmap extraction so a multi-format clipboard cannot
             // insert text alongside the image attachment.
             args.Handled = true;
-            try
-            {
-                var attachment = await TryReadImageFromClipboardAsync(clipboardContent);
-                if (attachment is null)
-                    return;
-
-                onAttachmentPasted.Current(attachment);
-            }
-            catch (Exception ex)
-            {
-                OpenClawTray.Services.Logger.Debug(
-                    $"Reactor chat composer: clipboard image paste failed: {ex.Message}");
-            }
+            await PasteImageFromClipboardAsync(clipboardContent, onAttachmentPasted.Current);
         });
         var inputText = UseRef(text);
         var inputControl = UseRef<TextBox?>(null);
@@ -1140,8 +1123,20 @@ public sealed class ReactorChatComposer : Component<ReactorChatComposerProps>
                 control.Resources["TextControlBorderBrushFocused"] = transparent;
                 control.Resources["TextControlBorderBrushPointerOver"] = transparent;
             })
-            .OnMount(control => ((TextBox)control).Paste += pasteHandler.Current)
-            .OnUnmount(control => ((TextBox)control).Paste -= pasteHandler.Current);
+            .OnMount(control =>
+            {
+                var textBox = (TextBox)control;
+                textBox.Paste += pasteHandler.Current;
+                textBox.ContextFlyout = CreateComposerContextFlyout(
+                    textBox,
+                    () => onAttachmentPasted.Current);
+            })
+            .OnUnmount(control =>
+            {
+                var textBox = (TextBox)control;
+                textBox.Paste -= pasteHandler.Current;
+                textBox.ContextFlyout = null;
+            });
         UseEffect((Func<Action>)(() =>
         {
             if (inputControl.Current is { } anchor)
@@ -1743,6 +1738,154 @@ public sealed class ReactorChatComposer : Component<ReactorChatComposerProps>
             Content = Convert.ToBase64String(bytes),
             SizeBytes = size,
         };
+    }
+
+    private static global::Windows.ApplicationModel.DataTransfer.DataPackageView? GetBitmapClipboardContent()
+    {
+        try
+        {
+            var content = global::Windows.ApplicationModel.DataTransfer.Clipboard.GetContent();
+            return content is not null
+                && content.Contains(
+                    global::Windows.ApplicationModel.DataTransfer.StandardDataFormats.Bitmap)
+                    ? content
+                    : null;
+        }
+        catch (System.Runtime.InteropServices.COMException ex)
+        {
+            OpenClawTray.Services.Logger.Debug(
+                $"Reactor chat composer: clipboard access failed: {ex.Message}");
+            return null;
+        }
+    }
+
+    private static MenuFlyout CreateComposerContextFlyout(
+        TextBox textBox,
+        Func<Action<ChatAttachment>> getOnAttachmentPasted)
+    {
+        var undoItem = CreateStandardMenuItem(
+            Microsoft.UI.Xaml.Input.StandardUICommandKind.Undo,
+            textBox.Undo);
+        var redoItem = CreateStandardMenuItem(
+            Microsoft.UI.Xaml.Input.StandardUICommandKind.Redo,
+            textBox.Redo);
+        var cutItem = CreateStandardMenuItem(
+            Microsoft.UI.Xaml.Input.StandardUICommandKind.Cut,
+            textBox.CutSelectionToClipboard);
+        var copyItem = CreateStandardMenuItem(
+            Microsoft.UI.Xaml.Input.StandardUICommandKind.Copy,
+            textBox.CopySelectionToClipboard);
+        var pasteItem = CreateStandardMenuItem(
+            Microsoft.UI.Xaml.Input.StandardUICommandKind.Paste,
+            () =>
+            {
+                if (GetBitmapClipboardContent() is { } clipboardContent)
+                    _ = PasteImageFromClipboardAsync(clipboardContent, getOnAttachmentPasted());
+                else
+                    PasteTextFromClipboard(textBox);
+            });
+        var selectAllItem = CreateStandardMenuItem(
+            Microsoft.UI.Xaml.Input.StandardUICommandKind.SelectAll,
+            textBox.SelectAll);
+        Microsoft.UI.Xaml.Automation.AutomationProperties.SetAutomationId(
+            pasteItem,
+            "ChatComposerPasteMenuItem");
+
+        var editSeparator = new MenuFlyoutSeparator();
+        var selectAllSeparator = new MenuFlyoutSeparator();
+        var menu = new MenuFlyout();
+        menu.Items.Add(undoItem);
+        menu.Items.Add(redoItem);
+        menu.Items.Add(editSeparator);
+        menu.Items.Add(cutItem);
+        menu.Items.Add(copyItem);
+        menu.Items.Add(pasteItem);
+        menu.Items.Add(selectAllSeparator);
+        menu.Items.Add(selectAllItem);
+        menu.Opening += (_, _) =>
+        {
+            var state = ChatComposerContextMenuState.Project(
+                textBox.CanUndo,
+                textBox.CanRedo,
+                textBox.SelectionLength > 0,
+                ClipboardContainsPasteContent(),
+                !string.IsNullOrEmpty(textBox.Text));
+            undoItem.Visibility = ToVisibility(state.ShowUndo);
+            redoItem.Visibility = ToVisibility(state.ShowRedo);
+            cutItem.Visibility = ToVisibility(state.ShowCut);
+            copyItem.Visibility = ToVisibility(state.ShowCopy);
+            pasteItem.Visibility = ToVisibility(state.ShowPaste);
+            selectAllItem.Visibility = ToVisibility(state.ShowSelectAll);
+            editSeparator.Visibility = ToVisibility(state.ShowEditSeparator);
+            selectAllSeparator.Visibility = ToVisibility(state.ShowSelectAllSeparator);
+        };
+        return menu;
+    }
+
+    private static Visibility ToVisibility(bool visible) =>
+        visible ? Visibility.Visible : Visibility.Collapsed;
+
+    private static MenuFlyoutItem CreateStandardMenuItem(
+        Microsoft.UI.Xaml.Input.StandardUICommandKind kind,
+        Action execute)
+    {
+        var command = new Microsoft.UI.Xaml.Input.StandardUICommand(kind);
+        command.CanExecuteRequested += (_, args) => args.CanExecute = true;
+        command.ExecuteRequested += (_, _) => execute();
+        return new MenuFlyoutItem
+        {
+            Command = command,
+            Visibility = Visibility.Collapsed,
+        };
+    }
+
+    private static bool ClipboardContainsPasteContent()
+    {
+        try
+        {
+            var content = global::Windows.ApplicationModel.DataTransfer.Clipboard.GetContent();
+            return content is not null
+                && (content.Contains(
+                        global::Windows.ApplicationModel.DataTransfer.StandardDataFormats.Bitmap)
+                    || content.Contains(
+                        global::Windows.ApplicationModel.DataTransfer.StandardDataFormats.Text));
+        }
+        catch (System.Runtime.InteropServices.COMException ex)
+        {
+            OpenClawTray.Services.Logger.Debug(
+                $"Reactor chat composer: clipboard access failed: {ex.Message}");
+            return false;
+        }
+    }
+
+    private static void PasteTextFromClipboard(TextBox textBox)
+    {
+        try
+        {
+            textBox.PasteFromClipboard();
+        }
+        catch (System.Runtime.InteropServices.COMException ex)
+        {
+            OpenClawTray.Services.Logger.Debug(
+                $"Reactor chat composer: clipboard text paste failed: {ex.Message}");
+        }
+    }
+
+    private static async Task PasteImageFromClipboardAsync(
+        global::Windows.ApplicationModel.DataTransfer.DataPackageView clipboardContent,
+        Action<ChatAttachment> onAttachmentPasted)
+    {
+        try
+        {
+            var attachment = await TryReadImageFromClipboardAsync(clipboardContent);
+            if (attachment is not null)
+                onAttachmentPasted(attachment);
+        }
+        catch (Exception ex)
+        {
+            OpenClawTray.Services.Logger.Debug(
+                $"Reactor chat composer: clipboard image paste failed: {ex.Message}");
+        }
     }
 
     private static string PlaceholderFor(string connectionState) => connectionState switch

--- a/tests/OpenClaw.Tray.Tests/ChatTimelinePresentationTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ChatTimelinePresentationTests.cs
@@ -247,9 +247,9 @@ public sealed class ChatTimelinePresentationTests
         const string handlerRef =
             "var pasteHandler = UseRef<TextControlPasteEventHandler>(async (_, args) =>";
         const string mount =
-            ".OnMount(control => ((TextBox)control).Paste += pasteHandler.Current)";
+            "textBox.Paste += pasteHandler.Current;";
         const string unmount =
-            ".OnUnmount(control => ((TextBox)control).Paste -= pasteHandler.Current)";
+            "textBox.Paste -= pasteHandler.Current;";
 
         var callbackRefIndex = composer.IndexOf(callbackRef, StringComparison.Ordinal);
         var callbackAssignmentIndex = composer.IndexOf(callbackAssignment, StringComparison.Ordinal);
@@ -263,8 +263,138 @@ public sealed class ChatTimelinePresentationTests
         Assert.True(mountIndex > handlerRefIndex);
         Assert.True(unmountIndex > mountIndex);
         Assert.Equal(1, composer.Split(handlerRef, StringSplitOptions.None).Length - 1);
-        Assert.Contains("onAttachmentPasted.Current(attachment);", composer);
+        var pasteHandlerBody = composer[handlerRefIndex..mountIndex];
+        Assert.Contains(
+            "if (GetBitmapClipboardContent() is not { } clipboardContent)",
+            pasteHandlerBody);
+        Assert.DoesNotContain(
+            "Windows.ApplicationModel.DataTransfer.Clipboard.GetContent()",
+            pasteHandlerBody);
+        Assert.Contains(
+            "await PasteImageFromClipboardAsync(clipboardContent, onAttachmentPasted.Current)",
+            composer);
+        Assert.Contains("onAttachmentPasted(attachment);", composer);
         Assert.DoesNotContain("pasteHooked", composer);
+    }
+
+    [Fact]
+    public void ReactorComposer_UsesBitmapOnlyContextMenuThatReentersStablePastePath()
+    {
+        var root = File.ReadAllText(Path.Combine(
+            TestRepositoryPaths.GetRepositoryRoot(),
+            "src",
+            "OpenClaw.Tray.WinUI",
+            "Chat",
+            "OpenClawReactorChatRoot.cs"));
+        var composer = root[root.IndexOf(
+            "public sealed class ReactorChatComposer",
+            StringComparison.Ordinal)..];
+
+        Assert.Contains("textBox.ContextFlyout = CreateComposerContextFlyout(", composer);
+        Assert.Contains("textBox.ContextFlyout = null;", composer);
+        Assert.DoesNotContain("ContextRequested", composer);
+        Assert.Contains("StandardUICommandKind.Undo", composer);
+        Assert.Contains("StandardUICommandKind.Redo", composer);
+        Assert.Contains("StandardUICommandKind.Cut", composer);
+        Assert.Contains("StandardUICommandKind.Copy", composer);
+        Assert.Contains("StandardUICommandKind.Paste", composer);
+        Assert.Contains("StandardUICommandKind.SelectAll", composer);
+        Assert.Contains("\"ChatComposerPasteMenuItem\"", composer);
+        Assert.Contains("var menu = new MenuFlyout();", composer);
+        Assert.Contains("menu.Items.Add(undoItem);", composer);
+        Assert.Contains("menu.Items.Add(redoItem);", composer);
+        Assert.Contains("menu.Items.Add(cutItem);", composer);
+        Assert.Contains("menu.Items.Add(copyItem);", composer);
+        Assert.Contains("menu.Items.Add(pasteItem);", composer);
+        Assert.Contains("menu.Items.Add(selectAllItem);", composer);
+        Assert.Contains("menu.Opening += (_, _) =>", composer);
+        Assert.Contains("var state = ChatComposerContextMenuState.Project(", composer);
+        Assert.Contains("pasteItem.Visibility = ToVisibility(state.ShowPaste);", composer);
+        Assert.Contains("textBox.PasteFromClipboard();", composer);
+        Assert.DoesNotContain("TextCommandBarFlyout", composer);
+
+        var menuStart = composer.IndexOf(
+            "private static MenuFlyout CreateComposerContextFlyout(",
+            StringComparison.Ordinal);
+        var standardItemStart = composer.IndexOf(
+            "private static MenuFlyoutItem CreateStandardMenuItem(",
+            StringComparison.Ordinal);
+        var menuFactory = composer[menuStart..standardItemStart];
+
+        Assert.DoesNotContain("TryReadImageFromClipboardAsync", menuFactory);
+        Assert.Contains("GetBitmapClipboardContent()", menuFactory);
+        Assert.Contains(
+            "_ = PasteImageFromClipboardAsync(clipboardContent, getOnAttachmentPasted())",
+            menuFactory);
+        Assert.Equal(
+            1,
+            composer.Split(
+                "await PasteImageFromClipboardAsync(clipboardContent, onAttachmentPasted.Current)",
+                StringSplitOptions.None).Length - 1);
+        Assert.Contains("PasteTextFromClipboard(textBox);", menuFactory);
+        Assert.Contains("private static void PasteTextFromClipboard(TextBox textBox)", composer);
+        Assert.Contains("catch (System.Runtime.InteropServices.COMException ex)", composer);
+        Assert.Contains("clipboard text paste failed", composer);
+        Assert.DoesNotContain("ClipboardContainsBitmap", composer);
+    }
+
+    [Fact]
+    public void ChatComposerContextMenuState_ProjectsNativeCommandVisibility()
+    {
+        Assert.Equal(
+            new ChatComposerContextMenuState(
+                ShowUndo: false,
+                ShowRedo: false,
+                ShowCut: false,
+                ShowCopy: false,
+                ShowPaste: false,
+                ShowSelectAll: false,
+                ShowEditSeparator: false,
+                ShowSelectAllSeparator: false),
+            ChatComposerContextMenuState.Project(
+                canUndo: false,
+                canRedo: false,
+                hasSelection: false,
+                canPaste: false,
+                hasText: false));
+
+        Assert.Equal(
+            new ChatComposerContextMenuState(
+                ShowUndo: true,
+                ShowRedo: true,
+                ShowCut: true,
+                ShowCopy: true,
+                ShowPaste: true,
+                ShowSelectAll: true,
+                ShowEditSeparator: true,
+                ShowSelectAllSeparator: true),
+            ChatComposerContextMenuState.Project(
+                canUndo: true,
+                canRedo: true,
+                hasSelection: true,
+                canPaste: true,
+                hasText: true));
+
+        var pasteOnly = ChatComposerContextMenuState.Project(
+            canUndo: false,
+            canRedo: false,
+            hasSelection: false,
+            canPaste: true,
+            hasText: false);
+        Assert.True(pasteOnly.ShowPaste);
+        Assert.False(pasteOnly.ShowEditSeparator);
+        Assert.False(pasteOnly.ShowSelectAllSeparator);
+
+        var selectedText = ChatComposerContextMenuState.Project(
+            canUndo: false,
+            canRedo: false,
+            hasSelection: true,
+            canPaste: false,
+            hasText: true);
+        Assert.True(selectedText.ShowCut);
+        Assert.True(selectedText.ShowCopy);
+        Assert.True(selectedText.ShowSelectAll);
+        Assert.True(selectedText.ShowSelectAllSeparator);
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/ChatTimelinePresentationTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ChatTimelinePresentationTests.cs
@@ -228,6 +228,46 @@ public sealed class ChatTimelinePresentationTests
     }
 
     [Fact]
+    public void ReactorComposer_ReattachesStableImagePasteHandlerAfterRemount()
+    {
+        var root = File.ReadAllText(Path.Combine(
+            TestRepositoryPaths.GetRepositoryRoot(),
+            "src",
+            "OpenClaw.Tray.WinUI",
+            "Chat",
+            "OpenClawReactorChatRoot.cs"));
+        var composer = root[root.IndexOf(
+            "public sealed class ReactorChatComposer",
+            StringComparison.Ordinal)..];
+
+        const string callbackRef =
+            "var onAttachmentPasted = UseRef<Action<ChatAttachment>>(props.OnAttachmentPasted);";
+        const string callbackAssignment =
+            "onAttachmentPasted.Current = props.OnAttachmentPasted;";
+        const string handlerRef =
+            "var pasteHandler = UseRef<TextControlPasteEventHandler>(async (_, args) =>";
+        const string mount =
+            ".OnMount(control => ((TextBox)control).Paste += pasteHandler.Current)";
+        const string unmount =
+            ".OnUnmount(control => ((TextBox)control).Paste -= pasteHandler.Current)";
+
+        var callbackRefIndex = composer.IndexOf(callbackRef, StringComparison.Ordinal);
+        var callbackAssignmentIndex = composer.IndexOf(callbackAssignment, StringComparison.Ordinal);
+        var handlerRefIndex = composer.IndexOf(handlerRef, StringComparison.Ordinal);
+        var mountIndex = composer.IndexOf(mount, StringComparison.Ordinal);
+        var unmountIndex = composer.IndexOf(unmount, StringComparison.Ordinal);
+
+        Assert.True(callbackRefIndex >= 0);
+        Assert.True(callbackAssignmentIndex > callbackRefIndex);
+        Assert.True(handlerRefIndex > callbackAssignmentIndex);
+        Assert.True(mountIndex > handlerRefIndex);
+        Assert.True(unmountIndex > mountIndex);
+        Assert.Equal(1, composer.Split(handlerRef, StringSplitOptions.None).Length - 1);
+        Assert.Contains("onAttachmentPasted.Current(attachment);", composer);
+        Assert.DoesNotContain("pasteHooked", composer);
+    }
+
+    [Fact]
     public void ReactorComposer_UsesReactorThemeResourcesWithoutManualThemeObservation()
     {
         var root = File.ReadAllText(Path.Combine(

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -43,6 +43,7 @@
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Chat\ChatTelemetryTracker.cs" Link="Chat\ChatTelemetryTracker.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Chat\ChatLifecycleCommandDispatcher.cs" Link="Chat\ChatLifecycleCommandDispatcher.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Chat\ChatComposerSubmissionPolicy.cs" Link="Chat\ChatComposerSubmissionPolicy.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Chat\ChatComposerContextMenuState.cs" Link="Chat\ChatComposerContextMenuState.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Chat\ChatCompactionPresentation.cs" Link="Chat\ChatCompactionPresentation.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Chat\ChatHistoryReplayProjection.cs" Link="Chat\ChatHistoryReplayProjection.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Chat\ChatToolActivityPresentation.cs" Link="Chat\ChatToolActivityPresentation.cs" />


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes issues where the chat composer stopped accepting Ctrl+V image pastes after the first attachment rerender and where its right-click editing menu could flicker, omit Paste, or become unavailable even when supported clipboard content existed.

## Why This Change Was Made

The composer now keeps one stable image-paste delegate and reconnects it to each native text box created by Reactor. It also uses a persistent context menu with platform-standard Undo, Redo, Cut, Copy, Paste, and Select All commands, recalculating command and separator visibility whenever the menu opens. Paste reads the current clipboard contents when activated, routes bitmap content through the existing attachment pipeline, preserves native text paste, and handles clipboard COM failures without crashing the tray.

## User Impact

Users can repeatedly paste images after attachment rerenders and can reliably use the full right-click editing menu. Paste appears only when the clipboard currently contains supported text or bitmap content, while other editing commands appear when applicable.

## Evidence

- The current PR-head recording below demonstrates repeated image paste, text paste, empty-clipboard visibility, and context-menu commands.
- Regression coverage verifies stable paste-handler lifecycle wiring and executes the context-menu visibility projection for empty, full, paste-only, and selected-text states.
- A local ordinary merge of current `origin/main` preserved merged #1114 native-tool correlation behavior. `a1d933a3` was an ancestor of validated candidate `c9656524`, and the PR's effective diff remained the same four composer/test files.

### WinUI recording

https://github.com/user-attachments/assets/346fcf10-f1d7-4c91-bd5c-16c6765e38dd

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs or instructions
- [x] Tests or validation
- [ ] Security hardening
- [ ] Chore or infrastructure

## Scope

- [x] Tray or WinUI UX
- [ ] Windows node capability
- [ ] Local MCP or `winnode`
- [ ] Gateway, connection, or pairing
- [ ] Setup or onboarding
- [ ] Permissions, privacy, or security
- [x] Tests, CI, or docs

## Validation

Validated local integration candidate `c9656524` after merging current `origin/main`:

- `.\build.ps1` - passed.
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj` - passed 3,413, skipped 32, failed 0.
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj` - passed 2,208, failed 0.
- Focused composer/context-menu filter - passed 3, failed 0.
- `dotnet build .\tests\OpenClaw.Tray.UITests\OpenClaw.Tray.UITests.csproj -r win-x64` - passed.
- Axe accessibility scans - passed 20, failed 0.
- Reactor/native-tool UIA proof tests - passed 2, failed 0.
- Rubber-duck review - no blockers.
- Exact remote head `661827d3576a6fd43216e0dbb949dedc2f4cba8b` - all active checks passed or skipped; merge state clean and mergeable before landing.

## Real Behavior Proof

- Environment tested: Windows 11 x64, isolated WinUI tray data.
- Remote PR head: `661827d3576a6fd43216e0dbb949dedc2f4cba8b`.
- Validated local integration candidate: `c9656524`.
- Existing recording: verified for remote PR head and linked above.
- Integration compatibility proof: focused composer tests, Axe scans, and Reactor/UIA proof tests all passed against current `main` plus the unchanged four-file PR diff.
- Not verified / blocked: isolated integration-candidate computer-use repetition entered onboarding instead of the seeded chat harness. Existing remote-head recording and current-main automated/UIA proof cover the changed behavior.

## Security Impact

- New permissions or capabilities? (`Yes`/`No`): No
- Secrets or tokens handling changed? (`Yes`/`No`): No
- New or changed network calls? (`Yes`/`No`): No
- Command or tool execution surface changed? (`Yes`/`No`): No
- Data access scope changed? (`Yes`/`No`): No

## Compatibility and Migration

- Backward compatible? (`Yes`/`No`): Yes
- Config or environment changes? (`Yes`/`No`): No
- Migration needed? (`Yes`/`No`): No

## Landing Result

Squash-merged unchanged exact head `661827d3576a6fd43216e0dbb949dedc2f4cba8b` with `--match-head-commit` after its active dispatch check completed successfully. Merge commit: `89666df49eb9da0f684851be088181065ca4b993`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation addressed by this PR.
- [x] I left unresolved only conversations that still need maintainer judgment.
