### PR TITLE
fix: keepalive process inspection can hang after PowerShell exits

### DIFF
--- a/src/OpenClaw.Connection/WindowsTcpListenerSnapshot.cs
+++ b/src/OpenClaw.Connection/WindowsTcpListenerSnapshot.cs
@@ -53,19 +53,58 @@ public static class WindowsTcpListenerSnapshot
                 return null;
 
             var readTask = process.StandardOutput.ReadToEndAsync();
-            if (!process.WaitForExit(5_000))
-            {
-                try { process.Kill(entireProcessTree: true); } catch { }
-                return null;
-            }
-
-            return readTask.GetAwaiter().GetResult().Trim();
+            var output = AwaitRedirectedOutput(process, readTask, timeoutMs: 5_000);
+            return output?.Trim();
         }
         catch
         {
             return null;
         }
     }
+
+    /// <summary>
+    /// Wait for the child, then drain redirected stdout with the leftover
+    /// timeout. WaitForExit returns when the child exits, but ReadToEnd
+    /// completes only after the write end of the pipe closes. A descendant
+    /// that inherited stdout can keep the pipe open, so unbounded
+    /// GetResult() would hang past the inspection timeout.
+    /// </summary>
+    internal static string? AwaitRedirectedOutput(Process process, Task<string> readTask, int timeoutMs)
+    {
+        const int minDrainMs = 250;
+        var sw = Stopwatch.StartNew();
+        if (!process.WaitForExit(timeoutMs))
+        {
+            try { process.Kill(entireProcessTree: true); } catch { }
+            ObserveQuietly(readTask);
+            return null;
+        }
+
+        var elapsedMs = (int)Math.Min(sw.ElapsedMilliseconds, timeoutMs);
+        var drainBudgetMs = Math.Max(timeoutMs - elapsedMs, minDrainMs);
+        try
+        {
+            if (!readTask.Wait(drainBudgetMs))
+            {
+                try { process.Kill(entireProcessTree: true); } catch { }
+                ObserveQuietly(readTask);
+                return null;
+            }
+        }
+        catch (AggregateException)
+        {
+            return null;
+        }
+
+        return readTask.Status == TaskStatus.RanToCompletion ? readTask.Result : null;
+    }
+
+    private static void ObserveQuietly(Task task) =>
+        _ = task.ContinueWith(
+            static t => { _ = t.Exception; },
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
 
     private static bool CaptureIpv4(List<WindowsTcpListenerInfo> destination)
     {

--- a/src/OpenClaw.Connection/WindowsTcpListenerSnapshot.cs
+++ b/src/OpenClaw.Connection/WindowsTcpListenerSnapshot.cs
@@ -56,8 +56,11 @@ public static class WindowsTcpListenerSnapshot
             var output = AwaitRedirectedOutput(process, readTask, timeoutMs: 5_000);
             return output?.Trim();
         }
-        catch
+        catch (Exception ex)
         {
+            Trace.WriteLine(
+                $"Windows process command-line lookup failed for PID {processId}: " +
+                $"{ex.GetType().Name}: {ex.Message}");
             return null;
         }
     }
@@ -75,8 +78,10 @@ public static class WindowsTcpListenerSnapshot
         var sw = Stopwatch.StartNew();
         if (!process.WaitForExit(timeoutMs))
         {
+            Trace.WriteLine(
+                $"Windows process command-line lookup timed out waiting for PID {process.Id}.");
             try { process.Kill(entireProcessTree: true); } catch { }
-            ObserveQuietly(readTask);
+            AbandonRead(process, readTask);
             return null;
         }
 
@@ -86,8 +91,10 @@ public static class WindowsTcpListenerSnapshot
         {
             if (!readTask.Wait(drainBudgetMs))
             {
+                Trace.WriteLine(
+                    $"Windows process command-line lookup timed out draining PID {process.Id} stdout.");
                 try { process.Kill(entireProcessTree: true); } catch { }
-                ObserveQuietly(readTask);
+                AbandonRead(process, readTask);
                 return null;
             }
         }
