### PR TITLE
feat(setup): guide channel readiness handoff

### DIFF
--- a/docs/ONBOARDING_WIZARD.md
+++ b/docs/ONBOARDING_WIZARD.md
@@ -56,6 +56,8 @@ When the gateway config wizard surfaces an error and the active gateway is an ap
 ### All set
 Displays a completion summary, a Launch at startup toggle, and a Finish button that saves the startup preference before restarting the tray. Launch at startup defaults on so OpenClaw is ready after reboot.
 
+Completion reports the local gateway and Windows device as ready independently from mobile and chat channels. **Set up or verify channels** restarts the tray directly into Channels, where each channel exposes its current gateway-reported state. Configuration supported by the Gateway API stays in-app. If a gateway-host plugin is missing, the page provides the exact copyable install command, explains why it must run on the gateway host, states the expected result, and asks the user to return and refresh until the channel reports connected or running. The setup UI does not infer channel readiness from a successful Gateway connection and does not automate unknown Gateway commands.
+
 ## Security
 
 The onboarding wizard follows these security practices:

--- a/docs/SETUP_ENGINE_REDESIGN.md
+++ b/docs/SETUP_ENGINE_REDESIGN.md
@@ -10,6 +10,8 @@ The Setup Engine is a **config-driven system** for provisioning an OpenClaw WSL 
 
 The bundled `default-config.json` ships with the tray executable and provides secure defaults (loopback bind, WSL isolation, systemd enabled). Defaults can be overridden via config file or environment variables.
 
+The completion page treats Gateway/device readiness and channel readiness as separate states. Its channel handoff carries a typed `SetupCompletionDestination.Channels` result back to the tray composition root. The tray performs its normal restart, opens the existing Channels surface, and lets that surface verify live Gateway channel state. Setup does not own channel lifecycle or construct a parallel Gateway client.
+
 > **Status note (2026-07-06):** Current default setup includes `WindowsNodeBootstrapContextStep`, which injects Windows-node context into the WSL workspace `AGENTS.md` after onboarding.
 
 ---

--- a/src/OpenClaw.SetupEngine.UI/Pages/CompletePage.xaml
+++ b/src/OpenClaw.SetupEngine.UI/Pages/CompletePage.xaml
@@ -83,6 +83,22 @@
                             <FontIcon Grid.Column="2" Glyph="&#xE73E;" FontSize="16" Foreground="{ThemeResource SystemFillColorSuccessBrush}" VerticalAlignment="Center" />
                         </Grid>
                     </Border>
+                    <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" BorderThickness="1" CornerRadius="4" Padding="14,12">
+                        <Grid ColumnDefinitions="Auto,*" ColumnSpacing="14">
+                            <FontIcon Grid.Column="0" Glyph="&#xE8BD;" FontSize="18" VerticalAlignment="Center" />
+                            <StackPanel Grid.Column="1" Spacing="6">
+                                <TextBlock Text="Mobile and chat channels" Style="{StaticResource BodyStrongTextBlockStyle}" />
+                                <TextBlock Text="Gateway connected does not mean a channel is ready. Review each channel separately, complete any gateway-host step, then refresh until it shows connected or running."
+                                           TextWrapping="Wrap"
+                                           Style="{StaticResource CaptionTextBlockStyle}"
+                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                                <Button x:Name="ChannelSetupButton"
+                                        Content="Set up or verify channels"
+                                        HorizontalAlignment="Left"
+                                        Click="ChannelSetupButton_Click" />
+                            </StackPanel>
+                        </Grid>
+                    </Border>
                 </StackPanel>
 
                 <Border x:Name="ErrorCard" CornerRadius="4" Padding="16,12,16,12"

--- a/src/OpenClaw.SetupEngine.UI/Pages/CompletePage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/CompletePage.xaml.cs
@@ -105,12 +105,22 @@ public sealed partial class CompletePage : Page
     {
         if (LaunchButton.Content?.ToString() != "Close")
         {
-            var enableAutoStart = StartupRow.Visibility == Visibility.Visible && StartupToggle.IsOn;
-            if (SetupWindow.Active?.RequestSetupCompleted(enableAutoStart) == true)
+            if (CompleteSetup(SetupCompletionDestination.Chat))
                 return;
         }
 
         SetupWindow.Active?.Close();
+    }
+
+    private void ChannelSetupButton_Click(object sender, RoutedEventArgs e)
+    {
+        CompleteSetup(SetupCompletionDestination.Channels);
+    }
+
+    private bool CompleteSetup(SetupCompletionDestination destination)
+    {
+        var enableAutoStart = StartupRow.Visibility == Visibility.Visible && StartupToggle.IsOn;
+        return SetupWindow.Active?.RequestSetupCompleted(enableAutoStart, destination) == true;
     }
 
     private void ViewLog_Click(object sender, RoutedEventArgs e)

