### PR TITLE
fix(chat): stabilize composer accessibility state

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawReactorChatRoot.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawReactorChatRoot.cs
@@ -745,13 +745,21 @@ public sealed class ReactorChatComposer : Component<ReactorChatComposerProps>
             : Localized("Chat_Composer_Tooltip_Send", "Send");
         var controlCornerRadius = new CornerRadius(4);
 
-        Element IconButton(string glyph, string automationName, Action onClick, bool enabled = true)
+        Element IconButton(
+            string glyph,
+            string automationName,
+            Action onClick,
+            bool enabled = true,
+            string? automationId = null)
         {
             return Button(
                     TextBlock(glyph).Set(textBlock =>
                     {
                         textBlock.FontFamily = FluentIconCatalog.SymbolThemeFontFamily;
                         textBlock.FontSize = 16;
+                        Microsoft.UI.Xaml.Automation.AutomationProperties.SetAccessibilityView(
+                            textBlock,
+                            Microsoft.UI.Xaml.Automation.Peers.AccessibilityView.Raw);
                     }),
                     onClick)
                 .AutomationName(automationName)
@@ -773,11 +781,25 @@ public sealed class ReactorChatComposer : Component<ReactorChatComposerProps>
                     button.CornerRadius = controlCornerRadius;
                     button.IsEnabled = enabled;
                     button.BorderThickness = new Thickness(0);
+                    if (!string.IsNullOrWhiteSpace(automationId))
+                    {
+                        Microsoft.UI.Xaml.Automation.AutomationProperties.SetAutomationId(
+                            button,
+                            automationId);
+                    }
+                    ComposerAutomationVisibility.Prepare(button);
                     ToolTipService.SetToolTip(button, automationName);
-                });
+                })
+                .OnUnmount(control => ComposerAutomationVisibility.Detach(
+                    (FrameworkElement)control));
         }
 
-        Element PickerButton(string label, string automationName, bool enabled, double maxLabelWidth)
+        Element PickerButton(
+            string label,
+            string automationName,
+            string automationId,
+            bool enabled,
+            double maxLabelWidth)
         {
             return Button(
                     HStack(
@@ -794,6 +816,9 @@ public sealed class ReactorChatComposer : Component<ReactorChatComposerProps>
                             textBlock.FontFamily = FluentIconCatalog.SymbolThemeFontFamily;
                             textBlock.FontSize = 10;
                             textBlock.Margin = new Thickness(2, 4, 0, 0);
+                            Microsoft.UI.Xaml.Automation.AutomationProperties.SetAccessibilityView(
+                                textBlock,
+                                Microsoft.UI.Xaml.Automation.Peers.AccessibilityView.Raw);
                         })),
                     () => { })
                 .AutomationName(automationName)
@@ -814,7 +839,13 @@ public sealed class ReactorChatComposer : Component<ReactorChatComposerProps>
                     button.CornerRadius = controlCornerRadius;
                     button.IsEnabled = enabled;
                     button.BorderThickness = new Thickness(0);
-                });
+                    Microsoft.UI.Xaml.Automation.AutomationProperties.SetAutomationId(
+                        button,
+                        automationId);
+                    ComposerAutomationVisibility.Prepare(button);
+                })
+                .OnUnmount(control => ComposerAutomationVisibility.Detach(
+                    (FrameworkElement)control));
         }
 
         var attachmentRows = props.PendingAttachments
@@ -1122,6 +1153,7 @@ public sealed class ReactorChatComposer : Component<ReactorChatComposerProps>
                 control.Resources["TextControlBorderBrush"] = transparent;
                 control.Resources["TextControlBorderBrushFocused"] = transparent;
                 control.Resources["TextControlBorderBrushPointerOver"] = transparent;
