### PR TITLE
fix: Local AI fails to start after first setup

### DIFF
--- a/src/OpenClaw.Connection/LocalAi/LocalAiGatewayProviderDefinition.cs
+++ b/src/OpenClaw.Connection/LocalAi/LocalAiGatewayProviderDefinition.cs
@@ -86,12 +86,9 @@ public static class LocalAiGatewayProviderDefinition
     private static string BuildProviderJson(LocalAiResolvedInstall install, string apiKey)
     {
         ArgumentNullException.ThrowIfNull(install);
+        LocalModelInfo model = GetQualifiedModel(install);
         Uri endpoint = install.Endpoint
             ?? throw new InvalidOperationException("The verified Local AI endpoint is required.");
-        LocalModelInfo model = LocalModelCatalog.Find(install.Manifest.ModelCatalogId)
-            ?? throw new InvalidDataException("The managed Local AI model is no longer qualified.");
-        if (!string.Equals(model.Id, install.Manifest.ModelAlias, StringComparison.Ordinal))
-            throw new InvalidDataException("The managed Local AI model alias does not match the qualified catalog.");
 
         var value = new
         {
@@ -122,7 +119,17 @@ public static class LocalAiGatewayProviderDefinition
     public static string BuildPrimaryModel(LocalAiResolvedInstall install)
     {
         ArgumentNullException.ThrowIfNull(install);
+        _ = GetQualifiedModel(install);
         return $"llamacpp/{install.Manifest.ModelAlias}";
+    }
+
+    private static LocalModelInfo GetQualifiedModel(LocalAiResolvedInstall install)
+    {
+        LocalModelInfo model = LocalModelCatalog.Find(install.Manifest.ModelCatalogId)
+            ?? throw new InvalidDataException("The managed Local AI model is no longer qualified.");
+        if (!string.Equals(model.Id, install.Manifest.ModelAlias, StringComparison.Ordinal))
+            throw new InvalidDataException("The managed Local AI model alias does not match the qualified catalog.");
+        return model;
     }
 
     public static void ValidateFallbackModel(string? model)

--- a/src/OpenClaw.Tray.WinUI/Services/LocalAiGatewayProviderCoordinator.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/LocalAiGatewayProviderCoordinator.cs
@@ -41,19 +41,23 @@ internal sealed class LocalAiGatewayProviderCoordinator : ILocalAiEndpointLifecy
         string managedPrimary;
         try
         {
-            _ = LocalAiGatewayProviderDefinition.BuildProviderJson(install);
             managedPrimary = LocalAiGatewayProviderDefinition.BuildPrimaryModel(install);
             LocalAiGatewayProviderDefinition.ValidateFallbackModel(
                 install.Manifest.GatewayFallbackModel);
+            if (current.ProviderExists)
+            {
+                _ = LocalAiGatewayProviderDefinition.BuildProviderJson(install);
+                if (!LocalAiGatewayProviderDefinition.MatchesProviderJson(
+                        current.ProviderJson!,
+                        install))
+                {
+                    return Failed("The llamacpp provider was changed outside the companion; preserving it and refusing to cycle the managed endpoint.");
+                }
+            }
         }
         catch (Exception ex) when (ex is InvalidDataException or InvalidOperationException)
         {
             return Failed(ex.Message);
-        }
-        if (current.ProviderExists &&
-            !LocalAiGatewayProviderDefinition.MatchesProviderJson(current.ProviderJson!, install))
-        {
-            return Failed("The llamacpp provider was changed outside the companion; preserving it and refusing to cycle the managed endpoint.");
         }
 
         bool primaryIsManaged = current.PrimaryExists &&

--- a/tests/OpenClaw.Tray.Tests/LocalAiGatewayProviderCoordinatorTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalAiGatewayProviderCoordinatorTests.cs
@@ -64,6 +64,112 @@ public sealed class LocalAiGatewayProviderCoordinatorTests
     }
 
     [Fact]
+    public async Task Quiesce_NoProviderWithoutEndpoint_Succeeds()
+    {
+        LocalAiResolvedInstall install = InstallWithoutEndpoint(28_765);
+        var commands = new FakeWslCommandRunner(providerJson: null);
+        var coordinator = CreateCoordinator(commands);
+
+        LocalAiEndpointLifecycleResult result = await coordinator.QuiesceAsync(install);
+
+        Assert.True(result.Success);
+        Assert.Null(commands.ProviderJson);
+        Assert.Null(commands.PrimaryModel);
+        Assert.DoesNotContain(commands.Calls, call => call.Contains("unset"));
+    }
+
+    [Fact]
+    public async Task Quiesce_ExistingProviderWithoutEndpoint_PreservesProviderAndFailsClosed()
+    {
+        LocalAiResolvedInstall runningInstall = Install(28_765);
+        string provider = LocalAiGatewayProviderDefinition.BuildProviderJson(runningInstall);
+        var commands = new FakeWslCommandRunner(
+            provider,
+            LocalAiGatewayProviderDefinition.BuildPrimaryModel(runningInstall));
+        var coordinator = CreateCoordinator(commands);
+
+        LocalAiEndpointLifecycleResult result = await coordinator.QuiesceAsync(
+            InstallWithoutEndpoint(28_765));
+
+        Assert.False(result.Success);
+        Assert.Contains("verified Local AI endpoint is required", result.Detail, StringComparison.Ordinal);
+        Assert.Equal(provider, commands.ProviderJson);
+        Assert.Equal(LocalAiGatewayProviderDefinition.BuildPrimaryModel(runningInstall), commands.PrimaryModel);
+        Assert.DoesNotContain(commands.Calls, call => call.Contains("unset"));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Quiesce_NoProviderWithUnqualifiedManagedModel_PreservesPrimaryAndFailsClosed(
+        bool unknownCatalog)
+    {
+        LocalAiResolvedInstall valid = InstallWithoutEndpoint(28_765);
+        LocalAiResolvedInstall tampered = valid with
+        {
+            Manifest = valid.Manifest with
+            {
+                ModelCatalogId = unknownCatalog ? "missing-model" : valid.Manifest.ModelCatalogId,
+                ModelAlias = unknownCatalog ? valid.Manifest.ModelAlias : "tampered-model",
+            },
+        };
+        string primary = $"llamacpp/{tampered.Manifest.ModelAlias}";
+        var commands = new FakeWslCommandRunner(providerJson: null, primary);
+        var coordinator = CreateCoordinator(commands);
+
+        LocalAiEndpointLifecycleResult result = await coordinator.QuiesceAsync(tampered);
+
+        Assert.False(result.Success);
+        Assert.Contains("qualified", result.Detail, StringComparison.Ordinal);
+        Assert.Null(commands.ProviderJson);
+        Assert.Equal(primary, commands.PrimaryModel);
+        Assert.DoesNotContain(commands.Calls, call => call.Contains("unset"));
+        Assert.DoesNotContain(commands.Calls, call => call.Contains("/bin/sh"));
+    }
+
+    [Fact]
+    public async Task Quiesce_NoProviderWithoutEndpoint_UnsetsManagedPrimary()
+    {
+        LocalAiResolvedInstall install = InstallWithoutEndpoint(28_765);
+        var commands = new FakeWslCommandRunner(
+            providerJson: null,
+            LocalAiGatewayProviderDefinition.BuildPrimaryModel(install));
+        var coordinator = CreateCoordinator(commands);
+
+        LocalAiEndpointLifecycleResult result = await coordinator.QuiesceAsync(install);
+
+        Assert.True(result.Success);
+        Assert.Null(commands.ProviderJson);
+        Assert.Null(commands.PrimaryModel);
+        Assert.Contains(commands.Calls, call =>
+            call.Contains("unset") &&
+            call.Contains(LocalAiGatewayProviderDefinition.PrimaryModelPath));
+    }
+
+    [Fact]
+    public async Task Quiesce_NoProviderWithoutEndpoint_RestoresFallbackPrimary()
+    {
+        LocalAiResolvedInstall install = InstallWithoutEndpoint(28_765, "openai/gpt-5");
+        var commands = new FakeWslCommandRunner(
+            providerJson: null,
+            LocalAiGatewayProviderDefinition.BuildPrimaryModel(install))
+        {
+            PrimaryAfterApply = "openai/gpt-5",
+        };
+        var coordinator = CreateCoordinator(commands);
+
+        LocalAiEndpointLifecycleResult result = await coordinator.QuiesceAsync(install);
+
+        Assert.True(result.Success);
+        Assert.Null(commands.ProviderJson);
+        Assert.Equal("openai/gpt-5", commands.PrimaryModel);
+        Assert.Contains(commands.Calls, call => call.Contains("/bin/sh"));
+        Assert.DoesNotContain(commands.Calls, call =>
+            call.Contains("unset") &&
+            call.Contains(LocalAiGatewayProviderDefinition.ProviderPath));
+    }
+
+    [Fact]
     public async Task Publish_UsesVerifiedEndpointAndNonDefaultManagedDistro()
     {
         LocalAiResolvedInstall install = Install(28_766);
@@ -320,6 +426,18 @@ public sealed class LocalAiGatewayProviderCoordinatorTests
             ContextLength = LocalModelCatalog.NativeContextTokens,
         };
         return new(manifest, "llama-server.exe", "model.gguf", endpoint);
+    }
+
+    private static LocalAiResolvedInstall InstallWithoutEndpoint(
+        int port,
+        string? fallbackModel = null)
+    {
+        LocalAiResolvedInstall install = Install(port, fallbackModel);
+        return install with
+        {
+            Manifest = install.Manifest with { Endpoint = null },
+            Endpoint = null,
+        };
     }
 
     private static string RedactApiKey(string value) => value.Replace(


### PR DESCRIPTION
Related: #1178

## What Problem This Solves

Fixes an issue where users who completed a fresh managed Local AI setup could not start the runtime from the Tray because the first quiesce required a verified endpoint that is only recorded after llama-server starts successfully.

## Why This Change Was Made

A provider-absent first start may safely quiesce before an endpoint exists. Existing providers still require the verified endpoint and exact ownership match before any mutation. Catalog/alias qualification, primary ownership, and fallback validation remain fail-closed.

## User Impact

Fresh managed Local AI installations can proceed to their first start instead of entering `Failed` with every runtime control disabled.

## Evidence

- Failed-first disposable Windows/WSL reproduction acquired the managed model, then the Tray logged `The verified Local AI endpoint is required`, never launched llama-server, and disabled Start/Stop/Restart/Logs.
- New catalog and alias tampering regressions failed before the final qualification fix.
- Focused coordinator suite: 19/19 passed on this exact tree.
- Repository-required `./build.ps1`: passed.
- Full Shared suite: 3,812 passed, 32 skipped, 0 failed (3,844 total).
- Complete Tray suite: 2,709 passed, 0 skipped, 0 failed.
- CI at exact head: all required test, E2E, win-x64, win-arm64, hygiene, and setup-gate checks passed; no failed or pending checks.
- Exact-head disposable native Windows/WSL proof: 1/1 passed in 7m48s.
- `git diff --check`: clean apart from line-ending notices.
- Independent exact-diff review: no actionable findings.
- `openclaw-autoreview` with `gpt-5.6-sol` high: clean, patch correct (0.97), no actionable correctness or security findings.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs or instructions
- [x] Tests or validation
- [x] Security hardening
- [ ] Chore or infrastructure

## Scope

- [x] Tray or WinUI UX
- [ ] Windows node capability
- [ ] Local MCP or `winnode`
- [x] Gateway, connection, or pairing
- [ ] Setup or onboarding
- [x] Permissions, privacy, or security
- [x] Tests, CI, or docs

## Validation

- `./build.ps1` — PASS
- Full `OpenClaw.Shared.Tests` — PASS, 3,812 passed / 32 skipped / 0 failed
- Full `OpenClaw.Tray.Tests` — PASS, 2,709 passed / 0 skipped / 0 failed
- Focused `LocalAiGatewayProviderCoordinatorTests` — PASS, 19/19
- Exact-head native `LocalAiInstalledRuntimeAvailabilityProofTests.PriorQualifiedInstall_CurrentUnavailableHardware_KeepsHealthyInstalledActionsAvailable` — PASS, 1/1 in 7m48s

## Real Behavior Proof

- Environment tested: disposable Windows 11 app data plus an isolated WSL Gateway; no production Companion, Gateway, settings, credentials, pairings, or existing distros were used or changed.
- PR head tested: `de890ce876b8476846cbea997c3cc0d3f43af830`
- Exact executable SHA-256: `C14241FE7F8BEDABE8D5EE93977C83EC1596A6F97F8B9556443AB7514D780266`
- Exact path exercised: persist a fresh qualified managed Local AI install with no endpoint, launch the exact candidate Tray, let its real background first-start lifecycle quiesce the absent provider, start the managed llama process, persist the verified loopback endpoint, and expose the installed controls.
- Observed result: Start disabled; Stop, Restart, Open logs, and Open chat enabled; Retry absent; no action error. The route was `background-autostart`.
- Runtime provenance: llama.cpp `b10488-cuda13-x64`, model `qwen3.5-9b-mtp-q4-k-m`, expected acquisition 6,406,621,974 bytes; all pinned asset hashes matched the qualified manifest.
- Cleanup: exact Tray and managed llama processes absent, isolated Tray and Gateway roots removed, Gateway disposed, exact temporary WSL distro unregistered. Port-connectivity checks remained diagnostic-only; identity-bound process/root/distro cleanup gates passed.
- Redacted evidence hashes:
  - UI state JSON: `3310D8DBE6300E0399CE820A154F8CFAD5F8F1B0156F9801EF95BCFF3AB3CB69`
  - Redacted native screenshot: `B756A11BF0185E9EBC47389424EC4DD4C1B3395090363EC7AC99EAB43330EEE6`
  - Proof provenance JSON: `31544D40D407F83EF352DBE8D4D2F5D65E3A671926BE859C3E1D32A474881921`
- Screenshot or artifact links verified? (`Yes`/`No`/`N/A`): Yes, inspected locally; only the redacted state/provenance and their hashes are published here. Raw logs, private paths, endpoints, IDs, tokens, and credentials are excluded.
- Not claimed by this PR: `LocalAiUnavailableInfoBar` visibility. That banner behavior belongs to the separate #1206 UI lane and was diagnostic-only in this proof.

## Security Impact

- New permissions or capabilities? (`Yes`/`No`): No
- Secrets or tokens handling changed? (`Yes`/`No`): No
- New or changed network calls? (`Yes`/`No`): No
- Command or tool execution surface changed? (`Yes`/`No`): No
- Data access scope changed? (`Yes`/`No`): No
- If any answer is `Yes`, explain the risk and mitigation: N/A

## Compatibility and Migration

- Backward compatible? (`Yes`/`No`): Yes
- Config or environment changes? (`Yes`/`No`): No
- Migration needed? (`Yes`/`No`): No
- If yes, list the exact upgrade steps: N/A

## Review Conversations

- [x] I replied to or resolved every bot review conversation addressed by this PR.
- [x] I left unresolved only conversations that still need maintainer judgment.
