### PR TITLE
fix(mxc): bound termination and output drain cleanup

### DIFF
--- a/src/OpenClaw.Shared/Mxc/MxcExecutor.cs
+++ b/src/OpenClaw.Shared/Mxc/MxcExecutor.cs
@@ -188,8 +188,8 @@ public sealed class MxcExecutor
 
             if (!completed)
             {
-                try { _processTreeKiller(process); }
-                catch (Exception ex) { Trace.WriteLine($"MxcExecutor: process kill (cancellation path) failed: {ex.Message}"); }
+                if (!await KillProcessTreeWithTimeoutAsync(process))
+                    Trace.WriteLine($"MxcExecutor: process kill (cancellation path) timed out or failed (pid={process.Id}).");
                 if (!await WaitForCleanupAsync(processExited.Task, stdoutClosed.Task, stderrClosed.Task, _cleanupTimeout))
                     Trace.WriteLine($"MxcExecutor: cancellation cleanup timed out (pid={process.Id}).");
 
@@ -207,12 +207,11 @@ public sealed class MxcExecutor
                 };
             }
 
-            // Normal completion keeps the established lossless drain behavior.
-            // The bounded cleanup exists specifically for cancellation, where
-            // availability takes precedence over waiting indefinitely for a
-            // launcher or inherited pipe handle that ignored termination.
-            try { process.WaitForExit(); }
-            catch (Exception ex) { Trace.WriteLine($"MxcExecutor: post-exit drain failed: {ex.Message}"); }
+            // The launcher exited, but a descendant may still hold an inherited
+            // stdout/stderr write handle. Bound the drain so a completed launcher
+            // cannot pin the node invocation slot indefinitely.
+            if (!await WaitForCleanupAsync(processExited.Task, stdoutClosed.Task, stderrClosed.Task, _cleanupTimeout))
+                Trace.WriteLine($"MxcExecutor: post-exit output drain timed out (pid={process.Id}).");
 
             sw.Stop();
             string outRaw, errRaw;
@@ -241,6 +240,40 @@ public sealed class MxcExecutor
                 Error = $"Failed to launch wxc-exec.exe: {ex.Message}",
                 DurationMs = sw.ElapsedMilliseconds,
             };
+        }
+    }
+
+    private async Task<bool> KillProcessTreeWithTimeoutAsync(Process process)
+    {
+        var killTask = Task.Factory.StartNew(
+            () =>
+            {
+                try
+                {
+                    _processTreeKiller(process);
+                    return (Exception?)null;
+                }
+                catch (Exception ex)
+                {
+                    return ex;
+                }
+            },
+            CancellationToken.None,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default);
+
+        try
+        {
+            var error = await killTask.WaitAsync(_cleanupTimeout);
+            if (error is null)
+                return true;
+
+            Trace.WriteLine($"MxcExecutor: process kill (cancellation path) failed: {error.Message}");
+            return false;
+        }
+        catch (TimeoutException)
+        {
+            return false;
         }
     }
 

--- a/src/OpenClaw.Shared/Mxc/MxcExecutor.cs
+++ b/src/OpenClaw.Shared/Mxc/MxcExecutor.cs
@@ -13,7 +13,11 @@ public sealed class MxcExecutor
 {
     private const int DefaultStdoutCapBytes = 40_000;
     private const int DefaultStderrCapBytes = 5_000;
+    internal const int ProcessTreeKillWorkerLimit = 8;
     private static readonly TimeSpan s_defaultCleanupTimeout = TimeSpan.FromMilliseconds(500);
+    private static readonly SemaphoreSlim s_processTreeKillWorkers = new(
+        ProcessTreeKillWorkerLimit,
+        ProcessTreeKillWorkerLimit);
 
     private readonly string _wxcExePath;
     private readonly int _stdoutCapBytes;
@@ -243,28 +247,57 @@ public sealed class MxcExecutor
         }
     }
 
