### PR TITLE
fix: MCP server accepts malformed IPv6 loopback hosts

### DIFF
--- a/src/OpenClaw.Shared/Mcp/McpHttpServer.cs
+++ b/src/OpenClaw.Shared/Mcp/McpHttpServer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Net;
 using System.Security.Cryptography;
@@ -762,7 +763,7 @@ public sealed class McpHttpServer : IDisposable, IAsyncDisposable
             Encoding.UTF8.GetBytes(authToken));
     }
 
-    private static bool IsHostAllowed(string? host)
+    internal static bool IsHostAllowed(string? host)
     {
         if (string.IsNullOrEmpty(host)) return false;
         var trimmed = host.Trim();
@@ -772,7 +773,17 @@ public sealed class McpHttpServer : IDisposable, IAsyncDisposable
             var closeBracket = trimmed.IndexOf(']');
             if (closeBracket < 0) return false;
             var v6 = trimmed.Substring(1, closeBracket - 1);
-            return string.Equals(v6, "::1", StringComparison.Ordinal);
+            if (!string.Equals(v6, "::1", StringComparison.Ordinal)) return false;
+
+            var suffix = trimmed.AsSpan(closeBracket + 1);
+            if (suffix.IsEmpty) return true;
+            return suffix.Length > 1
+                && suffix[0] == ':'
+                && ushort.TryParse(
+                    suffix[1..],
+                    NumberStyles.None,
+                    CultureInfo.InvariantCulture,
+                    out _);
         }
         // IPv4 / hostname: strip trailing :port if present.
         var colon = trimmed.LastIndexOf(':');

--- a/tests/OpenClaw.Shared.Tests/McpHttpServerTests.cs
+++ b/tests/OpenClaw.Shared.Tests/McpHttpServerTests.cs
@@ -204,6 +204,24 @@ public class McpHttpServerTests
         finally { server.Dispose(); http.Dispose(); }
     }
 
+    [Theory]
+    [InlineData("[::1]")]
+    [InlineData("[::1]:8765")]
+    public void IsHostAllowed_AcceptsBracketedIpv6Loopback(string host)
+    {
+        Assert.True(McpHttpServer.IsHostAllowed(host));
+    }
+
+    [Theory]
+    [InlineData("[::1]evil")]
+    [InlineData("[::1]:")]
+    [InlineData("[::1]:not-a-port")]
+    [InlineData("[::1]:65536")]
+    public void IsHostAllowed_RejectsMalformedBracketedIpv6Loopback(string host)
+    {
+        Assert.False(McpHttpServer.IsHostAllowed(host));
+    }
+
     [Fact]
     public async Task Post_WithLocalhostHost_Accepted()
     {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where malformed bracketed IPv6 Host headers could pass the local MCP server's loopback Host validation when arbitrary text or an invalid port followed the closing bracket. This weakened the defensive Host-header gate intended to reject non-loopback request authorities.

## Why This Change Was Made

Validate the entire bracketed IPv6 authority, accepting only [::1] or [::1]:<numeric-port> within the 16-bit port range. The validator is internal so the existing friend test assembly can exercise this security boundary directly without adding public API surface.

## User Impact

Operators can expect the local MCP endpoint to reject malformed IPv6 Host values instead of treating them as valid loopback authorities. Normal IPv4 endpoints and valid bracketed IPv6 loopback hosts remain compatible.

## Evidence

Before the parser change, the focused regression run failed 4 malformed-host cases and passed 2 valid-host cases. At current head, the same focused run passes all 6 cases.

- Full build: all 5 projects passed on Windows ARM64.
- Shared tests: 3,704 passed, 32 skipped, 0 failed.
- Tray tests: 2,620 passed, 0 skipped, 0 failed.
- Focused current-head tests: 6 passed, 0 skipped, 0 failed.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs or instructions
- [x] Tests or validation
- [x] Security hardening
- [ ] Chore or infrastructure

## Scope

- [ ] Tray or WinUI UX
- [ ] Windows node capability
- [x] Local MCP or winnode
- [ ] Gateway, connection, or pairing
- [ ] Setup or onboarding
- [x] Permissions, privacy, or security
- [x] Tests, CI, or docs

## Validation

- powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\build.ps1
  - Passed: Shared, Cli, WinNodeCli, SetupEngine, and WinUI.
- dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore
  - Passed: 3,704; skipped: 32; failed: 0.
- dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore
  - Passed: 2,620; skipped: 0; failed: 0.
- dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore --filter FullyQualifiedName~IsHostAllowed
  - Passed: 6; skipped: 0; failed: 0.

## Real Behavior Proof

- Environment tested: Windows ARM64, .NET SDK 10.0.400
- PR head or commit tested: b48a24214d380adf2d09741848b2b79a75bebd05
- Exact steps or command run: dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore --filter FullyQualifiedName~IsHostAllowed
- Evidence after fix: Passed! Failed: 0, Passed: 6, Skipped: 0, Total: 6
- Observed result: [::1] and [::1]:8765 were accepted; [::1]evil, an empty port, a nonnumeric port, and port 65536 were rejected.
- Screenshot or artifact links verified? N/A
- Not verified or blocked: No manual raw-HTTP runtime test was performed; validation directly exercises the Host parser and includes the repository build and baseline suites.

## Security Impact

- New permissions or capabilities? No
- Secrets or tokens handling changed? No
- New or changed network calls? No
- Command or tool execution surface changed? No
- Data access scope changed? No
- If any answer is Yes, explain the risk and mitigation: N/A

## Compatibility and Migration

- Backward compatible? Yes
- Config or environment changes? No
- Migration needed? No
- If yes, list the exact upgrade steps: N/A

## Review Conversations

- [ ] I replied to or resolved every bot review conversation addressed by this PR.
- [ ] I left unresolved only conversations that still need maintainer judgment.