### PR TITLE
fix: preflight browser proxy readiness

### DIFF
--- a/docs/WINDOWS_NODE_TESTING.md
+++ b/docs/WINDOWS_NODE_TESTING.md
@@ -152,6 +152,11 @@ Local MCP clients also see MCP-only `app.*` commands such as `app.navigate`, `ap
 - Enter the gateway shared token in Settings, save, and reconnect node mode. Bootstrap tokens are not the shared gateway token.
 
 ### `browser.proxy` reports no browser-control host
+- The first `browser.proxy` call performs an authenticated read-only preflight before
+  the requested browser action. Its blocked result distinguishes endpoint setup, SSH
+  forwarding, an absent listener, an unreachable listener, missing authentication,
+  and rejected authentication. Follow that repair path instead of restarting the
+  Gateway; the Gateway connection and browser-control host are separate prerequisites.
 - Confirm the Browser proxy bridge toggle is enabled in Settings, then save and reconnect or re-pair if the gateway keeps an older command snapshot.
 - The bridge is local-only: it calls `http://127.0.0.1:<gateway-port+2>` from Windows. For a gateway on `ws://127.0.0.1:18789`, the browser-control host must listen on `127.0.0.1:18791`.
 - In managed SSH tunnel mode, keep Browser proxy bridge enabled so the tray forwards local gateway port + 2 to remote gateway port + 2. Settings shows a selectable preview of the exact `ssh -N -L ...` command.

--- a/src/OpenClaw.Shared/BrowserControlEndpoint.cs
+++ b/src/OpenClaw.Shared/BrowserControlEndpoint.cs
@@ -21,6 +21,15 @@ namespace OpenClaw.Shared;
 /// </summary>
 public static class BrowserControlEndpoint
 {
+    public enum Provenance
+    {
+        ExplicitOverride,
+        ManagedSshForward,
+        GatewayPortFallback,
+    }
+
+    public readonly record struct Resolution(int Port, Provenance Source);
+
     public static bool AllowsGatewayPortFallback(string? gatewayUrl)
     {
         var topology = GatewayTopologyClassifier.Classify(gatewayUrl, useSshTunnel: false);
@@ -45,7 +54,33 @@ public static class BrowserControlEndpoint
         out string error,
         bool allowGatewayPortFallback = true)
     {
-        controlPort = 0;
+        var resolved = TryResolve(
+            gatewayLocalPort,
+            useSshTunnel,
+            sshTunnelLocalPort,
+            controlPortOverride,
+            out var resolution,
+            out error,
+            allowGatewayPortFallback);
+        controlPort = resolved ? resolution.Port : 0;
+        return resolved;
+    }
+
+    /// <summary>
+    /// Resolves the endpoint together with its origin so readiness diagnostics can
+    /// distinguish an explicit/manual endpoint from the tray-managed SSH companion
+    /// forward and the co-located gateway fallback.
+    /// </summary>
+    public static bool TryResolve(
+        int? gatewayLocalPort,
+        bool useSshTunnel,
+        int? sshTunnelLocalPort,
+        int? controlPortOverride,
+        out Resolution resolution,
+        out string error,
+        bool allowGatewayPortFallback = true)
+    {
+        resolution = default;
         error = "";
 
         // (1) Explicit override pins the control port for the active connection.
@@ -56,7 +91,7 @@ public static class BrowserControlEndpoint
                 error = "Configured browser-control port is outside the valid TCP port range.";
                 return false;
             }
-            controlPort = overridePort;
+            resolution = new Resolution(overridePort, Provenance.ExplicitOverride);
             return true;
         }
 
@@ -68,7 +103,7 @@ public static class BrowserControlEndpoint
                 error = "SSH tunnel local port leaves no room for the browser-control port (local + 2).";
                 return false;
             }
-            controlPort = tunnelLocal + 2;
+            resolution = new Resolution(tunnelLocal + 2, Provenance.ManagedSshForward);
             return true;
         }
 
@@ -91,7 +126,7 @@ public static class BrowserControlEndpoint
                 error = "Browser proxy control port is outside the valid TCP port range.";
                 return false;
             }
-            controlPort = gatewayPort + 2;
+            resolution = new Resolution(gatewayPort + 2, Provenance.GatewayPortFallback);
             return true;
         }
 

--- a/src/OpenClaw.Shared/BrowserProxyReadiness.cs
+++ b/src/OpenClaw.Shared/BrowserProxyReadiness.cs
@@ -55,9 +55,10 @@ public static class BrowserProxyReadiness
         int? sshRemoteGatewayPort)
     {
         var state = connectionRefused ? Kind.HostAbsent : Kind.HostUnreachable;
+        var endpointDescription = DescribeEndpoint(provenance);
         var summary = connectionRefused
-            ? $"no browser-control host is listening at 127.0.0.1:{localPort}."
-            : $"the browser-control host at 127.0.0.1:{localPort} did not respond.";
+            ? $"no browser-control host is listening at 127.0.0.1:{localPort} ({endpointDescription})."
+            : $"the browser-control host at 127.0.0.1:{localPort} ({endpointDescription}) did not respond.";
         var repair = provenance == BrowserControlEndpoint.Provenance.ManagedSshForward ||
                      sshRemoteGatewayPort is not null
             ? BuildSshRepair(localPort, sshRemoteGatewayPort)
@@ -85,8 +86,8 @@ public static class BrowserProxyReadiness
         return hasSharedToken
             ? new Result(
                 Kind.AuthenticationRejected,
-                "the browser-control host rejected the saved shared gateway token.",
-                "Update the Gateway Token in Settings so it matches browser-control auth, or disable Browser proxy bridge.",
+                "the browser-control host rejected authentication for the saved shared gateway token.",
+                "Update the Gateway Token in Settings so it matches browser-control authentication, or disable Browser proxy bridge.",
                 provenance)
             : new Result(
                 Kind.AuthenticationRequired,
@@ -106,4 +107,13 @@ public static class BrowserProxyReadiness
                "Start the remote browser-control host, then retry. " +
                "If browser control is not intended, disable Browser proxy bridge in Settings.";
     }
+
+    private static string DescribeEndpoint(BrowserControlEndpoint.Provenance provenance) => provenance switch
+    {
+        BrowserControlEndpoint.Provenance.ExplicitOverride =>
+            "configured explicit browser-control port",
+        BrowserControlEndpoint.Provenance.ManagedSshForward =>
+            "managed SSH browser-control forward",
+        _ => "derived from gateway port + 2",
+    };
 }

