### PR TITLE
fix(update): suppress ordinary Windows updates on extended-stable

### DIFF
--- a/src/OpenClaw.Shared/IOperatorGatewayClient.cs
+++ b/src/OpenClaw.Shared/IOperatorGatewayClient.cs
@@ -138,6 +138,12 @@ public interface IOperatorGatewayClient
     Task<bool> StopChannelAsync(string channelName);
     /// <summary>Fetch the rich channels.status snapshot from the gateway. Mac/web canonical wire method.</summary>
     Task<ChannelsStatusSnapshot?> GetChannelsStatusAsync(bool probe = false, int timeoutMs = 12000);
+    /// <summary>
+    /// Fetches the gateway's resolved update track (<c>update.status</c>). Older
+    /// gateways return <c>null</c>, so callers retain their existing update behavior.
+    /// </summary>
+    Task<GatewayUpdateStatus?> GetUpdateStatusAsync(int timeoutMs = 5000) =>
+        Task.FromResult<GatewayUpdateStatus?>(null);
     /// <summary>Log out / unlink a channel (whatsapp, telegram). Sends channels.logout { channel }.</summary>
     Task<bool> LogoutChannelAsync(string channelName, int timeoutMs = 12000);
     /// <summary>Begin a QR linking flow (whatsapp, signal). Sends web.login.start { force, timeoutMs }.</summary>

--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -1650,6 +1650,26 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
         }
     }
 
