### PR TITLE
Add retry for failed WSL setup

### DIFF
--- a/docs/ONBOARDING_WIZARD.md
+++ b/docs/ONBOARDING_WIZARD.md
@@ -26,6 +26,8 @@ Displays the OpenClaw icon, app title, and a brief description. If an app-owned 
 ### Local setup progress
 Installs and connects a new app-owned `OpenClawGateway` WSL instance from a clean WSL baseline. Setup does not export from or mutate an existing user Ubuntu distro; if WSL cannot create the named app-owned distro directly, setup fails with an actionable update message. When replacing an app-owned local gateway, the removal step is shown as part of progress and can be retried on failure.
 
+If creating the managed WSL distro fails, the failure screen offers **Retry**. Retry restarts the setup pipeline, including its cleanup phase, so it can remove any partial app-owned distro before attempting the WSL installation again.
+
 The managed distro is locked down and is not intended to be a normal interactive Ubuntu profile. For editing `openclaw.json` as the `openclaw` user and using root for protected-file administration, see [Managing the locked-down WSL gateway](WSL_GATEWAY_ADMIN.md).
 
 ### Capabilities and Windows permissions

--- a/docs/ONBOARDING_WIZARD.md
+++ b/docs/ONBOARDING_WIZARD.md
@@ -26,7 +26,7 @@ Displays the OpenClaw icon, app title, and a brief description. If an app-owned 
 ### Local setup progress
 Installs and connects a new app-owned `OpenClawGateway` WSL instance from a clean WSL baseline. Setup does not export from or mutate an existing user Ubuntu distro; if WSL cannot create the named app-owned distro directly, setup fails with an actionable update message. When replacing an app-owned local gateway, the removal step is shown as part of progress and can be retried on failure.
 
-If creating the managed WSL distro fails, the failure screen offers **Retry**. Retry restarts the setup pipeline, including its cleanup phase, so it can remove any partial app-owned distro before attempting the WSL installation again.
+If creating the managed WSL distro fails, the failure screen offers **Retry**. Retry always enables the pipeline's app-owned cleanup phase, even if the original setup configuration skipped cleanup, so it can remove any partial app-owned distro before attempting the WSL installation again.
 
 The managed distro is locked down and is not intended to be a normal interactive Ubuntu profile. For editing `openclaw.json` as the `openclaw` user and using root for protected-file administration, see [Managing the locked-down WSL gateway](WSL_GATEWAY_ADMIN.md).
 

--- a/src/OpenClaw.SetupEngine.UI/Pages/CompletePage.xaml
+++ b/src/OpenClaw.SetupEngine.UI/Pages/CompletePage.xaml
@@ -127,10 +127,16 @@
         </ScrollViewer>
 
         <Grid Grid.Row="1" ColumnDefinitions="Auto,*,Auto" Margin="0,16,0,0">
-            <Button x:Name="FallbackButton" Grid.Column="0"
-                    Content="Retry with validated fallback"
-                    Visibility="Collapsed"
-                    Click="FallbackButton_Click" />
+            <StackPanel Grid.Column="0" Spacing="8">
+                <Button x:Name="RetryButton"
+                        Content="Retry"
+                        Visibility="Collapsed"
+                        Click="RetryButton_Click" />
+                <Button x:Name="FallbackButton"
+                        Content="Retry with validated fallback"
+                        Visibility="Collapsed"
+                        Click="FallbackButton_Click" />
+            </StackPanel>
             <StackPanel Grid.ColumnSpan="3" Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center" VerticalAlignment="Center"
                         IsTabStop="False" AutomationProperties.Name="Step 6 of 6">
                 <Border Width="8" Height="8" CornerRadius="4" VerticalAlignment="Center" Background="{ThemeResource SetupInactiveDotBrush}" />

--- a/src/OpenClaw.SetupEngine.UI/Pages/CompletePage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/CompletePage.xaml.cs
@@ -37,6 +37,7 @@ public sealed partial class CompletePage : Page
                 ErrorCard.Visibility = Visibility.Collapsed;
                 HelpLink.Visibility = Visibility.Collapsed;
                 FallbackButton.Visibility = Visibility.Collapsed;
