### PR TITLE
fix(setup): retry wizard startup migration lease handoff

### DIFF
--- a/src/OpenClaw.SetupEngine/SetupWizardRunner.cs
+++ b/src/OpenClaw.SetupEngine/SetupWizardRunner.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Runtime.ExceptionServices;
 using System.Text.Json;
 using System.Text.RegularExpressions;
@@ -10,17 +11,34 @@ public sealed class SetupWizardRunner
 {
     private const int MaxWizardSteps = 50;
     private const int MaxSameStepVisits = 3;
+    private static readonly TimeSpan ReloadRestorationTimeout = TimeSpan.FromSeconds(15);
+    private static readonly TimeSpan StartupMigrationLeaseRestoreInitialDelay =
+        TimeSpan.FromMilliseconds(250);
+    private static readonly TimeSpan StartupMigrationLeaseRestoreMaxDelay =
+        TimeSpan.FromSeconds(2);
+    internal const int StartupMigrationLeaseRestoreMaxAttempts = 8;
+    internal const string StartupMigrationLeaseDiagnostic =
+        "OpenClaw startup migrations are already running for this state directory;";
     private static readonly Regex s_normalizeKeyRegex = new("[^a-z0-9]+", RegexOptions.Compiled);
 
     // Progress steps can repeat while background work runs; keep bounded caps
     // so setup fails with a diagnostic instead of hanging.
 
     private readonly SetupContext _ctx;
+    private readonly Func<TimeSpan, CancellationToken, Task> _restorationDelayAsync;
     private bool _reloadSuspended;
 
     public SetupWizardRunner(SetupContext ctx)
+        : this(ctx, static (delay, cancellationToken) => Task.Delay(delay, cancellationToken))
+    {
+    }
+
+    internal SetupWizardRunner(
+        SetupContext ctx,
+        Func<TimeSpan, CancellationToken, Task> restorationDelayAsync)
     {
         _ctx = ctx;
+        _restorationDelayAsync = restorationDelayAsync;
     }
 
     public async Task<StepResult> RunAsync(CancellationToken ct)
@@ -552,16 +570,12 @@ public sealed class SetupWizardRunner
         var reloadMode = ConfigureGatewayStep.GetEffectiveReloadMode(_ctx.Config.Gateway);
         try
         {
-            var result = await _ctx.Commands.RunInWslAsync(
-                _ctx.DistroName!,
-                $"{_ctx.WslPathPrefix} && openclaw config set gateway.reload.mode {WslShellQuoting.QuotePosixSingleQuote(reloadMode)}",
-                TimeSpan.FromSeconds(15),
-                ct: CancellationToken.None);
+            var result = await RunReloadModeRestorationCommandAsync(reloadMode);
 
             if (result.ExitCode != 0)
             {
                 return StepResult.Fail(
-                    $"Failed to restore gateway.reload.mode after wizard (exit {result.ExitCode}): {result.Stderr.Trim()}");
+                    $"Failed to restore gateway.reload.mode after wizard (exit {result.ExitCode}): {CommandFailureOutput(result)}");
             }
 
             _ctx.Logger.Info(
@@ -591,6 +605,62 @@ public sealed class SetupWizardRunner
                 $"Failed to restore gateway.reload.mode after wizard: {ex.Message}",
                 ex);
         }