@@ -97,6 +104,12 @@ public static class WindowsTcpListenerSnapshot
         }
 
         return readTask.Status == TaskStatus.RanToCompletion ? readTask.Result : null;
+    }
+
+    private static void AbandonRead(Process process, Task readTask)
+    {
+        ObserveQuietly(readTask);
+        try { process.StandardOutput.Dispose(); } catch { }
     }
 
     private static void ObserveQuietly(Task task) =>

--- a/src/OpenClaw.SetupEngine/KeepaliveProcessRuntime.cs
+++ b/src/OpenClaw.SetupEngine/KeepaliveProcessRuntime.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using OpenClaw.Connection;
 
 namespace OpenClaw.SetupEngine;
 
@@ -19,9 +20,7 @@ internal interface IKeepaliveProcessRuntime
 
     /// <summary>
     /// Best-effort command-line lookup for a PID. Returns null if the process is gone or the
-    /// lookup otherwise fails to produce a value. May throw for exceptional OS failures — callers
-    /// in <see cref="KeepaliveProcessManager"/> catch per-call so one failure doesn't abort a
-    /// broader scan.
+    /// lookup otherwise fails to produce a value. The production runtime does not throw.
     /// </summary>
     string? GetCommandLine(int pid);
 
@@ -48,9 +47,8 @@ internal sealed record KeepaliveProcessStartSpec(string FileName, IReadOnlyList<
 
 /// <summary>
 /// Production <see cref="IKeepaliveProcessRuntime"/> backed by <see cref="System.Diagnostics.Process"/>
-/// and a WMI/CIM command-line lookup via a spawned <c>powershell.exe</c> helper (unchanged from the
-/// pre-extraction inline implementation). Every <see cref="Process"/> wrapper obtained here is
-/// disposed before the method returns.
+/// and the shared bounded WMI/CIM command-line lookup. Every <see cref="Process"/> wrapper obtained
+/// here is disposed before the method returns.
 /// </summary>
 internal sealed class ProcessKeepaliveRuntime : IKeepaliveProcessRuntime
 {
@@ -60,21 +58,8 @@ internal sealed class ProcessKeepaliveRuntime : IKeepaliveProcessRuntime
         return !process.HasExited;
     }
 
-    public string? GetCommandLine(int pid)
-    {
-        var psi = new ProcessStartInfo("powershell.exe",
-            $"-NoProfile -Command \"(Get-CimInstance Win32_Process -Filter 'ProcessId={pid}').CommandLine\"")
-        {
-            RedirectStandardOutput = true,
-            UseShellExecute = false,
-            CreateNoWindow = true
-        };
-        using var p = Process.Start(psi);
-        if (p == null) return null;
-        var output = p.StandardOutput.ReadToEnd();
-        p.WaitForExit(5000);
-        return output.Trim();
-    }
+    public string? GetCommandLine(int pid) =>
+        WindowsTcpListenerSnapshot.GetProcessCommandLine(pid);
 
     public IReadOnlyList<int> EnumerateProcessIds(string processName)
     {

--- a/src/OpenClaw.Tray.WinUI/Services/WslGatewayKeepAliveService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/WslGatewayKeepAliveService.cs
@@ -316,34 +316,7 @@ internal sealed class WslGatewayKeepAliveService(
     }
 
     private static string? GetProcessCommandLine(int pid)
-    {
-        try
-        {
-            var psi = new System.Diagnostics.ProcessStartInfo("powershell.exe",
-                $"-NoProfile -Command \"(Get-CimInstance Win32_Process -Filter 'ProcessId={pid}').CommandLine\"")
-            {
-                RedirectStandardOutput = true,
-                UseShellExecute = false,
-                CreateNoWindow = true
-            };
-            using var p = System.Diagnostics.Process.Start(psi);
-            if (p == null) return null;
-
-            // Drain stdout asynchronously so a large command line cannot deadlock the fixed-size pipe,
-            // and bound the whole inspection: WaitForExit(5000) returns before ReadToEnd could block
-            // forever on a hung CIM/PowerShell. On timeout, kill and report indeterminate (null).
-            var readTask = p.StandardOutput.ReadToEndAsync();
-            if (!p.WaitForExit(5000))
-            {
-                // slopwatch-ignore: SW003 Best-effort kill of a stuck inspection process; failure cannot improve caller state.
-                try { p.Kill(entireProcessTree: true); } catch { }
-                return null;
-            }
-
-            return readTask.GetAwaiter().GetResult()?.Trim();
-        }
-        catch { return null; }
-    }
+        => WindowsTcpListenerSnapshot.GetProcessCommandLine(pid);
 
     private static string ResolveWslExePath()
     {

--- a/tests/OpenClaw.Connection.Tests/WindowsTcpListenerSnapshotTests.cs
+++ b/tests/OpenClaw.Connection.Tests/WindowsTcpListenerSnapshotTests.cs
@@ -1,0 +1,35 @@
+using System.Diagnostics;
+
+namespace OpenClaw.Connection.Tests;
+
+public sealed class WindowsTcpListenerSnapshotTests
+{
+    [Fact]
+    public void GetProcessCommandLine_InvalidPid_ReturnsNull()
+    {
+        Assert.Null(WindowsTcpListenerSnapshot.GetProcessCommandLine(0));
+        Assert.Null(WindowsTcpListenerSnapshot.GetProcessCommandLine(-1));
+    }
+
+    [Fact]
+    public async Task AwaitRedirectedOutput_ReturnsNullWhenStdoutNeverCloses()
+    {
+        using var process = Process.Start(new ProcessStartInfo
+        {
+            FileName = OperatingSystem.IsWindows() ? "cmd.exe" : "/bin/sh",
+            Arguments = OperatingSystem.IsWindows() ? "/c exit 0" : "-c \"exit 0\"",
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        });
+        Assert.NotNull(process);
+
+        var never = new TaskCompletionSource<string>().Task;
+        var helper = Task.Run(() =>
+            WindowsTcpListenerSnapshot.AwaitRedirectedOutput(process, never, timeoutMs: 400));
+
+        var completed = await Task.WhenAny(helper, Task.Delay(TimeSpan.FromSeconds(3)));
+        Assert.Same(helper, completed);
+        Assert.Null(await helper);
+    }
+}

--- a/tests/OpenClaw.Connection.Tests/WindowsTcpListenerSnapshotTests.cs
+++ b/tests/OpenClaw.Connection.Tests/WindowsTcpListenerSnapshotTests.cs
@@ -24,7 +24,8 @@ public sealed class WindowsTcpListenerSnapshotTests
         });
         Assert.NotNull(process);
 
-        var never = new TaskCompletionSource<string>().Task;
+        var never = new TaskCompletionSource<string>(
+            TaskCreationOptions.RunContinuationsAsynchronously).Task;
         var helper = Task.Run(() =>
             WindowsTcpListenerSnapshot.AwaitRedirectedOutput(process, never, timeoutMs: 400));
 
@@ -32,4 +33,75 @@ public sealed class WindowsTcpListenerSnapshotTests
         Assert.Same(helper, completed);
         Assert.Null(await helper);
     }
