### PR TITLE
fix(connection): bind WSL relay trust to installed package

### DIFF
--- a/src/OpenClaw.Connection/WindowsAuthenticodeVerifier.cs
+++ b/src/OpenClaw.Connection/WindowsAuthenticodeVerifier.cs
@@ -2,6 +2,9 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Runtime.Versioning;
+using System.Security.AccessControl;
+using System.Security.Principal;
 using System.Text.Json;
 using System.Threading;
 using Microsoft.Security.Extensions;
@@ -24,7 +27,21 @@ internal readonly record struct AuthenticodeTrustResult(bool IsTrusted, string? 
 internal readonly record struct AppxPackageInfo(
     string? PackageFamilyName,
     string? Publisher,
-    string? SignatureKind);
+    string? SignatureKind,
+    string? InstallLocation,
+    string? Version);
+
+internal readonly record struct WslRelayPathInspection(
+    bool IsSecure,
+    string? FileVersion,
+    string? Detail)
+{
+    public static WslRelayPathInspection Secure(string? fileVersion) =>
+        new(true, fileVersion, null);
+
+    public static WslRelayPathInspection Rejected(string detail) =>
+        new(false, null, detail);
+}
 
 internal static class WindowsAuthenticodeVerifier
 {
@@ -33,19 +50,37 @@ internal static class WindowsAuthenticodeVerifier
     // re-signed with a different certificate would get a different family name.
     private const string WslPackageFamilyName =
         "MicrosoftCorporationII.WindowsSubsystemForLinux_8wekyb3d8bbwe";
+    private const string TrustedInstallerSid =
+        "S-1-5-80-956008885-3418522649-1831038044-1853292631-2271478464";
 
     public static AuthenticodeTrustResult VerifyMicrosoftSignedFile(string path) =>
-        VerifyMicrosoftSignedFile(path, LookupWslAppxPackageViaPowerShell);
+        VerifyMicrosoftSignedFile(
+            path,
+            VerifyAuthenticodeSignature,
+            LookupWslAppxPackageViaPowerShell,
+            InspectWslRelayPath);
 
     /// <summary>
-    /// Test seam: allows callers to substitute a fake WSL AppX package lookup
-    /// instead of shelling out to PowerShell.
+    /// Test seam for the primary signature, WSL package, and protected-path
+    /// evidence used by the package fallback.
     /// </summary>
     internal static AuthenticodeTrustResult VerifyMicrosoftSignedFile(
         string path,
-        Func<AppxPackageInfo?> lookupWslPackage)
+        Func<string, AuthenticodeTrustResult> verifyAuthenticode,
+        Func<AppxPackageInfo?> lookupWslPackage,
+        Func<string, string, WslRelayPathInspection> inspectRelayPath)
     {
-        var primary = VerifyAuthenticodeSignature(path);
+        AuthenticodeTrustResult primary;
+        try
+        {
+            primary = verifyAuthenticode(path);
+        }
+        catch
+        {
+            return AuthenticodeTrustResult.Rejected(
+                "WSL relay Authenticode verification could not complete.");
+        }
+
         if (primary.IsTrusted)
             return primary;
 
@@ -56,7 +91,7 @@ internal static class WindowsAuthenticodeVerifier
         if (!string.Equals(Path.GetFileName(path), "wslrelay.exe", StringComparison.OrdinalIgnoreCase))
             return primary;
 
-        return VerifyWslPackageFallback(primary, lookupWslPackage);
+        return VerifyWslPackageFallback(path, primary, lookupWslPackage, inspectRelayPath);
     }
 
     private static AuthenticodeTrustResult VerifyAuthenticodeSignature(string path)
@@ -92,8 +127,10 @@ internal static class WindowsAuthenticodeVerifier
     }
 
     private static AuthenticodeTrustResult VerifyWslPackageFallback(
+        string path,
         AuthenticodeTrustResult primaryFailure,
-        Func<AppxPackageInfo?> lookupWslPackage)
+        Func<AppxPackageInfo?> lookupWslPackage,
+        Func<string, string, WslRelayPathInspection> inspectRelayPath)
     {
         AppxPackageInfo? package;
         try
@@ -132,7 +169,96 @@ internal static class WindowsAuthenticodeVerifier
                 "WSL package signature verification failed: the installed WSL package's publisher is not Microsoft Corporation.");
         }
 
+        if (string.IsNullOrWhiteSpace(info.InstallLocation) ||
+            !Path.IsPathFullyQualified(info.InstallLocation))
+        {
+            return AuthenticodeTrustResult.Rejected(
+                "WSL package provenance verification failed: package location data is unavailable.");
+        }
+
+        string fullPath;
+        string installLocation;
+        try
+        {
+            fullPath = Path.GetFullPath(path);
+            installLocation = Path.GetFullPath(info.InstallLocation);
+        }
+        catch
+        {
+            return AuthenticodeTrustResult.Rejected(
+                "WSL package provenance verification failed: package location data is invalid.");
+        }
+
+        var programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+        var windowsAppsRoot = Path.Combine(programFiles, "WindowsApps");
+        if (IsPathWithin(installLocation, windowsAppsRoot) &&
+            IsPathWithin(fullPath, installLocation))
+        {
+            return ToTrustResult(
+                InspectProtectedRelayPath(fullPath, programFiles, inspectRelayPath));
+        }
+
+        var externalRelayPath = Path.Combine(programFiles, "WSL", "wslrelay.exe");
+        if (!string.Equals(fullPath, externalRelayPath, StringComparison.OrdinalIgnoreCase))
+        {
+            return AuthenticodeTrustResult.Rejected(
+                "WSL package provenance verification failed: the relay is not owned by the installed WSL package.");
+        }
+
+        var inspection = InspectProtectedRelayPath(
+            fullPath,
+            programFiles,
+            inspectRelayPath);
+        if (!inspection.IsSecure)
+            return ToTrustResult(inspection);
+
+        // The external WSL layout stamps wslrelay.exe with the package version.
+        // Exact equality binds the protected external bytes to the installed package.
+        if (!VersionsMatch(info.Version, inspection.FileVersion))
+        {
+            return AuthenticodeTrustResult.Rejected(
+                "WSL package provenance verification failed: the external relay version does not match the installed WSL package.");
+        }
+
         return AuthenticodeTrustResult.Trusted();