+                RetryButton.Visibility = Visibility.Collapsed;
                 SummaryPanel.Visibility = Visibility.Visible;
             }
             else
@@ -60,6 +61,9 @@ public sealed partial class CompletePage : Page
                 FallbackButton.Content = string.IsNullOrWhiteSpace(args.GatewayFallbackVersion)
                     ? "Retry with validated fallback"
                     : $"Retry with validated fallback {args.GatewayFallbackVersion}";
+                RetryButton.Visibility = args.CanRetryWslInstallation
+                    ? Visibility.Visible
+                    : Visibility.Collapsed;
 
                 // Show error card with details and log link
                 ErrorCard.Visibility = Visibility.Visible;
@@ -130,6 +134,11 @@ public sealed partial class CompletePage : Page
         FallbackButton.Visibility = Visibility.Collapsed;
         if (!string.IsNullOrWhiteSpace(error))
             ErrorText.Text = $"{ErrorText.Text}{Environment.NewLine}{error}";
+    }
+
+    private void RetryButton_Click(object sender, RoutedEventArgs e)
+    {
+        SetupWindow.Active?.RetryWslInstallation();
     }
 
 }

--- a/src/OpenClaw.SetupEngine.UI/Pages/ProgressPage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/ProgressPage.xaml.cs
@@ -195,7 +195,8 @@ public sealed partial class ProgressPage : Page
                     sw.Elapsed,
                     config.LogPath,
                     errorMsg,
-                    result.CompatibilityFailure);
+                    result.CompatibilityFailure,
+                    canRetryWslInstallation: result.FailedStepId == "wsl-create");
             }
         }
         catch (OperationCanceledException) when (cts.IsCancellationRequested)

--- a/src/OpenClaw.SetupEngine.UI/Pages/ProgressPage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/ProgressPage.xaml.cs
@@ -15,7 +15,8 @@ internal sealed record ProgressPageArgs(
     SetupConfig Config,
     bool ShowMilestoneOnly,
     string DataDir,
-    string LocalDataDir);
+    string LocalDataDir,
+    bool AppendLog);
 
 public sealed partial class ProgressPage : Page
 {
@@ -28,6 +29,7 @@ public sealed partial class ProgressPage : Page
     private bool _pipelineFinished;
     private string _dataDir = null!;
     private string _localDataDir = null!;
+    private bool _appendLog;
     private Uri? _tailscaleAuthorizationUri;
     private const int MaxLogLines = 200;
 
@@ -62,6 +64,7 @@ public sealed partial class ProgressPage : Page
         _config = args?.Config ?? e.Parameter as SetupConfig ?? new SetupConfig();
         _dataDir = args?.DataDir ?? SetupContext.ResolveDataDir();
         _localDataDir = args?.LocalDataDir ?? SetupContext.ResolveLocalDataDir();
+        _appendLog = args?.AppendLog == true;
         SubtitleText.Text = $"Creating {_config.DistroName} WSL instance";
 
         BuildStepRows();
@@ -141,7 +144,8 @@ public sealed partial class ProgressPage : Page
         try
         {
             _logger = new SetupLogger(config.LogPath,
-                Enum.TryParse<LogLevel>(config.LogLevel, true, out var lvl) ? lvl : LogLevel.Trace);
+                Enum.TryParse<LogLevel>(config.LogLevel, true, out var lvl) ? lvl : LogLevel.Trace,
+                append: _appendLog);
 
             _logger.LogEmitted += OnLogEmitted;
 
@@ -196,7 +200,7 @@ public sealed partial class ProgressPage : Page
                     config.LogPath,
                     errorMsg,
                     result.CompatibilityFailure,
-                    canRetryWslInstallation: result.FailedStepId == "wsl-create");
+                    canRetryWslInstallation: result.FailedStepId == CreateWslInstanceStep.StepId);
             }
         }
         catch (OperationCanceledException) when (cts.IsCancellationRequested)

