### PR TITLE
Fix silent WASAPI capture startup hang

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Services/AudioPipeline.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/AudioPipeline.cs
@@ -7,6 +7,7 @@ using NAudio.CoreAudioApi;
 using NAudio.Wave;
 using OpenClaw.Shared;
 using OpenClaw.Shared.Audio;
+using OpenClawTray.Helpers;
 
 namespace OpenClawTray.Services;
 
@@ -18,9 +19,21 @@ public sealed class AudioPipeline : IAsyncDisposable
 {
     private readonly IOpenClawLogger _logger;
     private readonly SpeechToTextService _stt;
-    private WasapiCapture? _capture;
+    private readonly object _captureGate = new();
+    private readonly SemaphoreSlim _stopGate = new(1, 1);
+    private readonly Func<IAudioCapture> _captureFactory;
+    private readonly Func<TimeSpan, CancellationToken, Task> _delayAsync;
+    private readonly Func<Task> _beforeFixedCaptureTeardownAsync;
+    private readonly TimeSpan _firstAudioTimeout;
+    private readonly Func<string> _firstAudioTimeoutMessage;
+    private IAudioCapture? _capture;
+    private EventHandler<WaveInEventArgs>? _dataAvailableHandler;
+    private EventHandler<StoppedEventArgs>? _recordingStoppedHandler;
     private WaveFormat? _captureFormat;
+    private CancellationTokenSource? _firstAudioCts;
+    private int _captureGeneration;
     private AudioPipelineOptions _options = new();
+    internal static readonly TimeSpan DefaultFirstAudioTimeout = TimeSpan.FromSeconds(5);
 
     // Resampling state
     private readonly List<float> _resampleBuffer = new();
@@ -36,7 +49,7 @@ public sealed class AudioPipeline : IAsyncDisposable
     private int _silenceChunksThreshold;
 
     // State
-    private AudioPipelineState _state = AudioPipelineState.Stopped;
+    private volatile AudioPipelineState _state = AudioPipelineState.Stopped;
     private CancellationTokenSource? _cts;
     private const int PipelineSampleRate = 16000;
     private const int VadChunkSamples = 512;
@@ -61,7 +74,7 @@ public sealed class AudioPipeline : IAsyncDisposable
     // _fixedCaptureBuffer for the duration of CaptureFixedDurationAsync.
     // This gives stt.transcribe a true bounded-window capture (vs.
     // stt.listen's silence-bounded behavior).
-    private bool _fixedCaptureMode;
+    private int _fixedCaptureGeneration;
     private readonly List<float> _fixedCaptureBuffer = new();
 
     /// <summary>Fired when a single Whisper segment has been transcribed.
@@ -95,74 +108,115 @@ public sealed class AudioPipeline : IAsyncDisposable
     public bool IsMuted { get; set; }
 
     public AudioPipeline(IOpenClawLogger logger, SpeechToTextService stt)
+        : this(
+            logger,
+            stt,
+            static () => new WasapiAudioCapture(),
+            static (delay, token) => Task.Delay(delay, token),
+            DefaultFirstAudioTimeout,
+            static () => LocalizationHelper.GetString("AudioPipeline_FirstAudioTimeout"),
+            static () => Task.CompletedTask)
+    {
+    }
+
+    internal AudioPipeline(
+        IOpenClawLogger logger,
+        SpeechToTextService stt,
+        Func<IAudioCapture> captureFactory,
+        Func<TimeSpan, CancellationToken, Task> delayAsync,
+        TimeSpan firstAudioTimeout,
+        Func<string> firstAudioTimeoutMessage,
+        Func<Task>? beforeFixedCaptureTeardownAsync = null)
     {
         _logger = logger;
         _stt = stt;
+        _captureFactory = captureFactory;
+        _delayAsync = delayAsync;
+        _firstAudioTimeout = firstAudioTimeout;
+        _firstAudioTimeoutMessage = firstAudioTimeoutMessage;
+        _beforeFixedCaptureTeardownAsync = beforeFixedCaptureTeardownAsync ?? (() => Task.CompletedTask);
     }
 
     /// <summary>Start capturing and processing audio.</summary>
     public async Task StartAsync(AudioPipelineOptions options, CancellationToken cancellationToken = default)
     {
-        if (_state != AudioPipelineState.Stopped)
-            throw new InvalidOperationException($"Pipeline is {_state}, must be Stopped to start.");
-
-        _options = options;
-        _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-
-        // Calculate silence threshold: how many VAD chunks = silence timeout
-        float chunkDurationSec = (float)VadChunkSamples / PipelineSampleRate;
-        _silenceChunksThreshold = Math.Max(1, (int)(options.SilenceTimeoutSeconds / chunkDurationSec));
-
-        SetState(AudioPipelineState.Starting);
-
+        await _stopGate.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            // WASAPI COM objects must be created on an MTA thread, not the
-            // WinUI STA dispatcher thread. Run capture init on the thread pool.
-            await Task.Run(() =>
+            if (_state != AudioPipelineState.Stopped)
+                throw new InvalidOperationException($"Pipeline is {_state}, must be Stopped to start.");
+
+            _options = options;
+            _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            var captureCancellation = _cts.Token;
+            var generation = BeginCaptureGeneration();
+
+            // Calculate silence threshold: how many VAD chunks = silence timeout
+            float chunkDurationSec = (float)VadChunkSamples / PipelineSampleRate;
+            _silenceChunksThreshold = Math.Max(1, (int)(options.SilenceTimeoutSeconds / chunkDurationSec));
+
+            SetState(AudioPipelineState.Starting);
+
+            try
             {
-                _capture = new WasapiCapture();
-                _captureFormat = _capture.WaveFormat;
-                _capture.DataAvailable += OnDataAvailable;
-                _capture.RecordingStopped += OnRecordingStopped;
-                _capture.StartRecording();
-            });
+                // WASAPI COM objects must be created on an MTA thread, not the
+                // WinUI STA dispatcher thread. Run capture init on the thread pool.
+                await InitializeCaptureAsync(generation, captureCancellation);
 
-            _speechBuffer.Clear();
-            _resampleBuffer.Clear();
-            _isSpeaking = false;
-            _silenceChunksCount = 0;
-            _dataCallbackCount = 0;
-            _vadChunkCount = 0;
+                _speechBuffer.Clear();
+                _resampleBuffer.Clear();
+                _isSpeaking = false;
+                _silenceChunksCount = 0;
+                _dataCallbackCount = 0;
+                _vadChunkCount = 0;
 
-            SetState(AudioPipelineState.Listening);
-            var captureFormat = _captureFormat ?? throw new InvalidOperationException("Audio capture format was not initialized.");
-            var sttStatus = _stt.IsModelLoaded ? "loaded" : "NOT loaded";
-            _logger.Info($"Audio pipeline started: {captureFormat.SampleRate}Hz {captureFormat.BitsPerSample}bit {captureFormat.Channels}ch → 16kHz mono, VAD=energy, STT={sttStatus}");
-            DiagnosticMessage?.Invoke($"Mic: {captureFormat.SampleRate}Hz, STT model: {sttStatus}");
+                if (!TrySetState(generation, AudioPipelineState.Listening))
+                    return;
+
+                var captureFormat = _captureFormat ?? throw new InvalidOperationException("Audio capture format was not initialized.");
+                var sttStatus = _stt.IsModelLoaded ? "loaded" : "NOT loaded";
+                _logger.Info($"Audio pipeline started: {captureFormat.SampleRate}Hz {captureFormat.BitsPerSample}bit {captureFormat.Channels}ch → 16kHz mono, VAD=energy, STT={sttStatus}");
+                DiagnosticMessage?.Invoke($"Mic: {captureFormat.SampleRate}Hz, STT model: {sttStatus}");
+            }
+            catch (System.Runtime.InteropServices.COMException ex) when (
+                ex.HResult == unchecked((int)0x80070005) || // E_ACCESSDENIED
+                ex.HResult == unchecked((int)0x88890008))   // AUDCLNT_E_DEVICE_INVALIDATED
+            {
+                if (!IsCurrentCapture(generation))
+                    return;
+
+                _logger.Error("Microphone access denied", ex);
+                SetState(AudioPipelineState.Error);
+                DiagnosticMessage?.Invoke("⚠️ Microphone access denied: check Windows Settings → Privacy → Microphone");
+                // Release the partially-initialised capture device.
+                CleanupCapture(stopCapture: true);
+                throw new InvalidOperationException(
+                    "Microphone access denied. Open Windows Settings → Privacy & Security → Microphone and enable 'Let desktop apps access your microphone'.",
+                    ex);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                CleanupCapture(stopCapture: true);
+                SetState(AudioPipelineState.Stopped);
+                throw;
+            }
+            catch (Exception ex)
+            {
+                if (!IsCurrentCapture(generation))
+                    return;
+
+                _logger.Error("Failed to start audio capture", ex);
+                SetState(AudioPipelineState.Error);
+                DiagnosticMessage?.Invoke($"⚠️ Mic error: {ex.Message}");
+                // Release the partially-initialised capture device and CTS so
+                // the mic LED doesn't stay on after a failed start.
+                CleanupCapture(stopCapture: true);
+                throw;
+            }
         }