+    }
+
+    private async Task<CommandResult> RunReloadModeRestorationCommandAsync(string reloadMode)
+    {
+        var command =
+            $"{_ctx.WslPathPrefix} && openclaw config set gateway.reload.mode {WslShellQuoting.QuotePosixSingleQuote(reloadMode)}";
+        var stopwatch = Stopwatch.StartNew();
+        CommandResult? lastResult = null;
+
+        for (var attempt = 1; ; attempt++)
+        {
+            var remaining = ReloadRestorationTimeout - stopwatch.Elapsed;
+            if (remaining <= TimeSpan.Zero)
+                return lastResult!;
+            if (lastResult is not null && remaining <= StartupMigrationLeaseRestoreInitialDelay)
+                return lastResult;
+
+            var result = await _ctx.Commands.RunInWslAsync(
+                _ctx.DistroName!,
+                command,
+                remaining,
+                ct: CancellationToken.None);
+            lastResult = result;
+            if (result.ExitCode == 0
+                || !IsStartupMigrationLeaseContention(result)
+                || attempt >= StartupMigrationLeaseRestoreMaxAttempts)
+            {
+                return result;
+            }
+
+            remaining = ReloadRestorationTimeout - stopwatch.Elapsed;
+            var delay = TimeSpan.FromMilliseconds(
+                Math.Min(
+                    StartupMigrationLeaseRestoreInitialDelay.TotalMilliseconds
+                        * Math.Pow(2, attempt - 1),
+                    StartupMigrationLeaseRestoreMaxDelay.TotalMilliseconds));
+            if (remaining <= delay)
+                return result;
+
+            _ctx.Logger.Warn(
+                $"Gateway startup migrations still own the state directory while restoring reload mode; retrying in {delay.TotalMilliseconds:0} ms (attempt {attempt + 1}/{StartupMigrationLeaseRestoreMaxAttempts})");
+            await _restorationDelayAsync(delay, CancellationToken.None);
+        }
+    }
+
+    internal static bool IsStartupMigrationLeaseContention(CommandResult result) =>
+        result.ExitCode != 0
+        && (result.Stdout.Contains(StartupMigrationLeaseDiagnostic, StringComparison.Ordinal)
+            || result.Stderr.Contains(StartupMigrationLeaseDiagnostic, StringComparison.Ordinal));
+
+    private static string CommandFailureOutput(CommandResult result)
+    {
+        var output = string.IsNullOrWhiteSpace(result.Stderr)
+            ? result.Stdout.Trim()
+            : result.Stderr.Trim();
+        return output.Length > 0 ? output : "no output";
     }
 
     private async Task<StepResult> VerifyExpectedManagedGatewayAsync(string phase)
