### PR TITLE
Fix chat bottom-anchor settling after history prepend

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatTimeline.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatTimeline.cs
@@ -2859,7 +2859,7 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
                 if (Props.ScrollToBottomToken != prevScrollToBottomTokenRef.Current)
                 {
                     prevScrollToBottomTokenRef.Current = Props.ScrollToBottomToken;
-                    QueueScrollToBottom(sv, Props.SessionId, disableAnimation: false);
+                    QueueScrollToBottom(sv, Props.SessionId, disableAnimation: true);
                 }
 
                 prevSessionIdRef.Current = Props.SessionId;

--- a/tests/OpenClaw.Tray.Tests/ChatTimelineVirtualizationContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ChatTimelineVirtualizationContractTests.cs
@@ -39,6 +39,10 @@ public sealed class ChatTimelineVirtualizationContractTests
         Assert.Contains("scrollPinPendingRef", timeline);
         Assert.Contains("UserScrolledAway", timeline);
         Assert.Contains("sv.UpdateLayout();", timeline);
+        Assert.Contains(
+            "prevScrollToBottomTokenRef.Current = Props.ScrollToBottomToken;" + Environment.NewLine +
+            "                    QueueScrollToBottom(sv, Props.SessionId, disableAnimation: true);",
+            timeline);
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.UITests/ChatTimelineVirtualizationProofTests.cs
+++ b/tests/OpenClaw.Tray.UITests/ChatTimelineVirtualizationProofTests.cs
@@ -629,6 +629,7 @@ public sealed class ChatTimelineVirtualizationProofTests
             Assert.True(
                 gap <= 4,
                 $"after prepend + restore, scroll-to-bottom must follow to the newest row; gap={gap:0.0}");
+            Assert.Equal(1.0, scrollViewer.VerticalAnchorRatio);
         });
 
         await _ui.RunOnUIAsync(() => host!.Dispose());


### PR DESCRIPTION
## Summary

- make explicit `ScrollToBottomToken` requests use an immediate first pin
- prevent the token request's own animated intermediate `ViewChanged` events from being mistaken for a user scroll and canceling settle
- leave appended-entry, reactive follow, session, layout, and user-scroll behavior unchanged
- guard the token-owner contract and assert bottom anchoring is restored after prepend

## Root cause

The focused proof reproduced the current-main flake on baseline run 24 with a 158.1px bottom gap. Transition capture showed the token bump's animated `ChangeView` emitting intermediate offsets far outside the follow band. Existing user-scroll-authority logic interpreted that owner animation as a reader scroll, canceled the settle timer, and left the animation short of the final bottom. Immediate targeted reruns passed, matching the reported intermittent behavior.

The existing settle timer already uses non-animated pins after its first tick, so making the explicit token request's first pin immediate removes the ambiguous intermediate owner state without changing unrelated follow paths or adding timing delays.

## Validation

Exact head `0fc747a3d6a973255225fcdddb6cde4bdb24b0c6`:

- `./build.ps1` - passed
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` - 3,631 passed, 32 skipped
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` - 2,246 passed
- focused `PrependHistory_PreservesOffset_AndRestoresBottomAnchoring` - 20/20 consecutive passes after rebase
- complete non-accessibility native UI lane - 114/114 passed, 3 consecutive fresh runs

Additional same-diff stress before the final rebase:

- focused prepend/bottom-anchor proof - 100/100 consecutive passes
- `ModerateScrollUpDuringSettleTimer_IsNotRepinned` - 30/30 consecutive passes

## Real behavior proof

The native WinUI/Reactor test host drives the real `ScrollViewer`, `ItemsRepeater`, layout queue, prepend remount, `ScrollToBottomToken`, and anchoring state. On the final head it proves:

- prepended history keeps the reader out of both the top and bottom bands
- the explicit token request reaches a bottom gap of at most 4px
- `VerticalAnchorRatio` is restored to exactly `1.0`
- the complete non-accessibility native UI lane passes 3 consecutive times

A live isolated app cannot deterministically synthesize earlier-history prepend without a connected chat session, so no unrelated screenshot is included.

## Review

- rubber-duck: clean on the final minimal diff
- autoreview (`gpt-5.6-sol`, high): clean, no accepted/actionable findings