--- a/src/OpenClaw.SetupEngine.UI/SetupWindow.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/SetupWindow.xaml.cs
@@ -273,7 +273,8 @@ public sealed partial class SetupWindow : Window
         TimeSpan elapsed,
         string? logPath,
         string? errorMessage = null,
-        GatewayCompatibilityFailureKind? compatibilityFailure = null)
+        GatewayCompatibilityFailureKind? compatibilityFailure = null,
+        bool canRetryWslInstallation = false)
     {
         var canRetryFallback =
             compatibilityFailure is { } failureKind &&
@@ -291,7 +292,8 @@ public sealed partial class SetupWindow : Window
                 CanRetryGatewayFallback: canRetryFallback,
                 GatewayFallbackVersion: canRetryFallback
                     ? GatewayReleasePolicy.FallbackVersion
-                    : null));
+                    : null,
+                CanRetryWslInstallation: canRetryWslInstallation));
     }
 
     public bool TryRetryWithGatewayFallback(out string? error)
@@ -302,6 +304,8 @@ public sealed partial class SetupWindow : Window
         NavigateToProgress();
         return true;
     }
+
+    public void RetryWslInstallation() => NavigateToProgress();
 
     private void ShowConfigurationError(string errorMessage)
     {
@@ -459,5 +463,6 @@ public sealed record CompletePageArgs(
     bool ShowStartupPreference = true,
     SetupReviewSummary? ReviewSummary = null,
     bool CanRetryGatewayFallback = false,
-    string? GatewayFallbackVersion = null);
+    string? GatewayFallbackVersion = null,
+    bool CanRetryWslInstallation = false);
 public sealed record SetupCompletedEventArgs(bool EnableAutoStart);

--- a/src/OpenClaw.SetupEngine.UI/SetupWindow.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/SetupWindow.xaml.cs
@@ -23,6 +23,7 @@ public sealed partial class SetupWindow : Window
     private bool _isClosed;
     private bool _persistStartupPreferenceOnComplete = true;
     private bool _showStartupPreferenceOnComplete = true;
+    private bool _appendLogOnNextProgressRun;
     private readonly string _dataDir;
     private readonly string _localDataDir;
 
@@ -199,8 +200,12 @@ public sealed partial class SetupWindow : Window
     public void NavigateToGatewayInstalledMilestone() =>
         NavigateTo(typeof(ProgressPage), CreateProgressPageArgs(showMilestoneOnly: true));
 
-    private ProgressPageArgs CreateProgressPageArgs(bool showMilestoneOnly) =>
-        new(_config, showMilestoneOnly, _dataDir, _localDataDir);
+    private ProgressPageArgs CreateProgressPageArgs(bool showMilestoneOnly)
+    {
+        var appendLog = _appendLogOnNextProgressRun;
+        _appendLogOnNextProgressRun = false;
+        return new(_config, showMilestoneOnly, _dataDir, _localDataDir, appendLog);
+    }
 
     public bool TryNavigateToGatewayInstalledMilestone()
     {
@@ -308,6 +313,7 @@ public sealed partial class SetupWindow : Window
     public void RetryWslInstallation()
     {
         SetupRetryPolicy.PrepareWslInstallationRetry(_config);
+        _appendLogOnNextProgressRun = true;
         NavigateToProgress();
     }
 

--- a/src/OpenClaw.SetupEngine.UI/SetupWindow.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/SetupWindow.xaml.cs
@@ -305,7 +305,11 @@ public sealed partial class SetupWindow : Window
         return true;
     }
 