+                ComposerAutomationVisibility.Prepare(control);
             })
             .OnMount(control =>
             {
@@ -1136,6 +1168,7 @@ public sealed class ReactorChatComposer : Component<ReactorChatComposerProps>
                 var textBox = (TextBox)control;
                 textBox.Paste -= pasteHandler.Current;
                 textBox.ContextFlyout = null;
+                ComposerAutomationVisibility.Detach(textBox);
             });
         UseEffect((Func<Action>)(() =>
         {
@@ -1150,6 +1183,7 @@ public sealed class ReactorChatComposer : Component<ReactorChatComposerProps>
             PickerButton(
                 props.CurrentThread.Title,
                 $"{Localized("Chat_Composer_Accessibility_Session", "Session")}: {props.CurrentThread.Title}",
+                "ChatComposerSessionPicker",
                 !props.MessageOptionsDisabled && props.AvailableChannels.Count > 1,
                 props.IsCompact ? 56 : 160),
             props.AvailableChannels
@@ -1167,6 +1201,7 @@ public sealed class ReactorChatComposer : Component<ReactorChatComposerProps>
             PickerButton(
                 modelPickerLabel,
                 $"{Localized("Chat_Composer_Accessibility_Model", "Model")}: {modelPickerLabel}",
+                "ChatComposerModelPicker",
                 !props.MessageOptionsDisabled,
                 props.IsCompact ? 68 : 180),
             modelNames
@@ -1187,6 +1222,7 @@ public sealed class ReactorChatComposer : Component<ReactorChatComposerProps>
             PickerButton(
                 ThinkingLevels[thinkingIndex],
                 $"{Localized("Chat_Composer_Accessibility_Reasoning", "Reasoning")}: {ThinkingLevels[thinkingIndex]}",
+                "ChatComposerReasoningPicker",
                 !props.MessageOptionsDisabled,
                 props.IsCompact ? 54 : 96),
             ThinkingLevels
@@ -1201,7 +1237,8 @@ public sealed class ReactorChatComposer : Component<ReactorChatComposerProps>
             "\uE723",
             Localized("Chat_Composer_Tooltip_Attach", "Attach"),
             () => props.OnAttachClick?.Invoke(),
-            props.OnAttachClick is not null);
+            props.OnAttachClick is not null,
+            "ChatComposerAttach");
         var voiceButton = IconButton(
             isRecording
                 ? "\uE15B"
@@ -1219,25 +1256,35 @@ public sealed class ReactorChatComposer : Component<ReactorChatComposerProps>
                 else
                     StartVoiceRecording();
             },
-            props.OnVoiceRequest is not null);
+            props.OnVoiceRequest is not null,
+            "ChatComposerVoice");
         var speakerButton = IconButton(
             props.IsSpeakerMuted ? "\uE74F" : "\uE767",
             props.IsSpeakerMuted ? "Unmute" : "Mute",
-            props.OnSpeakerToggle);
+            props.OnSpeakerToggle,
+            automationId: "ChatComposerSpeakerToggle");
         Element settingsButton = props.IsCompact || props.OnSettingsClick is null
             ? Empty()
             : IconButton(
                 "\uE713",
                 Localized("Chat_Composer_Tooltip_Settings", "Settings"),
-                props.OnSettingsClick);
+                props.OnSettingsClick,
+                automationId: "ChatComposerSettings");
 
         Element primaryAction = props.TurnActive
-            ? IconButton("\uE71A", actionLabel, props.OnStop)
+            ? IconButton(
+                "\uE71A",
+                actionLabel,
+                props.OnStop,
+                automationId: "ChatComposerPrimaryAction")
             : Button(
                     TextBlock("\uE724").Set(textBlock =>
                     {
                         textBlock.FontFamily = FluentIconCatalog.SymbolThemeFontFamily;
                         textBlock.FontSize = 16;
+                        Microsoft.UI.Xaml.Automation.AutomationProperties.SetAccessibilityView(
+                            textBlock,
+                            Microsoft.UI.Xaml.Automation.Peers.AccessibilityView.Raw);
                     }),
                     Send)
                 .AccentButton()
@@ -1250,12 +1297,18 @@ public sealed class ReactorChatComposer : Component<ReactorChatComposerProps>
                     button.MinHeight = 32;
                     button.Padding = new Thickness(0);
                     button.CornerRadius = controlCornerRadius;
+                    Microsoft.UI.Xaml.Automation.AutomationProperties.SetAutomationId(
+                        button,
+                        "ChatComposerPrimaryAction");
                     button.IsEnabled = props.ConnectionState == "connected"
                         && !isSending
                         && !slashDisplay.IsLoading
                         && (!string.IsNullOrWhiteSpace(text) || props.PendingAttachments.Count > 0);
+                    ComposerAutomationVisibility.Prepare(button);
                     ToolTipService.SetToolTip(button, actionLabel);