-        catch (System.Runtime.InteropServices.COMException ex) when (
-            ex.HResult == unchecked((int)0x80070005) || // E_ACCESSDENIED
-            ex.HResult == unchecked((int)0x88890008))   // AUDCLNT_E_DEVICE_INVALIDATED
+        finally
         {
-            _logger.Error("Microphone access denied", ex);
-            SetState(AudioPipelineState.Error);
-            DiagnosticMessage?.Invoke("⚠️ Microphone access denied: check Windows Settings → Privacy → Microphone");
-            // Release the partially-initialised capture device.
-            CleanupCapture();
-            throw new InvalidOperationException(
-                "Microphone access denied. Open Windows Settings → Privacy & Security → Microphone and enable 'Let desktop apps access your microphone'.",
-                ex);
-        }
-        catch (Exception ex)
-        {
-            _logger.Error("Failed to start audio capture", ex);
-            SetState(AudioPipelineState.Error);
-            DiagnosticMessage?.Invoke($"⚠️ Mic error: {ex.Message}");
-            // Release the partially-initialised capture device and CTS so
-            // the mic LED doesn't stay on after a failed start.
-            CleanupCapture();
-            throw;
+            _stopGate.Release();
         }
     }
 
@@ -175,34 +229,38 @@ public sealed class AudioPipeline : IAsyncDisposable
     /// </summary>
     public async Task<float[]> CaptureFixedDurationAsync(int durationMs, CancellationToken cancellationToken = default)
     {
-        if (_state != AudioPipelineState.Stopped)
-            throw new InvalidOperationException($"Pipeline is {_state}, must be Stopped to start capture.");
-        if (durationMs <= 0)
-            throw new ArgumentOutOfRangeException(nameof(durationMs), "Duration must be positive.");
-
-        _fixedCaptureMode = true;
-        _fixedCaptureBuffer.Clear();
-        _resampleBuffer.Clear();
-        _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-
-        SetState(AudioPipelineState.Starting);
+        await _stopGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        var lifecycleGateHeld = true;
+        var generation = 0;
         try
         {
-            await Task.Run(() =>
-            {
-                _capture = new WasapiCapture();
-                _captureFormat = _capture.WaveFormat;
-                _capture.DataAvailable += OnDataAvailable;
-                _capture.RecordingStopped += OnRecordingStopped;
-                _capture.StartRecording();
-            });
+            if (_state != AudioPipelineState.Stopped)
+                throw new InvalidOperationException($"Pipeline is {_state}, must be Stopped to start capture.");
+            if (durationMs <= 0)
+                throw new ArgumentOutOfRangeException(nameof(durationMs), "Duration must be positive.");
 
-            SetState(AudioPipelineState.Listening);
+            _fixedCaptureBuffer.Clear();
+            _resampleBuffer.Clear();
+            _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            var captureCancellation = _cts.Token;
+            generation = BeginCaptureGeneration();
+            Volatile.Write(ref _fixedCaptureGeneration, generation);
+
+            SetState(AudioPipelineState.Starting);
+            // Fixed-duration capture is already bounded by durationMs, so it
+            // does not use the streaming first-audio watchdog.
+            await InitializeCaptureAsync(generation, captureCancellation, armFirstAudioWatchdog: false);
+
+            if (!TrySetState(generation, AudioPipelineState.Listening))
+                return [];
+
             SafeRaiseDiag($"Recording {durationMs / 1000.0:F1}s...");
+            _stopGate.Release();
+            lifecycleGateHeld = false;
 
             try
             {
-                await Task.Delay(durationMs, _cts.Token).ConfigureAwait(false);
+                await Task.Delay(durationMs, captureCancellation).ConfigureAwait(false);
             }
             // slopwatch-ignore: SW003 Shutdown cancellation or disposal is expected and the caller already preserves the safe state.
             catch (TaskCanceledException)
@@ -210,8 +268,16 @@ public sealed class AudioPipeline : IAsyncDisposable
                 // External cancellation: return whatever we have so far.
             }
 
+            await _beforeFixedCaptureTeardownAsync().ConfigureAwait(false);
+            await _stopGate.WaitAsync().ConfigureAwait(false);
+            lifecycleGateHeld = true;
+
+            var capture = GetCurrentCapture(generation);
+            if (capture == null)
+                return [];
+
             // Stop capture and give NAudio a moment to flush its last buffer.
-            try { _capture?.StopRecording(); }
+            try { capture.StopRecording(); }
             catch (Exception ex) { _logger.Debug($"AudioPipeline: StopRecording during fixed-capture teardown threw: {ex.Message}"); }
             await Task.Delay(150).ConfigureAwait(false);
 
@@ -219,70 +285,98 @@ public sealed class AudioPipeline : IAsyncDisposable
         }
         finally
         {
-            _fixedCaptureMode = false;
-            _fixedCaptureBuffer.Clear();
-            CleanupCapture();
-            SetState(AudioPipelineState.Stopped);
+            if (!lifecycleGateHeld)
+            {
+                await _stopGate.WaitAsync().ConfigureAwait(false);
+                lifecycleGateHeld = true;
+            }
+
+            var cleanedCurrentCapture = generation != 0 && CleanupCapture(expectedGeneration: generation);
+            if (generation != 0 &&
+                Interlocked.CompareExchange(ref _fixedCaptureGeneration, 0, generation) == generation)
+            {
+                _fixedCaptureBuffer.Clear();
+            }
+
+            if (cleanedCurrentCapture)
+                SetState(AudioPipelineState.Stopped);
+
+            if (lifecycleGateHeld)
+                _stopGate.Release();
         }
     }
 
     /// <summary>Stop capturing and processing.</summary>
     public async Task StopAsync()
     {
-        if (_state == AudioPipelineState.Stopped)
-            return;
-
-        _isStopping = true;
+        await _stopGate.WaitAsync().ConfigureAwait(false);
         try
         {
-            // Order matters here. Previously we cancelled `_cts` first and THEN
-            // tried to flush the speech buffer — but the flush passed `_cts.Token`
-            // straight into Whisper.net, which honored the cancel and dropped the
-            // final utterance. Now:
-            //
-            //   1. Stop capturing new audio so the buffer doesn't grow further.
-            //   2. Wait briefly for any in-flight transcriptions (Task.Run-spawned
-            //      from earlier VAD bursts) to finish — so the user's last
-            //      utterance reaches Whisper instead of being killed mid-encode.
-            //   3. Flush any buffered speech using a fresh (non-cancelled) token
-            //      so anything left over also reaches Whisper.
-            //   4. Cancel `_cts` to stop background work that hasn't drained yet.
-            //   5. Tear down capture resources.
-            if (_capture != null)
+            if (_state == AudioPipelineState.Stopped)
+                return;
+
+            _isStopping = true;
+            try
             {
-                try { _capture.StopRecording(); }
-                catch (Exception ex) { _logger.Error("Error stopping capture", ex); }
-            }
+                CancelFirstAudioWatchdog();
 
-            // Drain in-flight transcriptions, capped at 3 s so Stop never hangs.
-            var drainDeadline = DateTime.UtcNow + TimeSpan.FromSeconds(3);
-            while (Volatile.Read(ref _inFlightTranscriptions) > 0 && DateTime.UtcNow < drainDeadline)
+                // Order matters here. Previously we cancelled `_cts` first and THEN
+                // tried to flush the speech buffer — but the flush passed `_cts.Token`
+                // straight into Whisper.net, which honored the cancel and dropped the
+                // final utterance. Now:
+                //
+                //   1. Stop capturing new audio so the buffer doesn't grow further.
+                //   2. Wait briefly for any in-flight transcriptions (Task.Run-spawned
+                //      from earlier VAD bursts) to finish — so the user's last
+                //      utterance reaches Whisper instead of being killed mid-encode.
+                //   3. Flush any buffered speech using a fresh (non-cancelled) token
+                //      so anything left over also reaches Whisper.
+                //   4. Cancel `_cts` to stop background work that hasn't drained yet.
+                //   5. Tear down capture resources.
+                var capture = GetCurrentCapture();
+                if (capture != null)
+                {
+                    try { capture.StopRecording(); }
+                    catch (Exception ex) { _logger.Error("Error stopping capture", ex); }
+                }
+
+                // Drain in-flight transcriptions, capped at 3 s so Stop never hangs.
+                var drainDeadline = DateTime.UtcNow + TimeSpan.FromSeconds(3);
+                while (Volatile.Read(ref _inFlightTranscriptions) > 0 && DateTime.UtcNow < drainDeadline)
+                {
+                    await Task.Delay(50).ConfigureAwait(false);
+                }
+
+                if (_speechBuffer.Count > 0 && _stt.IsModelLoaded)
+                {
+                    await FlushSpeechBufferAsync();
+                }
+
+                GetCurrentPipelineCancellation()?.Cancel();
+
+                CleanupCapture();
+                SetState(AudioPipelineState.Stopped);
+                _logger.Info("Audio pipeline stopped");
+            }
+            finally
             {
-                await Task.Delay(50).ConfigureAwait(false);
+                _isStopping = false;
             }
-
-            if (_speechBuffer.Count > 0 && _stt.IsModelLoaded)
-            {
-                await FlushSpeechBufferAsync();
-            }
-
-            _cts?.Cancel();
-
-            CleanupCapture();
-            SetState(AudioPipelineState.Stopped);
-            _logger.Info("Audio pipeline stopped");
         }
         finally
         {
-            _isStopping = false;
+            _stopGate.Release();
         }
     }
 
     private int _dataCallbackCount;
 