--- a/src/OpenClaw.Shared/BrowserProxyReadiness.cs
+++ b/src/OpenClaw.Shared/BrowserProxyReadiness.cs
@@ -1,0 +1,109 @@
+using System.Net;
+
+namespace OpenClaw.Shared;
+
+/// <summary>
+/// Pure classification contract for the browser-control prerequisite. Callers
+/// collect endpoint and HTTP facts; this type turns them into one stable state
+/// and repair path without handling or exposing credential values.
+/// </summary>
+public static class BrowserProxyReadiness
+{
+    public enum Kind
+    {
+        Ready,
+        EndpointInvalid,
+        SshForwardMissing,
+        HostAbsent,
+        HostUnreachable,
+        AuthenticationRequired,
+        AuthenticationRejected,
+    }
+
+    public readonly record struct Result(
+        Kind State,
+        string Summary,
+        string Repair,
+        BrowserControlEndpoint.Provenance? EndpointProvenance = null)
+    {
+        public bool IsReady => State == Kind.Ready;
+
+        public string ToError() =>
+            $"Browser control preflight blocked: {Summary} {Repair} " +
+            "The Gateway connection is separate and does not need to be restarted.";
+    }
+
+    public static Result EndpointFailure(
+        string endpointError,
+        bool sshConfigured,
+        bool explicitEndpointConfigured,
+        bool sshLocalEndpointConfigured) =>
+        sshConfigured && !explicitEndpointConfigured && !sshLocalEndpointConfigured
+            ? new Result(
+                Kind.SshForwardMissing,
+                endpointError,
+                "Enable the tray-managed SSH browser-proxy forward, or configure a trusted explicit local browser-control port.")
+            : new Result(
+                Kind.EndpointInvalid,
+                endpointError,
+                "Configure a trusted local browser-control endpoint, or disable Browser proxy bridge in Settings.");
+
+    public static Result HostFailure(
+        int localPort,
+        BrowserControlEndpoint.Provenance provenance,
+        bool connectionRefused,
+        int? sshRemoteGatewayPort)
+    {
+        var state = connectionRefused ? Kind.HostAbsent : Kind.HostUnreachable;
+        var summary = connectionRefused
+            ? $"no browser-control host is listening at 127.0.0.1:{localPort}."
+            : $"the browser-control host at 127.0.0.1:{localPort} did not respond.";
+        var repair = provenance == BrowserControlEndpoint.Provenance.ManagedSshForward ||
+                     sshRemoteGatewayPort is not null
+            ? BuildSshRepair(localPort, sshRemoteGatewayPort)
+            : $"Start or install the OpenClaw browser-control host on local port {localPort}, then retry. " +
+              $"If the Gateway is reached through SSH, also forward the browser-control port with: " +
+              $"ssh -N -L {localPort}:127.0.0.1:<remote-gateway-port+2> <user>@<host>. " +
+              "If browser control is not intended, disable Browser proxy bridge in Settings.";
+        return new Result(state, summary, repair, provenance);
+    }
+
+    public static Result FromHttpStatus(
+        HttpStatusCode statusCode,
+        bool hasSharedToken,
+        BrowserControlEndpoint.Provenance provenance)
+    {
+        if (statusCode is not (HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden))
+        {
+            return new Result(
+                Kind.Ready,
+                "the browser-control host is reachable and accepted authentication.",
+                "No repair is required.",
+                provenance);
+        }
+
+        return hasSharedToken
+            ? new Result(
+                Kind.AuthenticationRejected,
+                "the browser-control host rejected the saved shared gateway token.",
+                "Update the Gateway Token in Settings so it matches browser-control auth, or disable Browser proxy bridge.",
+                provenance)
+            : new Result(
+                Kind.AuthenticationRequired,
+                "the browser-control host requires authentication, but this gateway has no saved shared token.",
+                "Enter the matching shared Gateway Token in Settings, reconnect node mode, and retry. QR/bootstrap tokens are not the shared token.",
+                provenance);
+    }
+
+    private static string BuildSshRepair(int localPort, int? sshRemoteGatewayPort)
+    {
+        var remotePort = sshRemoteGatewayPort is >= 1 and <= 65533
+            ? (sshRemoteGatewayPort.Value + 2).ToString(System.Globalization.CultureInfo.InvariantCulture)
+            : "<remote-gateway-port+2>";
+        return $"Verify the SSH companion forward maps local port {localPort} " +
+               $"to remote browser-control port {remotePort}: " +
+               $"ssh -N -L {localPort}:127.0.0.1:{remotePort} <user>@<host>. " +
+               "Start the remote browser-control host, then retry. " +
+               "If browser control is not intended, disable Browser proxy bridge in Settings.";
+    }
+}