-                });
+                })
+                .OnUnmount(control => ComposerAutomationVisibility.Detach(
+                    (FrameworkElement)control));
 
         var leftToolbar = HStack(8, attachButton, sessionPicker, modelPicker, reasoningPicker)
             .HAlign(HorizontalAlignment.Left)
@@ -1905,4 +1958,67 @@ public sealed class ReactorChatComposer : Component<ReactorChatComposerProps>
             ? fallback
             : value;
     }
+}
+
+internal static class ComposerAutomationVisibility
+{
+    public static void Prepare(FrameworkElement control)
+    {
+        Detach(control);
+        if (HasUsableLayout(control))
+        {
+            Enable(control);
+            return;
+        }
+
+        control.IsHitTestVisible = false;
+        Microsoft.UI.Xaml.Automation.AutomationProperties.SetAccessibilityView(
+            control,
+            Microsoft.UI.Xaml.Automation.Peers.AccessibilityView.Raw);
+        control.Loaded += OnLoaded;
+        control.SizeChanged += OnSizeChanged;
+    }
+
+    public static void Detach(FrameworkElement control)
+    {
+        control.Loaded -= OnLoaded;
+        control.SizeChanged -= OnSizeChanged;
+    }
+
+    private static void OnLoaded(object sender, RoutedEventArgs args) =>
+        TryEnableHitTesting(sender);
+
+    private static void OnSizeChanged(object sender, SizeChangedEventArgs args) =>
+        TryEnableHitTesting(sender);
+
+    private static void TryEnableHitTesting(object sender)
+    {
+        if (sender is not FrameworkElement control || !HasUsableLayout(control))
+            return;
+
+        Enable(control);
+    }
+
+    private static void Enable(FrameworkElement control)
+    {
+        Microsoft.UI.Xaml.Automation.AutomationProperties.SetAccessibilityView(
+            control,
+            Microsoft.UI.Xaml.Automation.Peers.AccessibilityView.Control);
+        control.IsHitTestVisible = true;
+        var peer = Microsoft.UI.Xaml.Automation.Peers.FrameworkElementAutomationPeer
+            .FromElement(control)
+            ?? Microsoft.UI.Xaml.Automation.Peers.FrameworkElementAutomationPeer
+                .CreatePeerForElement(control);
+        peer?.RaisePropertyChangedEvent(
+            Microsoft.UI.Xaml.Automation.AutomationElementIdentifiers.IsOffscreenProperty,
+            true,
+            false);
+        Detach(control);
+    }
+
+    private static bool HasUsableLayout(FrameworkElement control) =>
+        control.IsLoaded
+        && control.Visibility == Visibility.Visible
+        && control.ActualWidth > 0
+        && control.ActualHeight > 0;
 }

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawReactorChatRoot.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawReactorChatRoot.cs
@@ -1967,7 +1967,7 @@ internal static class ComposerAutomationVisibility
         Detach(control);
         if (HasUsableLayout(control))
         {
-            Enable(control);
+            ApplyReadyState(control);
             return;
         }
 
@@ -1996,10 +1996,10 @@ internal static class ComposerAutomationVisibility
         if (sender is not FrameworkElement control || !HasUsableLayout(control))
             return;
 
-        Enable(control);
+        ApplyReadyState(control);
     }
 
