### PR TITLE
fix(setup): avoid duplicate failure message

### DIFF
--- a/src/OpenClaw.SetupEngine.UI/Pages/CompletePage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/CompletePage.xaml.cs
@@ -34,6 +34,7 @@ public sealed partial class CompletePage : Page
                 GatewaySummaryText.Text = (args.ReviewSummary ?? SetupReviewSummaryBuilder.Build(new SetupConfig())).CompletionGatewaySummary;
                 TitleText.Text = "All set!";
                 SubtitleText.Text = "OpenClaw is ready to go";
+                SubtitleText.Visibility = Visibility.Visible;
                 ErrorCard.Visibility = Visibility.Collapsed;
                 HelpLink.Visibility = Visibility.Collapsed;
                 FallbackButton.Visibility = Visibility.Collapsed;
@@ -47,9 +48,7 @@ public sealed partial class CompletePage : Page
                 SuccessIcon.Visibility = Visibility.Collapsed;
                 FailureIcon.Visibility = Visibility.Visible;
                 TitleText.Text = "Setup failed";
-                SubtitleText.Text = helpUrl is null
-                    ? args.ErrorMessage ?? "An error occurred during setup"
-                    : "Follow the steps below to resolve the setup issue and retry.";
+                SubtitleText.Visibility = Visibility.Collapsed;
                 NodeModeBanner.Visibility = Visibility.Collapsed;
                 StartupRow.Visibility = Visibility.Collapsed;
                 SummaryPanel.Visibility = Visibility.Collapsed;

--- a/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
@@ -1231,6 +1231,18 @@ public sealed class AppRefactorContractTests
     }
 
     [Fact]
+    public void CompletePage_ShowsFailureMessageOnlyInErrorCard()
+    {
+        var root = TestRepositoryPaths.GetRepositoryRoot();
+        var complete = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.SetupEngine.UI", "Pages", "CompletePage.xaml.cs"));
+
+        Assert.Contains("SubtitleText.Visibility = Visibility.Visible", complete);
+        Assert.Contains("SubtitleText.Visibility = Visibility.Collapsed", complete);
+        Assert.Contains("ErrorText.Text = errorMessage", complete);
+        Assert.DoesNotContain("SubtitleText.Text = helpUrl is null", complete);
+    }
+
+    [Fact]
     public void CompletePage_OffersExactFallbackOnlyThroughTypedCompatibilityPath()
     {
         var root = TestRepositoryPaths.GetRepositoryRoot();


### PR DESCRIPTION
## Summary

- show setup failure details only in the red error card
- hide the gray subtitle on failure while preserving it on success
- add a regression contract test for the single-message presentation

This is independent of #1178. The duplicate rendering already exists on `main`, and #1178 does not change the failure-state logic.

## Validation

- `.\build.ps1` (passed: Shared, CLI, WinNode CLI, SetupEngine, and WinUI)
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --filter 'FullyQualifiedName~AppRefactorContractTests.CompletePage_ShowsFailureMessageOnlyInErrorCard|FullyQualifiedName~AppRefactorContractTests.CompletePage_UsesCompletionArgsForStartupPreference|FullyQualifiedName~AppRefactorContractTests.CompletePage_OffersExactFallbackOnlyThroughTypedCompatibilityPath'` (passed: 3/3)
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj` (passed: 3,791; skipped: 32)
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore` (passed: 2,685)
- `git diff --check` (passed)
- Required GitHub checks on `e2a4c87546113c3d11edb9eb31f2793029de8349` (passed)

## Real behavior proof

Current-head native Windows proof passed. With `OPENCLAW_SETUP_PREVIEW_PAGE=complete-error`, `run-app-local.ps1 -NoBuild -Isolated -AllowNonMain` launched the failure completion page. The visible UI and accessibility tree showed:

- heading: `Setup failed`
- one error message in `ErrorText`: `Setup could not finish. Review the details, then retry setup when you are ready.`
- no visible subtitle or duplicate error message
- the `Close` recovery action remained available

Source inspection also confirms that full failure text remains assigned to `ErrorText`, while help, log, and validated-fallback recovery paths are unchanged. A synthetic merge with current `origin/main` was conflict-free and retained both this visibility fix and main's Local AI completion summary.

## Rubber-duck review

An independent high-confidence review found no blocking or non-blocking issues. It confirmed that distinct failure details remain visible in the error card, help/log/fallback actions are preserved, `NavigationCacheMode="Disabled"` prevents stale page state, and the synthetic merge with current main is behaviorally correct.