-    private async Task<bool> KillProcessTreeWithTimeoutAsync(Process process)
+    internal async Task<bool> KillProcessTreeWithTimeoutAsync(Process process)
     {
-        var killTask = Task.Factory.StartNew(
-            () =>
-            {
-                try
-                {
-                    _processTreeKiller(process);
-                    return (Exception?)null;
-                }
-                catch (Exception ex)
-                {
-                    return ex;
-                }
-            },
-            CancellationToken.None,
-            TaskCreationOptions.LongRunning,
-            TaskScheduler.Default);
+        var timeoutStarted = Stopwatch.GetTimestamp();
+        if (!await s_processTreeKillWorkers.WaitAsync(_cleanupTimeout))
+        {
+            Trace.WriteLine(
+                $"MxcExecutor: timed out waiting for process kill worker capacity " +
+                $"(limit={ProcessTreeKillWorkerLimit}, pid={process.Id}).");
+            return false;
+        }
 
+        Task<Exception?> killTask;
         try
         {
-            var error = await killTask.WaitAsync(_cleanupTimeout);
+            killTask = Task.Factory.StartNew(
+                () =>
+                {
+                    try
+                    {
+                        _processTreeKiller(process);
+                        return (Exception?)null;
+                    }
+                    catch (Exception ex)
+                    {
+                        return ex;
+                    }
+                    finally
+                    {
+                        s_processTreeKillWorkers.Release();
+                    }
+                },
+                CancellationToken.None,
+                TaskCreationOptions.LongRunning,
+                TaskScheduler.Default);
+        }
+        catch (Exception ex)
+        {
+            s_processTreeKillWorkers.Release();
+            Trace.WriteLine($"MxcExecutor: process kill worker failed to start: {ex.Message}");
+            return false;
+        }
+
+        var remainingTimeout = _cleanupTimeout - Stopwatch.GetElapsedTime(timeoutStarted);
+        try
+        {
+            if (!killTask.IsCompleted && remainingTimeout <= TimeSpan.Zero)
+                return false;
+
+            var error = killTask.IsCompleted
+                ? await killTask
+                : await killTask.WaitAsync(remainingTimeout);
             if (error is null)
                 return true;
 

--- a/tests/OpenClaw.Shared.Tests/Mxc/MxcExecutorTests.cs
+++ b/tests/OpenClaw.Shared.Tests/Mxc/MxcExecutorTests.cs
@@ -1,6 +1,8 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Text;
 using OpenClaw.Shared.Mxc;
+using OpenClaw.TestSupport;
 using Xunit;
 
 namespace OpenClaw.Shared.Tests.Mxc;
@@ -97,6 +99,122 @@ public class MxcExecutorTests
     }
 
     [Fact]
+    public async Task RunAsync_CancellationCleanupIsBounded_WhenProcessTreeKillBlocks()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return;
+
+        var launcherPid = 0;
+        Process? launcher = null;
+        using var killRelease = new ManualResetEventSlim(false);
+        var killStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cmdPath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.System),
+            "cmd.exe");
+        var executor = new MxcExecutor(
+            cmdPath,
+            stdoutCapBytes: null,
+            stderrCapBytes: null,
+            processFactory: _ => launcher = CreateProcess(
+                cmdPath,
+                "echo launcher-started & ping -n 31 127.0.0.1 >nul"),
+            processTreeKiller: _ =>
+            {
+                killStarted.TrySetResult();
+                killRelease.Wait();
+            },
+            cleanupTimeout: TimeSpan.FromMilliseconds(100));
+        using var cancellation = new CancellationTokenSource();
+
+        try
+        {
+            var run = executor.RunAsync(
+                new MxcConfig
+                {
+                    ContainerId = "bounded-kill-test",
+                    Process = new MxcProcess { CommandLine = "ignored-by-test-process" },
+                },
+                cancellation.Token);
+            await WaitForProcessStartAsync(() => launcher, TimeSpan.FromSeconds(5));
+            launcherPid = launcher!.Id;
+            var stopwatch = Stopwatch.StartNew();
+            cancellation.Cancel();
+            await killStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            var result = await run.WaitAsync(TimeSpan.FromSeconds(5));
+            stopwatch.Stop();
+
+            Assert.True(result.TimedOut);
+            Assert.Equal(-1, result.ExitCode);
+            Assert.Contains("cancelled", result.Error, StringComparison.OrdinalIgnoreCase);
+            Assert.True(
+                stopwatch.Elapsed < TimeSpan.FromSeconds(2),
+                $"Post-cancel cleanup took {stopwatch.ElapsedMilliseconds} ms.");
+        }
+        finally
+        {
+            killRelease.Set();
+            KillProcessTree(launcherPid);
+        }
+    }
+
+    [Fact]
+    public async Task RunAsync_OutputDrainIsBounded_WhenDescendantRetainsRedirectedHandlesAfterParentExit()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return;
+
+        using var temp = new TempDirectory("mxc-drain-test-");
+        var descendantPidPath = temp.Combine("descendant.pid");
+        var escapedPidPath = descendantPidPath.Replace("'", "''", StringComparison.Ordinal);
+        var childScript =
+            $"$PID | Set-Content -LiteralPath '{escapedPidPath}'; Start-Sleep -Seconds 30";
+        var encodedChildScript = Convert.ToBase64String(Encoding.Unicode.GetBytes(childScript));
+        var cmdPath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.System),
+            "cmd.exe");
+        var command =
+            "echo parent-output & start /b " +
+            "%SystemRoot%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe " +
+            $"-NoLogo -NoProfile -NonInteractive -EncodedCommand {encodedChildScript} & exit /b 0";
+        var executor = new MxcExecutor(
+            cmdPath,
+            stdoutCapBytes: null,
+            stderrCapBytes: null,
+            processFactory: _ => CreateProcess(cmdPath, command),
+            processTreeKiller: process => process.Kill(entireProcessTree: true),
+            cleanupTimeout: TimeSpan.FromMilliseconds(100));
+        var run = executor.RunAsync(new MxcConfig
+        {
+            ContainerId = "bounded-output-drain-test",
+            Process = new MxcProcess { CommandLine = "ignored-by-test-process" },
+        });
+        var descendantPid = 0;
+
+        try
+        {
+            await WaitForFileAsync(descendantPidPath, TimeSpan.FromSeconds(5));
+            descendantPid = int.Parse(await File.ReadAllTextAsync(descendantPidPath));
+            var stopwatch = Stopwatch.StartNew();
+            var result = await run.WaitAsync(TimeSpan.FromSeconds(2));
+            stopwatch.Stop();
+
+            Assert.True(result.Success);
+            Assert.False(result.TimedOut);
+            Assert.Equal(0, result.ExitCode);
+            Assert.Contains("parent-output", result.Output);
+            Assert.True(
+                stopwatch.Elapsed < TimeSpan.FromSeconds(1),
+                $"Post-exit output drain took {stopwatch.ElapsedMilliseconds} ms.");
+        }
+        finally
+        {
+            KillProcessTree(descendantPid);
+            try { await run.WaitAsync(TimeSpan.FromSeconds(5)); }
+            catch { }
+        }
+    }
+
+    [Fact]
     public async Task WaitForCleanupAsync_ReturnsTrue_WhenProcessAndPipesComplete()
     {
         var completed = Task.CompletedTask;
@@ -131,6 +249,20 @@ public class MxcExecutorTests
         }
 
         throw new TimeoutException("Test launcher did not start within the expected time.");