+    /// <summary>
+    /// Fetches the installed gateway's effective update channel. A missing field
+    /// is intentionally represented as null so older gateways keep the desktop
+    /// updater's existing behavior.
+    /// </summary>
+    public async Task<GatewayUpdateStatus?> GetUpdateStatusAsync(int timeoutMs = 5000)
+    {
+        if (!IsConnected) return null;
+        try
+        {
+            var response = await SendWizardRequestAsync("update.status", new { }, timeoutMs);
+            return GatewayUpdateStatusParser.Parse(response);
+        }
+        catch (Exception ex)
+        {
+            _logger.Warn($"update.status request failed: {ex.Message}");
+            return null;
+        }
+    }
+
     /// <summary>Log out / unlink a channel. Sends <c>channels.logout { channel }</c>.</summary>
     public async Task<bool> LogoutChannelAsync(string channelName, int timeoutMs = 12000)
     {

--- a/src/OpenClaw.Shared/UpdateStatus.cs
+++ b/src/OpenClaw.Shared/UpdateStatus.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Text.Json;
+
+namespace OpenClaw.Shared;
+
+/// <summary>
+/// The gateway's resolved update track. This is authoritative for the installed
+/// OpenClaw runtime, rather than the companion's separate release repository.
+/// </summary>
+public sealed class GatewayUpdateStatus
+{
+    public string? EffectiveChannel { get; init; }
+
+    public bool SuppressesCompanionUpdate => string.Equals(
+        EffectiveChannel,
+        "extended-stable",
+        StringComparison.OrdinalIgnoreCase);
+}
+
+public static class GatewayUpdateStatusParser
+{
+    /// <summary>
+    /// Parses the additive <c>effectiveChannel</c> field from <c>update.status</c>.
+    /// Older gateways omit it, which deliberately preserves the legacy updater path.
+    /// </summary>
+    public static GatewayUpdateStatus Parse(JsonElement payload) => new()
+    {
+        EffectiveChannel = payload.ValueKind == JsonValueKind.Object &&
+                           payload.TryGetProperty("effectiveChannel", out var channel) &&
+                           channel.ValueKind == JsonValueKind.String
+            ? channel.GetString()
+            : null
+    };
+}

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -210,6 +210,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     private AppState? _appState;
     internal AppState? AppState => _appState;
     private UpdateCoordinator? _updateCoordinator;
+    private IOperatorGatewayClient? _updateCheckClient;
     private GatewayService? _gatewayService;
     private PairingApprovalCoordinator? _pairingApprovalCoordinator;
     private OpenClawTray.Dialogs.PairingApprovalDialog? _pairingApprovalDialog;
@@ -642,6 +643,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             AppUpdater,
             _appState,
             _settings,
+            () => _connectionManager?.OperatorClient,
             () =>
             {
                 XamlRoot? r = null;
@@ -705,19 +707,6 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         // in-progress download/extraction. We still control shutdown
         // explicitly via Application.Exit().
         DispatcherShutdownMode = DispatcherShutdownMode.OnExplicitShutdown;
-
-        // Check for updates before launching. Skip in test instances — no UI dialogs,
-        // no network calls, no startup delay.
-        if (DataDirOverride is null &&
-            Environment.GetEnvironmentVariable("OPENCLAW_SKIP_UPDATE_CHECK") != "1")
-        {
-            var shouldLaunch = await _updateCoordinator.CheckForUpdatesAsync();
-            if (!shouldLaunch)
-            {
-                Exit();
-                return;
-            }
-        }
 
         // Register toast activation handler
         ToastNotificationManagerCompat.OnActivated += OnToastActivated;
@@ -2166,6 +2155,11 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
 
         // Delegate all 27 event subscriptions to GatewayService
         _gatewayService?.AttachClient(e.NewClient, e.OldClient);
+        if (e.OldClient != null)
+            e.OldClient.HandshakeSucceeded -= OnGatewayUpdateCheckHandshakeSucceeded;
+        _updateCheckClient = e.NewClient;
+        if (e.NewClient != null)
+            e.NewClient.HandshakeSucceeded += OnGatewayUpdateCheckHandshakeSucceeded;
 
         // Configure new client
         if (e.NewClient is { } client)
@@ -2189,6 +2183,18 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         // Update UI references
         if (_appState != null)
             _appState.GatewaySelf = null;
+    }
+
+    private void OnGatewayUpdateCheckHandshakeSucceeded(object? sender, EventArgs e)
+    {
+        if (sender is not IOperatorGatewayClient client || !ReferenceEquals(client, _updateCheckClient) ||
+            DataDirOverride is not null ||
+            Environment.GetEnvironmentVariable("OPENCLAW_SKIP_UPDATE_CHECK") == "1")
+        {
+            return;
+        }
+
+        OnUiThread(() => _ = _updateCoordinator?.CheckForAutomaticUpdatesAfterHandshakeAsync(client));
     }
 
     private void RaiseChatProviderChanged()

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -909,6 +909,13 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         _managedLocalAutoRepairMonitor.Start();
 
         InitializeGatewayClient();
+        if (_connectionManager.CurrentSnapshot.OperatorState == RoleConnectionState.Idle &&
+            _connectionManager.OperatorClient is null)
+        {
+            // InitializeGatewayClient found no operator connection to resolve. This
+            // is a terminal startup state, so retain the standalone updater path.
+            StartAutomaticUpdateCheckWithoutGateway();
+        }
 
         // Pre-warm chat window (WebView2 init takes 1-3s, do it now so left-click is instant)
         if (_settings != null &&
@@ -2144,6 +2151,14 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     /// </summary>
     private void OnOperatorClientChanged(object? sender, OperatorClientChangedEventArgs e)
     {
+        // Subscribe before UI dispatch: GatewayConnectionManager starts its transport
+        // immediately after this event, and a local hello-ok can otherwise win the race.
+        if (e.OldClient != null)
+            e.OldClient.HandshakeSucceeded -= OnGatewayUpdateCheckHandshakeSucceeded;
+        _updateCheckClient = e.NewClient;
+        if (e.NewClient != null)
+            e.NewClient.HandshakeSucceeded += OnGatewayUpdateCheckHandshakeSucceeded;
+
         if (_dispatcherQueue is { HasThreadAccess: false } dispatcher)
         {
             if (!dispatcher.TryEnqueue(() => OnOperatorClientChanged(sender, e)))
@@ -2155,11 +2170,6 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
 
         // Delegate all 27 event subscriptions to GatewayService
         _gatewayService?.AttachClient(e.NewClient, e.OldClient);
-        if (e.OldClient != null)
-            e.OldClient.HandshakeSucceeded -= OnGatewayUpdateCheckHandshakeSucceeded;
-        _updateCheckClient = e.NewClient;
-        if (e.NewClient != null)
-            e.NewClient.HandshakeSucceeded += OnGatewayUpdateCheckHandshakeSucceeded;
 
         // Configure new client
         if (e.NewClient is { } client)
@@ -2194,7 +2204,18 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             return;
         }
 
-        OnUiThread(() => _ = _updateCoordinator?.CheckForAutomaticUpdatesAfterHandshakeAsync(client));
+        OnUiThread(() => _ = _updateCoordinator?.CheckForAutomaticUpdatesAfterGatewayResolutionAsync(client));
+    }
+
+    private void StartAutomaticUpdateCheckWithoutGateway()
+    {
+        if (DataDirOverride is not null ||
+            Environment.GetEnvironmentVariable("OPENCLAW_SKIP_UPDATE_CHECK") == "1")
+        {
+            return;
+        }
+
+        OnUiThread(() => _ = _updateCoordinator?.CheckForAutomaticUpdatesAfterGatewayResolutionAsync());
     }
 
     private void RaiseChatProviderChanged()
@@ -2241,6 +2262,9 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         {
             _lastManagerConnectedSideEffectsKey = null;
         }
+
+        if (snap.OperatorState == RoleConnectionState.Error)
+            StartAutomaticUpdateCheckWithoutGateway();
     }
 
     private NodeService? EnsureNodeService(SettingsManager settings)

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -2263,7 +2263,10 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             _lastManagerConnectedSideEffectsKey = null;
         }
 
