### PR TITLE
fix: run the released Tray in candidate E2E

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,7 +310,7 @@ jobs:
         include:
           - name: setup-connect
             timeout_minutes: 45
-            filter: "FullyQualifiedName~OpenClaw.E2ETests.Setup.SetupAndConnectTests|FullyQualifiedName~OpenClaw.E2ETests.Setup.MxcSetupAndConnectTests|FullyQualifiedName~OpenClaw.E2ETests.Setup.MirroredWslPortLeaseTests|FullyQualifiedName~OpenClaw.E2ETests.Setup.SshOwnershipAdversarialProofTests"
+            filter: "FullyQualifiedName~OpenClaw.E2ETests.Setup.SetupAndConnectTests|FullyQualifiedName~OpenClaw.E2ETests.Setup.MxcSetupAndConnectTests|FullyQualifiedName~OpenClaw.E2ETests.Setup.MirroredWslPortLeaseTests|FullyQualifiedName~OpenClaw.E2ETests.Setup.SshOwnershipAdversarialProofTests|FullyQualifiedName~OpenClaw.E2ETests.Setup.TrayExecutableResolutionTests"
           - name: revocation-recovery
             timeout_minutes: 25
             filter: FullyQualifiedName~OpenClaw.E2ETests.Setup.RevocationAndRecoveryTests

--- a/tests/OpenClaw.E2ETests/Setup/E2ESetupFixture.cs
+++ b/tests/OpenClaw.E2ETests/Setup/E2ESetupFixture.cs
@@ -977,8 +977,31 @@ public sealed class E2ESetupFixture : IAsyncLifetime
             .Any(segment => segment.Equals("gateways", StringComparison.OrdinalIgnoreCase));
     }
 