-    private void OnDataAvailable(object? sender, WaveInEventArgs e)
+    private void OnDataAvailable(int generation, object? sender, WaveInEventArgs e)
     {
-        if (_cts?.IsCancellationRequested == true || e.BytesRecorded == 0 || IsMuted)
+        if (e.BytesRecorded == 0 || !TryAcceptFirstAudio(generation))
+            return;
+
+        if (_cts?.IsCancellationRequested == true || _isStopping || IsMuted)
             return;
 
         _dataCallbackCount++;
@@ -310,7 +404,7 @@ public sealed class AudioPipeline : IAsyncDisposable
             // Fixed-duration capture mode: skip VAD entirely; we want every
             // sample for the full window. CaptureFixedDurationAsync drains
             // the buffer when the timer fires.
-            if (_fixedCaptureMode)
+            if (generation == Volatile.Read(ref _fixedCaptureGeneration))
             {
                 _fixedCaptureBuffer.AddRange(resampled);
                 return;
@@ -542,13 +636,37 @@ public sealed class AudioPipeline : IAsyncDisposable
         }
     }
 
-    private void OnRecordingStopped(object? sender, StoppedEventArgs e)
+    private void OnRecordingStopped(int generation, object? sender, StoppedEventArgs e)
     {
-        if (e.Exception != null)
+        if (e.Exception == null)
+            return;
+
+        _ = HandleRecordingStoppedErrorAsync(generation, e.Exception);
+    }
+
+    private async Task HandleRecordingStoppedErrorAsync(int generation, Exception exception)
+    {
+        await _stopGate.WaitAsync().ConfigureAwait(false);
+        try
         {
-            _logger.Error("Recording stopped with error", e.Exception);
-            SetState(AudioPipelineState.Error);
-            DiagnosticMessage?.Invoke($"⚠️ Microphone error: {e.Exception.Message}");
+            if (!IsCurrentCapture(generation))
+                return;
+
+            var fixedCapture = generation == Volatile.Read(ref _fixedCaptureGeneration);
+            if (fixedCapture)
+                Interlocked.CompareExchange(ref _fixedCaptureGeneration, 0, generation);
+
+            GetCurrentPipelineCancellation()?.Cancel();
+            CleanupCapture(expectedGeneration: generation);
+            _state = AudioPipelineState.Error;
+            _logger.Error("Recording stopped with error", exception);
+            try { StateChanged?.Invoke(AudioPipelineState.Error); }
+            catch (Exception ex) { _logger.Error("Recording stopped state handler failed", ex); }
+            SafeRaiseDiag($"⚠️ Microphone error: {exception.Message}");
+        }
+        finally
+        {
+            _stopGate.Release();
         }
     }
 