-    public void RetryWslInstallation() => NavigateToProgress();
+    public void RetryWslInstallation()
+    {
+        SetupRetryPolicy.PrepareWslInstallationRetry(_config);
+        NavigateToProgress();
+    }
 
     private void ShowConfigurationError(string errorMessage)
     {

--- a/src/OpenClaw.SetupEngine/SetupLogger.cs
+++ b/src/OpenClaw.SetupEngine/SetupLogger.cs
@@ -25,7 +25,10 @@ public sealed partial class SetupLogger : IDisposable
     public string RunId => _runId;
     public string? FilePath => _filePath;
 
-    public SetupLogger(string? filePath, LogLevel minLevel = LogLevel.Trace)
+    public SetupLogger(
+        string? filePath,
+        LogLevel minLevel = LogLevel.Trace,
+        bool append = false)
     {
         _minLevel = minLevel;
         _runId = Guid.NewGuid().ToString("N")[..12];
@@ -35,7 +38,7 @@ public sealed partial class SetupLogger : IDisposable
             _filePath = filePath;
             var dir = Path.GetDirectoryName(filePath);
             if (dir != null) Directory.CreateDirectory(dir);
-            _writer = new StreamWriter(filePath, append: false) { AutoFlush = true };
+            _writer = new StreamWriter(filePath, append) { AutoFlush = true };
         }
     }
 

--- a/src/OpenClaw.SetupEngine/SetupRetryPolicy.cs
+++ b/src/OpenClaw.SetupEngine/SetupRetryPolicy.cs
@@ -1,0 +1,10 @@
+namespace OpenClaw.SetupEngine;
+
+public static class SetupRetryPolicy
+{
+    public static void PrepareWslInstallationRetry(SetupConfig config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        config.CleanBeforeRun = true;
+    }
+}

--- a/src/OpenClaw.SetupEngine/SetupSteps.cs
+++ b/src/OpenClaw.SetupEngine/SetupSteps.cs
@@ -741,6 +741,7 @@ public sealed class PreflightPortStep : SetupStep
 
 public sealed class CreateWslInstanceStep : SetupStep
 {
+    public const string StepId = "wsl-create";
     private static readonly TimeSpan DistroVersionVerificationTimeout = TimeSpan.FromMinutes(1);
     private static readonly TimeSpan[] FreshDistroProbeTimeouts =
     [
@@ -749,7 +750,7 @@ public sealed class CreateWslInstanceStep : SetupStep
         TimeSpan.FromSeconds(90),
     ];
 
-    public override string Id => "wsl-create";
+    public override string Id => StepId;
     public override string DisplayName => "Create WSL instance";
     public override bool CanRetry => false;
 

--- a/tests/OpenClaw.SetupEngine.Tests/SetupLoggerTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupLoggerTests.cs
@@ -182,6 +182,26 @@ public class SetupLoggerTests : IDisposable
     }
 
     [Fact]