+
+    [Fact]
+    public void AwaitRedirectedOutput_PreservesOutputCompletedDuringDrainGrace()
+    {
+        using var process = StartExitingProcess();
+        Assert.True(process.WaitForExit(3_000));
+        var outputTask = Task.Run(async () =>
+        {
+            await Task.Delay(100);
+            return "complete output";
+        });
+
+        var output = WindowsTcpListenerSnapshot.AwaitRedirectedOutput(
+            process,
+            outputTask,
+            timeoutMs: 400);
+
+        Assert.Equal("complete output", output);
+    }
+
+    [Fact]
+    public async Task AwaitRedirectedOutput_ReturnsNullWhenDescendantKeepsStdoutOpen()
+    {
+        var (fileName, arguments) = DescendantPipeHolderCommand();
+        using var process = Process.Start(new ProcessStartInfo
+        {
+            FileName = fileName,
+            Arguments = arguments,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        });
+        Assert.NotNull(process);
+
+        var readTask = process.StandardOutput.ReadToEndAsync();
+        var stopwatch = Stopwatch.StartNew();
+        var output = WindowsTcpListenerSnapshot.AwaitRedirectedOutput(
+            process,
+            readTask,
+            timeoutMs: 400);
+
+        Assert.Null(output);
+        Assert.InRange(stopwatch.Elapsed, TimeSpan.Zero, TimeSpan.FromSeconds(2));
+        await readTask.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public void GetProcessCommandLine_CurrentProcess_IsBoundedOnWindows()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        var stopwatch = Stopwatch.StartNew();
+        _ = WindowsTcpListenerSnapshot.GetProcessCommandLine(Environment.ProcessId);
+
+        Assert.InRange(stopwatch.Elapsed, TimeSpan.Zero, TimeSpan.FromSeconds(7));
+    }
+
+    private static Process StartExitingProcess() =>
+        Process.Start(new ProcessStartInfo
+        {
+            FileName = OperatingSystem.IsWindows() ? "cmd.exe" : "/bin/sh",
+            Arguments = OperatingSystem.IsWindows() ? "/d /c exit 0" : "-c \"exit 0\"",
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        })!;
+
+    private static (string FileName, string Arguments) DescendantPipeHolderCommand() =>
+        OperatingSystem.IsWindows()
+            ? ("cmd.exe", "/d /s /c \"start /b ping 127.0.0.1 -n 3\"")
+            : ("/bin/sh", "-c \"sleep 2 & exit 0\"");
 }