--- a/src/OpenClaw.SetupEngine.UI/SetupWindow.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/SetupWindow.xaml.cs
@@ -352,7 +352,9 @@ public sealed partial class SetupWindow : Window
         AdvancedSetupRequested?.Invoke(this, EventArgs.Empty);
     }
 
-    public bool RequestSetupCompleted(bool enableAutoStart)
+    public bool RequestSetupCompleted(
+        bool enableAutoStart,
+        SetupCompletionDestination destination = SetupCompletionDestination.Chat)
     {
         var handler = SetupCompleted;
         if (handler == null)
@@ -374,7 +376,7 @@ public sealed partial class SetupWindow : Window
             return true;
         }
 
-        handler.Invoke(this, new SetupCompletedEventArgs(enableAutoStart));
+        handler.Invoke(this, new SetupCompletedEventArgs(enableAutoStart, destination));
         return true;
     }
 
@@ -460,4 +462,12 @@ public sealed record CompletePageArgs(
     SetupReviewSummary? ReviewSummary = null,
     bool CanRetryGatewayFallback = false,
     string? GatewayFallbackVersion = null);
-public sealed record SetupCompletedEventArgs(bool EnableAutoStart);
+public enum SetupCompletionDestination
+{
+    Chat,
+    Channels,
+}
+
+public sealed record SetupCompletedEventArgs(
+    bool EnableAutoStart,
+    SetupCompletionDestination Destination = SetupCompletionDestination.Chat);

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -36,6 +36,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Updatum;
 using WinUIEx;
+using SetupCompletionDestination = OpenClaw.SetupEngine.UI.SetupCompletionDestination;
 using SetupCompletedEventArgs = OpenClaw.SetupEngine.UI.SetupCompletedEventArgs;
 using SetupWindow = OpenClaw.SetupEngine.UI.SetupWindow;
 