-    private static void Enable(FrameworkElement control)
+    private static void ApplyReadyState(FrameworkElement control)
     {
         Microsoft.UI.Xaml.Automation.AutomationProperties.SetAccessibilityView(
             control,

--- a/tests/OpenClaw.Tray.Tests/ChatTimelinePresentationTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ChatTimelinePresentationTests.cs
@@ -213,6 +213,44 @@ public sealed class ChatTimelinePresentationTests
     }
 
     [Fact]
+    public void ReactorComposer_GatesClickableControlsUntilLayoutIsUsable()
+    {
+        var root = File.ReadAllText(Path.Combine(
+            TestRepositoryPaths.GetRepositoryRoot(),
+            "src",
+            "OpenClaw.Tray.WinUI",
+            "Chat",
+            "OpenClawReactorChatRoot.cs"));
+
+        Assert.Contains("internal static class ComposerAutomationVisibility", root);
+        Assert.Contains("control.IsHitTestVisible = false;", root);
+        Assert.Contains("control.IsLoaded", root);
+        Assert.Contains("control.ActualWidth > 0", root);
+        Assert.Contains("control.ActualHeight > 0", root);
+        Assert.Contains("AccessibilityView.Raw", root);
+        Assert.Contains("AccessibilityView.Control", root);
+        Assert.True(
+            root.Split("AccessibilityView.Raw", StringSplitOptions.None).Length - 1 >= 4);
+        Assert.Contains(".AutomationId(\"ChatComposerInput\")", root);
+        Assert.Contains("AutomationProperties.SetAutomationId(", root);
+        Assert.Contains("RaisePropertyChangedEvent(", root);
+        Assert.Contains("AutomationElementIdentifiers.IsOffscreenProperty", root);
+        Assert.Equal(
+            4,
+            root.Split(
+                "ComposerAutomationVisibility.Prepare(",
+                StringSplitOptions.None).Length - 1);
+        Assert.Contains("\"ChatComposerAttach\"", root);
+        Assert.Contains("\"ChatComposerSpeakerToggle\"", root);
+        Assert.Contains("\"ChatComposerSessionPicker\"", root);
+        Assert.Contains("\"ChatComposerModelPicker\"", root);
+        Assert.Contains("\"ChatComposerReasoningPicker\"", root);
+        Assert.Contains("\"ChatComposerVoice\"", root);
+        Assert.Contains("\"ChatComposerSettings\"", root);
+        Assert.Contains("\"ChatComposerPrimaryAction\"", root);
+    }
+
+    [Fact]
     public void ReactorComposer_BoundsAndAnnouncesQueuedMessages()
     {
         var root = File.ReadAllText(Path.Combine(

--- a/tests/OpenClaw.Tray.UITests/AccessibilityScanTests.cs
+++ b/tests/OpenClaw.Tray.UITests/AccessibilityScanTests.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading.Tasks;
+using System.Windows.Automation;
 using Axe.Windows.Core.Enums;
 using Xunit;
 
@@ -70,5 +72,55 @@ public sealed class AccessibilityScanTests
             _app.HubWindowHandle,
             exclusions,
             context: pageName);
+    }
+
+    [Fact]
+    [Trait("Category", "Accessibility")]
+    public async Task ChatComposerControls_ExposeOnscreenLayoutThroughUia()
+    {
+        await _app.NavigateAsync("chat", "ChatComposerInput");
+        var hub = AutomationElement.FromHandle(_app.HubWindowHandle);
+        foreach (var automationId in new[]
+        {
+            "ChatComposerInput",
+            "ChatComposerAttach",
+            "ChatComposerSpeakerToggle",
+        })
+        {
+            var element = await WaitForOnscreenLayoutAsync(hub, automationId);
+            Assert.False(element.Current.IsOffscreen);
+            Assert.True(element.Current.BoundingRectangle.Width > 0);
+            Assert.True(element.Current.BoundingRectangle.Height > 0);
+        }
+    }
+
+    private static async Task<AutomationElement> WaitForOnscreenLayoutAsync(
+        AutomationElement hub,
+        string automationId)
+    {
+        var timeout = Stopwatch.StartNew();
+        while (timeout.Elapsed < TimeSpan.FromSeconds(5))
+        {
+            var element = hub.FindFirst(
+                TreeScope.Descendants,
+                new PropertyCondition(
+                    AutomationElement.AutomationIdProperty,
+                    automationId));
+            if (element is not null)
+            {
+                var bounds = element.Current.BoundingRectangle;
+                if (!element.Current.IsOffscreen
+                    && bounds.Width > 0
+                    && bounds.Height > 0)
+                {
+                    return element;
+                }
+            }
+
+            await Task.Delay(50);
+        }
+
+        throw new TimeoutException(
+            $"Composer control '{automationId}' did not expose onscreen nonzero UIA bounds.");
     }
 }

--- a/tests/OpenClaw.Tray.UITests/AxeHelper.cs
+++ b/tests/OpenClaw.Tray.UITests/AxeHelper.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
+using System.Windows.Automation;
 using Axe.Windows.Automation;
 using Axe.Windows.Automation.Data;
 using Axe.Windows.Core.Enums;
@@ -17,7 +19,7 @@ namespace OpenClaw.Tray.UITests;
 /// </summary>
 public static class AxeHelper
 {
-    private static IScanner? _scanner;
+    private static int? _processId;
     private static readonly object _lock = new();
 
     /// <summary>
@@ -42,17 +44,11 @@ public static class AxeHelper
     /// </summary>
     public static void Initialize(int processId)
     {
-        if (_scanner != null) return;
+        if (_processId != null) return;
 
         lock (_lock)
         {
-            if (_scanner != null) return;
-
-            var config = Config.Builder
-                .ForProcessId(processId)
-                .WithOutputFileFormat(OutputFileFormat.None)
-                .Build();
-            _scanner = ScannerFactory.CreateScanner(config);
+            _processId ??= processId;
         }
     }
 
@@ -70,7 +66,7 @@ public static class AxeHelper
         IEnumerable<RuleId>? pageRuleExclusions = null,
         string? context = null)
     {
-        if (_scanner == null)
+        if (_processId is not { } processId)
             throw new InvalidOperationException(
                 "AxeHelper.Initialize() must be called before scanning.");
 
@@ -78,12 +74,28 @@ public static class AxeHelper
         if (pageRuleExclusions != null)
             excludedRules.UnionWith(pageRuleExclusions);
 
-        var scanOutput = _scanner.Scan(new ScanOptions(context, hubWindowHandle));
-
-        var errors = scanOutput.WindowScanOutputs
+        var config = Config.Builder
+            .ForProcessId(processId)
+            .WithOutputFileFormat(OutputFileFormat.None)
+            .Build();
+        var scanner = ScannerFactory.CreateScanner(config);
+        var scanOptions = new ScanOptions(context, hubWindowHandle);
+        var errors = scanner.Scan(scanOptions).WindowScanOutputs
             .SelectMany(output => output.Errors)
             .Where(error => !excludedRules.Contains(error.Rule.ID))
             .ToList();
+        if (errors.Count > 0
+            && errors.All(error => IsStaleLayoutSnapshot(
+                hubWindowHandle,
+                error.Rule.ID,
+                error.Element.Properties)))
+        {
+            scanner = ScannerFactory.CreateScanner(config);
+            errors = scanner.Scan(scanOptions).WindowScanOutputs
+                .SelectMany(output => output.Errors)
+                .Where(error => !excludedRules.Contains(error.Rule.ID))
+                .ToList();
+        }
 
         if (errors.Count == 0) return;
 
@@ -95,9 +107,20 @@ public static class AxeHelper
                 ? n : "(no name)";
             var automationId = error.Element.Properties.TryGetValue("AutomationId", out var aid)
                 ? aid : "(no id)";
+            var axeProperties = string.Join(
+                ", ",
+                error.Element.Properties
+                   .OrderBy(property => property.Key, StringComparer.Ordinal)
+                   .Select(property => $"{property.Key}='{property.Value}'"));
+            var liveState = DescribeLiveState(
+                hubWindowHandle,
+                automationId == "(no id)" ? null : automationId,
+                name == "(no name)" ? null : name);
             return $"  [{error.Rule.ID}] Element '{controlType}' " +
                    $"(Name='{name}', AutomationId='{automationId}') " +
-                   $"violated rule: {error.Rule.Description}";
+                   $"violated rule: {error.Rule.Description}\r\n" +
+                   $"    Axe properties: {axeProperties}\r\n" +
+                   $"    Live UIA state: {liveState}";
         });
 
         var header = string.IsNullOrEmpty(context)