+    }
+
+    private static WslRelayPathInspection InspectProtectedRelayPath(
+        string fullPath,
+        string trustedRoot,
+        Func<string, string, WslRelayPathInspection> inspectRelayPath)
+    {
+        try
+        {
+            return inspectRelayPath(fullPath, trustedRoot);
+        }
+        catch
+        {
+            return WslRelayPathInspection.Rejected(
+                "WSL package provenance verification failed: the relay path could not be inspected.");
+        }
+    }
+
+    private static AuthenticodeTrustResult ToTrustResult(WslRelayPathInspection inspection) =>
+        inspection.IsSecure
+            ? AuthenticodeTrustResult.Trusted()
+            : AuthenticodeTrustResult.Rejected(
+                inspection.Detail ??
+                "WSL package provenance verification failed: the relay path is not protected.");
+
+    private static bool VersionsMatch(string? packageVersion, string? fileVersion) =>
+        Version.TryParse(packageVersion, out var parsedPackageVersion) &&
+        Version.TryParse(fileVersion, out var parsedFileVersion) &&
+        parsedPackageVersion.Equals(parsedFileVersion);
+
+    private static bool IsPathWithin(string path, string root)
+    {
+        var relative = Path.GetRelativePath(root, path);
+        return !Path.IsPathRooted(relative) &&
+               !string.Equals(relative, "..", StringComparison.Ordinal) &&
+               !relative.StartsWith(
+                   $"..{Path.DirectorySeparatorChar}",
+                   StringComparison.Ordinal);
     }
 
     internal static bool HasMicrosoftPublisherIdentity(string subject) =>
@@ -162,7 +288,10 @@ internal static class WindowsAuthenticodeVerifier
             psi.ArgumentList.Add("-Command");
             psi.ArgumentList.Add(
                 "Get-AppxPackage -Name 'MicrosoftCorporationII.WindowsSubsystemForLinux' | " +
-                "Select-Object -First 1 PackageFamilyName, Publisher, SignatureKind | " +
+                "Sort-Object Version -Descending | " +
+                "Select-Object -First 1 PackageFamilyName, Publisher, InstallLocation, " +
+                "@{Name='SignatureKind'; Expression={$_.SignatureKind.ToString()}}, " +
+                "@{Name='Version'; Expression={$_.Version.ToString()}} | " +
                 "ConvertTo-Json -Compress");
 
             process = Process.Start(psi);
@@ -237,7 +366,9 @@ internal static class WindowsAuthenticodeVerifier
             return new AppxPackageInfo(
                 familyName,
                 GetStringProperty(root, "Publisher"),
-                GetStringProperty(root, "SignatureKind"));
+                GetStringProperty(root, "SignatureKind"),
+                GetStringProperty(root, "InstallLocation"),
+                GetStringProperty(root, "Version"));
         }
         catch
         {
@@ -249,4 +380,138 @@ internal static class WindowsAuthenticodeVerifier
         element.TryGetProperty(propertyName, out var value) && value.ValueKind == JsonValueKind.String
             ? value.GetString()
             : null;
+
+    private static WslRelayPathInspection InspectWslRelayPath(
+        string path,
+        string trustedRoot)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return WslRelayPathInspection.Rejected(
+                "WSL package provenance verification is only available on Windows.");
+        }
+
+        try
+        {
+            var fullPath = Path.GetFullPath(path);
+            var fullRoot = Path.GetFullPath(trustedRoot);
+            if (!File.Exists(fullPath) || !IsPathWithin(fullPath, fullRoot))
+            {
+                return WslRelayPathInspection.Rejected(
+                    "WSL package provenance verification failed: the relay path is unavailable or outside its trusted root.");
+            }
+
+            for (var current = fullPath; ; current = Path.GetDirectoryName(current)!)
+            {
+                if ((File.GetAttributes(current) & FileAttributes.ReparsePoint) != 0)
+                {
+                    return WslRelayPathInspection.Rejected(
+                        "WSL package provenance verification failed: the relay path contains a reparse point.");
+                }
+
+                FileSystemSecurity security =
+                    string.Equals(current, fullPath, StringComparison.OrdinalIgnoreCase)
+                        ? new FileInfo(current).GetAccessControl(
+                            AccessControlSections.Owner | AccessControlSections.Access)
+                        : new DirectoryInfo(current).GetAccessControl(
+                            AccessControlSections.Owner | AccessControlSections.Access);
+                if (!HasProtectedOwnershipAndWriteAcl(security))
+                {
+                    return WslRelayPathInspection.Rejected(
+                        "WSL package provenance verification failed: the relay path permits untrusted modification.");
+                }
+
+                if (string.Equals(current, fullRoot, StringComparison.OrdinalIgnoreCase))
+                    break;
+
+                if (string.IsNullOrWhiteSpace(Path.GetDirectoryName(current)))
+                {
+                    return WslRelayPathInspection.Rejected(
+                        "WSL package provenance verification failed: the relay path escaped its trusted root.");
+                }
+            }
+
+            return WslRelayPathInspection.Secure(
+                FileVersionInfo.GetVersionInfo(fullPath).FileVersion);
+        }
+        catch
+        {
+            return WslRelayPathInspection.Rejected(
+                "WSL package provenance verification failed: the relay path could not be inspected.");
+        }
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static bool HasProtectedOwnershipAndWriteAcl(FileSystemSecurity security)
+    {
+        var owner = security.GetOwner(typeof(SecurityIdentifier)) as SecurityIdentifier;
+        var rules = security.GetAccessRules(
+                includeExplicit: true,
+                includeInherited: true,
+                targetType: typeof(SecurityIdentifier))
+            .OfType<FileSystemAccessRule>();
+        var descriptor = new RawSecurityDescriptor(
+            security.GetSecurityDescriptorBinaryForm(),
+            offset: 0);
+        var hasDiscretionaryAcl =
+            (descriptor.ControlFlags & ControlFlags.DiscretionaryAclPresent) != 0 &&
+            descriptor.DiscretionaryAcl is not null;
+        return HasProtectedOwnershipAndWriteAcl(
+            owner,
+            rules,
+            hasDiscretionaryAcl);
+    }
+
+    [SupportedOSPlatform("windows")]
+    internal static bool HasProtectedOwnershipAndWriteAcl(
+        SecurityIdentifier? owner,
+        IEnumerable<FileSystemAccessRule> rules,
+        bool hasDiscretionaryAcl)
+    {
+        if (!hasDiscretionaryAcl)
+            return false;
+
+        var system = new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null);
+        var administrators = new SecurityIdentifier(
+            WellKnownSidType.BuiltinAdministratorsSid,
+            null);
+        var trustedInstaller = new SecurityIdentifier(TrustedInstallerSid);
+        if (owner is null ||
+            (!owner.Equals(system) &&
+             !owner.Equals(administrators) &&
+             !owner.Equals(trustedInstaller)))
+        {
+            return false;
+        }
+
+        const FileSystemRights writeRights =
+            FileSystemRights.WriteData |
+            FileSystemRights.AppendData |
+            FileSystemRights.WriteExtendedAttributes |
+            FileSystemRights.WriteAttributes |
+            FileSystemRights.DeleteSubdirectoriesAndFiles |
+            FileSystemRights.Delete |
+            FileSystemRights.ChangePermissions |
+            FileSystemRights.TakeOwnership;
+
+        foreach (var rule in rules)
+        {
+            if ((rule.PropagationFlags & PropagationFlags.InheritOnly) != 0 ||
+                rule.AccessControlType != AccessControlType.Allow ||
+                (rule.FileSystemRights & writeRights) == 0)
+            {
+                continue;
+            }
+
+            if (rule.IdentityReference is not SecurityIdentifier sid ||
+                (!sid.Equals(system) &&
+                 !sid.Equals(administrators) &&
+                 !sid.Equals(trustedInstaller)))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }

--- a/src/OpenClaw.Connection/WindowsAuthenticodeVerifier.cs
+++ b/src/OpenClaw.Connection/WindowsAuthenticodeVerifier.cs
@@ -1,5 +1,9 @@
 using System;
+using System.Diagnostics;
 using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
 using Microsoft.Security.Extensions;
 
 namespace OpenClaw.Connection;
@@ -11,9 +15,51 @@ internal readonly record struct AuthenticodeTrustResult(bool IsTrusted, string? 
     public static AuthenticodeTrustResult Rejected(string detail) => new(false, detail);
 }
 
+/// <summary>
+/// Minimal projection of a Windows AppX/MSIX package as reported by
+/// <c>Get-AppxPackage</c>, used to corroborate genuine Microsoft WSL binaries that
+/// ship without a per-file Authenticode/catalog signature (MSIX packages are
+/// trusted at the package level, not per-file).
+/// </summary>
+internal readonly record struct AppxPackageInfo(
+    string? PackageFamilyName,
+    string? Publisher,
+    string? SignatureKind);
+
 internal static class WindowsAuthenticodeVerifier
 {
-    public static AuthenticodeTrustResult VerifyMicrosoftSignedFile(string path)
+    // Modern WSL ships as an MSIX package. The trailing suffix is a hash derived
+    // from the publisher's signing certificate/public key, so an impostor package
+    // re-signed with a different certificate would get a different family name.
+    private const string WslPackageFamilyName =
+        "MicrosoftCorporationII.WindowsSubsystemForLinux_8wekyb3d8bbwe";
+
+    public static AuthenticodeTrustResult VerifyMicrosoftSignedFile(string path) =>
+        VerifyMicrosoftSignedFile(path, LookupWslAppxPackageViaPowerShell);
+
+    /// <summary>
+    /// Test seam: allows callers to substitute a fake WSL AppX package lookup
+    /// instead of shelling out to PowerShell.
+    /// </summary>
+    internal static AuthenticodeTrustResult VerifyMicrosoftSignedFile(
+        string path,
+        Func<AppxPackageInfo?> lookupWslPackage)
+    {
+        var primary = VerifyAuthenticodeSignature(path);
+        if (primary.IsTrusted)
+            return primary;
+
+        // MSIX packages (modern WSL) don't carry a per-file Authenticode/catalog
+        // signature, so a failed classic check isn't conclusive for wslrelay.exe.
+        // Only consult the package-level fallback for the WSL binaries this
+        // codebase actually cares about; never widen trust for arbitrary files.
+        if (!string.Equals(Path.GetFileName(path), "wslrelay.exe", StringComparison.OrdinalIgnoreCase))
+            return primary;
+
+        return VerifyWslPackageFallback(primary, lookupWslPackage);
+    }
+
+    private static AuthenticodeTrustResult VerifyAuthenticodeSignature(string path)
     {
         try
         {
@@ -45,6 +91,50 @@ internal static class WindowsAuthenticodeVerifier
         }
     }
 
+    private static AuthenticodeTrustResult VerifyWslPackageFallback(
+        AuthenticodeTrustResult primaryFailure,
+        Func<AppxPackageInfo?> lookupWslPackage)
+    {
+        AppxPackageInfo? package;
+        try
+        {
+            package = lookupWslPackage();
+        }
+        catch
+        {
+            package = null;
+        }
+
+        if (package is not { } info)
+        {
+            // No genuine WSL AppX package installed to corroborate; surface the
+            // original Authenticode diagnostic rather than a new, less useful one.
+            return primaryFailure;
+        }
+
+        if (!string.Equals(info.PackageFamilyName, WslPackageFamilyName, StringComparison.Ordinal))
+        {
+            // Doesn't match the well-known family name (a different/impostor
+            // package can't corroborate this binary); surface the original detail.
+            return primaryFailure;
+        }
+
+        if (string.IsNullOrEmpty(info.SignatureKind) ||
+            string.Equals(info.SignatureKind, "None", StringComparison.OrdinalIgnoreCase))
+        {
+            return AuthenticodeTrustResult.Rejected(
+                "WSL package signature verification failed: the installed WSL package is unsigned.");
+        }
+
+        if (info.Publisher is null || !HasMicrosoftPublisherIdentity(info.Publisher))
+        {
+            return AuthenticodeTrustResult.Rejected(
+                "WSL package signature verification failed: the installed WSL package's publisher is not Microsoft Corporation.");
+        }
+
+        return AuthenticodeTrustResult.Trusted();
+    }
+
     internal static bool HasMicrosoftPublisherIdentity(string subject) =>
         subject.Split(',')
             .Select(part => part.Trim())
@@ -53,4 +143,110 @@ internal static class WindowsAuthenticodeVerifier
                     part,
                     "O=Microsoft Corporation",
                     StringComparison.OrdinalIgnoreCase));
