### PR TITLE
fix(setup): preserve trailing command output while bounding inherited-pipe waits

### DIFF
--- a/src/OpenClaw.SetupEngine/CleanupStaleDistroStep.cs
+++ b/src/OpenClaw.SetupEngine/CleanupStaleDistroStep.cs
@@ -24,7 +24,12 @@ public sealed class CleanupStaleDistroStep : SetupStep
         if (!DistroInstallPathPolicy.TryGetManagedInstallPath(ctx.LocalDataDir, distro, out var wslDir, out var pathError))
             return StepResult.Terminal(pathError);
 
-        var list = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--list", "--quiet"], TimeSpan.FromSeconds(15), ct: ct);
+        var list = await ctx.Commands.RunAsync(
+            WslConstants.WslExePath,
+            ["--list", "--quiet"],
+            TimeSpan.FromSeconds(15),
+            ct: ct,
+            allowInheritedPipeHandleEscape: true);
         if (list.ExitCode != 0)
             return StepResult.Ok("WSL not available or no distros - nothing to clean");
 

--- a/src/OpenClaw.SetupEngine/CommandRunner.cs
+++ b/src/OpenClaw.SetupEngine/CommandRunner.cs
@@ -17,7 +17,8 @@ public interface ICommandRunner
         string? workingDirectory = null,
         string? stdinInput = null,
         CancellationToken ct = default,
-        Stream? stdinStream = null);
+        Stream? stdinStream = null,
+        bool allowInheritedPipeHandleEscape = false);
 
     /// <summary>
     /// Run a command inside a WSL distro.
@@ -86,7 +87,8 @@ public sealed class CommandRunner : ICommandRunner
         string? workingDirectory = null,
         string? stdinInput = null,
         CancellationToken ct = default,
-        Stream? stdinStream = null)
+        Stream? stdinStream = null,
+        bool allowInheritedPipeHandleEscape = false)
     {
         ArgumentNullException.ThrowIfNull(executable);
         ArgumentNullException.ThrowIfNull(arguments);
@@ -192,12 +194,17 @@ public sealed class CommandRunner : ICommandRunner
             throw;
         }
 