+    }
+
+    private static async Task WaitForFileAsync(string path, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (File.Exists(path))
+                return;
+
+            await Task.Delay(10);
+        }
+
+        throw new TimeoutException("Test descendant did not report its process ID within the expected time.");
     }
 
     private static Process CreateProcess(string cmdPath, string command)

--- a/tests/OpenClaw.Shared.Tests/Mxc/MxcExecutorTests.cs
+++ b/tests/OpenClaw.Shared.Tests/Mxc/MxcExecutorTests.cs
@@ -108,6 +108,12 @@ public class MxcExecutorTests
         Process? launcher = null;
         using var killRelease = new ManualResetEventSlim(false);
         var killStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var killFinished = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        Action<Process> blockingKiller = _ =>
+        {
+            killStarted.TrySetResult();
+            killRelease.Wait();
+        };
         var cmdPath = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.System),
             "cmd.exe");
@@ -118,10 +124,10 @@ public class MxcExecutorTests
             processFactory: _ => launcher = CreateProcess(
                 cmdPath,
                 "echo launcher-started & ping -n 31 127.0.0.1 >nul"),
-            processTreeKiller: _ =>
+            processTreeKiller: process =>
             {
-                killStarted.TrySetResult();
-                killRelease.Wait();
+                blockingKiller(process);
+                killFinished.TrySetResult();
             },
             cleanupTimeout: TimeSpan.FromMilliseconds(100));
         using var cancellation = new CancellationTokenSource();