@@ -874,7 +944,7 @@ public sealed class SetupWizardRunner
                 {
                     var status = payload.TryGetProperty("status", out var statusProperty) ? statusProperty.ToString() : "";
                     var error = payload.TryGetProperty("error", out var errorProperty) ? errorProperty.ToString() : null;
-                    return new(true, sessionId, "", "", "", "", "", false, 0, 0, [], 
+                    return new(true, sessionId, "", "", "", "", "", false, 0, 0, [],
                         string.Equals(status, "error", StringComparison.OrdinalIgnoreCase) ? error ?? "Wizard returned error status." : null);
                 }
 

--- a/src/OpenClaw.SetupEngine/SetupWizardRunner.cs
+++ b/src/OpenClaw.SetupEngine/SetupWizardRunner.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Runtime.ExceptionServices;
 using System.Text.Json;
 using System.Text.RegularExpressions;
@@ -16,7 +15,8 @@ public sealed class SetupWizardRunner
         TimeSpan.FromMilliseconds(250);
     private static readonly TimeSpan StartupMigrationLeaseRestoreMaxDelay =
         TimeSpan.FromSeconds(2);
-    internal const int StartupMigrationLeaseRestoreMaxAttempts = 8;
+    private static readonly TimeSpan MinimumReloadRestorationCommandTimeout =
+        TimeSpan.FromMilliseconds(500);
     internal const string StartupMigrationLeaseDiagnostic =
         "OpenClaw startup migrations are already running for this state directory;";
     private static readonly Regex s_normalizeKeyRegex = new("[^a-z0-9]+", RegexOptions.Compiled);
@@ -26,19 +26,25 @@ public sealed class SetupWizardRunner
 
     private readonly SetupContext _ctx;
     private readonly Func<TimeSpan, CancellationToken, Task> _restorationDelayAsync;
+    private readonly TimeProvider _timeProvider;
     private bool _reloadSuspended;
 
     public SetupWizardRunner(SetupContext ctx)
-        : this(ctx, static (delay, cancellationToken) => Task.Delay(delay, cancellationToken))
+        : this(
+            ctx,
+            static (delay, cancellationToken) => Task.Delay(delay, cancellationToken),
+            TimeProvider.System)
     {
     }
 
     internal SetupWizardRunner(
         SetupContext ctx,
-        Func<TimeSpan, CancellationToken, Task> restorationDelayAsync)
+        Func<TimeSpan, CancellationToken, Task> restorationDelayAsync,
+        TimeProvider? timeProvider = null)
     {
         _ctx = ctx;
         _restorationDelayAsync = restorationDelayAsync;
+        _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
     public async Task<StepResult> RunAsync(CancellationToken ct)
@@ -611,15 +617,16 @@ public sealed class SetupWizardRunner
     {
         var command =
             $"{_ctx.WslPathPrefix} && openclaw config set gateway.reload.mode {WslShellQuoting.QuotePosixSingleQuote(reloadMode)}";
-        var stopwatch = Stopwatch.StartNew();
+        var startedAt = _timeProvider.GetTimestamp();
         CommandResult? lastResult = null;
 
         for (var attempt = 1; ; attempt++)
         {
-            var remaining = ReloadRestorationTimeout - stopwatch.Elapsed;
+            var remaining =
+                ReloadRestorationTimeout - _timeProvider.GetElapsedTime(startedAt);
             if (remaining <= TimeSpan.Zero)
                 return lastResult!;
-            if (lastResult is not null && remaining <= StartupMigrationLeaseRestoreInitialDelay)
+            if (lastResult is not null && remaining < MinimumReloadRestorationCommandTimeout)
                 return lastResult;
 
             var result = await _ctx.Commands.RunInWslAsync(
@@ -629,23 +636,25 @@ public sealed class SetupWizardRunner
                 ct: CancellationToken.None);
             lastResult = result;
             if (result.ExitCode == 0
-                || !IsStartupMigrationLeaseContention(result)
-                || attempt >= StartupMigrationLeaseRestoreMaxAttempts)
+                || !IsStartupMigrationLeaseContention(result))
             {
                 return result;
             }
 
-            remaining = ReloadRestorationTimeout - stopwatch.Elapsed;
-            var delay = TimeSpan.FromMilliseconds(
+            remaining =
+                ReloadRestorationTimeout - _timeProvider.GetElapsedTime(startedAt);
+            var scheduledDelay = TimeSpan.FromMilliseconds(
                 Math.Min(
                     StartupMigrationLeaseRestoreInitialDelay.TotalMilliseconds
                         * Math.Pow(2, attempt - 1),
                     StartupMigrationLeaseRestoreMaxDelay.TotalMilliseconds));
-            if (remaining <= delay)
+            var maximumDelay = remaining - MinimumReloadRestorationCommandTimeout;
+            if (maximumDelay <= TimeSpan.Zero)
                 return result;
+            var delay = scheduledDelay < maximumDelay ? scheduledDelay : maximumDelay;
 
             _ctx.Logger.Warn(
-                $"Gateway startup migrations still own the state directory while restoring reload mode; retrying in {delay.TotalMilliseconds:0} ms (attempt {attempt + 1}/{StartupMigrationLeaseRestoreMaxAttempts})");
+                $"Gateway startup migrations still own the state directory while restoring reload mode; retrying in {delay.TotalMilliseconds:0} ms (attempt {attempt + 1})");
             await _restorationDelayAsync(delay, CancellationToken.None);
         }
     }