-        // A surviving descendant can keep inherited pipe handles open after the child
-        // exits. Preserve output already in flight without charging the command's full
-        // timeout to an EOF that may never arrive.
-        await Task.WhenAny(
-            Task.WhenAll(stdoutClosed.Task, stderrClosed.Task),
-            Task.Delay(s_outputDrainGrace));
+        var outputClosed = Task.WhenAll(stdoutClosed.Task, stderrClosed.Task);
+        if (timedOut || allowInheritedPipeHandleEscape)
+        {
+            // Some WSL inspection commands can leave a descendant holding inherited
+            // pipe handles. Bound only those known waits, plus timeout cleanup.
+            await Task.WhenAny(outputClosed, Task.Delay(s_outputDrainGrace));
+        }
+        else
+        {
+            await outputClosed;
+        }
 
         sw.Stop();
         var result = new CommandResult(

--- a/src/OpenClaw.SetupEngine/CreateWslInstanceStep.cs
+++ b/src/OpenClaw.SetupEngine/CreateWslInstanceStep.cs
@@ -41,7 +41,12 @@ public sealed class CreateWslInstanceStep : SetupStep
 
         ctx.Logger.Info($"Creating clean app-owned WSL distro '{distro}' from '{baseDistro}' at '{installPath}'");
 
-        var existing = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--list", "--quiet"], TimeSpan.FromSeconds(15), ct: ct);
+        var existing = await ctx.Commands.RunAsync(
+            WslConstants.WslExePath,
+            ["--list", "--quiet"],
+            TimeSpan.FromSeconds(15),
+            ct: ct,
+            allowInheritedPipeHandleEscape: true);
         if (existing.ExitCode != 0)
             return StepResult.Fail($"Failed to list WSL distros before creating '{distro}': {existing.Stderr}");
 
@@ -108,7 +113,12 @@ public sealed class CreateWslInstanceStep : SetupStep
 
     private static async Task<StepResult> VerifyFreshDistro(SetupContext ctx, string distro, string installPath, CancellationToken ct)
     {
-        var list = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--list", "--quiet"], TimeSpan.FromSeconds(15), ct: ct);
+        var list = await ctx.Commands.RunAsync(
+            WslConstants.WslExePath,
+            ["--list", "--quiet"],
+            TimeSpan.FromSeconds(15),
+            ct: ct,
+            allowInheritedPipeHandleEscape: true);
         if (list.ExitCode != 0 || !WslInstallSupport.ContainsDistro(list.Stdout, distro))
         {
             var environmentIssue = await PreflightWslStep.DetectEnvironmentIssueAsync(ctx, ct);
@@ -120,7 +130,8 @@ public sealed class CreateWslInstanceStep : SetupStep
             WslConstants.WslExePath,
             ["--list", "--verbose"],
             DistroVersionVerificationTimeout,
-            ct: ct);
+            ct: ct,
+            allowInheritedPipeHandleEscape: true);
         if (verbose.ExitCode != 0 || !WslInstallSupport.TryGetDistroVersion(verbose.Stdout, distro, out var version))
             return StepResult.Fail($"Fresh WSL install registered '{distro}', but setup could not verify it is WSL2.");
 
@@ -164,7 +175,12 @@ public sealed class CreateWslInstanceStep : SetupStep
     {
         var cleanupErrors = new List<string>();
         var installPathExists = Directory.Exists(installPath) || File.Exists(installPath);
-        var list = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--list", "--quiet"], TimeSpan.FromSeconds(15), ct: ct);
+        var list = await ctx.Commands.RunAsync(
+            WslConstants.WslExePath,
+            ["--list", "--quiet"],
+            TimeSpan.FromSeconds(15),
+            ct: ct,
+            allowInheritedPipeHandleEscape: true);
         var registrationStateKnown = list.ExitCode == 0;
         var distroExists = registrationStateKnown && WslInstallSupport.ContainsDistro(list.Stdout, distro);
         var canDeleteInstallPath = registrationStateKnown && !distroExists;

--- a/src/OpenClaw.SetupEngine/ExistingConfigDetector.cs
+++ b/src/OpenClaw.SetupEngine/ExistingConfigDetector.cs
@@ -31,7 +31,11 @@ public sealed class ExistingConfigDetector
 
         var logger = new SetupLogger(filePath: null, LogLevel.Warn);
         var result = new CommandRunner(logger)
-            .RunAsync(WslConstants.WslExePath, ["--list", "--quiet"], TimeSpan.FromSeconds(5))
+            .RunAsync(
+                WslConstants.WslExePath,
+                ["--list", "--quiet"],
+                TimeSpan.FromSeconds(5),
+                allowInheritedPipeHandleEscape: true)
             .GetAwaiter()
             .GetResult();
         var hasDistro = InterpretDistroList(result, targetDistroName);

--- a/src/OpenClaw.SetupEngine/PreflightWslStep.cs
+++ b/src/OpenClaw.SetupEngine/PreflightWslStep.cs
@@ -48,7 +48,8 @@ internal static class WslViabilityInspector
                 WslConstants.WslExePath,
                 ["--version"],
                 TimeSpan.FromSeconds(5),
-                ct: ct);
+                ct: ct,
+                allowInheritedPipeHandleEscape: true);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -106,7 +107,8 @@ internal static class WslViabilityInspector
                 WslConstants.WslExePath,
                 ["--status"],
                 TimeSpan.FromSeconds(10),
-                ct: ct);
+                ct: ct,
+                allowInheritedPipeHandleEscape: true);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -186,7 +188,8 @@ public sealed class PreflightWslStep : SetupStep
             WslConstants.WslExePath,
             ["--status"],
             TimeSpan.FromSeconds(10),
-            ct: ct);
+            ct: ct,
+            allowInheritedPipeHandleEscape: true);
         var combined = $"{status.Stdout}\n{status.Stderr}";
         if (!WslInstallSupport.TryGetEnvironmentIssue(combined, out var message))
             return null;
@@ -230,7 +233,8 @@ public sealed class PreflightWslStep : SetupStep
                 WslConstants.WslExePath,
                 ["--version"],
                 TimeSpan.FromSeconds(5),