@@ -635,54 +753,292 @@ public sealed class AudioPipeline : IAsyncDisposable
         StateChanged?.Invoke(newState);
     }
 
-    private void CleanupCapture()
+    private int BeginCaptureGeneration()
     {
-        if (_capture != null)
+        lock (_captureGate)
         {
-            try
+            return ++_captureGeneration;
+        }
+    }
+
+    private async Task InitializeCaptureAsync(
+        int generation,
+        CancellationToken captureCancellation,
+        bool armFirstAudioWatchdog = true)
+    {
+        await Task.Run(() =>
+        {
+            var capture = _captureFactory();
+            var dataAvailableHandler = new EventHandler<WaveInEventArgs>(
+                (sender, args) => OnDataAvailable(generation, sender, args));
+            var recordingStoppedHandler = new EventHandler<StoppedEventArgs>(
+                (sender, args) => OnRecordingStopped(generation, sender, args));
+
+            capture.DataAvailable += dataAvailableHandler;
+            capture.RecordingStopped += recordingStoppedHandler;
+
+            CancellationTokenSource? watchdogCts = null;
+            lock (_captureGate)
             {
-                _capture.DataAvailable -= OnDataAvailable;
-                _capture.RecordingStopped -= OnRecordingStopped;
-            }
-            catch (Exception ex)
-            {
-                _logger.Error("Error detaching capture event handlers", ex);
+                if (generation != _captureGeneration || captureCancellation.IsCancellationRequested)
+                {
+                    capture.DataAvailable -= dataAvailableHandler;
+                    capture.RecordingStopped -= recordingStoppedHandler;
+                    capture.Dispose();
+                    captureCancellation.ThrowIfCancellationRequested();
+                    return;
+                }
+
+                _capture = capture;
+                _captureFormat = capture.WaveFormat;
+                _dataAvailableHandler = dataAvailableHandler;
+                _recordingStoppedHandler = recordingStoppedHandler;
+                if (armFirstAudioWatchdog)
+                    watchdogCts = CancellationTokenSource.CreateLinkedTokenSource(captureCancellation);
+                _firstAudioCts = watchdogCts;
             }
 
-            try
-            {
-                _capture.Dispose();
-            }
-            catch (Exception ex)
-            {
-                // NAudio's WasapiCapture.Dispose may throw on a stuck COM
-                // object. Log but never propagate — this method is called
-                // from finally-blocks and re-throwing would mask the original
-                // failure AND leave the mic device held by the OS until
-                // process exit.
-                _logger.Error("Error disposing audio capture", ex);
-            }
-            finally
-            {
-                _capture = null;
-            }
+            if (watchdogCts != null)
+                _ = WatchForFirstAudioAsync(generation, watchdogCts.Token);
+            capture.StartRecording();
+        }).ConfigureAwait(false);
+    }
+
+    private async Task WatchForFirstAudioAsync(int generation, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _delayAsync(_firstAudioTimeout, cancellationToken).ConfigureAwait(false);
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
+
+        await HandleFirstAudioTimeoutAsync(generation).ConfigureAwait(false);
+    }
+
+    private async Task HandleFirstAudioTimeoutAsync(int generation)
+    {
+        await _stopGate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            IAudioCapture? capture;
+            EventHandler<WaveInEventArgs>? dataAvailableHandler;
+            EventHandler<StoppedEventArgs>? recordingStoppedHandler;
+            CancellationTokenSource? watchdogCts;
+            CancellationTokenSource? pipelineCts;
+            bool stateChanged;
+
+            lock (_captureGate)
+            {
+                if (generation != _captureGeneration || _firstAudioCts == null)
+                    return;
+
+                ++_captureGeneration;
+                capture = _capture;
+                dataAvailableHandler = _dataAvailableHandler;
+                recordingStoppedHandler = _recordingStoppedHandler;
+                watchdogCts = _firstAudioCts;
+                pipelineCts = _cts;
+
+                _capture = null;
+                _captureFormat = null;
+                _dataAvailableHandler = null;
+                _recordingStoppedHandler = null;
+                _firstAudioCts = null;
+                _cts = null;
+                stateChanged = _state != AudioPipelineState.Error;
+                _state = AudioPipelineState.Error;
+            }
+
+            CancelAndDispose(watchdogCts);
+            CancelAndDispose(pipelineCts);
+            ReleaseCapture(capture, dataAvailableHandler, recordingStoppedHandler, stopCapture: true);
+            _resampleBuffer.Clear();
+            _speechBuffer.Clear();
+
+            _logger.Error($"Audio capture produced no data within {_firstAudioTimeout.TotalSeconds:F1} seconds");
+            if (stateChanged)
+            {
+                try { StateChanged?.Invoke(AudioPipelineState.Error); }
+                catch (Exception ex) { _logger.Error("Audio timeout state handler failed", ex); }
+            }
+
+            try { SafeRaiseDiag(_firstAudioTimeoutMessage()); }
+            catch (Exception ex) { _logger.Error("Audio timeout diagnostic localization failed", ex); }
+        }
+        finally
+        {
+            _stopGate.Release();
+        }
+    }
+
+    private bool TryAcceptFirstAudio(int generation)
+    {
+        CancellationTokenSource? watchdogCts;
+        lock (_captureGate)
+        {
+            if (generation != _captureGeneration || _capture == null)
+                return false;
+
+            watchdogCts = _firstAudioCts;
+            _firstAudioCts = null;
+        }
+
+        CancelAndDispose(watchdogCts);
+        return true;
+    }
+
+    private void CancelFirstAudioWatchdog()
+    {
+        CancellationTokenSource? watchdogCts;
+        lock (_captureGate)
+        {
+            watchdogCts = _firstAudioCts;
+            _firstAudioCts = null;
+        }
+
+        CancelAndDispose(watchdogCts);
+    }
+
+    private IAudioCapture? GetCurrentCapture(int? expectedGeneration = null)
+    {
+        lock (_captureGate)
+        {
+            if (expectedGeneration.HasValue && expectedGeneration.Value != _captureGeneration)
+                return null;
+
+            return _capture;
+        }
+    }
+
+    private CancellationTokenSource? GetCurrentPipelineCancellation()
+    {
+        lock (_captureGate)
+        {
+            return _cts;
+        }
+    }
+
+    private bool IsCurrentCapture(int generation)
+    {
+        lock (_captureGate)
+        {
+            return generation == _captureGeneration;
+        }
+    }
+
+    private bool TrySetState(int generation, AudioPipelineState state)
+    {
+        bool stateChanged;
+        lock (_captureGate)
+        {
+            if (generation != _captureGeneration || _capture == null)
+                return false;
+
+            stateChanged = _state != state;
+            _state = state;
+        }
+
+        if (stateChanged)
+            StateChanged?.Invoke(state);
+        return true;
+    }
+
+    private bool CleanupCapture(bool stopCapture = false, int? expectedGeneration = null)
+    {
+        IAudioCapture? capture;
+        EventHandler<WaveInEventArgs>? dataAvailableHandler;
+        EventHandler<StoppedEventArgs>? recordingStoppedHandler;
+        CancellationTokenSource? watchdogCts;
+        CancellationTokenSource? pipelineCts;
+
+        lock (_captureGate)
+        {
+            if (expectedGeneration.HasValue && expectedGeneration.Value != _captureGeneration)
+                return false;
+
+            ++_captureGeneration;
+            capture = _capture;
+            dataAvailableHandler = _dataAvailableHandler;
+            recordingStoppedHandler = _recordingStoppedHandler;
+            watchdogCts = _firstAudioCts;
+            pipelineCts = _cts;
+
+            _capture = null;
+            _captureFormat = null;
+            _dataAvailableHandler = null;
+            _recordingStoppedHandler = null;
+            _firstAudioCts = null;
+            _cts = null;
+        }
+
+        CancelAndDispose(watchdogCts);
+        ReleaseCapture(capture, dataAvailableHandler, recordingStoppedHandler, stopCapture);
 
         try
         {
-            _cts?.Dispose();
+            pipelineCts?.Dispose();
         }
         catch (Exception ex)
         {
             _logger.Error("Error disposing pipeline cancellation source", ex);
         }
-        finally
-        {
-            _cts = null;
-        }
 
         _resampleBuffer.Clear();
         _speechBuffer.Clear();
+        return true;
+    }
+
+    private void ReleaseCapture(
+        IAudioCapture? capture,
+        EventHandler<WaveInEventArgs>? dataAvailableHandler,
+        EventHandler<StoppedEventArgs>? recordingStoppedHandler,
+        bool stopCapture)
+    {
+        if (capture == null)
+            return;
+
+        try
+        {
+            if (dataAvailableHandler != null)
+                capture.DataAvailable -= dataAvailableHandler;
+            if (recordingStoppedHandler != null)
+                capture.RecordingStopped -= recordingStoppedHandler;
+        }
+        catch (Exception ex)
+        {
+            _logger.Error("Error detaching capture event handlers", ex);
+        }
+
+        if (stopCapture)
+        {
+            try { capture.StopRecording(); }
+            catch (Exception ex) { _logger.Error("Error stopping capture", ex); }
+        }
+
+        try
+        {
+            capture.Dispose();
+        }
+        catch (Exception ex)
+        {
+            // NAudio's WasapiCapture.Dispose may throw on a stuck COM
+            // object. Log but never propagate because teardown must remain
+            // idempotent and preserve the original failure.
+            _logger.Error("Error disposing audio capture", ex);
+        }
+    }
+
+    private static void CancelAndDispose(CancellationTokenSource? cts)
+    {
+        if (cts == null)
+            return;
+
+        try { cts.Cancel(); }
+        catch (ObjectDisposedException) { }
+        cts.Dispose();
     }
 
     public async ValueTask DisposeAsync()