--- a/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
@@ -2187,6 +2187,7 @@ public class SetupStepsTests : IDisposable
     public async Task SetupWizard_LeaseContentionExhaustionPreservesWizardAndRestorationFailures()
     {
         var restoreAttempts = 0;
+        var timeProvider = new ManualTimeProvider();
         var commands = new FakeCommandRunner(
             _ => Ok(),
             (_, command, _) =>
@@ -2198,11 +2199,13 @@ public class SetupStepsTests : IDisposable
         ctx.DistroName = "test-distro";
         var runner = new SetupWizardRunner(
             ctx,
-            (_, _) =>
+            (delay, _) =>
             {
                 restoreAttempts++;
+                timeProvider.Advance(delay);
                 return Task.CompletedTask;
-            });
+            },
+            timeProvider);
 
         var result = await runner.RunWithReloadRestorationAsync(() =>
         {
@@ -2214,13 +2217,16 @@ public class SetupStepsTests : IDisposable
         Assert.Contains("Failed to restore gateway.reload.mode", result.Message);
         Assert.Contains(SetupWizardRunner.StartupMigrationLeaseDiagnostic, result.Message);
         Assert.Contains("wizard failed", result.Message);
+        Assert.Equal(10, restoreAttempts);
         Assert.Equal(
-            SetupWizardRunner.StartupMigrationLeaseRestoreMaxAttempts - 1,
-            restoreAttempts);
-        Assert.Equal(
-            SetupWizardRunner.StartupMigrationLeaseRestoreMaxAttempts,
+            11,
             commands.WslCalls.Count(
                 call => call.Command.Contains("config set gateway.reload.mode 'hybrid'")));
+        Assert.Equal(TimeSpan.FromSeconds(14.5), timeProvider.Elapsed);
+        Assert.All(
+            commands.WslCalls.Where(
+                call => call.Command.Contains("config set gateway.reload.mode 'hybrid'")),
+            call => Assert.True(call.Timeout >= TimeSpan.FromMilliseconds(500)));
         Assert.DoesNotContain(
             commands.WslCalls,
             call => call.Command.Contains("openclaw gateway restart"));
@@ -4447,6 +4453,19 @@ public class SetupStepsTests : IDisposable
 
             return Task.FromResult(runInWsl(distroName, command, timeout));
         }
+    }
+
+    private sealed class ManualTimeProvider : TimeProvider
+    {
+        private long _timestamp;
+
+        public TimeSpan Elapsed => TimeSpan.FromTicks(_timestamp);
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public override long GetTimestamp() => _timestamp;
+
+        public void Advance(TimeSpan duration) => _timestamp += duration.Ticks;
     }
 
     private sealed class RecordingAuthorizationPresenter : IExternalAuthorizationPresenter

--- a/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
@@ -2052,6 +2052,48 @@ public class SetupStepsTests : IDisposable
     }
 
     [Fact]
+    public async Task SetupWizard_RestoreReloadModeRetriesExactStartupMigrationLeaseContention()
+    {
+        var restoreAttempts = 0;
+        var delays = new List<TimeSpan>();
+        var commands = new FakeCommandRunner(
+            _ => Ok(),
+            (_, command, _) => command switch
+            {
+                var value when value.Contains("config set gateway.reload.mode 'hybrid'") =>
+                    ++restoreAttempts < 3
+                        ? Fail($"{SetupWizardRunner.StartupMigrationLeaseDiagnostic} retry after the other OpenClaw process finishes. (held by pid 266)")
+                        : Ok(),
+                var value when value.Contains("openclaw gateway restart") => Ok(),
+                var value when value.Contains("curl -s") => Ok("200"),
+                _ => Fail($"Unexpected command: {command}"),
+            });
+        var ctx = CreateContext(commands: commands);
+        ctx.DistroName = "test-distro";
+        TrustManagedEndpoint(ctx);
+        var runner = new SetupWizardRunner(
+            ctx,
+            (delay, cancellationToken) =>
+            {
+                Assert.False(cancellationToken.CanBeCanceled);
+                delays.Add(delay);
+                return Task.CompletedTask;
+            });
+
+        var result = await runner.RestoreReloadModeAsync();
+
+        Assert.True(result.IsSuccess, result.Message);
+        Assert.Equal(3, restoreAttempts);
+        Assert.Equal(2, delays.Count);
+        Assert.Equal(TimeSpan.FromMilliseconds(250), delays[0]);
+        Assert.Equal(TimeSpan.FromMilliseconds(500), delays[1]);
+        Assert.Single(
+            commands.WslCalls,
+            call => call.Command.Contains("openclaw gateway restart"));
+        AssertReloadRestorationCompleted(commands);
+    }
+
+    [Fact]
     public async Task SetupWizard_OrchestratorRestoresAfterSuccessfulWizard()
     {
         var commands = CreateReloadRestorationRunner();
@@ -2071,13 +2113,32 @@ public class SetupStepsTests : IDisposable
     }
 
     [Fact]