@@ -604,7 +605,10 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands, IPer
                 ?? (_startupArgs.Length > 1 && IsDeepLinkArg(_startupArgs[1])
                     ? _startupArgs[1] : null)
                 ?? (string.Equals(_postSetupLaunch, "chat", StringComparison.OrdinalIgnoreCase)
-                    ? $"{AppIdentity.ProtocolScheme}://chat" : null);
+                    ? $"{AppIdentity.ProtocolScheme}://chat"
+                    : string.Equals(_postSetupLaunch, "channels", StringComparison.OrdinalIgnoreCase)
+                        ? $"{AppIdentity.ProtocolScheme}://notifications"
+                        : null);
             if (deepLink != null)
             {
                 SendDeepLinkToRunningInstance(deepLink);
@@ -958,6 +962,10 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands, IPer
         else if (!setupShownDuringStartup && string.Equals(_postSetupLaunch, "chat", StringComparison.OrdinalIgnoreCase))
         {
             await HandleDeepLinkAsync($"{AppIdentity.ProtocolScheme}://chat");
+        }
+        else if (!setupShownDuringStartup && string.Equals(_postSetupLaunch, "channels", StringComparison.OrdinalIgnoreCase))
+        {
+            ShowHub("channels");
         }
 
         Logger.Info("Application started (WinUI 3)");
@@ -4153,11 +4161,13 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands, IPer
 
     private void OnSetupCompleted(object? sender, SetupCompletedEventArgs e) =>
         AsyncEventHandlerGuard.Run(
-            () => RestartAfterSetupAsync(e.EnableAutoStart),
+            () => RestartAfterSetupAsync(e.EnableAutoStart, e.Destination),
             new AppLogger(),
             nameof(OnSetupCompleted));
 
-    private async Task RestartAfterSetupAsync(bool enableAutoStart)
+    private async Task RestartAfterSetupAsync(
+        bool enableAutoStart,
+        SetupCompletionDestination destination)
     {
         var exePath = ResolveCurrentExecutablePath();
         if (string.IsNullOrWhiteSpace(exePath) || !File.Exists(exePath))
@@ -4188,7 +4198,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands, IPer
             psi.ArgumentList.Add("--wait-for-pid");
             psi.ArgumentList.Add(Environment.ProcessId.ToString(CultureInfo.InvariantCulture));
             psi.ArgumentList.Add("--post-setup-launch");
-            psi.ArgumentList.Add("chat");
+            psi.ArgumentList.Add(destination == SetupCompletionDestination.Channels ? "channels" : "chat");
 
             var restarted = Process.Start(psi);
             if (restarted == null)

--- a/src/OpenClaw.Tray.WinUI/Pages/ChannelsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ChannelsPage.xaml.cs
@@ -2153,7 +2153,7 @@ public sealed partial class ChannelsPage : Page
 
         body.Children.Add(new TextBlock
         {
-            Text = "Run this command on the machine that hosts your gateway. After it finishes, come back and click Refresh.",
+            Text = "Run this command on the machine that hosts your gateway. Expected result: the plugin installs without an error. Return here, click Refresh, then start or save the channel until its status shows connected or running.",
             Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
             Foreground = (Brush)Application.Current.Resources["TextFillColorTertiaryBrush"],
             TextWrapping = TextWrapping.Wrap,

--- a/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
@@ -1137,6 +1137,36 @@ public sealed class AppRefactorContractTests
     }
 
     [Fact]
+    public void CompletePage_SeparatesGatewayReadinessFromChannelVerification()
+    {
+        var root = TestRepositoryPaths.GetRepositoryRoot();
+        var setupWindow = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.SetupEngine.UI", "SetupWindow.xaml.cs"));
+        var completeXaml = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.SetupEngine.UI", "Pages", "CompletePage.xaml"));
+        var completeCode = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.SetupEngine.UI", "Pages", "CompletePage.xaml.cs"));
+        var app = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.Tray.WinUI", "App.xaml.cs"));
+
+        Assert.Contains("Gateway connected does not mean a channel is ready", completeXaml);
+        Assert.Contains("Set up or verify channels", completeXaml);
+        Assert.Contains("CompleteSetup(SetupCompletionDestination.Channels)", completeCode);
+        Assert.Contains("SetupCompletionDestination Destination", setupWindow);
+        Assert.Contains("ShowHub(\"channels\")", app);
+        Assert.Contains("destination == SetupCompletionDestination.Channels ? \"channels\" : \"chat\"", app);
+    }
+
+    [Fact]
+    public void ChannelsPage_GatewayHostHandoff_IsCopyableAndVerifiable()
+    {
+        var root = TestRepositoryPaths.GetRepositoryRoot();
+        var channels = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.Tray.WinUI", "Pages", "ChannelsPage.xaml.cs"));
+
+        Assert.Contains("openclaw plugins install {pkg}", channels);
+        Assert.Contains("pkgData.SetText(cmd)", channels);
+        Assert.Contains("Expected result: the plugin installs without an error", channels);
+        Assert.Contains("click Refresh", channels);
+        Assert.Contains("status shows connected or running", channels);
+    }
+
+    [Fact]
     public void CompletePage_OffersExactFallbackOnlyThroughTypedCompatibilityPath()
     {
         var root = TestRepositoryPaths.GetRepositoryRoot();


### PR DESCRIPTION
## Summary

- distinguish a connected Gateway and paired Windows device from mobile/chat channel readiness on setup completion
- let users finish directly into Channels through a typed post-setup destination while preserving existing owners
- make the gateway-host plugin handoff explain why terminal use is required, give the exact copyable command, state the expected result, and provide return-to-app verification
- document the boundary and add focused setup/tray contract coverage

Addresses #1156.
Contributes to #843.

## Validation

- git diff --check: passed before commit
- autoreview --mode local --stream-engine-output: clean, no accepted/actionable findings (confidence 0.93)
- build.ps1, Shared tests, Tray tests, and SetupEngine tests: not run, blocked before sync because this Linux controller has no dotnet/PowerShell and Crabbox could not establish SSH to three native Windows desktop leases

Crabbox attempts:

- Azure / windows / normal / desktop / blue-hermit-8666: lease ended before SSH became usable
- Azure / windows / normal / desktop / golden-krill: lease ended before SSH became usable
- AWS broker / windows / normal / desktop / jade-krill: SSH endpoint was never populated or reachable

CI remains required for the automated suites at this head.

## Real behavior proof

Not verified / blocked. No Crabbox native Windows lease reached source sync, so current-head isolated setup and visible completion-to-Channels proof could not be captured. Before readiness, a current-head Windows run must show:

1. setup completion with Gateway/device readiness separate from the channel card
2. Set up or verify channels restarts into Channels
3. a non-running channel exposes the copyable gateway-host plugin command, expected result, and Refresh guidance

## Ownership and safety

- SetupWindow continues to own setup completion and startup preference persistence.
- App remains the composition/restart owner and routes only the typed destination.
- ChannelsPage remains the owner of Gateway channel state and verification.
- No channel command is inferred or automated, no parallel Gateway client is created, and no credentials are logged or displayed.

## Review

- Rubber-duck/source review traced success, failure, default Chat, Channels, restart, and single-instance forwarding paths.
- Structured autoreview was clean; no findings were accepted or rejected.