@@ -699,4 +1055,36 @@ public sealed class AudioPipeline : IAsyncDisposable
         try { DiagnosticMessage?.Invoke(message); }
         catch (Exception ex) { _logger.Debug($"AudioPipeline: DiagnosticMessage handler threw: {ex.Message}"); }
     }
+}
+
+internal interface IAudioCapture : IDisposable
+{
+    WaveFormat WaveFormat { get; }
+    event EventHandler<WaveInEventArgs>? DataAvailable;
+    event EventHandler<StoppedEventArgs>? RecordingStopped;
+    void StartRecording();
+    void StopRecording();
+}
+
+internal sealed class WasapiAudioCapture : IAudioCapture
+{
+    private readonly WasapiCapture _capture = new();
+
+    public WaveFormat WaveFormat => _capture.WaveFormat;
+
+    public event EventHandler<WaveInEventArgs>? DataAvailable
+    {
+        add => _capture.DataAvailable += value;
+        remove => _capture.DataAvailable -= value;
+    }
+
+    public event EventHandler<StoppedEventArgs>? RecordingStopped
+    {
+        add => _capture.RecordingStopped += value;
+        remove => _capture.RecordingStopped -= value;
+    }
+
+    public void StartRecording() => _capture.StartRecording();
+    public void StopRecording() => _capture.StopRecording();
+    public void Dispose() => _capture.Dispose();
 }

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -2828,6 +2828,9 @@ Use one of these options:
   <data name="VoiceOverlayWindow_StatusErrorOccurred" xml:space="preserve">
     <value>An error occurred</value>
   </data>
+  <data name="AudioPipeline_FirstAudioTimeout" xml:space="preserve">
+    <value>No audio was received. Check that your microphone is connected and selected as the Windows input device, then try again.</value>
+  </data>
   <data name="VoiceOverlayWindow_winexWindowEx_2.Title" xml:space="preserve">
     <value>Companion Voice</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -2781,6 +2781,9 @@ Utilisez l'une de ces options :
   <data name="VoiceOverlayWindow_StatusErrorOccurred" xml:space="preserve">
     <value>Une erreur s'est produite</value>
   </data>
+  <data name="AudioPipeline_FirstAudioTimeout" xml:space="preserve">
+    <value>Aucun son n’a été reçu. Vérifiez que votre microphone est connecté et sélectionné comme périphérique d’entrée Windows, puis réessayez.</value>
+  </data>
   <data name="VoiceOverlayWindow_winexWindowEx_2.Title" xml:space="preserve">
     <value>Companion Voice</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -2782,6 +2782,9 @@ Gebruik een van deze opties:
   <data name="VoiceOverlayWindow_StatusErrorOccurred" xml:space="preserve">
     <value>Er is een fout opgetreden</value>
   </data>
+  <data name="AudioPipeline_FirstAudioTimeout" xml:space="preserve">
+    <value>Er is geen audio ontvangen. Controleer of uw microfoon is aangesloten en geselecteerd als Windows-invoerapparaat en probeer het opnieuw.</value>
+  </data>
   <data name="VoiceOverlayWindow_winexWindowEx_2.Title" xml:space="preserve">
     <value>Companion Voice</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -2781,6 +2781,9 @@
   <data name="VoiceOverlayWindow_StatusErrorOccurred" xml:space="preserve">
     <value>发生错误</value>
   </data>