-    public async Task SetupWizard_OrchestratorRestoresBeforePropagatingCancellation()
+    public async Task SetupWizard_OrchestratorRestoresThroughLeaseContentionBeforePropagatingCancellation()
     {
-        var commands = CreateReloadRestorationRunner();
+        var restoreAttempts = 0;
+        var delayTokens = new List<CancellationToken>();
+        var commands = new FakeCommandRunner(
+            _ => Ok(),
+            (_, command, _) => command switch
+            {
+                var value when value.Contains("config set gateway.reload.mode 'hybrid'") =>
+                    ++restoreAttempts == 1
+                        ? Fail($"{SetupWizardRunner.StartupMigrationLeaseDiagnostic} retry after the other OpenClaw process finishes.")
+                        : Ok(),
+                var value when value.Contains("openclaw gateway restart") => Ok(),
+                var value when value.Contains("curl -s") => Ok("200"),
+                _ => Fail($"Unexpected command: {command}"),
+            });
         var ctx = CreateContext(commands: commands);
         ctx.DistroName = "test-distro";
         TrustManagedEndpoint(ctx);
-        var runner = new SetupWizardRunner(ctx);
+        var runner = new SetupWizardRunner(
+            ctx,
+            (_, cancellationToken) =>
+            {
+                delayTokens.Add(cancellationToken);
+                return Task.CompletedTask;
+            });
 
         await Assert.ThrowsAsync<OperationCanceledException>(() =>
             runner.RunWithReloadRestorationAsync(async () =>
@@ -2087,11 +2148,14 @@ public class SetupStepsTests : IDisposable
                 throw new OperationCanceledException();
             }));
 
+        Assert.Equal(2, restoreAttempts);
+        Assert.Single(delayTokens);
+        Assert.False(delayTokens[0].CanBeCanceled);
         AssertReloadRestorationCompleted(commands);
     }
 
     [Fact]