+    public void WritesToFile_AppendsWhenRequested()
+    {
+        var path = Path.Combine(_tempDir, "append.jsonl");
+        using (var logger = new SetupLogger(path))
+        {
+            logger.Info("first attempt");
+        }
+
+        using (var logger = new SetupLogger(path, append: true))
+        {
+            logger.Info("retry attempt");
+        }
+
+        var lines = File.ReadAllLines(path);
+        Assert.Equal(2, lines.Length);
+        Assert.Contains("first attempt", lines[0]);
+        Assert.Contains("retry attempt", lines[1]);
+    }
+
+    [Fact]
     public void CommandCompleted_WritesReadableJsonWithoutUnicodeOrNewlineEscapes()
     {
         var path = Path.Combine(_tempDir, "readable.jsonl");

--- a/tests/OpenClaw.SetupEngine.Tests/SetupRetryPolicyTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupRetryPolicyTests.cs
@@ -1,0 +1,33 @@
+namespace OpenClaw.SetupEngine.Tests;
+
+public sealed class SetupRetryPolicyTests
+{
+    [Fact]
+    public void PrepareWslInstallationRetry_EnablesCleanupWhenInitialSetupDidNot()
+    {
+        var config = new SetupConfig { CleanBeforeRun = false };
+
+        SetupRetryPolicy.PrepareWslInstallationRetry(config);
+
+        Assert.True(config.CleanBeforeRun);
+    }
+
+    [Fact]
+    public void PrepareWslInstallationRetry_MakesStaleDistroCleanupEligible()
+    {
+        var config = new SetupConfig { CleanBeforeRun = false };
+        using var logger = new SetupLogger(filePath: null);
+        using var journal = new TransactionJournal(filePath: null, logger);
+        var context = new SetupContext(
+            config,
+            logger,
+            journal,
+            new CommandRunner(logger),
+            CancellationToken.None);
+        var cleanup = new CleanupStaleDistroStep();
+
+        SetupRetryPolicy.PrepareWslInstallationRetry(config);
+
+        Assert.False(cleanup.CanSkip(context));
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
@@ -1153,6 +1153,20 @@ public sealed class AppRefactorContractTests
     }
 
     [Fact]
+    public void CompletePage_OffersRetryForFailedWslInstallation()
+    {
+        var root = TestRepositoryPaths.GetRepositoryRoot();
+        var setupWindow = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.SetupEngine.UI", "SetupWindow.xaml.cs"));
+        var complete = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.SetupEngine.UI", "Pages", "CompletePage.xaml.cs"));
+        var progress = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.SetupEngine.UI", "Pages", "ProgressPage.xaml.cs"));
+
+        Assert.Contains("canRetryWslInstallation: result.FailedStepId == \"wsl-create\"", progress);
+        Assert.Contains("public void RetryWslInstallation() => NavigateToProgress();", setupWindow);
+        Assert.Contains("RetryButton.Visibility = args.CanRetryWslInstallation", complete);
+        Assert.Contains("SetupWindow.Active?.RetryWslInstallation();", complete);
+    }
+
+    [Fact]
     public void CapabilitiesPage_PersistsSelectedProfileIntoRuntimeNodeSettings()
     {
         var root = TestRepositoryPaths.GetRepositoryRoot();

--- a/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
@@ -1160,8 +1160,9 @@ public sealed class AppRefactorContractTests
         var complete = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.SetupEngine.UI", "Pages", "CompletePage.xaml.cs"));
         var progress = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.SetupEngine.UI", "Pages", "ProgressPage.xaml.cs"));
 
-        Assert.Contains("canRetryWslInstallation: result.FailedStepId == \"wsl-create\"", progress);
+        Assert.Contains("canRetryWslInstallation: result.FailedStepId == CreateWslInstanceStep.StepId", progress);
         Assert.Contains("SetupRetryPolicy.PrepareWslInstallationRetry(_config);", setupWindow);
+        Assert.Contains("_appendLogOnNextProgressRun = true;", setupWindow);
         Assert.Contains("RetryButton.Visibility = args.CanRetryWslInstallation", complete);
         Assert.Contains("SetupWindow.Active?.RetryWslInstallation();", complete);
     }

--- a/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
@@ -1161,7 +1161,7 @@ public sealed class AppRefactorContractTests
         var progress = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.SetupEngine.UI", "Pages", "ProgressPage.xaml.cs"));
 
         Assert.Contains("canRetryWslInstallation: result.FailedStepId == \"wsl-create\"", progress);
-        Assert.Contains("public void RetryWslInstallation() => NavigateToProgress();", setupWindow);
+        Assert.Contains("SetupRetryPolicy.PrepareWslInstallationRetry(_config);", setupWindow);
         Assert.Contains("RetryButton.Visibility = args.CanRetryWslInstallation", complete);
         Assert.Contains("SetupWindow.Active?.RetryWslInstallation();", complete);
     }


### PR DESCRIPTION
## Summary
- add a Retry button when the WSL distro creation (`wsl-create`) step fails
- restart setup through the existing cleanup phase so a partial app-owned distro is removed before installation is attempted again
- retain the independent validated gateway fallback retry and document the recovery behavior

## Validation
- `./build.ps1`
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` (3,654 passed, 32 skipped)
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` (2,428 passed)

## Real behavior proof
Not verified / blocked: this is a native WinUI failure state. The available computer-use tools can control browser pages only, and reproducing `wsl-create` would require intentionally failing a WSL distro download. The retry wiring is covered by the tray contract test and the current build/tests above.

## Review
Not verified / blocked: `.agents/skills/autoreview/scripts/autoreview --mode local` could not run because neither `python` nor the Windows `py` launcher is installed or available on PATH.