+  <data name="AudioPipeline_FirstAudioTimeout" xml:space="preserve">
+    <value>未收到音频。请检查麦克风是否已连接并在 Windows 中选作输入设备，然后重试。</value>
+  </data>
   <data name="VoiceOverlayWindow_winexWindowEx_2.Title" xml:space="preserve">
     <value>Companion Voice</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -2781,6 +2781,9 @@
   <data name="VoiceOverlayWindow_StatusErrorOccurred" xml:space="preserve">
     <value>發生錯誤</value>
   </data>
+  <data name="AudioPipeline_FirstAudioTimeout" xml:space="preserve">
+    <value>未收到音訊。請確認麥克風已連線，並在 Windows 中選為輸入裝置，然後再試一次。</value>
+  </data>
   <data name="VoiceOverlayWindow_winexWindowEx_2.Title" xml:space="preserve">
     <value>Companion Voice</value>
   </data>

--- a/tests/OpenClaw.Tray.Tests/SpeechInputContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/SpeechInputContractTests.cs
@@ -26,6 +26,16 @@ public sealed class SpeechInputContractTests
     }
 
     [Fact]
+    public void AudioPipeline_FirstAudioTimeout_UsesLocalizedActionableMessage()
+    {
+        var pipeline = Read("src", "OpenClaw.Tray.WinUI", "Services", "AudioPipeline.cs");
+        var resources = Read("src", "OpenClaw.Tray.WinUI", "Strings", "en-us", "Resources.resw");
+
+        Assert.Contains("LocalizationHelper.GetString(\"AudioPipeline_FirstAudioTimeout\")", pipeline);
+        Assert.Contains("Check that your microphone is connected and selected as the Windows input device", resources);
+    }
+
+    [Fact]
     public void ChatVoiceDialogs_RouteDisabledSttCapabilityToPermissions_AndMissingModelToVoiceSettings()
     {
         var chatPage = Read("src", "OpenClaw.Tray.WinUI", "Pages", "ChatPage.xaml.cs");

--- a/tests/OpenClaw.Tray.UITests/AudioPipelineFirstAudioTimeoutTests.cs
+++ b/tests/OpenClaw.Tray.UITests/AudioPipelineFirstAudioTimeoutTests.cs
@@ -1,0 +1,394 @@
+using NAudio.Wave;
+using OpenClaw.Shared;
+using OpenClaw.Shared.Audio;
+using OpenClawTray.Services;
+using System.Collections.Concurrent;
+
+namespace OpenClaw.Tray.UITests;
+
+public sealed class AudioPipelineFirstAudioTimeoutTests
+{
+    private const string TimeoutMessage =
+        "No audio was received. Check that your microphone is connected and selected as the Windows input device, then try again.";
+
+    [Fact]
+    public async Task NoCallback_StopsAndDisposesCapture_AndReportsError()
+    {
+        var delay = new ControlledDelay();
+        var capture = new FakeAudioCapture();
+        await using var pipeline = CreatePipeline(() => capture, delay.DelayAsync);
+        var diagnostics = new ConcurrentQueue<string>();
+        pipeline.DiagnosticMessage += diagnostics.Enqueue;
+
+        await pipeline.StartAsync(new AudioPipelineOptions());
+        delay.Expire();
+        await WaitForStateAsync(pipeline, AudioPipelineState.Error);
+        await WaitForConditionAsync(() => diagnostics.Contains(TimeoutMessage));
+
+        Assert.Equal(1, capture.StopCount);
+        Assert.Equal(1, capture.DisposeCount);
+        Assert.Contains(TimeoutMessage, diagnostics);
+
+        capture.EmitLateData([0, 0]);
+        Assert.Equal(AudioPipelineState.Error, pipeline.State);
+
+        await pipeline.StopAsync().WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.Equal(AudioPipelineState.Stopped, pipeline.State);
+    }
+
+    [Fact]
+    public async Task FirstNonemptyAudio_CancelsTimeout()
+    {
+        var delay = new ControlledDelay();
+        var capture = new FakeAudioCapture();
+        await using var pipeline = CreatePipeline(() => capture, delay.DelayAsync);
+
+        await pipeline.StartAsync(new AudioPipelineOptions());
+        capture.EmitData([0, 0]);
+        delay.Expire();
+        await Task.Delay(50);
+
+        Assert.Equal(AudioPipelineState.Listening, pipeline.State);
+        Assert.Equal(0, capture.StopCount);
+        Assert.Equal(0, capture.DisposeCount);
+    }
+
+    [Fact]
+    public async Task StopBeforeTimeout_PreventsLateError()
+    {
+        var delay = new ControlledDelay();
+        var capture = new FakeAudioCapture();
+        await using var pipeline = CreatePipeline(() => capture, delay.DelayAsync);
+
+        await pipeline.StartAsync(new AudioPipelineOptions());
+        await pipeline.StopAsync();
+        delay.Expire();
+        await Task.Delay(50);
+
+        Assert.Equal(AudioPipelineState.Stopped, pipeline.State);
+        Assert.Equal(1, capture.StopCount);
+        Assert.Equal(1, capture.DisposeCount);
+    }
+
+    [Fact]
+    public async Task Restart_DoesNotRetainPriorWatchdog()
+    {
+        var firstDelay = new ControlledDelay();
+        var secondDelay = new ControlledDelay();
+        var delays = new Queue<ControlledDelay>([firstDelay, secondDelay]);
+        var firstCapture = new FakeAudioCapture();
+        var secondCapture = new FakeAudioCapture();
+        var captures = new Queue<FakeAudioCapture>([firstCapture, secondCapture]);
+        await using var pipeline = CreatePipeline(
+            () => captures.Dequeue(),
+            (timeout, token) => delays.Dequeue().DelayAsync(timeout, token));
+
+        await pipeline.StartAsync(new AudioPipelineOptions());
+        await pipeline.StopAsync();
+        await pipeline.StartAsync(new AudioPipelineOptions());
+
+        firstDelay.Expire();
+        await Task.Delay(50);
+
+        Assert.Equal(AudioPipelineState.Listening, pipeline.State);
+        Assert.Equal(0, secondCapture.StopCount);
+        Assert.Equal(0, secondCapture.DisposeCount);
+
+        secondCapture.EmitData([0, 0]);
+        secondDelay.Expire();
+        await Task.Delay(50);
+        Assert.Equal(AudioPipelineState.Listening, pipeline.State);
+    }
+
+    [Fact]
+    public async Task RecordingStoppedError_CancelsTimeout_AndKeepsExistingErrorRoute()
+    {
+        var delay = new ControlledDelay();
+        var capture = new FakeAudioCapture();
+        await using var pipeline = CreatePipeline(() => capture, delay.DelayAsync);
+        var diagnostics = new ConcurrentQueue<string>();
+        pipeline.DiagnosticMessage += diagnostics.Enqueue;
+
+        await pipeline.StartAsync(new AudioPipelineOptions());
+        capture.EmitRecordingStopped(new InvalidOperationException("device lost"));
+        delay.Expire();
+        await Task.Delay(50);
+
+        Assert.Equal(AudioPipelineState.Error, pipeline.State);
+        Assert.Contains("⚠️ Microphone error: device lost", diagnostics);
+        Assert.DoesNotContain(TimeoutMessage, diagnostics);
+        Assert.Equal(1, capture.DisposeCount);
+    }
+
+    [Fact]
+    public async Task FixedCaptureRecordingError_CleansUpAndCanRestart()
+    {
+        var firstCapture = new FakeAudioCapture();
+        var secondCapture = new FakeAudioCapture();
+        var captures = new Queue<FakeAudioCapture>([firstCapture, secondCapture]);
+        await using var pipeline = CreatePipeline(
+            () => captures.Dequeue(),
+            static (timeout, token) => Task.Delay(timeout, token));
+
+        var fixedCaptureTask = pipeline.CaptureFixedDurationAsync(10_000);
+        Assert.True(firstCapture.StartRecordingEntered.Wait(TimeSpan.FromSeconds(2)));
+        firstCapture.EmitRecordingStopped(new InvalidOperationException("device lost"));
+        await WaitForStateAsync(pipeline, AudioPipelineState.Error);
+
+        Assert.Equal(1, firstCapture.DisposeCount);
+        await pipeline.StopAsync();
+        await pipeline.StartAsync(new AudioPipelineOptions());
+
+        Assert.Equal(AudioPipelineState.Listening, pipeline.State);
+        Assert.Equal(0, secondCapture.DisposeCount);
+        await fixedCaptureTask.WaitAsync(TimeSpan.FromSeconds(2));
+    }
+
+    [Fact]
+    public async Task CleanRecordingStopBeforeFirstAudio_DoesNotDisableTimeout()
+    {
+        var delay = new ControlledDelay();
+        var capture = new FakeAudioCapture();
+        await using var pipeline = CreatePipeline(() => capture, delay.DelayAsync);
+
+        await pipeline.StartAsync(new AudioPipelineOptions());
+        capture.EmitRecordingStopped();
+        delay.Expire();
+        await WaitForStateAsync(pipeline, AudioPipelineState.Error);
+
+        Assert.Equal(1, capture.StopCount);
+        Assert.Equal(1, capture.DisposeCount);
+    }
+
+    [Fact]
+    public async Task ConcurrentStopAndDispose_AreIdempotent()
+    {
+        var delay = new ControlledDelay();
+        var capture = new FakeAudioCapture();
+        var pipeline = CreatePipeline(() => capture, delay.DelayAsync);
+
+        await pipeline.StartAsync(new AudioPipelineOptions());
+        await Task.WhenAll(pipeline.StopAsync(), pipeline.DisposeAsync().AsTask());
+
+        Assert.Equal(AudioPipelineState.Stopped, pipeline.State);
+        Assert.Equal(1, capture.StopCount);
+        Assert.Equal(1, capture.DisposeCount);
+    }
+
+    [Fact]
+    public async Task TimeoutAndStop_AreSerializedWithoutLateError()
+    {
+        var delay = new ControlledDelay();
+        var capture = new FakeAudioCapture { BlockStopRecording = true };
+        await using var pipeline = CreatePipeline(() => capture, delay.DelayAsync);
+        var states = new ConcurrentQueue<AudioPipelineState>();
+        pipeline.StateChanged += states.Enqueue;
+
+        await pipeline.StartAsync(new AudioPipelineOptions());
+        delay.Expire();
+        Assert.True(capture.StopRecordingEntered.Wait(TimeSpan.FromSeconds(2)));
+
+        var stopTask = pipeline.StopAsync();
+        await Task.Delay(50);
+        Assert.False(stopTask.IsCompleted);
+
+        capture.AllowStopRecording.Set();
+        await stopTask.WaitAsync(TimeSpan.FromSeconds(2));
+
+        Assert.Equal(AudioPipelineState.Stopped, pipeline.State);
+        Assert.Equal(AudioPipelineState.Stopped, states.Last());
+        Assert.Equal(1, capture.StopCount);
+        Assert.Equal(1, capture.DisposeCount);
+    }
+
+    [Fact]
+    public async Task StopDuringStartup_WaitsForInitializationThenCleansUp()
+    {
+        var delay = new ControlledDelay();
+        var capture = new FakeAudioCapture { BlockStartRecording = true };
+        await using var pipeline = CreatePipeline(() => capture, delay.DelayAsync);
+
+        var startTask = pipeline.StartAsync(new AudioPipelineOptions());
+        Assert.True(capture.StartRecordingEntered.Wait(TimeSpan.FromSeconds(2)));
+
+        var stopTask = pipeline.StopAsync();
+        await Task.Delay(50);
+        Assert.False(stopTask.IsCompleted);
+
+        capture.AllowStartRecording.Set();
+        await startTask.WaitAsync(TimeSpan.FromSeconds(2));
+        await stopTask.WaitAsync(TimeSpan.FromSeconds(2));
+
+        Assert.Equal(AudioPipelineState.Stopped, pipeline.State);
+        Assert.Equal(1, capture.StopCount);
+        Assert.Equal(1, capture.DisposeCount);
+    }
+
+    [Fact]
+    public async Task FixedDurationCapture_DoesNotArmStreamingWatchdog()
+    {
+        var delay = new ControlledDelay();
+        var capture = new FakeAudioCapture();
+        await using var pipeline = CreatePipeline(() => capture, delay.DelayAsync);
+
+        var samples = await pipeline.CaptureFixedDurationAsync(25);
+
+        Assert.Empty(samples);
+        Assert.Equal(0, delay.CallCount);
+        Assert.Equal(AudioPipelineState.Stopped, pipeline.State);
+        Assert.Equal(1, capture.DisposeCount);
+    }
+
+    [Fact]
+    public async Task FixedCaptureLateTeardown_CannotStopRestartedStream()
+    {
+        var delay = new ControlledDelay();
+        var teardownGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var firstCapture = new FakeAudioCapture();
+        var secondCapture = new FakeAudioCapture();
+        var captures = new Queue<FakeAudioCapture>([firstCapture, secondCapture]);
+        await using var pipeline = CreatePipeline(
+            () => captures.Dequeue(),
+            delay.DelayAsync,
+            () => teardownGate.Task);
+
+        var fixedCaptureTask = pipeline.CaptureFixedDurationAsync(10_000);
+        Assert.True(firstCapture.StartRecordingEntered.Wait(TimeSpan.FromSeconds(2)));
+        await pipeline.StopAsync();
+
+        await pipeline.StartAsync(new AudioPipelineOptions());
+        teardownGate.SetResult();
+        await fixedCaptureTask.WaitAsync(TimeSpan.FromSeconds(2));
+
+        Assert.Equal(AudioPipelineState.Listening, pipeline.State);
+        Assert.Equal(0, secondCapture.StopCount);
+        Assert.Equal(0, secondCapture.DisposeCount);
+    }
+
+    [Fact]
+    public async Task StartupCancellation_ReturnsToStoppedWithoutMicrophoneError()
+    {
+        var delay = new ControlledDelay();
+        var factoryEntered = new ManualResetEventSlim();
+        var allowFactory = new ManualResetEventSlim();
+        var capture = new FakeAudioCapture();
+        using var cancellation = new CancellationTokenSource();
+        await using var pipeline = CreatePipeline(
+            () =>
+            {
+                factoryEntered.Set();
+                allowFactory.Wait(TimeSpan.FromSeconds(2));
+                return capture;
+            },
+            delay.DelayAsync);
+        var diagnostics = new ConcurrentQueue<string>();
+        pipeline.DiagnosticMessage += diagnostics.Enqueue;
+
+        var startTask = pipeline.StartAsync(new AudioPipelineOptions(), cancellation.Token);
+        Assert.True(factoryEntered.Wait(TimeSpan.FromSeconds(2)));
+        cancellation.Cancel();
+        allowFactory.Set();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => startTask);
+        Assert.Equal(AudioPipelineState.Stopped, pipeline.State);
+        Assert.DoesNotContain(diagnostics, message => message.Contains("Mic error", StringComparison.Ordinal));
+        Assert.Equal(1, capture.DisposeCount);
+    }
+
+    private static AudioPipeline CreatePipeline(
+        Func<IAudioCapture> captureFactory,
+        Func<TimeSpan, CancellationToken, Task> delayAsync,
+        Func<Task>? beforeFixedCaptureTeardownAsync = null)
+    {
+        return new AudioPipeline(
+            NullLogger.Instance,
+            new SpeechToTextService(NullLogger.Instance),
+            captureFactory,
+            delayAsync,
+            TimeSpan.FromSeconds(5),
+            () => TimeoutMessage,
+            beforeFixedCaptureTeardownAsync);
+    }
+
+    private static async Task WaitForStateAsync(AudioPipeline pipeline, AudioPipelineState state)
+        => await WaitForConditionAsync(() => pipeline.State == state);
+
+    private static async Task WaitForConditionAsync(Func<bool> condition)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(2);
+        while (!condition() && DateTime.UtcNow < deadline)
+            await Task.Delay(10);
+
+        Assert.True(condition());
+    }
+
+    private sealed class ControlledDelay
+    {
+        private readonly TaskCompletionSource _completion =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public int CallCount { get; private set; }
+
+        public Task DelayAsync(TimeSpan timeout, CancellationToken cancellationToken)
+        {
+            CallCount++;
+            cancellationToken.Register(() => _completion.TrySetCanceled(cancellationToken));
+            return _completion.Task;
+        }
+
+        public void Expire() => _completion.TrySetResult();
+    }
+
+    private sealed class FakeAudioCapture : IAudioCapture
+    {
+        private EventHandler<WaveInEventArgs>? _dataAvailable;
+        private EventHandler<WaveInEventArgs>? _lastDataAvailable;
+
+        public WaveFormat WaveFormat { get; } = new(16000, 16, 1);
+        public int StopCount { get; private set; }
+        public int DisposeCount { get; private set; }
+        public bool BlockStartRecording { get; init; }
+        public bool BlockStopRecording { get; init; }
+        public ManualResetEventSlim StartRecordingEntered { get; } = new();
+        public ManualResetEventSlim AllowStartRecording { get; } = new();
+        public ManualResetEventSlim StopRecordingEntered { get; } = new();
+        public ManualResetEventSlim AllowStopRecording { get; } = new();
+
+        public event EventHandler<WaveInEventArgs>? DataAvailable
+        {
+            add
+            {
+                _dataAvailable += value;
+                _lastDataAvailable = value;
+            }
+            remove => _dataAvailable -= value;
+        }
+
+        public event EventHandler<StoppedEventArgs>? RecordingStopped;
+
+        public void StartRecording()
+        {
+            StartRecordingEntered.Set();
+            if (BlockStartRecording)
+                AllowStartRecording.Wait(TimeSpan.FromSeconds(2));
+        }
+
+        public void StopRecording()
+        {
+            StopCount++;
+            StopRecordingEntered.Set();
+            if (BlockStopRecording)
+                AllowStopRecording.Wait(TimeSpan.FromSeconds(2));
+        }
+
+        public void Dispose() => DisposeCount++;
+
+        public void EmitData(byte[] data) =>
+            _dataAvailable?.Invoke(this, new WaveInEventArgs(data, data.Length));
+
+        public void EmitLateData(byte[] data) =>
+            _lastDataAvailable?.Invoke(this, new WaveInEventArgs(data, data.Length));
+
+        public void EmitRecordingStopped(Exception? exception = null) =>
+            RecordingStopped?.Invoke(this, new StoppedEventArgs(exception));
+    }
+}