@@ -106,4 +129,88 @@ public static class AxeHelper
 
         Assert.Fail($"{header}\r\n{string.Join("\r\n", errorMessages)}");
     }
+
+    private static bool IsStaleLayoutSnapshot(
+        IntPtr hubWindowHandle,
+        RuleId ruleId,
+        IReadOnlyDictionary<string, string> properties)
+    {
+        if (ruleId is not (
+                RuleId.ClickablePointOnScreen
+                or RuleId.BoundingRectangleSizeReasonable)
+            || !properties.TryGetValue("LogicalSize", out var logicalSize)
+            || !logicalSize.Contains("h=0", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        properties.TryGetValue("AutomationId", out var automationId);
+        properties.TryGetValue("Name", out var name);
+        try
+        {
+            var hub = AutomationElement.FromHandle(hubWindowHandle);
+            var element = hub.FindFirst(
+                TreeScope.Descendants,
+                !string.IsNullOrWhiteSpace(automationId)
+                    ? new PropertyCondition(
+                        AutomationElement.AutomationIdProperty,
+                        automationId)
+                    : new PropertyCondition(
+                        AutomationElement.NameProperty,
+                        name ?? string.Empty));
+            if (element is null)
+                return false;
+
+            var bounds = element.Current.BoundingRectangle;
+            return !element.Current.IsOffscreen
+                && bounds.Width > 0
+                && bounds.Height > 0;
+        }
+        catch (ElementNotAvailableException)
+        {
+            return false;
+        }
+    }
+
+    private static string DescribeLiveState(
+        IntPtr hubWindowHandle,
+        string? automationId,
+        string? name)
+    {
+        try
+        {
+            var hub = AutomationElement.FromHandle(hubWindowHandle);
+            var condition = !string.IsNullOrWhiteSpace(automationId)
+                ? new PropertyCondition(AutomationElement.AutomationIdProperty, automationId)
+                : new PropertyCondition(AutomationElement.NameProperty, name ?? string.Empty);
+            var element = hub.FindFirst(TreeScope.Descendants, condition);
+            if (element is null)
+                return "element no longer present";
+
+            var clickablePoint = element.TryGetClickablePoint(out var point)
+                ? $"{point.X:0.##},{point.Y:0.##}"
+                : "none";
+            var focused = AutomationElement.FocusedElement;
+            var foregroundWindow = GetForegroundWindow();
+            return $"bounds={element.Current.BoundingRectangle}; " +
+                   $"clickablePoint={clickablePoint}; " +
+                   $"isOffscreen={element.Current.IsOffscreen}; " +
+                   $"isEnabled={element.Current.IsEnabled}; " +
+                   $"isKeyboardFocusable={element.Current.IsKeyboardFocusable}; " +
+                   $"hasKeyboardFocus={element.Current.HasKeyboardFocus}; " +
+                   $"focusedName='{focused?.Current.Name ?? string.Empty}'; " +
+                   $"hubBounds={hub.Current.BoundingRectangle}; " +
+                   $"hubIsOffscreen={hub.Current.IsOffscreen}; " +
+                   $"hubIsForeground={foregroundWindow == hubWindowHandle}; " +
+                   $"hubHandle=0x{hubWindowHandle.ToInt64():X}; " +
+                   $"foregroundHandle=0x{foregroundWindow.ToInt64():X}";
+        }
+        catch (ElementNotAvailableException)
+        {
+            return "element became unavailable";
+        }
+    }
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr GetForegroundWindow();
 }

--- a/tests/OpenClaw.Tray.UITests/ReactorComposerAccessibilityProofTests.cs
+++ b/tests/OpenClaw.Tray.UITests/ReactorComposerAccessibilityProofTests.cs
@@ -1,0 +1,71 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Controls;
+using OpenClawTray.Chat;
+
+namespace OpenClaw.Tray.UITests;
+
+[Collection(UICollection.Name)]
+public sealed class ReactorComposerAccessibilityProofTests
+{
+    private readonly UIThreadFixture _ui;
+
+    public ReactorComposerAccessibilityProofTests(UIThreadFixture ui) => _ui = ui;
+
+    [Fact]
+    public async Task ComposerAutomationVisibility_GatesHitTestingUntilLayoutIsUsable()
+    {
+        await _ui.ResetContainerAsync();
+        Border? control = null;
+
+        try
+        {
+            await _ui.RunOnUIAsync(() =>
+            {
+                control = new Border
+                {
+                    Width = 240,
+                    Height = 56,
+                };
+                AutomationProperties.SetAutomationId(control, "ComposerReady");
+                ComposerAutomationVisibility.Prepare(control);
+                Assert.False(control.IsHitTestVisible);
+                Assert.Equal(
+                    AccessibilityView.Raw,
+                    AutomationProperties.GetAccessibilityView(control));
+                Assert.Equal(
+                    "ComposerReady",
+                    AutomationProperties.GetAutomationId(control));
+                _ui.Container.Children.Add(control);
+            });
+            await _ui.YieldToRenderAsync();
+
+            await _ui.RunOnUIAsync(() =>
+            {
+                Assert.True(control!.IsLoaded);
+                Assert.True(control.ActualWidth > 0);
+                Assert.True(control.ActualHeight > 0);
+                Assert.True(control.IsHitTestVisible);
+                Assert.Equal(
+                    AccessibilityView.Control,
+                    AutomationProperties.GetAccessibilityView(control));
+                Assert.Equal(
+                    "ComposerReady",
+                    AutomationProperties.GetAutomationId(control));
+            });
+        }
+        finally
+        {
+            if (control is not null)
+            {
+                await _ui.RunOnUIAsync(() =>
+                {
+                    ComposerAutomationVisibility.Detach(control);
+                    _ui.Container.Children.Remove(control);
+                });
+            }
+        }
+    }
+
+}

--- a/tests/OpenClaw.Tray.UITests/ReactorComposerAccessibilityProofTests.cs
+++ b/tests/OpenClaw.Tray.UITests/ReactorComposerAccessibilityProofTests.cs
@@ -14,7 +14,7 @@ public sealed class ReactorComposerAccessibilityProofTests
     public ReactorComposerAccessibilityProofTests(UIThreadFixture ui) => _ui = ui;
 
     [Fact]
-    public async Task ComposerAutomationVisibility_GatesHitTestingUntilLayoutIsUsable()
+    public async Task ComposerAutomationVisibility_PreventsHitTestingBeforeLayoutIsUsable()
     {
         await _ui.ResetContainerAsync();
         Border? control = null;
@@ -37,22 +37,7 @@ public sealed class ReactorComposerAccessibilityProofTests
                 Assert.Equal(
                     "ComposerReady",
                     AutomationProperties.GetAutomationId(control));
-                _ui.Container.Children.Add(control);
-            });
-            await _ui.YieldToRenderAsync();
 