-    public async Task SetupWizard_OrchestratorReturnsRestorationFailure()
+    public async Task SetupWizard_OrchestratorDoesNotRetryUnrelatedRestorationFailure()
     {
         var commands = new FakeCommandRunner(
             _ => Ok(),
@@ -2111,23 +2175,34 @@ public class SetupStepsTests : IDisposable
 
         Assert.False(result.IsSuccess);
         Assert.Contains("Failed to restore gateway.reload.mode", result.Message);
+        Assert.Single(
+            commands.WslCalls,
+            call => call.Command.Contains("config set gateway.reload.mode 'hybrid'"));
         Assert.DoesNotContain(
             commands.WslCalls,
             call => call.Command.Contains("openclaw gateway restart"));
     }
 
     [Fact]
-    public async Task SetupWizard_OrchestratorPreservesWizardAndRestorationFailures()
+    public async Task SetupWizard_LeaseContentionExhaustionPreservesWizardAndRestorationFailures()
     {
+        var restoreAttempts = 0;
         var commands = new FakeCommandRunner(
             _ => Ok(),
             (_, command, _) =>
                 command.Contains("config set gateway.reload.mode 'hybrid'")
-                    ? Fail("restore failed")
+                    ? FailWithStdout(
+                        $"{SetupWizardRunner.StartupMigrationLeaseDiagnostic} retry after the other OpenClaw process finishes. (held by pid 247)")
                     : Fail($"Unexpected command: {command}"));
         var ctx = CreateContext(commands: commands);
         ctx.DistroName = "test-distro";
-        var runner = new SetupWizardRunner(ctx);
+        var runner = new SetupWizardRunner(
+            ctx,
+            (_, _) =>
+            {
+                restoreAttempts++;
+                return Task.CompletedTask;
+            });
 
         var result = await runner.RunWithReloadRestorationAsync(() =>
         {
@@ -2137,7 +2212,18 @@ public class SetupStepsTests : IDisposable
 
         Assert.False(result.IsSuccess);
         Assert.Contains("Failed to restore gateway.reload.mode", result.Message);
+        Assert.Contains(SetupWizardRunner.StartupMigrationLeaseDiagnostic, result.Message);
         Assert.Contains("wizard failed", result.Message);
+        Assert.Equal(
+            SetupWizardRunner.StartupMigrationLeaseRestoreMaxAttempts - 1,
+            restoreAttempts);
+        Assert.Equal(
+            SetupWizardRunner.StartupMigrationLeaseRestoreMaxAttempts,
+            commands.WslCalls.Count(
+                call => call.Command.Contains("config set gateway.reload.mode 'hybrid'")));
+        Assert.DoesNotContain(
+            commands.WslCalls,
+            call => call.Command.Contains("openclaw gateway restart"));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Retry only the exact OpenClaw startup-migration lease contention diagnostic while restoring `gateway.reload.mode` after the Gateway wizard.
- Keep retries inside the existing 15-second restoration budget with 250 ms exponential backoff capped at 2 seconds, while reserving at least 500 ms for the final CLI attempt.
- Preserve fail-closed restoration, wizard plus restoration diagnostics, intentional cancellation ordering, and the one-shot explicit managed Gateway restart.

## Failure evidence

- Windows node base: `9f9a8eda6340c7ec6f0acbc410de4f6b7d24a3ce` from #1104.
- Upstream proof: `openclaw/openclaw#119762` at `96053618cf58626df109f537ca64dd5efb3ad376`, pinned to that Windows node SHA.
- [Durable child run 31258766425](https://github.com/openclaw/openclaw/actions/runs/31258766425): exact artifact, SHA, and OIDC binding passed; prerelease passed; stable failed during `run-wizard`.
- [Exact-head retry 31259368066](https://github.com/openclaw/openclaw/actions/runs/31259368066): stable and prerelease failed when the restoring CLI encountered `OpenClaw startup migrations are already running for this state directory` while the restarting Gateway PID still owned the lease.

## Validation

- `dotnet format .\openclaw-windows-node.slnx --no-restore --include .\src\OpenClaw.SetupEngine\SetupWizardRunner.cs .\tests\OpenClaw.SetupEngine.Tests\SetupStepsTests.cs`
- Focused wizard tests: 12 passed, 0 failed, 0 skipped.
- `.\build.ps1`: all projects built; documentation validation passed for 46 files.
- Shared tests: 3,631 passed, 0 failed, 32 environment-gated skips.
- Tray tests: 2,246 passed, 0 failed, 0 skipped.
- SetupEngine tests: 814 passed, 0 failed, 0 skipped.
- Connection tests: 574 passed, 0 failed, 0 skipped.
- `.\scripts\validate-mxc-e2e.ps1` without `-AllowSkip`: 17 passed, 0 failed, 0 skipped.

## Real behavior proof

The strict MXC run used an isolated `OpenClawE2E-*` WSL distro and isolated tray data. Current-head output showed:

```text
Starting gateway wizard
Restored gateway.reload.mode to hybrid after wizard; restarting gateway to apply wizard configuration
step.completed: run-wizard -> Success
OPENCLAW_GATEWAY_SYSTEM_RUN_MXC_OK
Test Run Successful.
```

The same run proved `mxc-direct-appc; contained=True`, `containment=mxc` for successful and denied-write paths, and 17/17 tests passed. No real user profile, credentials, firewall state, or unrelated process was mutated.

Focused deterministic tests cover exact contention recovery, unrelated failure without retry, full-budget exhaustion preserving wizard plus restoration diagnostics, cancellation restoring before propagation, and one-shot restart ordering.

## Hosted CI

- Exact head: `89a04d544d0b49b855a35ef36b9476fc1418a6b0`.
- [Build and Test run 31262216127, attempt 2](https://github.com/openclaw/openclaw-windows-node/actions/runs/31262216127): aggregate tests, setup-connect E2E, network-recovery E2E, revocation-recovery E2E, repo hygiene, and x64/ARM64 builds all passed.
- CodeQL actions, C#, and Python analyses passed. No checks remain pending or failed.
- Attempt 1 had two unrelated hosted flakes: `SessionTitleBehaviorProofTests` timed out waiting for `SessionsPageMarker`, and setup-connect exceeded its 45-minute job timeout. The failed jobs were rerun on the same exact SHA without code changes; both passed on attempt 2.

## Reviews

- Rubber-duck review rerun after fixes: no blocking or non-blocking correctness findings.
- Project autoreview in branch mode against `origin/main`: initial P2 finding about stopping before the 15-second deadline was accepted and fixed; final rerun reported no accepted or actionable findings with 0.95 confidence.
- Optional aggregate exhaustion logging was not added because each retry is already logged and the final failure preserves the exact upstream CLI diagnostic plus the wizard failure.