### PR TITLE
test: prevent testhost firewall consent prompts

### DIFF
--- a/docs/TEST_COVERAGE.md
+++ b/docs/TEST_COVERAGE.md
@@ -118,6 +118,12 @@ dotnet test --logger "console;verbosity=detailed"
 In a fresh worktree, run the project once without `--no-restore` or build it
 first so `dotnet test --no-restore` cannot no-op before `bin\` exists.
 
+Test-owned TCP listeners must bind only to loopback addresses. A successful
+wildcard bind from `testhost.exe` can trigger a per-worktree Windows Defender
+Firewall consent dialog and block unattended validation. Tests for production
+LAN-bind conflict handling should occupy loopback first so the production
+wildcard bind fails without opening a network-reachable listener.
+
 ## Not fully covered by automated tests
 
 - Real shell tray hover/click behavior against Explorer.

--- a/tests/OpenClaw.E2ETests/Setup/E2ESetupFixture.cs
+++ b/tests/OpenClaw.E2ETests/Setup/E2ESetupFixture.cs
@@ -386,7 +386,7 @@ public sealed class E2ESetupFixture : IAsyncLifetime
             {
                 "outside-windows-dynamic-range",
                 "outside-windows-excluded-ranges",
-                "exclusive-ipv4-ipv6-bind-probe",
+                "exclusive-ipv4-ipv6-loopback-bind-probe",
                 "cross-process-fixture-lease",
             },
         };

--- a/tests/OpenClaw.E2ETests/Setup/MirroredWslPortLease.cs
+++ b/tests/OpenClaw.E2ETests/Setup/MirroredWslPortLease.cs
@@ -210,6 +210,10 @@ internal sealed class MirroredWslPortLease : IDisposable
     public const int CandidateRangeStart = 20_000;
     public const int CandidateRangeEnd = 39_999;
     private const int CandidateCount = CandidateRangeEnd - CandidateRangeStart + 1;
+    internal static IReadOnlyList<IPAddress> BindProbeAddresses { get; } =
+        Socket.OSSupportsIPv6
+            ? [IPAddress.Loopback, IPAddress.IPv6Loopback]
+            : [IPAddress.Loopback];
 
     private FileStream? _leaseStream;
 
@@ -234,7 +238,7 @@ internal sealed class MirroredWslPortLease : IDisposable
         return Acquire(
             CreateCandidateSequence(startOffset),
             windowsPortState,
-            CanBindExclusively,
+            CanBindLoopbackExclusively,
             leaseDirectory);
     }
 
@@ -308,22 +312,17 @@ internal sealed class MirroredWslPortLease : IDisposable
         Interlocked.Exchange(ref _leaseStream, null)?.Dispose();
     }
 
-    private static bool CanBindExclusively(int port)
+    internal static bool CanBindLoopbackExclusively(int port)
     {
-        TcpListener? ipv4 = null;
-        TcpListener? ipv6 = null;
+        var listeners = new List<TcpListener>(BindProbeAddresses.Count);
         try
         {
-            ipv4 = new TcpListener(IPAddress.Any, port);
-            ipv4.Server.ExclusiveAddressUse = true;
-            ipv4.Start();
-
-            if (Socket.OSSupportsIPv6)
+            foreach (var address in BindProbeAddresses)
             {
-                ipv6 = new TcpListener(IPAddress.IPv6Any, port);
-                ipv6.Server.DualMode = false;
-                ipv6.Server.ExclusiveAddressUse = true;
-                ipv6.Start();
+                var listener = new TcpListener(address, port);
+                listeners.Add(listener);
+                listener.Server.ExclusiveAddressUse = true;
+                listener.Start();
             }
 
             return true;
@@ -334,8 +333,8 @@ internal sealed class MirroredWslPortLease : IDisposable
         }
         finally
         {
-            ipv6?.Stop();
-            ipv4?.Stop();
+            foreach (var listener in listeners)
+                listener.Stop();
         }
     }
 }

--- a/tests/OpenClaw.E2ETests/Setup/MirroredWslPortLeaseTests.cs
+++ b/tests/OpenClaw.E2ETests/Setup/MirroredWslPortLeaseTests.cs
@@ -1,4 +1,6 @@
 using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
 
 namespace OpenClaw.E2ETests.Setup;
 
@@ -18,6 +20,53 @@ public sealed class MirroredWslPortLeaseTests
             MirroredWslPortLease.CandidateRangeStart,
             MirroredWslPortLease.CandidateRangeEnd));
         Assert.Equal(MirroredWslPortLease.CandidateRangeStart + 137, candidates[0]);
+    }
+
+    [Fact]
+    public void BindProbe_UsesOnlyLoopbackAddressesAndReleasesThePort()
+    {
+        Assert.Equal(IPAddress.Loopback, MirroredWslPortLease.BindProbeAddresses[0]);
+        Assert.All(MirroredWslPortLease.BindProbeAddresses, address =>
+        {
+            Assert.True(IPAddress.IsLoopback(address));
+            Assert.NotEqual(IPAddress.Any, address);
+            Assert.NotEqual(IPAddress.IPv6Any, address);
+        });
+
+        var reservation = new TcpListener(IPAddress.Loopback, 0);
+        reservation.Start();
+        var port = ((IPEndPoint)reservation.LocalEndpoint).Port;
+        reservation.Stop();
+
+        Assert.True(MirroredWslPortLease.CanBindLoopbackExclusively(port));
+
+        var rebound = new TcpListener(IPAddress.Loopback, port);
+        rebound.Server.ExclusiveAddressUse = true;
+        rebound.Start();
+        rebound.Stop();
+    }
+
+    [Fact]
+    public void BindProbe_RejectsIpv6LoopbackCollision()
+    {
+        if (!Socket.OSSupportsIPv6)
+            return;
+
+        var ipv6Reservation = new TcpListener(IPAddress.IPv6Loopback, 0);
+        ipv6Reservation.Server.ExclusiveAddressUse = true;
+        ipv6Reservation.Start();
+        var port = ((IPEndPoint)ipv6Reservation.LocalEndpoint).Port;
+
+        try
+        {
+            Assert.False(MirroredWslPortLease.CanBindLoopbackExclusively(port));
+        }
+        finally
+        {
+            ipv6Reservation.Stop();
+        }
+
+        Assert.True(MirroredWslPortLease.CanBindLoopbackExclusively(port));
     }
 
     [Fact]

--- a/tests/OpenClaw.E2ETests/Setup/SshOwnershipAdversarialProofTests.cs
+++ b/tests/OpenClaw.E2ETests/Setup/SshOwnershipAdversarialProofTests.cs
@@ -872,12 +872,12 @@ public sealed class SshOwnershipAdversarialProofTests
         for (var attempt = 0; attempt < 100; attempt++)
         {
             var candidate = Random.Shared.Next(20_000, 40_000);
-            TcpListener? gatewayForward = null;
-            TcpListener? browserForward = null;
+            IReadOnlyList<TcpListener>? gatewayForward = null;
+            IReadOnlyList<TcpListener>? browserForward = null;
             try
             {
-                gatewayForward = StartExclusiveDualStackListener(candidate);
-                browserForward = StartExclusiveDualStackListener(candidate + 2);
+                gatewayForward = StartExclusiveLoopbackListeners(candidate);
+                browserForward = StartExclusiveLoopbackListeners(candidate + 2);
                 return candidate;
             }
             catch (SocketException)
@@ -886,21 +886,43 @@ public sealed class SshOwnershipAdversarialProofTests
             }
             finally
             {
-                browserForward?.Stop();
-                gatewayForward?.Stop();
+                StopListeners(browserForward);
+                StopListeners(gatewayForward);
             }
         }
 
         throw new InvalidOperationException("Unable to allocate an SSH forward port pair.");
     }
 
-    private static TcpListener StartExclusiveDualStackListener(int port)
+    private static IReadOnlyList<TcpListener> StartExclusiveLoopbackListeners(int port)
     {
-        var listener = new TcpListener(IPAddress.IPv6Any, port);
-        listener.Server.DualMode = true;
-        listener.Server.ExclusiveAddressUse = true;
-        listener.Start();
-        return listener;
+        var listeners = new List<TcpListener>(MirroredWslPortLease.BindProbeAddresses.Count);
+        try
+        {
+            foreach (var address in MirroredWslPortLease.BindProbeAddresses)
+            {
+                var listener = new TcpListener(address, port);
+                listeners.Add(listener);
+                listener.Server.ExclusiveAddressUse = true;
+                listener.Start();
+            }
+
+            return listeners;
+        }
+        catch
+        {
+            StopListeners(listeners);
+            throw;
+        }
+    }
+
+    private static void StopListeners(IReadOnlyList<TcpListener>? listeners)
+    {
+        if (listeners is null)
+            return;
+
+        foreach (var listener in listeners)
+            listener.Stop();
     }
 
     private sealed record ProcessResult(int ExitCode, string Stdout, string Stderr);

--- a/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
@@ -980,9 +980,9 @@ public class SetupStepsTests : IDisposable
     }
 
     [Fact]
-    public async Task PreflightPort_Lan_FailsWhenAnyBindPortInUse()
+    public async Task PreflightPort_Lan_FailsWhenLoopbackPortInUse()
     {
-        var listener = new TcpListener(IPAddress.Any, 0)
+        var listener = new TcpListener(IPAddress.Loopback, 0)
         {
             ExclusiveAddressUse = true
         };


### PR DESCRIPTION
## Summary

- keep every repository test-owned TCP listener on IPv4/IPv6 loopback instead of wildcard interfaces
- preserve mirrored-WSL port collision checks and SSH forward pair reservation across both loopback families
- test production LAN-bind conflict handling by occupying loopback, so the production wildcard bind fails without exposing `testhost.exe`
- document the loopback-only rule for test listeners

## Root cause

Windows Defender Firewall event 2099 recorded per-worktree inbound rules for:

- `tests\OpenClaw.E2ETests\bin\Debug\net10.0-windows\testhost.exe`
- `tests\OpenClaw.E2ETests\bin\Debug\net10.0-windows\win-x64\testhost.exe`
- `tests\OpenClaw.SetupEngine.Tests\bin\Debug\net10.0\testhost.exe`

The triggering paths were `MirroredWslPortLease.CanBindExclusively`, the SSH forward port-pair allocator, and `PreflightPort_Lan_FailsWhenAnyBindPortInUse`. Those tests successfully listened on `IPAddress.Any` or `IPAddress.IPv6Any`, which made the per-worktree .NET `testhost.exe` network reachable and caused Windows to request an interactive firewall decision.

## Validation

- `./build.ps1`: passed
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore`: 3,623 passed, 32 skipped
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore`: 2,241 passed
- `dotnet test ./tests/OpenClaw.E2ETests/OpenClaw.E2ETests.csproj -c Debug -r win-x64 --no-restore --filter "FullyQualifiedName~MirroredWslPortLeaseTests"`: 11 passed
- `dotnet test ./tests/OpenClaw.SetupEngine.Tests/OpenClaw.SetupEngine.Tests.csproj -c Debug -r win-x64 --no-restore --filter "FullyQualifiedName~PreflightPort_Lan_FailsWhenLoopbackPortInUse"`: 1 passed
- `git diff --check`: passed

## Real behavior proof

Before the fix, Windows Firewall event 2099 created or modified inbound `testhost` rules for E2E and SetupEngine worktree paths. After the fix, the focused tests and the full required closeout ran while monitoring `Microsoft-Windows-Windows Firewall With Advanced Security/Firewall`; both completed with `FIREWALL_EVENT_DELTA=0` for this worktree. No firewall dialog interaction, elevated mutation, firewall rule change, or global firewall weakening was used.

Autoreview initially found loss of IPv6 loopback collision coverage in the SSH allocator. The allocator was corrected to reserve both `127.0.0.1` and `::1`, with a focused IPv6 collision regression. The final autoreview reported no actionable findings. Rubber-duck review found the missing behavioral regression and was addressed.