+
+    private static AppxPackageInfo? LookupWslAppxPackageViaPowerShell()
+    {
+        Process? process = null;
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = ResolvePowerShellPath(),
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+            };
+            psi.ArgumentList.Add("-NoProfile");
+            psi.ArgumentList.Add("-NonInteractive");
+            psi.ArgumentList.Add("-Command");
+            psi.ArgumentList.Add(
+                "Get-AppxPackage -Name 'MicrosoftCorporationII.WindowsSubsystemForLinux' | " +
+                "Select-Object -First 1 PackageFamilyName, Publisher, SignatureKind | " +
+                "ConvertTo-Json -Compress");
+
+            process = Process.Start(psi);
+            if (process is null)
+                return null;
+
+            using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(8));
+            var stdoutTask = process.StandardOutput.ReadToEndAsync(timeout.Token);
+            var stderrTask = process.StandardError.ReadToEndAsync(timeout.Token);
+
+            if (!process.WaitForExit(8_000))
+            {
+                try { process.Kill(entireProcessTree: true); } catch { }
+                return null;
+            }
+
+            string output;
+            try
+            {
+                output = stdoutTask.GetAwaiter().GetResult();
+                _ = stderrTask.GetAwaiter().GetResult();
+            }
+            catch
+            {
+                return null;
+            }
+
+            if (process.ExitCode != 0 || string.IsNullOrWhiteSpace(output))
+                return null;
+
+            return ParseAppxPackageJson(output);
+        }
+        catch
+        {
+            return null;
+        }
+        finally
+        {
+            process?.Dispose();
+        }
+    }
+
+    private static string ResolvePowerShellPath()
+    {
+        var systemRoot = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
+        if (string.IsNullOrWhiteSpace(systemRoot))
+            systemRoot = Environment.GetEnvironmentVariable("SystemRoot");
+        if (string.IsNullOrWhiteSpace(systemRoot))
+            systemRoot = @"C:\Windows";
+        return Path.Combine(systemRoot, "System32", "WindowsPowerShell", "v1.0", "powershell.exe");
+    }
+
+    private static AppxPackageInfo? ParseAppxPackageJson(string json)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(json);
+            var root = document.RootElement;
+            if (root.ValueKind == JsonValueKind.Array)
+            {
+                if (root.GetArrayLength() == 0)
+                    return null;
+                root = root[0];
+            }
+            if (root.ValueKind != JsonValueKind.Object)
+                return null;
+
+            var familyName = GetStringProperty(root, "PackageFamilyName");
+            if (familyName is null)
+                return null;
+
+            return new AppxPackageInfo(
+                familyName,
+                GetStringProperty(root, "Publisher"),
+                GetStringProperty(root, "SignatureKind"));
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static string? GetStringProperty(JsonElement element, string propertyName) =>
+        element.TryGetProperty(propertyName, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
 }

--- a/tests/OpenClaw.Connection.Tests/ManagedLocalGatewayPortProvenanceServiceTests.cs
+++ b/tests/OpenClaw.Connection.Tests/ManagedLocalGatewayPortProvenanceServiceTests.cs
@@ -1,4 +1,7 @@
 using System.Net;
+using System.Runtime.Versioning;
+using System.Security.AccessControl;
+using System.Security.Principal;
 using OpenClaw.Shared;
 using Xunit;
 
@@ -55,41 +58,120 @@ public class ManagedLocalGatewayPortProvenanceServiceTests
 
     private const string WslPackageFamilyName =
         "MicrosoftCorporationII.WindowsSubsystemForLinux_8wekyb3d8bbwe";
-    private const string NonCanonicalWslRelayPath = @"C:\Program Files\WSL\wslrelay.exe";
+    private const string WslPackageInstallLocation =
+        @"C:\Program Files\WindowsApps\MicrosoftCorporationII.WindowsSubsystemForLinux_2.9.4.0_x64__8wekyb3d8bbwe";
+    private const string ExternalWslRelayPath = @"C:\Program Files\WSL\wslrelay.exe";
+    private const string PackageVersion = "2.9.4.0";
 
     [Fact]
-    public void VerifyMicrosoftSignedFile_AuthenticodeFailsButWslPackageCorroborates_IsTrusted()
+    public void VerifyMicrosoftSignedFile_AuthenticodeFailsButProtectedExternalRelayMatchesPackage_IsTrusted()
     {
-        var result = WindowsAuthenticodeVerifier.VerifyMicrosoftSignedFile(
-            NonCanonicalWslRelayPath,
-            () => new AppxPackageInfo(
-                WslPackageFamilyName,
-                "CN=Microsoft Windows, O=Microsoft Corporation, C=US",
-                "Developer"));
+        var result = VerifyPackageFallback(ExternalWslRelayPath, ValidWslPackage());
 
         Assert.True(result.IsTrusted, result.Detail);
     }
 
     [Fact]