-    private static string LocateTrayExe()
+    private const string TrayExecutableOverrideEnvironmentVariable = "OPENCLAW_E2E_TRAY_EXE";
+
+    private static string LocateTrayExe() => ResolveTrayExecutable(
+        Environment.GetEnvironmentVariable(TrayExecutableOverrideEnvironmentVariable),
+        repoRoot: null);
+
+    internal static string ResolveTrayExecutable(string? overridePath, string? repoRoot)
     {
+        if (!string.IsNullOrWhiteSpace(overridePath))
+        {
+            var executable = Path.GetFullPath(overridePath);
+            // The release gate must exercise its verified artifact, never silently
+            // fall back to a checkout build when that artifact is unavailable.
+            if (!Path.GetExtension(executable).Equals(".exe", StringComparison.OrdinalIgnoreCase) ||
+                !File.Exists(executable))
+            {
+                throw new FileNotFoundException(
+                    $"{TrayExecutableOverrideEnvironmentVariable} must name an existing .exe file.",
+                    executable);
+            }
+
+            return executable;
+        }
+
+        repoRoot ??= FindRepoRoot();
         var rid = RuntimeInformation.ProcessArchitecture switch
         {
             Architecture.Arm64 => "win-arm64",
@@ -993,7 +1016,6 @@ public sealed class E2ESetupFixture : IAsyncLifetime
             "Release";
 #endif
 
-        var repoRoot = FindRepoRoot();
         var targetFramework = GetTrayTargetFramework(repoRoot);
         var exe = Path.Combine(
             repoRoot,

--- a/tests/OpenClaw.E2ETests/Setup/TrayExecutableResolutionTests.cs
+++ b/tests/OpenClaw.E2ETests/Setup/TrayExecutableResolutionTests.cs
@@ -1,0 +1,50 @@
+namespace OpenClaw.E2ETests.Setup;
+
+public sealed class TrayExecutableResolutionTests
+{
+    [Fact]
+    public void ResolveTrayExecutable_UsesExistingOverrideBeforeSourceTreeLookup()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), $"openclaw-e2e-tray-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        var releasedTray = Path.Combine(directory, "OpenClaw.Tray.WinUI.exe");
+        File.WriteAllText(releasedTray, string.Empty);
+
+        try
+        {
+            var resolved = E2ESetupFixture.ResolveTrayExecutable(
+                releasedTray,
+                Path.Combine(directory, "checkout-does-not-exist"));
+
+            Assert.Equal(Path.GetFullPath(releasedTray), resolved);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData("missing.exe")]
+    [InlineData("not-an-executable.txt")]
+    public void ResolveTrayExecutable_RejectsInvalidOverride(string fileName)
+    {
+        var directory = Path.Combine(Path.GetTempPath(), $"openclaw-e2e-tray-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        var overridePath = Path.Combine(directory, fileName);
+        if (fileName.EndsWith(".txt", StringComparison.Ordinal))
+            File.WriteAllText(overridePath, string.Empty);
+
+        try
+        {
+            var exception = Assert.Throws<FileNotFoundException>(() =>
+                E2ESetupFixture.ResolveTrayExecutable(overridePath, directory));
+
+            Assert.Contains("OPENCLAW_E2E_TRAY_EXE", exception.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Windows release-candidate workflow could verify a published Tray archive but start the checkout-built Tray during E2E. That could record a green Gateway/Tray compatibility result without exercising the released Windows app.

Related: #1104

## Why This Change Was Made

`E2ESetupFixture` now resolves the explicit release executable before looking for a source-tree build. The override must name an existing `.exe`; an invalid override fails instead of silently falling back to the checkout artifact. The default source-build path remains unchanged for ordinary E2E runs. The resolver regression tests are included in the existing Windows setup-connect CI shard.

## User Impact

Release operators can rely on the candidate E2E outcome to represent the verified published Windows Tray paired with the Gateway candidate.

## Evidence

- `git diff --check`: passed.
- Focused regression coverage covers valid override precedence and missing/non-`.exe` rejection.
- Structured autoreview: clean after fixing an initial eager source-root lookup finding; the CI-filter update was separately reviewed clean.
- Local Windows build/test commands were not runnable on this macOS host because `dotnet` is unavailable. Exact-head Windows CI passed: [Build and Test 31299568545](https://github.com/openclaw/openclaw-windows-node/actions/runs/31299568545) completed the normal suite, all E2E shards, and x64/ARM64 builds.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs or instructions
- [x] Tests or validation
- [ ] Security hardening
- [ ] Chore or infrastructure

## Scope

- [ ] Tray or WinUI UX
- [ ] Windows node capability
- [ ] Local MCP or `winnode`
- [x] Gateway, connection, or pairing
- [ ] Setup or onboarding
- [ ] Permissions, privacy, or security
- [x] Tests, CI, or docs

## Validation

- `git diff --check`: passed.
- `dotnet test ./tests/OpenClaw.E2ETests/OpenClaw.E2ETests.csproj --filter FullyQualifiedName~TrayExecutableResolutionTests`: blocked locally, `dotnet` is not installed on the host.
- Required Windows build, Shared tests, Tray tests, setup-connect E2E with `TrayExecutableResolutionTests`, recovery E2E shards, and x64/ARM64 builds: passed in [Build and Test 31299568545](https://github.com/openclaw/openclaw-windows-node/actions/runs/31299568545).

## Real Behavior Proof

- Environment tested: Windows hosted CI plus deterministic resolver tests.
- PR head or commit tested: `a62b5d3c202f3fadec70e0c8222b12825df31405`.
- Exact steps or command run: set `OPENCLAW_E2E_TRAY_EXE` to the verified release `.exe`; resolver returns it before any repository lookup.
- Evidence after fix: invalid override names fail with an explicit `OPENCLAW_E2E_TRAY_EXE` error rather than launching a local build.
- Observed result: current-head Windows build and E2E matrix passed. The cross-repository candidate run remains blocked by the absence of an eligible canonical production prerelease Windows release.
- Screenshot or artifact links verified? (`Yes`/`No`/`N/A`): N/A.
- Not verified or blocked: local Windows/.NET runtime unavailable; CI is the current-head proof route.

## Security Impact

- New permissions or capabilities? No.
- Secrets or tokens handling changed? No.
- New or changed network calls? No.
- Command or tool execution surface changed? No.
- Data access scope changed? No.

## Compatibility and Migration

- Backward compatible? Yes.
- Config or environment changes? No. The workflow-only `OPENCLAW_E2E_TRAY_EXE` contract is now enforced.
- Migration needed? No.

## Review Conversations

- [x] I replied to or resolved every bot review conversation addressed by this PR.
- [ ] I left unresolved only conversations that still need maintainer judgment.