### PR TITLE
refactor(local-ai): clarify managed-model probe contract

### DIFF
--- a/src/OpenClaw.Connection/LocalAi/LlamaServerClient.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerClient.cs
@@ -134,7 +134,7 @@ public static class LlamaServerModelStatusParser
 
 internal interface ILlamaServerClient : IDisposable
 {
-    Task<LlamaServerRouterProbeResult> ProbeRouterAsync(
+    Task<LlamaServerRouterProbeResult> ProbeManagedModelAsync(
         Uri endpoint,
         string modelAlias,
         string expectedModelPath,
@@ -164,7 +164,7 @@ public sealed class LlamaServerClient : ILlamaServerClient
         };
     }
 
-    public async Task<LlamaServerRouterProbeResult> ProbeRouterAsync(
+    public async Task<LlamaServerRouterProbeResult> ProbeManagedModelAsync(
         Uri endpoint,
         string modelAlias,
         string expectedModelPath,

--- a/src/OpenClaw.Connection/LocalAi/LlamaServerClient.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerClient.cs
@@ -199,6 +199,14 @@ public sealed class LlamaServerClient : ILlamaServerClient
         }
     }
 
+    [Obsolete("Use ProbeManagedModelAsync instead.")]
+    public Task<LlamaServerRouterProbeResult> ProbeRouterAsync(
+        Uri endpoint,
+        string modelAlias,
+        string expectedModelPath,
+        CancellationToken cancellationToken = default) =>
+        ProbeManagedModelAsync(endpoint, modelAlias, expectedModelPath, cancellationToken);
+
     private async Task<bool> ProbeHealthAsync(Uri endpoint, CancellationToken cancellationToken)
     {
         try

--- a/src/OpenClaw.Connection/LocalAi/LlamaServerInferenceClient.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerInferenceClient.cs
@@ -12,6 +12,11 @@ public sealed record LlamaServerInferenceVerification(
 
 public interface ILlamaServerInferenceClient : IDisposable
 {
+    /// <summary>
+    /// Sends one bounded OpenAI-compatible request to the managed endpoint, intentionally triggering
+    /// lazy model loading during setup. Verifies the response plus token and timing evidence without
+    /// returning or logging prompt or response content.
+    /// </summary>
     Task<LlamaServerInferenceVerification> VerifyAsync(
         Uri endpoint,
         string modelAlias,
@@ -45,6 +50,11 @@ public sealed class LlamaServerInferenceClient : ILlamaServerInferenceClient
         };
     }
 
+    /// <summary>
+    /// Sends one bounded OpenAI-compatible request to the managed endpoint, intentionally triggering
+    /// lazy model loading during setup. Verifies the response plus token and timing evidence without
+    /// returning or logging prompt or response content.
+    /// </summary>
     public async Task<LlamaServerInferenceVerification> VerifyAsync(
         Uri endpoint,
         string modelAlias,

--- a/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
@@ -240,7 +240,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                 }
                 if (ownership.Endpoint is not null)
                 {
-                    LlamaServerRouterProbeResult probe = await _client.ProbeRouterAsync(
+                    LlamaServerRouterProbeResult probe = await _client.ProbeManagedModelAsync(
                             ownership.Endpoint,
                             install.Manifest.ModelAlias,
                             install.ModelPath,
@@ -340,7 +340,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         if (ownership.Endpoint is null)
             return Publish(LocalAiRuntimeState.Starting, LocalAiOwnership.CompanionManaged, "The local AI router has not opened its endpoint yet.", _managedProcess.ProcessId, _managedProcess.StartedAtUtc);
 
-        LlamaServerRouterProbeResult probe = await _client.ProbeRouterAsync(
+        LlamaServerRouterProbeResult probe = await _client.ProbeManagedModelAsync(
                 ownership.Endpoint,
                 install.Manifest.ModelAlias,
                 install.ModelPath,

--- a/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
+++ b/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
@@ -21,6 +21,18 @@ public sealed class LocalAiPortLifecycleTests
     }
 
     [Fact]
+    public void LegacyRouterProbe_RemainsSourceCompatible()
+    {
+        using var client = new LlamaServerClient();
+#pragma warning disable CS0618
+        Func<Uri, string, string, CancellationToken, Task<LlamaServerRouterProbeResult>> legacyProbe =
+            client.ProbeRouterAsync;
+#pragma warning restore CS0618
+
+        Assert.NotNull(legacyProbe);
+    }
+
+    [Fact]
     public async Task Manifest_RoundTripsValidatedGatewayFallbackModel()
     {
         using var temp = new TempDirectory("local-ai-manifest-");

--- a/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
+++ b/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
@@ -443,7 +443,7 @@ public sealed class LocalAiPortLifecycleTests
     {
         public List<int> ProbedPorts { get; } = [];
 
-        public Task<LlamaServerRouterProbeResult> ProbeRouterAsync(
+        public Task<LlamaServerRouterProbeResult> ProbeManagedModelAsync(
             Uri endpoint,
             string modelAlias,
             string expectedModelPath,


### PR DESCRIPTION
Closes #1198
Related: #1192

## What Problem This Solves

The Local AI probe name implied that it checked only router health, even though the operation also verifies one configured model alias and expected managed path. The setup-time inference verification contract was also documented only at the class level, leaving callers and generated method documentation without the full boundary.

## Why This Change Was Made

Rename the internal probe consistently to `ProbeManagedModelAsync` across the client contract, runtime callers, and test fake. Preserve the existing public `ProbeRouterAsync` source contract as an obsolete forwarding wrapper. Add method-level XML summaries to both the inference interface and implementation that describe the bounded request, intentional lazy model load, response and token/timing verification, and content-handling boundary.

This PR does not change readiness behavior. Issue #1192 remains the separate correction for the probe result predicate.

## User Impact

There is no user-visible runtime behavior change. Developers get a more precise managed-model API name and method documentation, while existing direct callers of `ProbeRouterAsync` continue to compile.

## Evidence

- All internal interface, runtime, and test-fake call sites use `ProbeManagedModelAsync`.
- The public `ProbeRouterAsync` method remains available as an obsolete forwarding wrapper with the same parameters and return type.
- Focused compatibility coverage binds the legacy method to its original delegate signature.
- The inference interface and implementation both expose the bounded-request and content-handling documentation.

## Change Type

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [x] Docs or instructions
- [x] Tests or validation
- [ ] Security hardening
- [ ] Chore or infrastructure

## Scope

- [ ] Tray or WinUI UX
- [ ] Windows node capability
- [ ] Local MCP or `winnode`
- [ ] Gateway, connection, or pairing
- [ ] Setup or onboarding
- [ ] Permissions, privacy, or security
- [x] Tests, CI, or docs

## Validation

Current head: `23387c4754d71d60cbdd536a22256db4563367d0`

- `.\build.ps1`: passed, 5 of 5 repository build targets.
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj`: passed, 3,812 passed and 32 environment-gated skips.
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj`: passed, 2,703 passed.
- `dotnet test .\tests\OpenClaw.Connection.Tests\OpenClaw.Connection.Tests.csproj --no-restore`: passed, 681 passed.
- `dotnet test .\tests\OpenClaw.Connection.Tests\OpenClaw.Connection.Tests.csproj --filter "FullyQualifiedName~LocalAi"`: passed, 21 passed.
- `git diff --check`: passed.
- `python .agents\skills\autoreview\scripts\autoreview --mode branch --base origin/main --stream-engine-output`: clean, no accepted or actionable findings; patch correct at 0.98 confidence.

## Real Behavior Proof

- Environment tested: Windows x64, .NET SDK 10.0.303.
- PR head tested: `23387c4754d71d60cbdd536a22256db4563367d0`.
- Exact proof: compiled the legacy public method against its original `Func<Uri, string, string, CancellationToken, Task<LlamaServerRouterProbeResult>>` signature, then ran the focused Local AI and full Connection suites.
- Observed result: existing source callers can still bind to `ProbeRouterAsync`; the wrapper delegates directly to `ProbeManagedModelAsync`; all managed runtime paths use the clearer internal contract.
- Screenshot or artifact links verified? (`Yes`/`No`/`N/A`): N/A.
- Not verified or blocked: Live llama-server inference was not repeated because the patch changes naming, documentation, and source compatibility only. The separately scoped readiness correction remains #1192.

## Security Impact

- New permissions or capabilities? (`Yes`/`No`): No
- Secrets or tokens handling changed? (`Yes`/`No`): No
- New or changed network calls? (`Yes`/`No`): No
- Command or tool execution surface changed? (`Yes`/`No`): No
- Data access scope changed? (`Yes`/`No`): No
- If any answer is `Yes`, explain the risk and mitigation: N/A

## Compatibility and Migration

- Backward compatible? (`Yes`/`No`): Yes
- Config or environment changes? (`Yes`/`No`): No
- Migration needed? (`Yes`/`No`): No
- Compatibility detail: direct callers may continue using `ProbeRouterAsync`; new code should use `ProbeManagedModelAsync`.

## Review Conversations

- [x] The actionable compatibility finding is fixed on the PR branch.
- [x] No unresolved inline review threads remain.