@@ -153,7 +159,150 @@ public class MxcExecutorTests
         finally
         {
             killRelease.Set();
+            await killFinished.Task.WaitAsync(TimeSpan.FromSeconds(5));
             KillProcessTree(launcherPid);
+        }
+    }
+
+    [Fact]
+    public async Task KillProcessTreeWithTimeoutAsync_RepeatedBlockedKillsDoNotExceedProcessWideWorkerLimit()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return;
+
+        var killStartedCount = 0;
+        using var killRelease = new ManualResetEventSlim(false);
+        using var killStarted = new CountdownEvent(MxcExecutor.ProcessTreeKillWorkerLimit);
+        using var killFinished = new CountdownEvent(MxcExecutor.ProcessTreeKillWorkerLimit);
+        var cmdPath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.System),
+            "cmd.exe");
+        var attemptCount = MxcExecutor.ProcessTreeKillWorkerLimit + 2;
+        var workersFinished = false;
+        using var process = Process.GetCurrentProcess();
+
+        try
+        {
+            var killAttempts = Enumerable.Range(0, attemptCount).Select(_ =>
+            {
+                var executor = new MxcExecutor(
+                    cmdPath,
+                    stdoutCapBytes: null,
+                    stderrCapBytes: null,
+                    processFactory: _ => throw new InvalidOperationException("Not used by this test."),
+                    processTreeKiller: _ =>
+                    {
+                        Interlocked.Increment(ref killStartedCount);
+                        killStarted.Signal();
+                        try
+                        {
+                            killRelease.Wait();
+                        }
+                        finally
+                        {
+                            killFinished.Signal();
+                        }
+                    },
+                    cleanupTimeout: TimeSpan.FromMilliseconds(100));
+                return executor.KillProcessTreeWithTimeoutAsync(process);
+            }).ToArray();
+
+            var results = await Task.WhenAll(killAttempts).WaitAsync(TimeSpan.FromSeconds(5));
+            var workersStarted = killStarted.Wait(TimeSpan.FromSeconds(5));
+
+            Assert.All(results, Assert.False);
+            Assert.True(workersStarted, "Blocked kill workers did not all start within the test bound.");
+            Assert.Equal(
+                MxcExecutor.ProcessTreeKillWorkerLimit,
+                Volatile.Read(ref killStartedCount));
+        }
+        finally
+        {
+            killRelease.Set();
+            workersFinished = killFinished.Wait(TimeSpan.FromSeconds(5));
+        }
+
+        Assert.True(workersFinished, "Blocked kill workers did not exit after the test released them.");
+
+        var recoveredKillStarted = false;
+        var recoveredExecutor = new MxcExecutor(
+            cmdPath,
+            stdoutCapBytes: null,
+            stderrCapBytes: null,
+            processFactory: _ => throw new InvalidOperationException("Not used by this test."),
+            processTreeKiller: _ => recoveredKillStarted = true,
+            cleanupTimeout: TimeSpan.FromMilliseconds(100));
+        var recovered = false;
+        for (var attempt = 0; attempt < 50 && !recovered; attempt++)
+        {
+            recovered = await recoveredExecutor.KillProcessTreeWithTimeoutAsync(process);
+            if (!recovered)
+                await Task.Delay(10);
+        }
+
+        Assert.True(recovered, "Process-wide kill worker capacity did not recover.");
+        Assert.True(recoveredKillStarted);
+    }
+
+    [Fact]
+    public async Task KillProcessTreeWithTimeoutAsync_WaitsForTransientWorkerCapacityWithinCleanupBudget()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return;
+
+        using var process = Process.GetCurrentProcess();
+        using var killRelease = new SemaphoreSlim(0, MxcExecutor.ProcessTreeKillWorkerLimit);
+        using var killStarted = new CountdownEvent(MxcExecutor.ProcessTreeKillWorkerLimit);
+        var cmdPath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.System),
+            "cmd.exe");
+        var blockingAttempts = Array.Empty<Task<bool>>();
+
+        try
+        {
+            blockingAttempts = Enumerable.Range(0, MxcExecutor.ProcessTreeKillWorkerLimit)
+                .Select(_ =>
+                {
+                    var executor = new MxcExecutor(
+                        cmdPath,
+                        stdoutCapBytes: null,
+                        stderrCapBytes: null,
+                        processFactory: _ => throw new InvalidOperationException("Not used by this test."),
+                        processTreeKiller: _ =>
+                        {
+                            killStarted.Signal();
+                            killRelease.Wait();
+                        },
+                        cleanupTimeout: TimeSpan.FromSeconds(5));
+                    return executor.KillProcessTreeWithTimeoutAsync(process);
+                })
+                .ToArray();
+            Assert.True(
+                killStarted.Wait(TimeSpan.FromSeconds(5)),
+                "Initial kill workers did not occupy the process-wide limit.");
+
+            var queuedKillStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var queuedExecutor = new MxcExecutor(
+                cmdPath,
+                stdoutCapBytes: null,
+                stderrCapBytes: null,
+                processFactory: _ => throw new InvalidOperationException("Not used by this test."),
+                processTreeKiller: _ => queuedKillStarted.TrySetResult(),
+                cleanupTimeout: TimeSpan.FromSeconds(2));
+            var queuedAttempt = queuedExecutor.KillProcessTreeWithTimeoutAsync(process);
+
+            await Task.Delay(100);
+            Assert.False(queuedKillStarted.Task.IsCompleted);
+            killRelease.Release();
+
+            Assert.True(await queuedAttempt.WaitAsync(TimeSpan.FromSeconds(5)));
+            await queuedKillStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        finally
+        {
+            killRelease.Release(MxcExecutor.ProcessTreeKillWorkerLimit);
+            try { await Task.WhenAll(blockingAttempts).WaitAsync(TimeSpan.FromSeconds(5)); }
+            catch { }
         }
     }
 


