### PR TITLE
fix: preserve Core updates across restart timeouts

### DIFF
--- a/src/OpenClaw.Connection/WslCommandRunner.cs
+++ b/src/OpenClaw.Connection/WslCommandRunner.cs
@@ -5,7 +5,11 @@ using System.Text;
 
 namespace OpenClaw.Connection;
 
-public sealed record WslCommandResult(int ExitCode, string StandardOutput, string StandardError)
+public sealed record WslCommandResult(
+    int ExitCode,
+    string StandardOutput,
+    string StandardError,
+    bool TimedOut = false)
 {
     public bool Success => ExitCode == 0;
 }
@@ -171,7 +175,7 @@ public sealed class WslExeCommandRunner : IWslCommandRunner
         try { stderr = await stderrTask; } catch { stderr = string.Empty; }
 
         return timedOut
-            ? new WslCommandResult(-1, stdout, "wsl.exe timed out")
+            ? new WslCommandResult(-1, stdout, "wsl.exe timed out", TimedOut: true)
             : new WslCommandResult(process.ExitCode, stdout, stderr);
     }
 }

--- a/src/OpenClaw.Connection/WslGatewayController.cs
+++ b/src/OpenClaw.Connection/WslGatewayController.cs
@@ -15,7 +15,8 @@ public sealed record WslGatewayControlResult(
     WslGatewayControlAction Action,
     int ExitCode,
     string StandardOutput,
-    string StandardError)
+    string StandardError,
+    bool TimedOut = false)
 {
     public bool Success => ExitCode == 0;
 
@@ -96,7 +97,8 @@ public sealed class WslGatewayController(IWslCommandRunner commandRunner, IOpenC
             action,
             result.ExitCode,
             result.StandardOutput,
-            result.StandardError);
+            result.StandardError,
+            result.TimedOut);
     }
 
     /// <summary>

--- a/src/OpenClaw.Tray.WinUI/Services/ManagedLocalGatewayRepairAdapters.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/ManagedLocalGatewayRepairAdapters.cs
@@ -31,6 +31,17 @@ public sealed class WslManagedLocalGatewayRestarter(WslGatewayController control
         if (result.Success)
             return new ManagedLocalGatewayRestartResult(true);
 
+        // A timeout only proves that the host-side wsl.exe client stopped waiting. The in-distro
+        // restart (or a detached update handoff that triggered it) may still be running. Terminating
+        // the whole distro here can kill healthy, long-running maintenance, so fail closed and let
+        // the normal reconnect/repair loop observe the eventual outcome.
+        if (result.TimedOut)
+        {
+            return new ManagedLocalGatewayRestartResult(
+                false,
+                "Gateway restart timed out; skipped forced distro termination because completion is unknown.");
+        }
+
         if (!canContinue())
             return new ManagedLocalGatewayRestartResult(false, "Gateway changed before forced restart.");
 

--- a/tests/OpenClaw.Tray.Tests/WslGatewayControllerTests.cs
+++ b/tests/OpenClaw.Tray.Tests/WslGatewayControllerTests.cs
@@ -119,6 +119,29 @@ public class WslGatewayControllerTests
     }
 
     [Fact]