-    public void VerifyMicrosoftSignedFile_AuthenticodeFailsAndNoWslPackageFound_IsRejectedWithOriginalDetail()
+    public void VerifyMicrosoftSignedFile_AuthenticodeFailsButPackageOwnsWindowsAppsRelay_IsTrusted()
     {
+        var packageRelayPath = Path.Combine(WslPackageInstallLocation, "wslrelay.exe");
+
+        var result = VerifyPackageFallback(
+            packageRelayPath,
+            ValidWslPackage(),
+            WslRelayPathInspection.Secure("different-file-version"));
+
+        Assert.True(result.IsTrusted, result.Detail);
+    }
+
+    [Fact]
+    public void VerifyMicrosoftSignedFile_SiblingWindowsAppsRelay_IsRejectedWithoutPathInspection()
+    {
+        var inspected = false;
+        var siblingRelayPath = Path.Combine(
+            @"C:\Program Files\WindowsApps\SomeOther.Package_1.0.0.0_x64__deadbeefcafe",
+            "wslrelay.exe");
+
         var result = WindowsAuthenticodeVerifier.VerifyMicrosoftSignedFile(
-            NonCanonicalWslRelayPath,
-            () => null);
+            siblingRelayPath,
+            _ => AuthenticodeTrustResult.Rejected("Injected primary failure."),
+            () => ValidWslPackage(),
+            (_, _) =>
+            {
+                inspected = true;
+                return WslRelayPathInspection.Secure(PackageVersion);
+            });
 
         Assert.False(result.IsTrusted);