### PR DESCRIPTION
Closes #1097

## Summary

- add one generation-scoped, cancellable first-nonempty-audio deadline to `AudioPipeline`
- stop and dispose a capture that opens but emits no audio, then use the existing `Error` state and localized actionable microphone diagnostic route
- serialize Start, Stop, timeout, recording errors, disposal, and restart boundaries so late callbacks and stale watchdogs cannot revive or tear down a newer capture
- retain existing `RecordingStopped` error behavior and keep bounded fixed-duration capture independent of the streaming startup watchdog
- add an injectable capture seam and deterministic lifecycle/race tests

## Validation

- `./build.ps1` - passed
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` - 3,609 passed, 32 skipped
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` - 2,206 passed
- `dotnet test ./tests/OpenClaw.Tray.UITests/OpenClaw.Tray.UITests.csproj -r win-x64 --no-restore --filter FullyQualifiedName~AudioPipelineFirstAudioTimeoutTests` - 13 passed
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore --filter FullyQualifiedName~SpeechInputContractTests` - 5 passed
- rubber-duck review - no blocking findings
- `python ./.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` - clean, no accepted/actionable findings

## Real behavior proof

Current head: `a7407f6fed4b3e70dd59f9caef859a30aa6750c8`

- Deterministic silent-capture simulation opens successfully and emits no callbacks. After the first-audio deadline, the pipeline reaches `Error`, calls Stop and Dispose exactly once, surfaces the localized actionable microphone message, accepts Stop promptly, and ignores a deliberately invoked late callback.
- Deterministic tests also prove healthy first audio cancels the deadline, Stop before timeout suppresses the error, restart cannot inherit an old watchdog, startup cancellation returns to Stopped, concurrent Stop/Dispose is idempotent, clean and error `RecordingStopped` paths remain bounded, and fixed-duration teardown cannot affect a restarted stream.
- Supplemental production WASAPI stress used the real default microphone on a machine with four present input endpoints. The first of eight six-second runs reproduced the no-data path and reached `Error`; Stop recovered to `Stopped`. The next seven runs received audio, remained `Listening`, and stopped in 34-60 ms.
- The isolated current-head Dev app launched with dedicated tray data and remained responsive while navigating Connection, Voice & Audio, and Permissions and toggling Node mode.

No permanent known-silent hardware endpoint was available. The one real no-data occurrence was transient; deterministic fake-capture coverage is the repeatable broken-device proof.