### PR DESCRIPTION
## Summary

This addresses NODE-2 in issue #1122. It intentionally does not close #1122 because that issue contains multiple findings.

## Root cause

Cancellation could block synchronously in process-tree termination. The normal launcher-exit path could also wait indefinitely when a descendant retained inherited stdout or stderr handles. The first bounded-kill implementation could retain one dedicated worker per permanently blocked kill.

## Change

- Bounds process-tree kill and redirected-output drain waits.
- Caps process-tree kill workers process-wide at eight.
- Waits for transient worker capacity within the existing cleanup timeout, then uses only the remaining timeout for the kill.
- Releases worker capacity on completion and worker-start failure.
- Preserves cancellation, result, containment, approval, and output semantics.

## Regression coverage

- A blocking kill cannot pin the caller.
- Ten repeated permanently blocked kills start no more than eight process-wide workers, all callers remain bounded, and capacity recovers after release.
- A kill queued behind eight workers starts when transient capacity returns inside the same cleanup budget.
- A real descendant retaining inherited redirected handles cannot pin a completed launcher result.

## Validation

Current head: `bb12539e`

- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\build.ps1`: passed. Shared, CLI, WinNode CLI, SetupEngine, and WinUI built successfully; documentation validation passed for 46 Markdown files.
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore --filter FullyQualifiedName~Mxc`: 200 passed, 7 environment-gated skips, 0 failed.
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore`: 3,698 passed, 32 skipped, 4 failed. The four failures are unchanged `ExecReusableCommandBinderTests` failures and all four reproduced on pristine base `fc9add75` in a detached temporary worktree.
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore`: 2,469 passed, 0 skipped, 0 failed.
- `python .\.agents\skills\autoreview\scripts\autoreview --mode local ...`: clean, with no accepted or actionable findings after the concurrency and test-determinism fixes.

The four base-reproduced Shared failures are:

- `CarrierPayloadWithExplicitRelativePath_IsNotTreatedAsAmbiguous`
- `AcceptedSpaceGrammar_MatchesRealCmdChildArgv`
- `AcceptedMultiElementTail_MatchesRealCmdChildArgv`
- `AcceptedTabGrammar_MatchesRealCmdChildArgv`

## Real behavior proof

Current-head local Windows process regressions passed:

```text
Repeated blocked-kill regression:
10 attempts
8 process-wide workers started
all attempts returned within the cleanup bound
worker capacity recovered after release

Transient saturation regression:
8 worker slots occupied
9th kill waited without starting
1 slot released
9th kill started and completed inside its cleanup budget

MXC-focused result:
Failed: 0, Passed: 200, Skipped: 7, Total: 207
```

The descendant-retained-handle test launches a real Windows child process that inherits stdout and stderr handles after its parent exits. The parent result returned successfully inside the bound, and the test cleaned up the descendant.

## Proof limitation

Gateway MXC E2E was not run because this task explicitly prohibited Gateway MXC E2E. It is not presented as passed. No Gateway, pairing, permission, credential, or Pavilion install path was used.

## Security and capability impact

No new permissions, identity, pairing, network, sandbox, or command authority.