### PR TITLE
fix(tray): restore icon after Explorer restart

### DIFF
--- a/src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj
+++ b/src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj
@@ -15,6 +15,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <Platforms>x64;ARM64</Platforms>
     <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
+    <!-- WinUIEx 2.9.3 marks its legacy Icon type obsolete, but the WinUI XAML generator still emits Icon.FromFile. -->
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);CS0618</WarningsNotAsErrors>
   </PropertyGroup>
 
   <!-- Dev build identity: allows side-by-side installation with Release.
@@ -77,7 +79,7 @@
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$(MicrosoftWindowsSdkBuildToolsVersion)" />
     <PackageReference Include="OpenTelemetry" Version="1.16.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
-    <PackageReference Include="WinUIEx" Version="2.9.0" />
+    <PackageReference Include="WinUIEx" Version="2.9.3" />
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
     <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.3.260402-preview2" />
     <PackageReference Include="CommunityToolkit.WinUI.Controls.Sizers" Version="8.3.260402-preview2" />


### PR DESCRIPTION
Fixes #1176.

## Summary

- bump WinUIEx from 2.9.0 to 2.9.3
- use WinUIEx's upstream `TaskbarCreated` recovery so the existing tray icon is re-registered after `explorer.exe` restarts
- keep the WinUI-generated `WinUIEx.Icon.FromFile` obsolete warning visible but non-fatal until the XAML generator stops emitting that legacy type

This preserves the existing `TrayController` ownership boundary and does not add a parallel shell-recovery implementation.

## Validation

Validated on exact commit `f960a908` on Windows x64:

- `./build.ps1` passed: Shared, CLI, WinNodeCli, SetupEngine, and WinUI
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` passed: 3,698 passed, 32 skipped, 0 failed
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` passed: 2,619 passed, 0 skipped, 0 failed
- focused code review found no significant issues
- `git diff --check` passed

## Real behavior proof

Current-head native Windows proof exercised the real taskbar shell:

1. launched the exact built `OpenClaw.Tray.WinUI.exe`
2. verified the taskbar accessibility tree exposed an enabled **OpenClaw Tray** notification icon
3. recorded the app PID and Explorer shell PID
4. forcibly restarted that exact Explorer shell process
5. verified the same OpenClaw process remained alive
6. inspected the replacement taskbar and verified an enabled **OpenClaw Tray** notification icon was present again

Observed proof:

```text
BEFORE shell=104516 app=101864 icon=visible
AFTER  shell=106720 app=101864 icon=visible
```

Local proof artifacts include before/after taskbar Live Visual Tree dumps and screenshots from the exact fixed build.

## Risk

Low. The behavior change is isolated to a patch-level dependency update whose release notes specifically identify the Explorer restart tray-icon fix. The only additional project setting downgrades CS0618 from error to warning because WinUI-generated `XamlTypeInfo.g.cs` references WinUIEx's now-obsolete `Icon.FromFile` API.