-        if (snap.OperatorState == RoleConnectionState.Error)
+        // Only a successful operator handshake can identify the Gateway's release track.
+        // PairingRequired intentionally persists after its socket closes, so preserve the
+        // pre-existing standalone updater instead of silently losing automatic checks.
+        if (snap.OperatorState is RoleConnectionState.Error or RoleConnectionState.PairingRequired)
             StartAutomaticUpdateCheckWithoutGateway();
     }
 

--- a/src/OpenClaw.Tray.WinUI/Services/UpdateCoordinator.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/UpdateCoordinator.cs
@@ -26,6 +26,7 @@ internal sealed class UpdateCoordinator(
     Action exit)
 {
     private readonly SettingsManager? _settings = settings;
+    private readonly Func<IOperatorGatewayClient?> _getGatewayClient = getGatewayClient;
 
     // Cross-path concurrency for update checks, split into two phases:
     //  - _updateCheckGate: held only during the metadata/network check.
@@ -101,7 +102,7 @@ internal sealed class UpdateCoordinator(
         try
         {
             var gatewayUpdateStatus = await TryGetGatewayUpdateStatusAsync(
-                handshakeClient ?? getGatewayClient());
+                handshakeClient ?? GetGatewayClient());
             if (gatewayUpdateStatus?.SuppressesCompanionUpdate == true)
             {
                 Logger.Info("Skipping companion update check: gateway is on extended-stable");
@@ -364,6 +365,8 @@ internal sealed class UpdateCoordinator(
             return null;
         }
     }
+
+    private IOperatorGatewayClient? GetGatewayClient() => _getGatewayClient();
 
     // Re-entrancy guard: the button/menu/deep-link are all fire-and-forget
     // (`_ = CheckForUpdatesUserInitiatedAsync()`), so a double-click would

--- a/src/OpenClaw.Tray.WinUI/Services/UpdateCoordinator.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/UpdateCoordinator.cs
@@ -20,6 +20,7 @@ internal sealed class UpdateCoordinator(
     UpdatumManager updater,
     AppState appState,
     SettingsManager? settings,
+    Func<IOperatorGatewayClient?> getGatewayClient,
     Func<XamlRoot?> getXamlRoot,
     Action refreshStatus,
     Action exit)
@@ -37,6 +38,7 @@ internal sealed class UpdateCoordinator(
     private int _updateInstallInProgress;
 #endif
     private int _manualUpdateCheckInFlight;
+    private int _automaticUpdateCheckStarted;
 
     public static UpdateCommandCenterInfo BuildInitialInfo() => new()
     {
@@ -44,7 +46,9 @@ internal sealed class UpdateCoordinator(
         CurrentVersion = AppVersionInfo.Version
     };
 
-    public async Task<bool> CheckForUpdatesAsync(bool userInitiated = false)
+    public async Task<bool> CheckForUpdatesAsync(
+        bool userInitiated = false,
+        IOperatorGatewayClient? handshakeClient = null)
     {
         // === Stage 1: metadata check (gate-protected) ===
         if (!await _updateCheckGate.WaitAsync(TimeSpan.FromSeconds(30)))
@@ -96,6 +100,21 @@ internal sealed class UpdateCoordinator(
         string changelog;
         try
         {
+            var gatewayUpdateStatus = await TryGetGatewayUpdateStatusAsync(
+                handshakeClient ?? getGatewayClient());
+            if (gatewayUpdateStatus?.SuppressesCompanionUpdate == true)
+            {
+                Logger.Info("Skipping companion update check: gateway is on extended-stable");
+                appState.UpdateInfo = new UpdateCommandCenterInfo
+                {
+                    Status = "Skipped",
+                    CurrentVersion = AppVersionInfo.Version,
+                    CheckedAt = DateTime.UtcNow,
+                    Detail = "The connected Gateway uses extended-stable, so ordinary Windows release updates are not offered."
+                };
+                return true;
+            }
+
             Logger.Info("Checking for updates...");
             appState.UpdateInfo = new UpdateCommandCenterInfo
             {
@@ -314,6 +333,36 @@ internal sealed class UpdateCoordinator(
 #endif
     }
 
+    /// <summary>
+    /// Starts the one automatic update check only after hello-ok. The Gateway owns
+    /// the installed release track; startup has no authenticated client yet.
+    /// </summary>
+    public async Task CheckForAutomaticUpdatesAfterHandshakeAsync(IOperatorGatewayClient client)
+    {
+        if (Interlocked.Exchange(ref _automaticUpdateCheckStarted, 1) != 0)
+            return;
+        if (!await CheckForUpdatesAsync(handshakeClient: client))
+            exit();
+    }
+
+    private static async Task<GatewayUpdateStatus?> TryGetGatewayUpdateStatusAsync(
+        IOperatorGatewayClient? gatewayClient)
+    {
+        if (gatewayClient is null)
+            return null;
+        try
+        {
+            return await gatewayClient.GetUpdateStatusAsync();
+        }
+        catch (Exception ex)
+        {
+            // An older or unauthorized gateway cannot identify its release track.
+            // Preserve the standalone updater behavior instead of losing update checks.
+            Logger.Info($"Gateway update channel unavailable; using companion updater: {ex.Message}");
+            return null;
+        }
+    }
+
     // Re-entrancy guard: the button/menu/deep-link are all fire-and-forget
     // (`_ = CheckForUpdatesUserInitiatedAsync()`), so a double-click would
     // otherwise open two ContentDialogs on the same XamlRoot which throws
@@ -369,7 +418,7 @@ internal sealed class UpdateCoordinator(
                         await ShowUpdateInfoDialogAsync(
                             "Skipped",
                             LocalizationHelper.GetString("Update_Title_Skipped"),
-                            LocalizationHelper.GetString(
+                            info.Detail ?? LocalizationHelper.GetString(
                                 AppIdentity.IsDev
                                     ? "Update_Message_Skipped_Dev"
                                     : "Update_Message_Skipped_Debug"));

--- a/src/OpenClaw.Tray.WinUI/Services/UpdateCoordinator.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/UpdateCoordinator.cs
@@ -334,10 +334,12 @@ internal sealed class UpdateCoordinator(
     }
 
     /// <summary>
-    /// Starts the one automatic update check only after hello-ok. The Gateway owns
-    /// the installed release track; startup has no authenticated client yet.
+    /// Starts the one automatic update check after Gateway resolution. A successful
+    /// hello-ok supplies the authoritative track; unavailable Gateway paths retain
+    /// the standalone updater's established behavior.
     /// </summary>
-    public async Task CheckForAutomaticUpdatesAfterHandshakeAsync(IOperatorGatewayClient client)
+    public async Task CheckForAutomaticUpdatesAfterGatewayResolutionAsync(
+        IOperatorGatewayClient? handshakeClient = null)
     {
         if (Interlocked.Exchange(ref _automaticUpdateCheckStarted, 1) != 0)
             return;

--- a/src/OpenClaw.Tray.WinUI/Services/UpdateCoordinator.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/UpdateCoordinator.cs
@@ -343,7 +343,7 @@ internal sealed class UpdateCoordinator(
     {
         if (Interlocked.Exchange(ref _automaticUpdateCheckStarted, 1) != 0)
             return;
-        if (!await CheckForUpdatesAsync(handshakeClient: client))
+        if (!await CheckForUpdatesAsync(handshakeClient: handshakeClient))
             exit();
     }
 

--- a/tests/OpenClaw.Shared.Tests/GatewayProtocolModelsTests.cs
+++ b/tests/OpenClaw.Shared.Tests/GatewayProtocolModelsTests.cs
@@ -36,6 +36,7 @@ public class GatewayProtocolModelsTests
             ("CreateSessionAsync", new[] { typeof(SessionCreateRequest), typeof(int) }),
             ("ResetSessionDetailedAsync", new[] { typeof(string), typeof(int) }),
             ("CompactSessionDetailedAsync", new[] { typeof(string), typeof(int) }),
+            ("GetUpdateStatusAsync", new[] { typeof(int) }),
         };
 
         foreach (var (name, args) in newMembers)

--- a/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
@@ -565,6 +565,69 @@ public class OpenClawGatewayClientTests
     }
 
     [Fact]
+    public async Task GetUpdateStatusAsync_RequestsEffectiveChannelAndParsesExtendedStable()
+    {
+        using var server = new LoopbackWebSocketServer();
+        using var identity = new TempDirectory("update-status-");
+        await server.StartAsync();
+        var helper = new GatewayClientTestHelper(
+            gatewayUrl: server.WebSocketUrl,
+            identityPath: identity.Path);
+        using var client = helper.Client;
+        await client.ConnectAsync();
+
+        var statusTask = client.GetUpdateStatusAsync(timeoutMs: 10_000);
+        var request = await server.ReceiveTextAsync().WaitAsync(TimeSpan.FromSeconds(2));
+        using var requestDocument = JsonDocument.Parse(request);
+        Assert.Equal("update.status", requestDocument.RootElement.GetProperty("method").GetString());
+        var requestId = ReadRequestId(request);
+
+        await server.SendTextAsync(
+            JsonSerializer.Serialize(new
+            {
+                type = "res",
+                id = requestId,
+                ok = true,
+                payload = new { effectiveChannel = "extended-stable" }
+            }));
+
+        var status = await statusTask.WaitAsync(TimeSpan.FromSeconds(2));
+
+        Assert.NotNull(status);
+        Assert.True(status!.SuppressesCompanionUpdate);
+    }
+
+    [Fact]
+    public async Task GetUpdateStatusAsync_GatewayError_PreservesLegacyUpdaterFallback()
+    {
+        using var server = new LoopbackWebSocketServer();
+        using var identity = new TempDirectory("update-status-");
+        await server.StartAsync();
+        var helper = new GatewayClientTestHelper(
+            gatewayUrl: server.WebSocketUrl,
+            identityPath: identity.Path);
+        using var client = helper.Client;
+        await client.ConnectAsync();
+
+        var statusTask = client.GetUpdateStatusAsync(timeoutMs: 10_000);
+        var request = await server.ReceiveTextAsync().WaitAsync(TimeSpan.FromSeconds(2));
+        var requestId = ReadRequestId(request);
+
+        await server.SendTextAsync(
+            JsonSerializer.Serialize(new
+            {
+                type = "res",
+                id = requestId,
+                ok = false,
+                error = new { message = "unknown method" }
+            }));
+
+        var status = await statusTask.WaitAsync(TimeSpan.FromSeconds(2));
+
+        Assert.Null(status);
+    }
+
+    [Fact]
     public async Task SendWizardRequestAsync_GatewayError_PropagatesUnchangedAndCleansTracking()
     {
         using var server = new LoopbackWebSocketServer();

--- a/tests/OpenClaw.Shared.Tests/UpdateStatusTests.cs
+++ b/tests/OpenClaw.Shared.Tests/UpdateStatusTests.cs
@@ -1,0 +1,33 @@
+using System.Text.Json;
+using OpenClaw.Shared;
+
+namespace OpenClaw.Shared.Tests;
+
+public sealed class UpdateStatusTests
+{
+    [Fact]
+    public void Parse_ExtendedStable_SuppressesCompanionUpdate()
+    {
+        using var document = JsonDocument.Parse("""{ "effectiveChannel": "extended-stable" }""");
+
+        var status = GatewayUpdateStatusParser.Parse(document.RootElement);
+
+        Assert.Equal("extended-stable", status.EffectiveChannel);
+        Assert.True(status.SuppressesCompanionUpdate);
+    }
+
+    [Theory]
+    [InlineData("stable")]
+    [InlineData("beta")]
+    [InlineData(null)]
+    public void Parse_OtherOrMissingChannel_PreservesCompanionUpdate(string? channel)
+    {
+        using var document = JsonDocument.Parse(channel is null
+            ? "{}"
+            : $$"""{ "effectiveChannel": "{{channel}}" }""");
+
+        var status = GatewayUpdateStatusParser.Parse(document.RootElement);
+
+        Assert.False(status.SuppressesCompanionUpdate);
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
@@ -48,6 +48,7 @@ public sealed class AppRefactorContractTests
         var source = ReadAppSources();
         var startup = ExtractMethod(source, "OnLaunchedAsync");
         var clientChanged = ExtractMethod(source, "OnOperatorClientChanged");
+        var managerStateChanged = ExtractMethod(source, "OnManagerStateChanged");
 
         Assert.DoesNotContain("await _updateCoordinator.CheckForUpdatesAsync()", startup);
         Assert.Contains("e.NewClient.HandshakeSucceeded += OnGatewayUpdateCheckHandshakeSucceeded", clientChanged);
@@ -65,7 +66,9 @@ public sealed class AppRefactorContractTests
             "e.NewClient.HandshakeSucceeded += OnGatewayUpdateCheckHandshakeSucceeded;",
             "if (_dispatcherQueue is { HasThreadAccess: false } dispatcher)");
         Assert.Contains("StartAutomaticUpdateCheckWithoutGateway();", startup);
-        Assert.Contains("if (snap.OperatorState == RoleConnectionState.Error)", source);
+        Assert.Contains(
+            "if (snap.OperatorState is RoleConnectionState.Error or RoleConnectionState.PairingRequired)",
+            managerStateChanged);
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
@@ -32,7 +32,6 @@ public sealed class AppRefactorContractTests
             "AppUserModelIdRegistrar.RegisterCurrentProcess(AppIdentity.AppUserModelId);",
             "appUserModelIdRegistration.Attempted",
             "_settings = new SettingsManager();",
-            "CheckForUpdatesAsync();",
             "ToastNotificationManagerCompat.OnActivated += OnToastActivated;",
             "InitializeTrayIcon();",
             "_gatewayRegistry = new GatewayRegistry",
@@ -40,7 +39,20 @@ public sealed class AppRefactorContractTests
             "await ShowOnboardingAsync();",
             "EnsureNodeService(_settings);",
             "InitializeGatewayClient();",
+            "client.HandshakeSucceeded += OnGatewayUpdateCheckHandshakeSucceeded;",
             "StartDeepLinkServer();");
+    }
+
+    [Fact]
+    public void AutomaticUpdateCheck_WaitsForAuthenticatedGatewayHandshake()
+    {
+        var source = ReadAppSources();
+        var startup = ExtractMethod(source, "OnLaunchedAsync");
+        var clientChanged = ExtractMethod(source, "OnOperatorClientChanged");
+
+        Assert.DoesNotContain("await _updateCoordinator.CheckForUpdatesAsync()", startup);
+        Assert.Contains("client.HandshakeSucceeded += OnGatewayUpdateCheckHandshakeSucceeded", clientChanged);
+        Assert.Contains("CheckForAutomaticUpdatesAfterHandshakeAsync(client)", source);
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
@@ -58,6 +58,7 @@ public sealed class AppRefactorContractTests
             "OpenClaw.Tray.WinUI",
             "Services",
             "UpdateCoordinator.cs"));
+        Assert.Contains("private readonly Func<IOperatorGatewayClient?> _getGatewayClient = getGatewayClient;", updateCoordinator);
         Assert.Contains("CheckForUpdatesAsync(handshakeClient: handshakeClient)", updateCoordinator);
         AssertInOrder(
             clientChanged,

--- a/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
@@ -39,7 +39,6 @@ public sealed class AppRefactorContractTests
             "await ShowOnboardingAsync();",
             "EnsureNodeService(_settings);",
             "InitializeGatewayClient();",
-            "e.NewClient.HandshakeSucceeded += OnGatewayUpdateCheckHandshakeSucceeded;",
             "StartDeepLinkServer();");
     }
 

--- a/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
@@ -57,6 +57,7 @@ public sealed class AppRefactorContractTests
             "e.NewClient.HandshakeSucceeded += OnGatewayUpdateCheckHandshakeSucceeded;",
             "if (_dispatcherQueue is { HasThreadAccess: false } dispatcher)");
         Assert.Contains("StartAutomaticUpdateCheckWithoutGateway();", startup);
+        Assert.Contains("if (snap.OperatorState == RoleConnectionState.Error)", source);
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
@@ -39,7 +39,7 @@ public sealed class AppRefactorContractTests
             "await ShowOnboardingAsync();",
             "EnsureNodeService(_settings);",
             "InitializeGatewayClient();",
-            "client.HandshakeSucceeded += OnGatewayUpdateCheckHandshakeSucceeded;",
+            "e.NewClient.HandshakeSucceeded += OnGatewayUpdateCheckHandshakeSucceeded;",
             "StartDeepLinkServer();");
     }
 
@@ -51,8 +51,13 @@ public sealed class AppRefactorContractTests
         var clientChanged = ExtractMethod(source, "OnOperatorClientChanged");
 
         Assert.DoesNotContain("await _updateCoordinator.CheckForUpdatesAsync()", startup);
-        Assert.Contains("client.HandshakeSucceeded += OnGatewayUpdateCheckHandshakeSucceeded", clientChanged);
-        Assert.Contains("CheckForAutomaticUpdatesAfterHandshakeAsync(client)", source);
+        Assert.Contains("e.NewClient.HandshakeSucceeded += OnGatewayUpdateCheckHandshakeSucceeded", clientChanged);
+        Assert.Contains("CheckForAutomaticUpdatesAfterGatewayResolutionAsync(client)", source);
+        AssertInOrder(
+            clientChanged,
+            "e.NewClient.HandshakeSucceeded += OnGatewayUpdateCheckHandshakeSucceeded;",
+            "if (_dispatcherQueue is { HasThreadAccess: false } dispatcher)");
+        Assert.Contains("StartAutomaticUpdateCheckWithoutGateway();", startup);
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
@@ -52,6 +52,13 @@ public sealed class AppRefactorContractTests
         Assert.DoesNotContain("await _updateCoordinator.CheckForUpdatesAsync()", startup);
         Assert.Contains("e.NewClient.HandshakeSucceeded += OnGatewayUpdateCheckHandshakeSucceeded", clientChanged);
         Assert.Contains("CheckForAutomaticUpdatesAfterGatewayResolutionAsync(client)", source);
+        var updateCoordinator = File.ReadAllText(Path.Combine(
+            TestRepositoryPaths.GetRepositoryRoot(),
+            "src",
+            "OpenClaw.Tray.WinUI",
+            "Services",
+            "UpdateCoordinator.cs"));
+        Assert.Contains("CheckForUpdatesAsync(handshakeClient: handshakeClient)", updateCoordinator);
         AssertInOrder(
             clientChanged,
             "e.NewClient.HandshakeSucceeded += OnGatewayUpdateCheckHandshakeSucceeded;",


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/118518

## What Problem This Solves

Fixes an issue where Windows Companion users on an extended-stable Gateway would be prompted to install the repository's ordinary latest Windows release.

## Why This Change Was Made

The Gateway is the authoritative owner of the installed OpenClaw update track. The companion now waits for an authenticated `hello-ok`, reads the additive `update.status.effectiveChannel` field, and suppresses Updatum only for `extended-stable`. A missing field, old or unauthorized Gateway, connection failure, and no configured operator Gateway retain the existing standalone updater behavior.

The companion PR depends on OpenClaw PR #118518 adding `effectiveChannel` to `update.status`; it remains compatible with older Gateways that omit the field.

## User Impact

Extended-stable users no longer see ordinary Windows release upgrade prompts. Stable and beta users, and users whose Gateway cannot provide the update track, continue receiving the existing Windows update experience.

## Evidence

Production LOC: +159/-15 (net +144). Tests: +123/-1 (net +122). The production growth is the additive typed Gateway contract and the one canonical lifecycle owner for update-track resolution; test growth covers parser policy, real loopback RPC frames, Gateway errors, startup fallback, and handshake ordering.

- `git diff --check` passed on this exact head.
- Local macOS host has no `dotnet`, so native build/test commands could not run there (`zsh: command not found: dotnet`).
- Parallels Windows proof on `7f03dffc2278a6a667812d71798a5f9137bd1438`: Debug WinUI build, required shared/tray tests, and active UI verification passed. It demonstrated extended-stable suppression and the visible ordinary update dialog fallback for missing/error Gateway status.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs or instructions
- [x] Tests or validation
- [ ] Security hardening
- [ ] Chore or infrastructure

## Scope

- [x] Tray or WinUI UX
- [ ] Windows node capability
- [ ] Local MCP or `winnode`
- [x] Gateway, connection, or pairing
- [ ] Setup or onboarding
- [ ] Permissions, privacy, or security
- [x] Tests, CI, or docs

## Validation

- `git diff --check` (passed)
- Parallels Windows: Debug WinUI build (passed)
- Parallels Windows: required shared tests (passed)
- Parallels Windows: required tray tests (passed)
- Local `dotnet` commands blocked because the macOS host does not have the .NET SDK.

## Real Behavior Proof

- Environment tested: Parallels Windows guest
- PR head or commit tested: `7f03dffc2278a6a667812d71798a5f9137bd1438`
- Exact steps or command run: connected the Companion to controlled Gateway responses for `update.status.effectiveChannel=extended-stable`, then missing/error status responses.
- Evidence after fix: extended-stable did not surface an ordinary Windows update prompt; missing/error status retained the visible normal update dialog.
- Observed result: only the authoritative extended-stable state suppresses the independent Updatum prompt.
- Screenshot or artifact links verified? N/A (guest proof reported directly)
- Not verified or blocked: no local .NET SDK on the macOS implementation host.

## Security Impact

- New permissions or capabilities? No
- Secrets or tokens handling changed? No
- New or changed network calls? Yes. The Companion calls authenticated Gateway `update.status` before its existing GitHub updater check; unavailable/unauthorized calls fall back without exposing credentials.
- Command or tool execution surface changed? No
- Data access scope changed? No

## Compatibility and Migration

- Backward compatible? Yes
- Config or environment changes? No
- Migration needed? No

## Review Conversations

- [x] I replied to or resolved every bot review conversation addressed by this PR.
- [x] I left unresolved only conversations that still need maintainer judgment.