-                ct: ct);
+                ct: ct,
+                allowInheritedPipeHandleEscape: true);
             if (probe.ExitCode != 0 || WslViabilityInspector.LooksUnavailable(probe))
             {
                 return StepResult.Terminal(

--- a/src/OpenClaw.SetupEngine/StartGatewayStep.cs
+++ b/src/OpenClaw.SetupEngine/StartGatewayStep.cs
@@ -148,7 +148,12 @@ public sealed class StartGatewayStep : SetupStep
         var distro = ctx.DistroName!;
 
         // Check if distro is running before trying systemctl stop
-        var list = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--list", "--quiet"], TimeSpan.FromSeconds(15), ct: ct);
+        var list = await ctx.Commands.RunAsync(
+            WslConstants.WslExePath,
+            ["--list", "--quiet"],
+            TimeSpan.FromSeconds(15),
+            ct: ct,
+            allowInheritedPipeHandleEscape: true);
         if (!WslInstallSupport.ContainsDistro(list.Stdout, distro))
         {
             ctx.Logger.Info("[Uninstall] Distro not registered — skipping gateway stop");
@@ -156,7 +161,12 @@ public sealed class StartGatewayStep : SetupStep
         }
 
         // Check distro state — only stop if Running
-        var verbose = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--list", "--verbose"], TimeSpan.FromSeconds(15), ct: ct);
+        var verbose = await ctx.Commands.RunAsync(
+            WslConstants.WslExePath,
+            ["--list", "--verbose"],
+            TimeSpan.FromSeconds(15),
+            ct: ct,
+            allowInheritedPipeHandleEscape: true);
         var isRunning = WslInstallSupport.Normalize(verbose.Stdout)
             .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)
             .Any(line => line.Contains(distro, StringComparison.OrdinalIgnoreCase)

--- a/tests/OpenClaw.SetupEngine.Tests/CommandRunnerTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/CommandRunnerTests.cs
@@ -42,6 +42,23 @@ public class CommandRunnerTests
     }
 
     [Fact]
+    public async Task RunAsync_ProcessTimeoutRemainsBounded()
+    {
+        var runner = CreateRunner();
+        var (executable, arguments) = SleepingCommand();
+        var stopwatch = Stopwatch.StartNew();
+
+        var result = await runner.RunAsync(
+            executable,
+            arguments,
+            TimeSpan.FromMilliseconds(250));
+
+        Assert.True(result.TimedOut);
+        Assert.Equal(-1, result.ExitCode);
+        Assert.InRange(stopwatch.Elapsed, TimeSpan.Zero, TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
     public async Task RunAsync_StreamStdinPreservesBinaryBytes()
     {
         var path = Path.Combine(Path.GetTempPath(), $"openclaw-stdin-{Guid.NewGuid():N}.bin");
@@ -87,11 +104,34 @@ public class CommandRunnerTests
         var (executable, arguments) = ExitsLeavingPipeHolderCommand();
         var stopwatch = Stopwatch.StartNew();
 
-        var result = await runner.RunAsync(executable, arguments, TimeSpan.FromSeconds(30));
+        var result = await runner.RunAsync(
+            executable,
+            arguments,
+            TimeSpan.FromSeconds(30),
+            allowInheritedPipeHandleEscape: true);
 
         Assert.False(result.TimedOut);
         Assert.Equal(0, result.ExitCode);
         Assert.InRange(stopwatch.Elapsed, TimeSpan.Zero, TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task RunAsync_DrainsHighVolumeStdoutAndStderrThroughTrailingMarkers()
+    {
+        const int lineCount = 8_000;
+        var (executable, arguments) = HighVolumeOutputCommand(lineCount);
+
+        var result = await CreateRunner().RunAsync(
+            executable,
+            arguments,
+            TimeSpan.FromSeconds(30));
+
+        Assert.False(result.TimedOut);
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(lineCount, CountLinesStartingWith(result.Stdout, "stdout-"));
+        Assert.Equal(lineCount, CountLinesStartingWith(result.Stderr, "stderr-"));
+        Assert.EndsWith($"STDOUT_MARKER{Environment.NewLine}", result.Stdout, StringComparison.Ordinal);
+        Assert.EndsWith($"STDERR_MARKER{Environment.NewLine}", result.Stderr, StringComparison.Ordinal);
     }
 
     private static CommandRunner CreateRunner()
@@ -106,6 +146,29 @@ public class CommandRunnerTests
         => OperatingSystem.IsWindows()
             ? ("cmd.exe", ["/d", "/s", "/c", "ping 127.0.0.1 -n 30 >nul"])
             : ("/bin/sh", ["-c", "sleep 30"]);
+
+    private static (string Executable, string[] Arguments) HighVolumeOutputCommand(int lineCount)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            var shellScript =
+                $"i=0; while [ $i -lt {lineCount} ]; do echo stdout-$i; echo stderr-$i >&2; i=$((i+1)); done; " +
+                "echo STDOUT_MARKER; echo STDERR_MARKER >&2";
+            return ("/bin/sh", ["-c", shellScript]);
+        }
+
+        var powerShellScript =
+            $"for ($i = 0; $i -lt {lineCount}; $i++) {{ " +
+            "[Console]::Out.WriteLine(\"stdout-$i\"); " +
+            "[Console]::Error.WriteLine(\"stderr-$i\") }; " +
+            "[Console]::Out.WriteLine('STDOUT_MARKER'); " +
+            "[Console]::Error.WriteLine('STDERR_MARKER')";
+        return ("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", powerShellScript]);
+    }
+
+    private static int CountLinesStartingWith(string value, string prefix)
+        => value.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)
+            .Count(line => line.StartsWith(prefix, StringComparison.Ordinal));
 
     private static (string Executable, string[] Arguments) CopyStdinCommand(string path)
     {

--- a/tests/OpenClaw.SetupEngine.Tests/LocalAiGatewayUninstallTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/LocalAiGatewayUninstallTests.cs
@@ -194,7 +194,8 @@ public sealed class LocalAiGatewayUninstallTests
             string? workingDirectory = null,
             string? stdinInput = null,
             CancellationToken ct = default,
-            Stream? stdinStream = null) => throw new NotSupportedException();
+            Stream? stdinStream = null,
+            bool allowInheritedPipeHandleEscape = false) => throw new NotSupportedException();
 
         public Task<CommandResult> RunInWslAsync(
             string distroName,

--- a/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
@@ -4592,7 +4592,8 @@ public class SetupStepsTests : IDisposable
             string? workingDirectory = null,
             string? stdinInput = null,
             CancellationToken ct = default,
-            Stream? stdinStream = null)
+            Stream? stdinStream = null,
+            bool allowInheritedPipeHandleEscape = false)
         {
             Calls.Add((executable, arguments));
             TimedCalls.Add((executable, arguments, timeout));


### PR DESCRIPTION
## Summary

`CommandRunner.RunAsync` always applied a short bounded grace (`s_outputDrainGrace`) to the stdout/stderr drain after the child process exited. On high-volume commands whose output was still draining when that grace elapsed, trailing output could be truncated even though the process exited cleanly.

This change preserves complete output on the normal path and keeps the bounded wait only where it is actually needed:

- On the normal exit path, `RunAsync` now awaits full stdout/stderr close so all trailing output is captured.
- The bounded grace is applied only on timeout cleanup, or when a caller opts in via the new `allowInheritedPipeHandleEscape` parameter for WSL inspection commands whose descendants can keep inherited pipe handles open after the direct child exits.
- The `wsl.exe --list` / `--verbose` / `--version` / `--status` inspection callers (`CleanupStaleDistroStep`, `CreateWslInstanceStep`, `ExistingConfigDetector`, `StartGatewayStep`, `PreflightWslStep`) opt into the bounded escape, since those are the calls that can leave a descendant holding inherited handles.

Timeout and cancellation behavior are unchanged.

Fixes #1194

## Validation

- `dotnet test tests/OpenClaw.SetupEngine.Tests` (subsystem touched by this change): full suite **949/949 passed** after restoring against a local NuGet feed.
- Focused `CommandRunnerTests`: **7/7 passed**, including the new high-volume drain and bounded-timeout tests.
- Required `./build.ps1` and the Shared/Tray closeout suites are **Not verified / blocked**: NuGet cannot reach `https://api.nuget.org/v3/index.json` on this host (NU1900 "Unable to load the service index"; underlying TLS/service-index handshake failure), and the global cache lacks `Microsoft.ML.OnnxRuntime 1.29.0`. A maintainer on a network-enabled host should run `./build.ps1`, `dotnet test tests/OpenClaw.Shared.Tests`, and `dotnet test tests/OpenClaw.Tray.Tests` to complete closeout before merge.

## Real behavior proof

- New regression test `RunAsync_DrainsHighVolumeStdoutAndStderrThroughTrailingMarkers` runs a command emitting 8,000 lines on each of stdout and stderr followed by `STDOUT_MARKER` / `STDERR_MARKER`, on the **default** (non-opt-in) path. It asserts all 8,000 lines on each stream are present and that the output ends with the trailing marker, directly proving trailing output is no longer truncated.
- `RunAsync_ProcessTimeoutRemainsBounded` proves the timeout path still returns bounded (`TimedOut`, exit `-1`) within the grace window.
- `RunAsync_ExitsLeavingPipeHolder...` now passes `allowInheritedPipeHandleEscape: true`, proving the opt-in path stays bounded when a descendant holds an inherited pipe handle open.

This PR is intentionally left as a **draft** for a human to complete full-repo `./build.ps1` + Shared/Tray validation on a network-enabled host before merge.