--- a/src/OpenClaw.Shared/Capabilities/BrowserProxyCapability.cs
+++ b/src/OpenClaw.Shared/Capabilities/BrowserProxyCapability.cs
@@ -4,8 +4,10 @@ using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Net.Sockets;
 using System.Text;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace OpenClaw.Shared.Capabilities;
@@ -26,6 +28,10 @@ public class BrowserProxyCapability : NodeCapabilityBase
     private readonly HttpClient _httpClient;
     private readonly Func<Uri, System.Threading.CancellationToken, Task<bool>>?
         _authorizeEndpointAsync;
+    private readonly SemaphoreSlim _preflightLock = new(1, 1);
+    private BrowserProxyReadiness.Result? _lastReadiness;
+
+    public BrowserProxyReadiness.Result? LastReadiness => _lastReadiness;
 
     public BrowserProxyCapability(
         IOpenClawLogger logger,
@@ -60,8 +66,16 @@ public class BrowserProxyCapability : NodeCapabilityBase
         if (!string.Equals(request.Command, "browser.proxy", StringComparison.OrdinalIgnoreCase))
             return Error($"Unknown command: {request.Command}");
 
-        if (!TryResolveControlEndpoint(out var controlPort, out var endpointError))
-            return Error(endpointError);
+        if (!TryResolveControlEndpoint(out var endpoint, out var endpointError))
+        {
+            var readiness = BrowserProxyReadiness.EndpointFailure(
+                endpointError,
+                _useSshTunnel,
+                explicitEndpointConfigured: _controlPortOverride.HasValue,
+                sshLocalEndpointConfigured: _sshTunnelLocalPort.HasValue);
+            _lastReadiness = readiness;
+            return Error(readiness.ToError());
+        }
 
         var method = GetStringArg(request.Args, "method", "GET")?.ToUpperInvariant() ?? "GET";
         if (method is not ("GET" or "POST" or "DELETE"))
@@ -74,7 +88,9 @@ public class BrowserProxyCapability : NodeCapabilityBase
         var timeoutMs = Math.Clamp(GetIntArg(request.Args, "timeoutMs", DefaultTimeoutMs), 1, MaxTimeoutMs);
         using var timeoutCts = new System.Threading.CancellationTokenSource(TimeSpan.FromMilliseconds(timeoutMs));
 
+        var controlPort = endpoint.Port;
         var uri = BuildUri(controlPort, path, request.Args);
+        var preflightPassed = false;
         try
         {
             if (!string.IsNullOrWhiteSpace(_bearerToken) &&
@@ -83,6 +99,11 @@ public class BrowserProxyCapability : NodeCapabilityBase
             {
                 return Error("Browser control authentication was blocked because the local listener owner could not be verified.");
             }
+
+            var preflight = await EnsurePreflightAsync(endpoint, timeoutCts.Token).ConfigureAwait(false);
+            if (!preflight.IsReady)
+                return Error(preflight.ToError());
+            preflightPassed = true;
 
             using var httpRequest = CreateHttpRequest(method, uri, request.Args, usePasswordAuth: false);
             using var response = await _httpClient.SendAsync(httpRequest, timeoutCts.Token);
@@ -101,12 +122,28 @@ public class BrowserProxyCapability : NodeCapabilityBase
         }
         catch (TaskCanceledException)
         {
-            return Error($"browser proxy timed out for {method} {path} after {timeoutMs}ms. {BuildReachabilityGuidance(controlPort, _sshRemoteGatewayPort)}");
+            if (!preflightPassed)
+            {
+                return Error(
+                    "Browser control preflight timed out before the requested browser action. Retry after verifying the trusted local browser-control listener. " +
+                    "The Gateway connection is separate and does not need to be restarted.");
+            }
+
+            return Error(
+                $"Browser proxy request timed out for {method} {path} after {timeoutMs}ms. " +
+                "Browser-control preflight passed; verify the requested browser action or profile. " +
+                "The Gateway connection is separate and does not need to be restarted.");
         }
         catch (HttpRequestException ex)
         {
             Logger.Warn($"browser proxy: control host unreachable on 127.0.0.1:{controlPort}: {ex.Message}");
-            return Error($"Browser control host is not reachable on 127.0.0.1:{controlPort}. {BuildReachabilityGuidance(controlPort, _sshRemoteGatewayPort)}");
+            var readiness = BrowserProxyReadiness.HostFailure(
+                controlPort,
+                endpoint.Source,
+                IsConnectionRefused(ex),
+                _sshRemoteGatewayPort);
+            _lastReadiness = readiness;
+            return Error(readiness.ToError());
         }
         catch (JsonException ex)
         {
@@ -171,6 +208,65 @@ public class BrowserProxyCapability : NodeCapabilityBase
             : Success(new { result, files });
     }
 
+    private async Task<BrowserProxyReadiness.Result> EnsurePreflightAsync(
+        BrowserControlEndpoint.Resolution endpoint,
+        CancellationToken cancellationToken)
+    {
+        if (_lastReadiness is { } ready && ready.IsReady)
+            return ready;
+
+        await _preflightLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_lastReadiness is { } cached && cached.IsReady)
+                return cached;
+
+            var preflightUri = BuildUri(endpoint.Port, "/", default);
+            using var request = CreateHttpRequest("GET", preflightUri, default, usePasswordAuth: false);
+            using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            var status = response.StatusCode;
+
+            if (status == HttpStatusCode.Unauthorized && !string.IsNullOrWhiteSpace(_bearerToken))
+            {
+                using var passwordRequest = CreateHttpRequest("GET", preflightUri, default, usePasswordAuth: true);
+                using var passwordResponse = await _httpClient.SendAsync(passwordRequest, cancellationToken).ConfigureAwait(false);
+                status = passwordResponse.StatusCode;
+            }
+
+            var result = BrowserProxyReadiness.FromHttpStatus(
+                status,
+                !string.IsNullOrWhiteSpace(_bearerToken),
+                endpoint.Source);
+            _lastReadiness = result;
+            return result;
+        }
+        catch (TaskCanceledException)
+        {
+            var result = BrowserProxyReadiness.HostFailure(
+                endpoint.Port,
+                endpoint.Source,
+                connectionRefused: false,
+                sshRemoteGatewayPort: _sshRemoteGatewayPort);
+            _lastReadiness = result;
+            return result;
+        }
+        catch (HttpRequestException ex)
+        {
+            Logger.Warn($"browser proxy preflight: control host unavailable on 127.0.0.1:{endpoint.Port}: {ex.Message}");
+            var result = BrowserProxyReadiness.HostFailure(
+                endpoint.Port,
+                endpoint.Source,
+                IsConnectionRefused(ex),
+                _sshRemoteGatewayPort);
+            _lastReadiness = result;
+            return result;
+        }
+        finally
+        {
+            _preflightLock.Release();
+        }
+    }
+
     private string BuildAuthenticationFailureGuidance()
     {
         return string.IsNullOrWhiteSpace(_bearerToken)
@@ -181,29 +277,34 @@ public class BrowserProxyCapability : NodeCapabilityBase
     // Resolves the browser-control port through the shared BrowserControlEndpoint contract
     // so the proxy, the Command Center diagnostics, and the copied SSH-forward guidance all
     // agree. Scoped to the active gateway/tunnel: override, else tunnel local + 2, else gateway + 2.
-    private bool TryResolveControlEndpoint(out int controlPort, out string error)
+    private bool TryResolveControlEndpoint(
+        out BrowserControlEndpoint.Resolution endpoint,
+        out string error)
     {
         int? gatewayLocalPort = null;
         if (Uri.TryCreate(_gatewayUrl, UriKind.Absolute, out var gatewayUri) && gatewayUri.Port > 0)
             gatewayLocalPort = gatewayUri.Port;
 
-        return BrowserControlEndpoint.TryResolveControlPort(
+        return BrowserControlEndpoint.TryResolve(
             gatewayLocalPort,
             _useSshTunnel,
             _sshTunnelLocalPort,
             _controlPortOverride,
-            out controlPort,
+            out endpoint,
             out error,
             _allowGatewayPortFallback);
     }
 
-    private static string BuildReachabilityGuidance(int localControlPort, int? sshRemoteGatewayPort)
+    private static bool IsConnectionRefused(Exception exception)
     {
-        var sshForward = sshRemoteGatewayPort is >= 1 and <= 65533
-            ? $"ssh -N -L {localControlPort}:127.0.0.1:{sshRemoteGatewayPort.Value + 2} <user>@<host>"
-            : $"ssh -N -L {localControlPort}:127.0.0.1:<remote-gateway-port+2> <user>@<host>";
-
-        return $"Start the local OpenClaw browser control host on gateway port + 2 ({localControlPort}). If the gateway is reached through SSH, also forward the browser-control port with: {sshForward}";
+        for (var current = exception; current is not null; current = current.InnerException!)
+        {
+            if (current is SocketException { SocketErrorCode: SocketError.ConnectionRefused })
+                return true;
+            if (current.InnerException is null)
+                break;
+        }
+        return false;
     }
 
     private static bool TryNormalizePath(string? rawPath, out string path, out string error)

--- a/src/OpenClaw.Shared/Mcp/McpToolBridge.cs
+++ b/src/OpenClaw.Shared/Mcp/McpToolBridge.cs
@@ -420,7 +420,7 @@ public class McpToolBridge
 
         // browser.*
         ["browser.proxy"] =
-            "Proxy an HTTP request to the local OpenClaw browser control host (CDP server) running on gateway port + 2. Args: path (string, required — a local control path like '/json/list' or '/json/activate/<id>'), method ('GET'|'POST'|'DELETE', default 'GET'), body (JSON object, POST/DELETE only), query (object, appended as query params), profile (string, optional browser profile), timeoutMs (int, default 20000, max 120000). Returns { result, files? } where files is present if the response included local file paths. Requires the gateway URL to have an explicit port and the browser control host to be running.",
+            "Proxy an HTTP request to the local OpenClaw browser control host (CDP server) running on gateway port + 2. Before the first requested browser action, Windows preflights endpoint reachability and authentication. A blocked result identifies endpoint, SSH-forward, absent-host, unreachable-host, or authentication repair and should not be diagnosed by restarting the Gateway. Args: path (string, required, a local control path like '/json/list' or '/json/activate/<id>'), method ('GET'|'POST'|'DELETE', default 'GET'), body (JSON object, POST/DELETE only), query (object, appended as query params), profile (string, optional browser profile), timeoutMs (int, default 20000, max 120000). Returns { result, files? } where files is present if the response included local file paths. Requires the gateway URL to have an explicit port and the browser control host to be running.",
     };
 
     private object? HandleCancelledNotification(JsonElement parameters)

--- a/src/OpenClaw.Tray.WinUI/Services/CommandCenterStateBuilder.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/CommandCenterStateBuilder.cs
@@ -355,6 +355,19 @@ internal sealed class CommandCenterStateBuilder
             if (port.Purpose.Equals("Browser proxy host", StringComparison.OrdinalIgnoreCase) &&
                 !port.IsListening)
             {
+                var endpointProvenance = browserControlPort is >= 1 and <= 65535
+                    ? BrowserControlEndpoint.Provenance.ExplicitOverride
+                    : topology.UsesSshTunnel
+                        ? BrowserControlEndpoint.Provenance.ManagedSshForward
+                        : BrowserControlEndpoint.Provenance.GatewayPortFallback;
+                var sshRemoteGatewayPort = TryGetEndpointPort(tunnel?.RemoteEndpoint, out var remoteGatewayPort)
+                    ? remoteGatewayPort
+                    : (int?)null;
+                var readiness = BrowserProxyReadiness.HostFailure(
+                    port.Port,
+                    endpointProvenance,
+                    connectionRefused: true,
+                    sshRemoteGatewayPort: sshRemoteGatewayPort);
                 if (topology.UsesSshTunnel)
                 {
                     yield return new GatewayDiagnosticWarning
@@ -362,7 +375,7 @@ internal sealed class CommandCenterStateBuilder
                         Severity = GatewayDiagnosticSeverity.Info,
                         Category = "browser",
                         Title = LocalizationHelper.GetString("CommandCenter_BrowserProxySshForwardNotListening"),
-                        Detail = $"browser.proxy over SSH needs a companion local forward for port {port.Port}. Add the browser-control forward to the same tunnel, or enable the managed SSH tunnel so Windows starts both forwards.",
+                        Detail = $"{readiness.Summary} {readiness.Repair}",
                         RepairAction = "Copy browser proxy SSH forward",
                         CopyText = BuildBrowserProxySshForwardHint(port.Port, tunnel, browserControlPort)
                     };
@@ -374,7 +387,7 @@ internal sealed class CommandCenterStateBuilder
                     Severity = GatewayDiagnosticSeverity.Info,
                     Category = "browser",
                     Title = LocalizationHelper.GetString("CommandCenter_BrowserProxyHostNotDetected"),
-                    Detail = "browser.proxy needs a compatible browser-control host listening on the gateway port + 2.",
+                    Detail = $"{readiness.Summary} {readiness.Repair}",
                     RepairAction = "Copy browser setup guidance",
                     // string formatter — no UI
                     CopyText = CommandCenterTextHelper.BuildBrowserSetupGuidance(port.Port, topology, tunnel, browserControlPort)

--- a/src/OpenClaw.WinNode.Cli/skill.md
+++ b/src/OpenClaw.WinNode.Cli/skill.md
@@ -622,6 +622,13 @@ Returns `{ result, files? }` - `files` is an array of `{ path, base64, mimeType 
 
 Requires the gateway URL to have an explicit port (e.g. `ws://localhost:8080`).
 The browser control host must be running locally on `127.0.0.1:<gatewayPort + 2>`.
+Before the first requested browser action, the Windows node sends an authenticated
+read-only preflight to the resolved local endpoint. A blocked response distinguishes
+an invalid endpoint, missing SSH companion forward, absent or unreachable host, and
+missing or rejected browser-control authentication. Follow the returned repair path;
+restarting the Gateway does not repair these browser-host prerequisites. If browser
+control is not intended, disable **Browser proxy bridge** in Settings so agents no
+longer attempt the capability.
 
 ---
 

--- a/tests/OpenClaw.Shared.Tests/BrowserControlEndpointTests.cs
+++ b/tests/OpenClaw.Shared.Tests/BrowserControlEndpointTests.cs
@@ -26,6 +26,27 @@ public class BrowserControlEndpointTests
     }
 
     [Theory]
+    [InlineData(false, null, 19000, BrowserControlEndpoint.Provenance.ExplicitOverride)]
+    [InlineData(true, 9100, null, BrowserControlEndpoint.Provenance.ManagedSshForward)]
+    [InlineData(false, null, null, BrowserControlEndpoint.Provenance.GatewayPortFallback)]
+    public void Resolve_PreservesEndpointProvenance(
+        bool useSshTunnel,
+        int? sshTunnelLocalPort,
+        int? controlPortOverride,
+        BrowserControlEndpoint.Provenance expected)
+    {
+        Assert.True(BrowserControlEndpoint.TryResolve(
+            18789,
+            useSshTunnel,
+            sshTunnelLocalPort,
+            controlPortOverride,
+            out var resolution,
+            out _));
+
+        Assert.Equal(expected, resolution.Source);
+    }
+
+    [Theory]
     [InlineData(18789, false, null)]  // co-located
     [InlineData(18789, true, 9100)]   // managed tunnel
     [InlineData(9000, true, 7000)]    // different active gateway + tunnel

--- a/tests/OpenClaw.Shared.Tests/BrowserProxyReadinessTests.cs
+++ b/tests/OpenClaw.Shared.Tests/BrowserProxyReadinessTests.cs
@@ -43,6 +43,7 @@ public sealed class BrowserProxyReadinessTests
 
         Assert.Equal(BrowserProxyReadiness.Kind.HostAbsent, result.State);
         Assert.Equal(BrowserControlEndpoint.Provenance.ManagedSshForward, result.EndpointProvenance);
+        Assert.Contains("managed SSH browser-control forward", result.Summary, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("remote browser-control port 18791", result.Repair, StringComparison.OrdinalIgnoreCase);
     }
 
@@ -56,6 +57,7 @@ public sealed class BrowserProxyReadinessTests
             sshRemoteGatewayPort: null);
 
         Assert.Equal(BrowserProxyReadiness.Kind.HostUnreachable, result.State);