--- a/tests/OpenClaw.Tray.Tests/ConnectionRegressionSourceTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ConnectionRegressionSourceTests.cs
@@ -161,6 +161,32 @@ public sealed class ConnectionRegressionSourceTests
     }
 
     [Fact]
+    public void SetupKeepaliveRuntime_UsesSharedBoundedCommandLineLookup()
+    {
+        var source = ReadSource("src", "OpenClaw.SetupEngine", "KeepaliveProcessRuntime.cs");
+
+        Assert.Contains(
+            "WindowsTcpListenerSnapshot.GetProcessCommandLine(pid)",
+            source);
+        Assert.DoesNotContain("StandardOutput.ReadToEnd", source);
+    }
+
+    [Fact]
+    public void TrayKeepaliveService_UsesSharedBoundedCommandLineLookup()
+    {
+        var source = ReadSource(
+            "src",
+            "OpenClaw.Tray.WinUI",
+            "Services",
+            "WslGatewayKeepAliveService.cs");
+
+        Assert.Contains(
+            "WindowsTcpListenerSnapshot.GetProcessCommandLine(pid)",
+            source);
+        Assert.DoesNotContain("StandardOutput.ReadToEnd", source);
+    }
+
+    [Fact]
     public void SetupKeepaliveManager_WritesMarkerAfterSuccessfulStart()
     {
         // KeepaliveProcessManager only ever writes the keepalive marker after receiving a


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users starting or repairing a local Windows gateway could see the tray or setup wizard hang after PowerShell finished listing a process command line. The hang occurs when keepalive cleanup or port ownership inspection sees the PowerShell child exit while a descendant still holds the redirected stdout pipe.

## Why This Change Was Made

The inspection waited five seconds for PowerShell to exit, then used an unbounded stdout read. `WaitForExit` completes when the child exits, but `ReadToEnd` completes only after every inherited write handle closes. The shared helper now bounds both child exit and stdout drain, observes abandoned reads, releases the owned stdout reader, and records distinct trace diagnostics for process, exit-timeout, and drain-timeout failures.

Tray keepalive and setup keepalive now use the same bounded command-line lookup instead of keeping separate implementations.

## User Impact

Local gateway keepalive and setup process inspection return `null` (indeterminate command line) instead of hanging when stdout never closes. Successful output that completes during the drain grace period is preserved.

## Evidence

Current-head Windows proof on `a2ff98889cd92b4d5b2040f7dbc7683f7f23d472`:

- Windows NT 10.0.26340.0, x64, .NET SDK 10.0.303.
- The real CIM/PowerShell lookup for the current process completed within the seven-second anti-hang bound.
- A real `cmd.exe` parent exited while a `ping.exe` descendant retained stdout. The helper returned `null` within two seconds instead of waiting for pipe EOF.
- The real inherited-pipe regression passed 20 of 20 repeated runs.
- A successful output task completing during the post-exit drain grace returned the full expected output.
- Setup and tray source guards verify both keepalive owners route through `WindowsTcpListenerSnapshot.GetProcessCommandLine` and do not reintroduce `StandardOutput.ReadToEnd`.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs or instructions
- [x] Tests or validation
- [ ] Security hardening
- [ ] Chore or infrastructure

## Scope

- [x] Tray or WinUI UX
- [ ] Windows node capability
- [ ] Local MCP or `winnode`
- [x] Gateway, connection, or pairing
- [x] Setup or onboarding
- [ ] Permissions, privacy, or security
- [x] Tests, CI, or docs

## Validation

```console
.\build.ps1
All builds succeeded.

dotnet test .\tests\OpenClaw.Connection.Tests\OpenClaw.Connection.Tests.csproj --no-restore --nologo
Passed: 686, Failed: 0, Skipped: 0

dotnet test .\tests\OpenClaw.SetupEngine.Tests\OpenClaw.SetupEngine.Tests.csproj --no-restore --nologo
Passed: 978, Failed: 0, Skipped: 0

dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore --nologo
Passed: 3813, Failed: 0, Skipped: 32

dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore --nologo
Passed: 2721, Failed: 0, Skipped: 0

# Repeated real descendant-held-pipe regression
Current-head inherited-pipe drain stress passed: 20/20 iterations.
```

The full validation tree included a normal merge of current `origin/main` before these commands, so the fix was exercised against the release-bound base without rewriting history.

## Real behavior proof

- **Behavior addressed:** command-line inspection no longer waits indefinitely after PowerShell exits while an inherited stdout handle remains open.
- **Environment:** Microsoft Windows NT 10.0.26340.0, x64, .NET SDK 10.0.303.
- **Current PR head:** `a2ff98889cd92b4d5b2040f7dbc7683f7f23d472`.
- **Production-path proof:** `GetProcessCommandLine(Environment.ProcessId)` exercised the real Windows PowerShell and CIM path and completed within the bounded window.
- **Failure-path proof:** a real parent/descendant process pair reproduced the inherited pipe-holder condition; the helper returned indeterminate rather than hanging, repeated 20 of 20 times.
- **Successful-output proof:** output completing during the reserved drain grace was returned intact.
- **Review proof:** adversarial Claude Opus and Codex reviews found no remaining release-blocking issue. Final confidence was 97% and 96%, respectively.

## Security Impact

- New permissions or capabilities? (`No`)
- Secrets or tokens handling changed? (`No`)
- New or changed network calls? (`No`)
- Command or tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any answer is `Yes`, explain the risk and mitigation:

## Compatibility and Migration

- Backward compatible? (`Yes`)
- Config or environment changes? (`No`)
- Migration needed? (`No`)
- If yes, list the exact upgrade steps:

## Review Conversations

- [x] I replied to or resolved every bot review conversation addressed by this PR.
- [x] No unresolved review thread remains.