+    public async Task Restarter_WhenInPlaceRestartTimesOut_DoesNotForceTerminate()
+    {
+        var runner = new FakeWslCommandRunner
+        {
+            Distros = [new WslDistroInfo("OpenClawGateway", "Running", 2)],
+            Result = new WslCommandResult(
+                -1,
+                string.Empty,
+                "wsl.exe timed out",
+                TimedOut: true),
+        };
+        var controller = new WslGatewayController(runner, NullLogger.Instance);
+        var restarter = new OpenClawTray.Services.WslManagedLocalGatewayRestarter(controller);
+
+        var result = await restarter.RestartAsync("OpenClawGateway", CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Contains("completion is unknown", result.Detail, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(0, runner.TerminateCount);
+        Assert.Equal(1, runner.InDistroCount);
+    }
+
+    [Fact]
     public async Task Restarter_WhenBothRestartsFail_ReportsFailure()
     {
         var runner = new FakeWslCommandRunner


### PR DESCRIPTION
Related: openclaw/openclaw#99666

## What Problem This Solves

Fixes an issue where the Windows Companion could interrupt a supported OpenClaw Core update when its automatic gateway repair timed out. After waiting 30 seconds for an in-distro restart, the Companion treated the timeout as a definitive failure and terminated the entire WSL distro, killing the detached Core updater.

## Why This Change Was Made

The WSL command runner now carries an explicit timeout result through the gateway controller. Automatic repair treats that result as indeterminate and skips forced distro termination. Definitive non-timeout restart failures retain the existing terminate-and-cold-restart recovery path.

This stays on the Windows Companion boundary. Core already owns the managed-service update handoff and its parent wait budget; the destructive escalation happened later in the external Windows supervisor.

## User Impact

Long-running Core updates are no longer killed merely because the Companion's host-side restart wait expired. Users still retain automatic recovery when an in-distro restart fails definitively.

## Evidence

Observed before the fix:

- `21:02:57`: Core accepted `update.run` and started the managed-service handoff.
- `21:03:21`: Companion auto-repair invoked an in-distro gateway restart.
- `21:03:51`: the 30-second wait timed out and Companion invoked `wsl.exe --terminate`, killing the detached updater.
- Core remained clean at the old commit while only `FETCH_HEAD` advanced.
- With the Companion stopped, the supported CLI update completed successfully.

The regression test now proves that a timed-out in-place restart makes zero terminate calls, while existing tests continue to prove that a definitive failure performs the terminate-and-cold-restart path.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs or instructions
- [x] Tests or validation
- [ ] Security hardening
- [ ] Chore or infrastructure

## Scope

- [ ] Tray or WinUI UX
- [ ] Windows node capability
- [ ] Local MCP or `winnode`
- [x] Gateway, connection, or pairing
- [ ] Setup or onboarding
- [ ] Permissions, privacy, or security
- [x] Tests, CI, or docs

## Validation

- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore --filter "FullyQualifiedName~WslGatewayControllerTests"`: 11 passed, 0 failed, 0 skipped.
- `.\build.ps1`: all 5 projects built; 46 documentation files validated.
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore`: 3,698 passed, 0 failed, 32 intentional environment/integration skips.
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore`: 2,621 passed, 0 failed, 0 skipped.
- `git diff --check`: clean apart from Git line-ending conversion notices.

## Real Behavior Proof

- Environment tested: Windows 11 with WSL 2; isolated source worktree based on Windows Companion `origin/main` `12b84457a46492b8e3f4df99ea1ea17370f75992`.
- PR head or commit tested: `e4dd1735b47eb7cadc19e0c73e9fea1c93d87e09`.
- Exact steps or command run: focused regression plus the required full repository validation commands listed above.
- Evidence after fix: the timeout regression returns failure with completion unknown, records zero distro terminations, and records one in-distro restart attempt. The existing definitive-failure regression still records one termination and the cold restart.
- Observed result: `test_proven` for the timeout decision and preserved definitive-failure path.
- Screenshot or artifact links verified? (`Yes`/`No`/`N/A`): N/A.
- Not verified or blocked: the installed official Companion remains unmodified, so the fixed source path is not yet `runtime_proven` or `end_to_end_proven`.

## Security Impact

- New permissions or capabilities? (`Yes`/`No`): No.
- Secrets or tokens handling changed? (`Yes`/`No`): No.
- New or changed network calls? (`Yes`/`No`): No.
- Command or tool execution surface changed? (`Yes`/`No`): Yes.
- Data access scope changed? (`Yes`/`No`): No.
- If any answer is `Yes`, explain the risk and mitigation: automatic repair no longer invokes the destructive host-side terminate command after an ambiguous timeout. The existing forced recovery remains available after a definitive non-timeout failure.

## Compatibility and Migration

- Backward compatible? (`Yes`/`No`): Yes.
- Config or environment changes? (`Yes`/`No`): No.
- Migration needed? (`Yes`/`No`): No.
- If yes, list the exact upgrade steps: N/A.

## Review Conversations

- [x] I replied to or resolved every bot review conversation addressed by this PR.
- [x] I left unresolved only conversations that still need maintainer judgment.