-        Assert.Contains("Authenticode", result.Detail, StringComparison.Ordinal);
+        Assert.False(inspected);
+        Assert.Contains("not owned", result.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void VerifyMicrosoftSignedFile_ExternalRelayVersionMismatch_IsRejected()
+    {
+        var result = VerifyPackageFallback(
+            ExternalWslRelayPath,
+            ValidWslPackage(),
+            WslRelayPathInspection.Secure("2.9.3.0"));
+
+        Assert.False(result.IsTrusted);
+        Assert.Contains("version does not match", result.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void VerifyMicrosoftSignedFile_ExternalRelayWithUnprotectedPath_IsRejected()
+    {
+        var result = VerifyPackageFallback(
+            ExternalWslRelayPath,
+            ValidWslPackage(),
+            WslRelayPathInspection.Rejected("Injected unprotected path."));
+
+        Assert.False(result.IsTrusted);
+        Assert.Contains("unprotected", result.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void VerifyMicrosoftSignedFile_RelativePackageLocation_IsRejectedWithoutPathInspection()
+    {
+        var inspected = false;
+        var package = ValidWslPackage() with { InstallLocation = @"relative\package" };
+
+        var result = WindowsAuthenticodeVerifier.VerifyMicrosoftSignedFile(
+            ExternalWslRelayPath,
+            _ => AuthenticodeTrustResult.Rejected("Injected primary failure."),
+            () => package,
+            (_, _) =>
+            {
+                inspected = true;
+                return WslRelayPathInspection.Secure(PackageVersion);
+            });
+
+        Assert.False(result.IsTrusted);
+        Assert.False(inspected);
+        Assert.Contains("location data is unavailable", result.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void VerifyMicrosoftSignedFile_AuthenticodeFailsAndNoWslPackageFound_IsRejectedWithOriginalDetail()
+    {
+        var result = VerifyPackageFallback(ExternalWslRelayPath, null);
+
+        Assert.False(result.IsTrusted);
+        Assert.Contains("Injected primary failure", result.Detail, StringComparison.Ordinal);
     }
 
     [Fact]
     public void VerifyMicrosoftSignedFile_AuthenticodeFailsAndWslPackageFamilyNameMismatches_IsRejected()
     {
-        var result = WindowsAuthenticodeVerifier.VerifyMicrosoftSignedFile(
-            NonCanonicalWslRelayPath,
-            () => new AppxPackageInfo(
+        var result = VerifyPackageFallback(
+            ExternalWslRelayPath,
+            new AppxPackageInfo(
                 "SomeImpostor.WindowsSubsystemForLinux_deadbeefcafe",
                 "CN=Microsoft Windows, O=Microsoft Corporation, C=US",
-                "Developer"));
+                "Developer",
+                WslPackageInstallLocation,
+                PackageVersion));
 
         Assert.False(result.IsTrusted);
     }
@@ -97,12 +179,14 @@ public class ManagedLocalGatewayPortProvenanceServiceTests
     [Fact]
     public void VerifyMicrosoftSignedFile_AuthenticodeFailsAndWslPackageUnsigned_IsRejected()
     {
-        var result = WindowsAuthenticodeVerifier.VerifyMicrosoftSignedFile(
-            NonCanonicalWslRelayPath,
-            () => new AppxPackageInfo(
+        var result = VerifyPackageFallback(
+            ExternalWslRelayPath,
+            new AppxPackageInfo(
                 WslPackageFamilyName,
                 "CN=Microsoft Windows, O=Microsoft Corporation, C=US",
-                "None"));
+                "None",
+                WslPackageInstallLocation,
+                PackageVersion));
 
         Assert.False(result.IsTrusted);
         Assert.Contains("WSL package", result.Detail, StringComparison.Ordinal);
@@ -111,12 +195,14 @@ public class ManagedLocalGatewayPortProvenanceServiceTests
     [Fact]
     public void VerifyMicrosoftSignedFile_AuthenticodeFailsAndWslPackagePublisherNotMicrosoft_IsRejected()
     {
-        var result = WindowsAuthenticodeVerifier.VerifyMicrosoftSignedFile(
-            NonCanonicalWslRelayPath,
-            () => new AppxPackageInfo(
+        var result = VerifyPackageFallback(
+            ExternalWslRelayPath,
+            new AppxPackageInfo(
                 WslPackageFamilyName,
                 "CN=Evil Corp, O=Evil Corp, C=US",
-                "Developer"));
+                "Developer",
+                WslPackageInstallLocation,
+                PackageVersion));
 
         Assert.False(result.IsTrusted);
         Assert.Contains("WSL package", result.Detail, StringComparison.Ordinal);
@@ -125,20 +211,112 @@ public class ManagedLocalGatewayPortProvenanceServiceTests
     [Fact]
     public void VerifyMicrosoftSignedFile_AuthenticodeSucceeds_NeverConsultsWslPackageFallback()
     {
-        var windowsDir = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
-        var wslPath = Path.Combine(windowsDir, "System32", "wsl.exe");
         var fallbackInvoked = false;
 
         var result = WindowsAuthenticodeVerifier.VerifyMicrosoftSignedFile(
-            wslPath,
+            ExternalWslRelayPath,
+            _ => AuthenticodeTrustResult.Trusted(),
             () =>
             {
                 fallbackInvoked = true;
                 throw new InvalidOperationException("Fallback should not be consulted.");
-            });
+            },
+            (_, _) => throw new InvalidOperationException("Path should not be inspected."));
 
         Assert.True(result.IsTrusted, result.Detail);
         Assert.False(fallbackInvoked);
+    }
+
+    [Fact]
+    public void VerifyMicrosoftSignedFile_NonRelayFailure_NeverConsultsWslPackageFallback()
+    {
+        var fallbackInvoked = false;
+
+        var result = WindowsAuthenticodeVerifier.VerifyMicrosoftSignedFile(
+            @"C:\Program Files\WSL\wsl.exe",
+            _ => AuthenticodeTrustResult.Rejected("Injected primary failure."),
+            () =>
+            {
+                fallbackInvoked = true;
+                return ValidWslPackage();
+            },
+            (_, _) => throw new InvalidOperationException("Path should not be inspected."));
+
+        Assert.False(result.IsTrusted);
+        Assert.Contains("Injected primary failure", result.Detail, StringComparison.Ordinal);
+        Assert.False(fallbackInvoked);
+    }
+
+    private static AppxPackageInfo ValidWslPackage() => new(
+        WslPackageFamilyName,
+        "CN=Microsoft Windows, O=Microsoft Corporation, C=US",
+        "Developer",
+        WslPackageInstallLocation,
+        PackageVersion);
+
+    private static AuthenticodeTrustResult VerifyPackageFallback(
+        string path,
+        AppxPackageInfo? package,
+        WslRelayPathInspection? pathInspection = null) =>
+        WindowsAuthenticodeVerifier.VerifyMicrosoftSignedFile(
+            path,
+            _ => AuthenticodeTrustResult.Rejected("Injected primary failure."),
+            () => package,
+            (_, _) => pathInspection ?? WslRelayPathInspection.Secure(PackageVersion));
+
+    [Fact]
+    [SupportedOSPlatform("windows")]
+    public void HasProtectedOwnershipAndWriteAcl_AllowsReadOnlyUsersButRejectsUserWrite()
+    {
+        var system = new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null);
+        var administrators = new SecurityIdentifier(
+            WellKnownSidType.BuiltinAdministratorsSid,
+            null);
+        var users = new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null);
+        FileSystemAccessRule[] protectedRules =
+        [
+            new(system, FileSystemRights.FullControl, AccessControlType.Allow),
+            new(administrators, FileSystemRights.Modify, AccessControlType.Allow),
+            new(users, FileSystemRights.ReadAndExecute, AccessControlType.Allow),
+            new(
+                new SecurityIdentifier(WellKnownSidType.CreatorOwnerSid, null),
+                FileSystemRights.FullControl,
+                InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit,
+                PropagationFlags.InheritOnly,
+                AccessControlType.Allow),
+        ];
+
+        Assert.True(
+            WindowsAuthenticodeVerifier.HasProtectedOwnershipAndWriteAcl(
+                system,
+                protectedRules,
+                hasDiscretionaryAcl: true));
+
+        var writableByUsers = protectedRules.Append(
+            new FileSystemAccessRule(
+                users,
+                FileSystemRights.WriteData,
+                AccessControlType.Allow));
+        Assert.False(
+            WindowsAuthenticodeVerifier.HasProtectedOwnershipAndWriteAcl(
+                system,
+                writableByUsers,
+                hasDiscretionaryAcl: true));
+        Assert.False(
+            WindowsAuthenticodeVerifier.HasProtectedOwnershipAndWriteAcl(
+                users,
+                protectedRules,
+                hasDiscretionaryAcl: true));
+        Assert.False(
+            WindowsAuthenticodeVerifier.HasProtectedOwnershipAndWriteAcl(
+                system,
+                [],
+                hasDiscretionaryAcl: false));
+        Assert.True(
+            WindowsAuthenticodeVerifier.HasProtectedOwnershipAndWriteAcl(
+                system,
+                [],
+                hasDiscretionaryAcl: true));
     }
 
     [Theory]

--- a/tests/OpenClaw.Connection.Tests/ManagedLocalGatewayPortProvenanceServiceTests.cs
+++ b/tests/OpenClaw.Connection.Tests/ManagedLocalGatewayPortProvenanceServiceTests.cs
@@ -53,6 +53,94 @@ public class ManagedLocalGatewayPortProvenanceServiceTests
         Assert.Contains("Authenticode verification failed", result.Detail);
     }
 
+    private const string WslPackageFamilyName =
+        "MicrosoftCorporationII.WindowsSubsystemForLinux_8wekyb3d8bbwe";
+    private const string NonCanonicalWslRelayPath = @"C:\Program Files\WSL\wslrelay.exe";
+
+    [Fact]
+    public void VerifyMicrosoftSignedFile_AuthenticodeFailsButWslPackageCorroborates_IsTrusted()
+    {
+        var result = WindowsAuthenticodeVerifier.VerifyMicrosoftSignedFile(
+            NonCanonicalWslRelayPath,
+            () => new AppxPackageInfo(
+                WslPackageFamilyName,
+                "CN=Microsoft Windows, O=Microsoft Corporation, C=US",
+                "Developer"));
+
+        Assert.True(result.IsTrusted, result.Detail);
+    }
+
+    [Fact]
+    public void VerifyMicrosoftSignedFile_AuthenticodeFailsAndNoWslPackageFound_IsRejectedWithOriginalDetail()
+    {
+        var result = WindowsAuthenticodeVerifier.VerifyMicrosoftSignedFile(
+            NonCanonicalWslRelayPath,
+            () => null);
+
+        Assert.False(result.IsTrusted);
+        Assert.Contains("Authenticode", result.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void VerifyMicrosoftSignedFile_AuthenticodeFailsAndWslPackageFamilyNameMismatches_IsRejected()
+    {
+        var result = WindowsAuthenticodeVerifier.VerifyMicrosoftSignedFile(
+            NonCanonicalWslRelayPath,
+            () => new AppxPackageInfo(
+                "SomeImpostor.WindowsSubsystemForLinux_deadbeefcafe",
+                "CN=Microsoft Windows, O=Microsoft Corporation, C=US",
+                "Developer"));
+
+        Assert.False(result.IsTrusted);
+    }
+
+    [Fact]
+    public void VerifyMicrosoftSignedFile_AuthenticodeFailsAndWslPackageUnsigned_IsRejected()
+    {
+        var result = WindowsAuthenticodeVerifier.VerifyMicrosoftSignedFile(
+            NonCanonicalWslRelayPath,
+            () => new AppxPackageInfo(
+                WslPackageFamilyName,
+                "CN=Microsoft Windows, O=Microsoft Corporation, C=US",
+                "None"));
+
+        Assert.False(result.IsTrusted);
+        Assert.Contains("WSL package", result.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void VerifyMicrosoftSignedFile_AuthenticodeFailsAndWslPackagePublisherNotMicrosoft_IsRejected()
+    {
+        var result = WindowsAuthenticodeVerifier.VerifyMicrosoftSignedFile(
+            NonCanonicalWslRelayPath,
+            () => new AppxPackageInfo(
+                WslPackageFamilyName,
+                "CN=Evil Corp, O=Evil Corp, C=US",
+                "Developer"));
+
+        Assert.False(result.IsTrusted);
+        Assert.Contains("WSL package", result.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void VerifyMicrosoftSignedFile_AuthenticodeSucceeds_NeverConsultsWslPackageFallback()
+    {
+        var windowsDir = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
+        var wslPath = Path.Combine(windowsDir, "System32", "wsl.exe");
+        var fallbackInvoked = false;
+
+        var result = WindowsAuthenticodeVerifier.VerifyMicrosoftSignedFile(
+            wslPath,
+            () =>
+            {
+                fallbackInvoked = true;
+                throw new InvalidOperationException("Fallback should not be consulted.");
+            });
+
+        Assert.True(result.IsTrusted, result.Detail);
+        Assert.False(fallbackInvoked);
+    }
+
     [Theory]
     [InlineData("CN=Microsoft Windows, O=Microsoft Corporation, C=US", true)]
     [InlineData("CN=Microsoft Corporation Test Certificate, O=Example Corp, C=US", false)]


### PR DESCRIPTION
## Summary

This is a maintainer follow-up to #1177. It preserves Pedro's original compatibility fix as the first commit, then completes the package-to-file provenance checks requested in the security review.

The compatibility problem in #1177 is real. Some Store/MSIX WSL installations can report a genuine `wslrelay.exe` as unsigned when inspected as an individual PE file, even though Windows trusted the MSIX package that installed it. The original PR correctly recognized that package trust can be relevant when per-file Authenticode is unavailable.

The missing piece was proving that the exact relay process owning the local listener came from that trusted package. It is not sufficient to prove these two facts independently:

1. A genuine Microsoft WSL package is installed.
2. A file named `wslrelay.exe` exists somewhere under a broadly accepted path.

The trusted package must own, or must be authoritatively bound to, the exact relay bytes being trusted.

## Credit

Pedro identified the Store/MSIX compatibility failure and implemented the initial package-level fallback in #1177. His original commit is preserved on this branch, including its authorship.

This follow-up does not replace that contribution. It builds on it by tightening the provenance contract at the credential-protection boundary.

## Background: why Windows signing has two relevant layers

Traditional Windows desktop binaries are often authenticated at the file layer:

- An executable can carry an embedded Authenticode signature.
- Windows can also establish file trust through a signed catalog.
- `FileSignatureInfo` gives us a useful file-level answer for those cases.

MSIX adds a package-level trust model:

- Windows validates the signed package during deployment.
- The package identity includes a package family, publisher, version, and installed location.
- Individual executable files inside or associated with the package do not always present the same file-level signature evidence that a traditional Win32 application would.

That means a failed per-file Authenticode result is not always proof that the WSL installation is malicious. However, package trust is not automatically transferable to an arbitrary file with the right name. Package trust answers "Windows trusts this package." It does not, by itself, answer "this exact process image came from that package."

## Why this is a security boundary

`ManagedLocalGatewayPortProvenanceService` is not merely displaying diagnostics. Its result helps decide whether OpenClaw may send shared or bootstrap credentials to a loopback listener.

Loopback is a network location, not an identity. A different local process can bind the expected port. If we trust a relay only because:

- its path looks generally plausible, and
- a genuine WSL package happens to be installed,

then an unrelated relay can inherit the package's trust without being owned by it. That creates a path for local credential disclosure.

The rule for this boundary is therefore:

> Before strong credentials cross the loopback boundary, every link from listener to process to executable to package must be positively established. Missing, ambiguous, or inconsistent evidence fails closed.

## Trust decision after this change

### 1. Keep file-level Authenticode first

The normal `FileSignatureInfo` path remains the primary check.

If the relay is signed and trusted by Microsoft at the file or catalog layer, the result returns immediately. Package lookup and filesystem fallback logic are not consulted.

Tests now inject this primary result explicitly. This matters because the relay on the maintainer test host is already validly Microsoft-signed. Without injection, fallback tests silently exercise the fast path and can appear to pass without testing package fallback at all.

### 2. Limit fallback to `wslrelay.exe`

A failed signature on any other filename returns the original failure. Installing WSL does not widen trust for arbitrary executables.

### 3. Validate the installed package identity

The fallback queries `Get-AppxPackage` for the active WSL package and reads:

- package family name
- publisher
- signature kind
- install location
- package version

The package must:

- match the known WSL package family exactly
- have a non-empty, non-`None` signature kind
- contain the exact `O=Microsoft Corporation` publisher identity
- report an absolute installed location

The PowerShell projection converts enum and version values to strings before JSON serialization. This was verified against the live `Get-AppxPackage` object because `SignatureKind` otherwise serializes in a shape the parser does not accept.

### 4. Bind WindowsApps relays to the exact package location

For a WindowsApps layout:

- the reported package install location must itself be below the real `Program Files\WindowsApps` root
- the inspected relay must be below that exact package install location
- a sibling package directory is rejected
- every path component from the relay through `WindowsApps` and `Program Files` is checked for reparse points
- ownership and effective write ACLs are checked on every component

This closes the original disconnect between "the WSL package is trusted" and "this relay path belongs to that package."

### 5. Bind the external Program Files relay

Current WSL packages can also use:

`C:\Program Files\WSL\wslrelay.exe`

That file is outside the package's immutable WindowsApps install directory, so package-location containment cannot prove ownership. The external path receives a stricter composite proof:

- the path must exactly equal the canonical `Program Files\WSL\wslrelay.exe`
- the relay and every parent through `Program Files` must contain no reparse point
- each component must be owned by SYSTEM, Administrators, or TrustedInstaller
- no other principal may have an effective allow ACE containing write, append, attribute-write, delete, DACL-change, or ownership-change rights
- the relay's file version must exactly equal the installed WSL package version

The exact version check binds the protected external relay to the installed package generation. A mismatch or an unreadable version fails closed.

## Windows ACL details worth preserving

Windows ACLs have several details that are easy to miss in security-sensitive code.

### Ownership is not the same as access

A SYSTEM-owned file can still be writable by another principal if its DACL grants that access. The implementation checks both owner and effective allow rules.

### Read access is expected

Users and application packages normally have read and execute access to files under `Program Files`. That is safe for this decision. The policy rejects modification rights, not ordinary read and execute rights.

### Inherit-only ACEs do not apply to the current object

A standard `Program Files` ACL can contain a `CREATOR OWNER` ACE marked `InheritOnly`. It describes permissions to materialize on descendants. It does not grant the creator rights on the current directory.

The policy ignores inherit-only ACEs while evaluating the current object. Descendants are each inspected separately, so effective inherited permissions are still checked where they apply.

### A null DACL is not an empty DACL

This distinction is especially important:

- An empty DACL denies access.
- A null or absent DACL grants full access to everyone.

High-level access-rule enumeration can look empty in both cases. The implementation reads the raw security descriptor and requires the `DiscretionaryAclPresent` control flag plus a non-null DACL before evaluating rules.

## Tests added or corrected

The focused tests now cover:

- primary Authenticode success never invokes fallback
- non-`wslrelay.exe` failures never invoke fallback
- a package-owned WindowsApps relay is accepted
- a sibling WindowsApps package relay is rejected before path inspection
- the protected external relay is accepted only with a package-version match
- an external relay version mismatch is rejected
- an unprotected external path is rejected
- a relative or unavailable package location is rejected
- missing package, wrong family, unsigned package, and non-Microsoft publisher are rejected
- Users may retain read and execute access
- a Users write ACE is rejected
- an untrusted owner is rejected
- an inherit-only `CREATOR OWNER` ACE does not create a false rejection
- a null DACL is rejected
- an empty DACL remains safe

## Validation

Executed from the isolated `C:\p1177` maintainer checkout with `OPENCLAW_REPO_ROOT=C:\p1177`:

```text
.\build.ps1
All builds succeeded.

dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore
Passed: 3791, Skipped: 32, Failed: 0

dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore
Passed: 2684, Skipped: 0, Failed: 0

dotnet test .\tests\OpenClaw.Connection.Tests\OpenClaw.Connection.Tests.csproj --no-restore
Passed: 673, Skipped: 0, Failed: 0

Focused ManagedLocalGatewayPortProvenanceServiceTests
Passed: 44, Skipped: 0, Failed: 0
```

One unrelated telemetry timing test failed once during closeout:

`McpHttpServerTelemetryTests.ShutdownWhileWaitingForHandler_RecordsShutdownNotBusyOrTimeout`

The exact test passed immediately on rerun. The complete required sequence then passed.

## Real behavior proof

The maintainer host has WSL 2.9.4 and a validly Microsoft-signed external relay, so normal execution returns through the primary Authenticode path. To exercise the fallback itself, the current-head assembly was invoked with an injected primary failure while retaining the production package lookup and production filesystem/ACL inspector.

```text
RelayPath              : C:\Program Files\WSL\wslrelay.exe
PackageFamilyName      : MicrosoftCorporationII.WindowsSubsystemForLinux_8wekyb3d8bbwe
PackageSignatureKind   : Developer
PackageInstallLocation : C:\Program Files\WindowsApps\
                         MicrosoftCorporationII.WindowsSubsystemForLinux_2.9.4.0_x64__8wekyb3d8bbwe
PackageVersion         : 2.9.4.0
RelayPathSecure        : True
RelayFileVersion       : 2.9.4.0
FallbackTrusted        : True
Detail                 :
```

This proves that the current-head package query, JSON projection, canonical external path, reparse walk, raw DACL handling, ownership/write policy, and version binding compose successfully on a real WSL installation.

### Proof limitation

A host where the genuine relay naturally reports an unsigned file-level result was not available for this maintainer pass. The fallback was therefore forced only at the injected primary-result seam. All downstream evidence came from the real installed package and real relay filesystem state.

## Review

The security-focused rubber-duck pass found no trust bypass. Its compatibility and path-ancestor suggestions were incorporated.

The structured ship review then found two Windows ACL edge cases:

1. Inherit-only `CREATOR OWNER` ACEs must not be treated as effective rights on the current object.
2. A null DACL must be distinguished from an empty DACL and rejected.

Both findings were fixed and covered by tests. The final structured review result was:

```text
autoreview clean: no accepted/actionable findings reported
overall: patch is correct
```

## Relationship to #1177

This PR supersedes #1177 for landing purposes while preserving and crediting its original compatibility contribution. The main change is not the goal of the fallback, which remains correct. The change is the proof required before package trust can be transferred to the exact listener-owning relay at a credential boundary.