+        Assert.Contains("gateway port + 2", result.Summary, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("did not respond", result.Summary, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("disable Browser proxy bridge", result.Repair, StringComparison.OrdinalIgnoreCase);
     }

--- a/tests/OpenClaw.Shared.Tests/BrowserProxyReadinessTests.cs
+++ b/tests/OpenClaw.Shared.Tests/BrowserProxyReadinessTests.cs
@@ -1,0 +1,106 @@
+using System.Net;
+using OpenClaw.Shared;
+
+namespace OpenClaw.Shared.Tests;
+
+public sealed class BrowserProxyReadinessTests
+{
+    [Fact]
+    public void EndpointFailure_ClassifiesMissingSshForward()
+    {
+        var result = BrowserProxyReadiness.EndpointFailure(
+            "Browser proxy requires an explicit browser-control port or a managed SSH browser-proxy forward.",
+            sshConfigured: true,
+            explicitEndpointConfigured: false,
+            sshLocalEndpointConfigured: false);
+
+        Assert.Equal(BrowserProxyReadiness.Kind.SshForwardMissing, result.State);
+        Assert.Contains("SSH", result.Repair, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("does not need to be restarted", result.ToError(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void EndpointFailure_PreservesInvalidExplicitEndpointUnderSsh()
+    {
+        var result = BrowserProxyReadiness.EndpointFailure(
+            "Configured browser-control port is outside the valid TCP port range.",
+            sshConfigured: true,
+            explicitEndpointConfigured: true,
+            sshLocalEndpointConfigured: true);
+
+        Assert.Equal(BrowserProxyReadiness.Kind.EndpointInvalid, result.State);
+        Assert.Contains("trusted local browser-control endpoint", result.Repair, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void HostFailure_PreservesManagedSshEndpointProvenance()
+    {
+        var result = BrowserProxyReadiness.HostFailure(
+            9102,
+            BrowserControlEndpoint.Provenance.ManagedSshForward,
+            connectionRefused: true,
+            sshRemoteGatewayPort: 18789);
+
+        Assert.Equal(BrowserProxyReadiness.Kind.HostAbsent, result.State);
+        Assert.Equal(BrowserControlEndpoint.Provenance.ManagedSshForward, result.EndpointProvenance);
+        Assert.Contains("remote browser-control port 18791", result.Repair, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void HostFailure_DistinguishesUnreachableFromAbsent()
+    {
+        var result = BrowserProxyReadiness.HostFailure(
+            18791,
+            BrowserControlEndpoint.Provenance.GatewayPortFallback,
+            connectionRefused: false,
+            sshRemoteGatewayPort: null);
+
+        Assert.Equal(BrowserProxyReadiness.Kind.HostUnreachable, result.State);
+        Assert.Contains("did not respond", result.Summary, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("disable Browser proxy bridge", result.Repair, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void HttpStatus_DistinguishesMissingAndRejectedAuthentication()
+    {
+        var missing = BrowserProxyReadiness.FromHttpStatus(
+            HttpStatusCode.Unauthorized,
+            hasSharedToken: false,
+            BrowserControlEndpoint.Provenance.GatewayPortFallback);
+        var rejected = BrowserProxyReadiness.FromHttpStatus(
+            HttpStatusCode.Unauthorized,
+            hasSharedToken: true,
+            BrowserControlEndpoint.Provenance.ExplicitOverride);
+
+        Assert.Equal(BrowserProxyReadiness.Kind.AuthenticationRequired, missing.State);
+        Assert.Equal(BrowserProxyReadiness.Kind.AuthenticationRejected, rejected.State);
+        Assert.Contains("QR/bootstrap", missing.Repair, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("matches browser-control auth", rejected.Repair, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.Unauthorized)]
+    [InlineData(HttpStatusCode.Forbidden)]
+    public void HttpStatus_AuthDenialsNeverBecomeReady(HttpStatusCode statusCode)
+    {
+        var result = BrowserProxyReadiness.FromHttpStatus(
+            statusCode,
+            hasSharedToken: true,
+            BrowserControlEndpoint.Provenance.ManagedSshForward);
+
+        Assert.Equal(BrowserProxyReadiness.Kind.AuthenticationRejected, result.State);
+        Assert.False(result.IsReady);
+    }
+
+    [Fact]
+    public void NonUnauthorizedHttpStatus_ProvesReadyEvenWhenHostReturnsAnHttpError()
+    {
+        var result = BrowserProxyReadiness.FromHttpStatus(
+            HttpStatusCode.NotFound,
+            hasSharedToken: true,
+            BrowserControlEndpoint.Provenance.ExplicitOverride);
+
+        Assert.True(result.IsReady);
+        Assert.Equal(BrowserControlEndpoint.Provenance.ExplicitOverride, result.EndpointProvenance);
+    }
+}

--- a/tests/OpenClaw.Shared.Tests/CapabilityTests.cs
+++ b/tests/OpenClaw.Shared.Tests/CapabilityTests.cs
@@ -948,6 +948,8 @@ public class BrowserProxyCapabilityTests
         });
 
         Assert.True(res.Ok);
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal("/", handler.Requests[0].RequestUri!.AbsolutePath);
         Assert.NotNull(handler.LastRequest);
         Assert.Equal(HttpMethod.Post, handler.LastRequest!.Method);
         Assert.Equal("http://127.0.0.1:18791/snapshot?format=aria&profile=openclaw", handler.LastRequest.RequestUri!.ToString());
@@ -1097,29 +1099,35 @@ public class BrowserProxyCapabilityTests
 
         var serverTask = Task.Run(async () =>
         {
-            using var client = await server.AcceptTcpClientAsync(cts.Token);
-            using var stream = client.GetStream();
-            var buffer = new byte[4096];
-            var sb = new StringBuilder();
-            while (!sb.ToString().Contains("\r\n\r\n"))
+            for (var requestIndex = 0; requestIndex < 2; requestIndex++)
             {
-                var n = await stream.ReadAsync(buffer, cts.Token);
-                if (n == 0) break;
-                sb.Append(Encoding.ASCII.GetString(buffer, 0, n));
-            }
+                using var client = await server.AcceptTcpClientAsync(cts.Token);
+                using var stream = client.GetStream();
+                var buffer = new byte[4096];
+                var sb = new StringBuilder();
+                while (!sb.ToString().Contains("\r\n\r\n"))
+                {
+                    var n = await stream.ReadAsync(buffer, cts.Token);
+                    if (n == 0) break;
+                    sb.Append(Encoding.ASCII.GetString(buffer, 0, n));
+                }
 
-            var headerLines = sb.ToString().Split("\r\n");
-            requestLine = headerLines.Length > 0 ? headerLines[0] : null;
-            foreach (var line in headerLines)
-            {
-                if (line.StartsWith("Authorization:", StringComparison.OrdinalIgnoreCase))
-                    authHeader = line["Authorization:".Length..].Trim();
-            }
+                var headerLines = sb.ToString().Split("\r\n");
+                if (requestIndex == 1)
+                {
+                    requestLine = headerLines.Length > 0 ? headerLines[0] : null;
+                    foreach (var line in headerLines)
+                    {
+                        if (line.StartsWith("Authorization:", StringComparison.OrdinalIgnoreCase))
+                            authHeader = line["Authorization:".Length..].Trim();
+                    }
+                }
 
-            const string body = "{\"ok\":true}";
-            var response = $"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {body.Length}\r\nConnection: close\r\n\r\n{body}";
-            await stream.WriteAsync(Encoding.ASCII.GetBytes(response), cts.Token);
-            await stream.FlushAsync(cts.Token);
+                const string body = "{\"ok\":true}";
+                var response = $"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {body.Length}\r\nConnection: close\r\n\r\n{body}";
+                await stream.WriteAsync(Encoding.ASCII.GetBytes(response), cts.Token);
+                await stream.FlushAsync(cts.Token);
+            }
         }, cts.Token);
 
         try
@@ -1196,11 +1204,12 @@ public class BrowserProxyCapabilityTests
     [Fact]
     public async Task BrowserProxy_ReturnsUnauthorizedAsAuthError()
     {
+        var handler = new CapturingHandler("Unauthorized", HttpStatusCode.Unauthorized);
         var cap = new BrowserProxyCapability(
             NullLogger.Instance,
             "ws://127.0.0.1:18789",
             "wrong-token",
-            new CapturingHandler("Unauthorized", HttpStatusCode.Unauthorized));
+            handler);
 
         var res = await cap.ExecuteAsync(new NodeInvokeRequest
         {
@@ -1210,8 +1219,10 @@ public class BrowserProxyCapabilityTests
         });
 
         Assert.False(res.Ok);
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.All(handler.Requests, request => Assert.Equal("/", request.RequestUri!.AbsolutePath));
         Assert.Contains("authentication", res.Error);
-        Assert.Contains("Verify the gateway token saved in Settings", res.Error);
+        Assert.Contains("matches browser-control auth", res.Error);
     }
 
     [Fact]
@@ -1231,8 +1242,8 @@ public class BrowserProxyCapabilityTests
         });
 
         Assert.False(res.Ok);
-        Assert.Contains("unauthenticated request", res.Error);
-        Assert.Contains("no gateway shared token saved", res.Error);
+        Assert.Contains("requires authentication", res.Error);
+        Assert.Contains("no saved shared token", res.Error);
         Assert.Contains("Settings", res.Error);
     }
 
@@ -1254,7 +1265,7 @@ public class BrowserProxyCapabilityTests
         });
 
         Assert.True(res.Ok);
-        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal(4, handler.Requests.Count);
         Assert.Equal("Bearer", handler.Requests[0].Headers.Authorization?.Scheme);
         Assert.Equal("Basic", handler.Requests[1].Headers.Authorization?.Scheme);
         Assert.Equal(
@@ -1262,6 +1273,8 @@ public class BrowserProxyCapabilityTests
             handler.Requests[1].Headers.Authorization?.Parameter);
         Assert.True(handler.Requests[1].Headers.TryGetValues("x-openclaw-password", out var passwordValues));
         Assert.Contains("browser-secret", passwordValues);
+        Assert.Equal("Bearer", handler.Requests[2].Headers.Authorization?.Scheme);
+        Assert.Equal("Basic", handler.Requests[3].Headers.Authorization?.Scheme);
     }
 
     [Fact]
@@ -1413,12 +1426,91 @@ public class BrowserProxyCapabilityTests
         Assert.Contains("profile=work", requestUri);
     }
 
+    [Fact]
+    public async Task BrowserProxy_ReadyPreflight_IsCachedAcrossRequestedActions()
+    {
+        var handler = new CapturingHandler("""{"ok":true}""");
+        var cap = new BrowserProxyCapability(
+            NullLogger.Instance,
+            "ws://127.0.0.1:18789",
+            "token",
+            handler);
+
+        var first = await cap.ExecuteAsync(new NodeInvokeRequest
+        {
+            Id = "preflight-cache-1",
+            Command = "browser.proxy",
+            Args = Parse("""{"path":"/tabs"}""")
+        });
+        var second = await cap.ExecuteAsync(new NodeInvokeRequest
+        {
+            Id = "preflight-cache-2",
+            Command = "browser.proxy",
+            Args = Parse("""{"path":"/status"}""")
+        });
+
+        Assert.True(first.Ok);
+        Assert.True(second.Ok);
+        Assert.Equal(new[] { "/", "/tabs", "/status" },
+            handler.Requests.Select(request => request.RequestUri!.AbsolutePath));
+        Assert.Equal(BrowserProxyReadiness.Kind.Ready, cap.LastReadiness?.State);
+    }
+
+    [Fact]
+    public async Task BrowserProxy_ActionTimeout_DoesNotMisreportPreflightFailure()
+    {
+        var cap = new BrowserProxyCapability(
+            NullLogger.Instance,
+            "ws://127.0.0.1:18789",
+            "token",
+            new ReadyThenTimeoutHandler());
+
+        var result = await cap.ExecuteAsync(new NodeInvokeRequest
+        {
+            Id = "action-timeout",
+            Command = "browser.proxy",
+            Args = Parse("""{"path":"/snapshot","timeoutMs":5000}""")
+        });
+
+        Assert.False(result.Ok);
+        Assert.Contains("request timed out for GET /snapshot", result.Error);
+        Assert.Contains("preflight passed", result.Error, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("preflight blocked", result.Error, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(BrowserProxyReadiness.Kind.Ready, cap.LastReadiness?.State);
+    }
+
+    [Fact]
+    public async Task BrowserProxy_AuthorizationTimeout_DoesNotClaimPreflightPassed()
+    {
+        var handler = new CapturingHandler("{}");
+        var cap = new BrowserProxyCapability(
+            NullLogger.Instance,
+            "ws://127.0.0.1:18789",
+            "token",
+            handler,
+            authorizeEndpointAsync: (_, _) => throw new TaskCanceledException("owner check timed out"));
+
+        var result = await cap.ExecuteAsync(new NodeInvokeRequest
+        {
+            Id = "authorization-timeout",
+            Command = "browser.proxy",
+            Args = Parse("""{"path":"/snapshot"}""")
+        });
+
+        Assert.False(result.Ok);
+        Assert.Contains("preflight timed out before", result.Error, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("preflight passed", result.Error, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(handler.Requests);
+        Assert.Null(cap.LastReadiness);
+    }
+
     private sealed class CapturingHandler : HttpMessageHandler
     {
         private readonly string _response;
         private readonly HttpStatusCode _statusCode;
 
         public HttpRequestMessage? LastRequest { get; private set; }
+        public List<HttpRequestMessage> Requests { get; } = new();
 
         public CapturingHandler(string response, HttpStatusCode statusCode = HttpStatusCode.OK)
         {
@@ -1431,6 +1523,7 @@ public class BrowserProxyCapabilityTests
             CancellationToken cancellationToken)
         {
             LastRequest = request;
+            Requests.Add(request);
             return Task.FromResult(new HttpResponseMessage(_statusCode)
             {
                 Content = new StringContent(_response)
@@ -1467,6 +1560,27 @@ public class BrowserProxyCapabilityTests
             HttpRequestMessage request,
             CancellationToken cancellationToken) =>
             throw new HttpRequestException("connection refused");
+    }
+
+    private sealed class ReadyThenTimeoutHandler : HttpMessageHandler
+    {
+        private int _requestCount;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            _requestCount++;
+            if (_requestCount == 1)
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{}")
+                });
+            }
+
+            throw new TaskCanceledException("requested action timed out");
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #1154

## Summary

- Add one pure `BrowserProxyReadiness` contract for endpoint, SSH-forward, host reachability, and authentication states.
- Preserve whether the endpoint came from an explicit override, managed SSH companion forward, or gateway-port fallback.
- Run one authenticated, read-only `GET /` preflight before the first requested browser action and cache only a ready result.
- Block the requested action with concrete repair guidance and keep browser-host failures separate from Gateway connection health.
- Reuse readiness guidance in Command Center warnings and MCP/CLI/testing documentation.

## Validation

- `git diff --check` - passed before commit.
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` - final run clean with no actionable findings.
- `./build.ps1` - not run: this Linux host has neither PowerShell nor the .NET SDK.
- Shared, Tray, and WinNode CLI test projects - not run: .NET SDK unavailable.
- First Windows CI test run on `5d0c0f76` reached the focused browser tests and exposed two guidance-copy regressions: missing literal `authentication` wording and missing `gateway port + 2` provenance. Both are corrected on current head `fe81645c`; rerun is pending.

Focused coverage was added for endpoint provenance, readiness classifications, HTTP 401/403 handling, authenticated preflight ordering/fallback, cached readiness, authorization timeout, action timeout, and the real loopback HTTP route.

## Real behavior proof

Not verified / blocked on this publication host:

- local MCP `tools/list` and `tools/call`
- gateway-mediated `browser.proxy`
- current-head Command Center UI
- native Windows build/test execution

The available OpenClaw remote-node route had no registered handler, so no connected Windows host was available. CI and a Windows current-head proof pass are required before merge.

## Review

Rubber-duck/autoreview drove fixes for action-timeout classification, preflight/authorization timeout classification, HTTP 403 denial, and invalid explicit endpoints under SSH. The final exact-diff review was clean.