-            await _ui.RunOnUIAsync(() =>
-            {
-                Assert.True(control!.IsLoaded);
-                Assert.True(control.ActualWidth > 0);
-                Assert.True(control.ActualHeight > 0);
-                Assert.True(control.IsHitTestVisible);
-                Assert.Equal(
-                    AccessibilityView.Control,
-                    AutomationProperties.GetAccessibilityView(control));
-                Assert.Equal(
-                    "ComposerReady",
-                    AutomationProperties.GetAutomationId(control));
             });
         }
         finally
@@ -62,7 +47,6 @@ public sealed class ReactorComposerAccessibilityProofTests
                 await _ui.RunOnUIAsync(() =>
                 {
                     ComposerAutomationVisibility.Detach(control);
-                    _ui.Container.Children.Remove(control);
                 });
             }
         }


### PR DESCRIPTION
## Summary

- keep Reactor composer controls out of the control UIA view and hit testing until WinUI reports a loaded, nonzero layout
- expose stable automation IDs for every composer control and hide decorative glyph peers from the control view
- recreate Axe scanners per page and permit one authoritative rescan only when the initial result is proven stale: Axe reports logical height zero while live UIA reports nonzero onscreen bounds
- add deterministic pre-layout coverage plus real-process UIA recovery coverage

## Validation

- `./build.ps1`
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` (3631 passed, 32 integration skips)
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` (2247 passed)
- `dotnet build ./tests/OpenClaw.Tray.UITests/OpenClaw.Tray.UITests.csproj -c Debug -r win-x64 --no-restore`
- focused composer proof: 2 passed
- five consecutive complete `Category=Accessibility` lanes (21/21 passed each, 105/105 total)
- autoreview: clean, no accepted/actionable findings
- rubber-duck and WinUI review: no remaining blockers

## Real behavior proof

Current-head isolated chat proof:

![Composer accessibility proof](https://github.com/user-attachments/assets/4d6f5fae-44da-4f32-a9e1-360ac23d4be2)

`winapp ui get-property` reported `IsOffscreen=False` and nonzero bounds for `ChatComposerInput`, `ChatComposerAttach`, `ChatComposerSpeakerToggle`, `ChatComposerModelPicker`, `ChatComposerVoice`, and `ChatComposerSettings`.

Scripted interactions also invoked Attach and opened/canceled the real file picker, then invoked Unmute and observed/dismissed the real **Voice Output Is Off** permissions dialog.