### PR TITLE
fix(local-ai): prevent routing to an unverified managed model

### DIFF
--- a/src/OpenClaw.Connection/LocalAi/LlamaServerClient.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerClient.cs
@@ -6,7 +6,14 @@ public sealed record LlamaServerRouterProbeResult(
     bool IsHealthy,
     LocalAiModelAvailabilityState ModelState,
     string? ReportedModelPath,
-    string? Detail);
+    string? Detail)
+{
+    internal bool IsReadyForManagedModel(string expectedModelPath) =>
+        IsHealthy &&
+        ModelState is LocalAiModelAvailabilityState.Verified or LocalAiModelAvailabilityState.Loaded &&
+        !string.IsNullOrWhiteSpace(ReportedModelPath) &&
+        LlamaServerModelStatusParser.PathsEqual(ReportedModelPath, expectedModelPath);
+}
 
 public sealed record LlamaServerModelStatusEvidence(
     LocalAiModelAvailabilityState State,
@@ -119,7 +126,7 @@ public static class LlamaServerModelStatusParser
         return modelPath;
     }
 
-    private static bool PathsEqual(string left, string right)
+    internal static bool PathsEqual(string left, string right)
     {
         try
         {
@@ -191,11 +198,11 @@ public sealed class LlamaServerClient : ILlamaServerClient
         }
         catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
         {
-            return new(true, LocalAiModelAvailabilityState.Unknown, null, "The model status check timed out.");
+            return new(false, LocalAiModelAvailabilityState.Unknown, null, "The model status check timed out.");
         }
         catch (Exception ex) when (ex is HttpRequestException or IOException or JsonException or InvalidDataException)
         {
-            return new(true, LocalAiModelAvailabilityState.Unknown, null, "The model status response was invalid.");
+            return new(false, LocalAiModelAvailabilityState.Unknown, null, "The model status response was invalid.");
         }
     }
 
@@ -257,9 +264,9 @@ public sealed class LlamaServerClient : ILlamaServerClient
             modelAlias,
             expectedModelPath);
         if (evidence is null)
-            return new(true, LocalAiModelAvailabilityState.NotInstalled, null, "The configured model is not registered.");
+            return new(false, LocalAiModelAvailabilityState.NotInstalled, null, "The configured model is not registered.");
         return new(
-            true,
+            evidence.State is LocalAiModelAvailabilityState.Verified or LocalAiModelAvailabilityState.Loaded,
             evidence.State,
             evidence.ModelPath,
             $"llama-server reports the model as {evidence.ServerStatus}.");

--- a/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
@@ -246,7 +246,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                             install.ModelPath,
                             cancellationToken)
                         .ConfigureAwait(false);
-                    if (probe.IsHealthy)
+                    if (probe.IsReadyForManagedModel(install.ModelPath))
                     {
                         LocalAiInstallManifest verifiedManifest = install.Manifest with
                         {
@@ -346,14 +346,46 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                 install.ModelPath,
                 cancellationToken)
             .ConfigureAwait(false);
-        return probe.IsHealthy
-            ? PublishHealthy(probe)
-            : Publish(
-                LocalAiRuntimeState.Starting,
+        if (probe.IsReadyForManagedModel(install.ModelPath))
+        {
+            if (_snapshot.State != LocalAiRuntimeState.Healthy)
+            {
+                LocalAiEndpointLifecycleResult published = await _options.EndpointLifecycle
+                    .PublishAsync(install, cancellationToken)
+                    .ConfigureAwait(false);
+                if (!published.Success)
+                {
+                    return Publish(
+                        LocalAiRuntimeState.Failed,
+                        LocalAiOwnership.CompanionManaged,
+                        published.Detail ?? "The verified Local AI endpoint could not be republished.",
+                        _managedProcess.ProcessId,
+                        _managedProcess.StartedAtUtc);
+                }
+            }
+
+            return PublishHealthy(probe);
+        }
+
+        LocalAiEndpointLifecycleResult quiesced = await _options.EndpointLifecycle
+            .QuiesceAsync(install, cancellationToken)
+            .ConfigureAwait(false);
+        if (!quiesced.Success)
+        {
+            return Publish(
+                LocalAiRuntimeState.Failed,
                 LocalAiOwnership.CompanionManaged,
-                "The local AI router is not healthy yet.",
+                quiesced.Detail ?? "The Local AI gateway provider could not be safely disabled.",
                 _managedProcess.ProcessId,
                 _managedProcess.StartedAtUtc);
+        }
+
+        return Publish(
+            LocalAiRuntimeState.Starting,
+            LocalAiOwnership.CompanionManaged,
+            probe.Detail ?? "The local AI router has not verified the managed model yet.",
+            _managedProcess.ProcessId,
+            _managedProcess.StartedAtUtc);
     }
 
     private async Task<bool> TryLoadInstallAsync(CancellationToken cancellationToken)

--- a/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
@@ -334,11 +334,40 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         LocalAiResolvedInstall install = _install!;
         EndpointOwnershipObservation ownership = DiscoverOwnedEndpoint(install, _managedProcess);
         if (!ownership.IsComplete)
-            return Publish(LocalAiRuntimeState.Conflict, LocalAiOwnership.None, "TCP listener ownership could not be determined.");
+        {
+            LocalAiRuntimeSnapshot? failure = await QuiesceOrStopAsync(
+                    install,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            return failure ?? Publish(
+                LocalAiRuntimeState.Conflict,
+                LocalAiOwnership.None,
+                "TCP listener ownership could not be determined.");
+        }
         if (ownership.ConflictDetail is not null)
-            return Publish(LocalAiRuntimeState.Conflict, LocalAiOwnership.None, ownership.ConflictDetail);
+        {
+            LocalAiRuntimeSnapshot? failure = await QuiesceOrStopAsync(
+                    install,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            return failure ?? Publish(
+                LocalAiRuntimeState.Conflict,
+                LocalAiOwnership.None,
+                ownership.ConflictDetail);
+        }
         if (ownership.Endpoint is null)
-            return Publish(LocalAiRuntimeState.Starting, LocalAiOwnership.CompanionManaged, "The local AI router has not opened its endpoint yet.", _managedProcess.ProcessId, _managedProcess.StartedAtUtc);
+        {
+            LocalAiRuntimeSnapshot? failure = await QuiesceOrStopAsync(
+                    install,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            return failure ?? Publish(
+                LocalAiRuntimeState.Starting,
+                LocalAiOwnership.CompanionManaged,
+                "The local AI router has not opened its endpoint yet.",
+                _managedProcess.ProcessId,
+                _managedProcess.StartedAtUtc);
+        }
 
         LlamaServerRouterProbeResult probe = await _client.ProbeManagedModelAsync(
                 ownership.Endpoint,
@@ -348,8 +377,24 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
             .ConfigureAwait(false);
         if (probe.IsReadyForManagedModel(install.ModelPath))
         {
-            if (_snapshot.State != LocalAiRuntimeState.Healthy)
+            bool endpointChanged = install.Endpoint != ownership.Endpoint;
+            if (_snapshot.State != LocalAiRuntimeState.Healthy || endpointChanged)
             {
+                if (endpointChanged && _snapshot.State == LocalAiRuntimeState.Healthy)
+                {
+                    LocalAiRuntimeSnapshot? failure = await QuiesceOrStopAsync(
+                            install,
+                            cancellationToken)
+                        .ConfigureAwait(false);
+                    if (failure is not null)
+                        return failure;
+                }
+
+                install = await BindVerifiedEndpointAsync(
+                        install,
+                        ownership.Endpoint,
+                        cancellationToken)
+                    .ConfigureAwait(false);
                 LocalAiEndpointLifecycleResult published = await _options.EndpointLifecycle
                     .PublishAsync(install, cancellationToken)
                     .ConfigureAwait(false);
@@ -367,18 +412,12 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
             return PublishHealthy(probe);
         }
 
-        LocalAiEndpointLifecycleResult quiesced = await _options.EndpointLifecycle
-            .QuiesceAsync(install, cancellationToken)
+        LocalAiRuntimeSnapshot? quiesceFailure = await QuiesceOrStopAsync(
+                install,
+                cancellationToken)
             .ConfigureAwait(false);
-        if (!quiesced.Success)
-        {
-            return Publish(
-                LocalAiRuntimeState.Failed,
-                LocalAiOwnership.CompanionManaged,
-                quiesced.Detail ?? "The Local AI gateway provider could not be safely disabled.",
-                _managedProcess.ProcessId,
-                _managedProcess.StartedAtUtc);
-        }
+        if (quiesceFailure is not null)
+            return quiesceFailure;
 
         return Publish(
             LocalAiRuntimeState.Starting,
@@ -386,6 +425,57 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
             probe.Detail ?? "The local AI router has not verified the managed model yet.",
             _managedProcess.ProcessId,
             _managedProcess.StartedAtUtc);
+    }
+
+    private async Task<LocalAiRuntimeSnapshot?> QuiesceOrStopAsync(
+        LocalAiResolvedInstall install,
+        CancellationToken cancellationToken)
+    {
+        LocalAiEndpointLifecycleResult? quiesced = null;
+        try
+        {
+            quiesced = await _options.EndpointLifecycle
+                .QuiesceAsync(install, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            if (quiesced is null)
+            {
+                ++_generation;
+                await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
+                Publish(
+                    LocalAiRuntimeState.Failed,
+                    LocalAiOwnership.None,
+                    "The Local AI gateway provider withdrawal did not complete.");
+            }
+        }
+        if (quiesced.Success)
+            return null;
+
+        ++_generation;
+        await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
+        return Publish(
+            LocalAiRuntimeState.Failed,
+            LocalAiOwnership.None,
+            quiesced.Detail ?? "The Local AI gateway provider could not be safely disabled.");
+    }
+
+    private async Task<LocalAiResolvedInstall> BindVerifiedEndpointAsync(
+        LocalAiResolvedInstall install,
+        Uri endpoint,
+        CancellationToken cancellationToken)
+    {
+        if (install.Endpoint == endpoint)
+            return install;
+
+        LocalAiInstallManifest verifiedManifest = install.Manifest with
+        {
+            Endpoint = endpoint.AbsoluteUri,
+        };
+        await _manifestStore.SaveAsync(verifiedManifest, cancellationToken).ConfigureAwait(false);
+        _install = _manifestStore.ResolveAndValidate(verifiedManifest);
+        return _install;
     }
 
     private async Task<bool> TryLoadInstallAsync(CancellationToken cancellationToken)

--- a/tests/OpenClaw.Connection.Tests/LlamaServerClientTests.cs
+++ b/tests/OpenClaw.Connection.Tests/LlamaServerClientTests.cs
@@ -1,0 +1,94 @@
+using OpenClaw.Connection.LocalAi;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+
+namespace OpenClaw.Connection.Tests;
+
+public sealed class LlamaServerClientTests
+{
+    private const string ModelAlias = "managed-model";
+    private static readonly Uri s_endpoint = new("http://127.0.0.1:18803/v1");
+    private static readonly string s_modelPath = Path.GetFullPath("managed-model.gguf");
+
+    [Theory]
+    [InlineData(ProbeCase.Timeout, LocalAiModelAvailabilityState.Unknown, false)]
+    [InlineData(ProbeCase.InvalidResponse, LocalAiModelAvailabilityState.Unknown, false)]
+    [InlineData(ProbeCase.MissingAlias, LocalAiModelAvailabilityState.NotInstalled, false)]
+    [InlineData(ProbeCase.UnknownState, LocalAiModelAvailabilityState.Unknown, false)]
+    [InlineData(ProbeCase.MissingPath, LocalAiModelAvailabilityState.Unknown, false)]
+    [InlineData(ProbeCase.WrongPath, LocalAiModelAvailabilityState.Unknown, false)]
+    [InlineData(ProbeCase.Verified, LocalAiModelAvailabilityState.Verified, true)]
+    [InlineData(ProbeCase.Loaded, LocalAiModelAvailabilityState.Loaded, true)]
+    public async Task ProbeManagedModelAsync_RequiresReadyModelEvidence(
+        ProbeCase probeCase,
+        LocalAiModelAvailabilityState expectedState,
+        bool expectedReady)
+    {
+        using var client = new LlamaServerClient(new DelegateHandler((request, _) =>
+            request.RequestUri?.AbsolutePath == "/health"
+                ? Task.FromResult(JsonResponse("{\"status\":\"ok\"}"))
+                : ModelResponseAsync(probeCase)));
+
+        LlamaServerRouterProbeResult result = await client.ProbeManagedModelAsync(
+            s_endpoint,
+            ModelAlias,
+            s_modelPath);
+
+        Assert.Equal(expectedReady, result.IsHealthy);
+        Assert.Equal(expectedState, result.ModelState);
+        Assert.Equal(expectedReady, result.IsReadyForManagedModel(s_modelPath));
+    }
+
+    private static Task<HttpResponseMessage> ModelResponseAsync(ProbeCase probeCase) => probeCase switch
+    {
+        ProbeCase.Timeout => Task.FromException<HttpResponseMessage>(new OperationCanceledException()),
+        ProbeCase.InvalidResponse => Task.FromResult(JsonResponse("{")),
+        ProbeCase.MissingAlias => Task.FromResult(JsonResponse(ModelStatus("other-model", "unloaded", s_modelPath))),
+        ProbeCase.UnknownState => Task.FromResult(JsonResponse(ModelStatus(ModelAlias, "unexpected", s_modelPath))),
+        ProbeCase.MissingPath => Task.FromResult(JsonResponse(ModelStatus(ModelAlias, "unloaded", null))),
+        ProbeCase.WrongPath => Task.FromResult(JsonResponse(ModelStatus(ModelAlias, "loaded", s_modelPath + ".other"))),
+        ProbeCase.Verified => Task.FromResult(JsonResponse(ModelStatus(ModelAlias, "unloaded", s_modelPath))),
+        ProbeCase.Loaded => Task.FromResult(JsonResponse(ModelStatus(ModelAlias, "loaded", s_modelPath))),
+        _ => throw new InvalidOperationException("Unknown probe test case."),
+    };
+
+    private static string ModelStatus(string alias, string status, string? path) => JsonSerializer.Serialize(new
+    {
+        data = new[]
+        {
+            new
+            {
+                id = alias,
+                status = path is null
+                    ? (object)new { value = status }
+                    : new { value = status, args = new[] { "--model", path } },
+            },
+        },
+    });
+
+    private static HttpResponseMessage JsonResponse(string payload) => new(HttpStatusCode.OK)
+    {
+        Content = new StringContent(payload, Encoding.UTF8, "application/json"),
+    };
+
+    public enum ProbeCase
+    {
+        Timeout,
+        InvalidResponse,
+        MissingAlias,
+        UnknownState,
+        MissingPath,
+        WrongPath,
+        Verified,
+        Loaded,
+    }
+
+    private sealed class DelegateHandler(
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) => handler(request, cancellationToken);
+    }
+}

--- a/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
+++ b/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
@@ -225,6 +225,181 @@ public sealed class LocalAiPortLifecycleTests
         Assert.Equal(["probe:28773", "publish:28773"], events);
     }
 
+    [Theory]
+    [InlineData(RefreshOwnershipLoss.Incomplete, LocalAiRuntimeState.Conflict)]
+    [InlineData(RefreshOwnershipLoss.Conflict, LocalAiRuntimeState.Conflict)]
+    [InlineData(RefreshOwnershipLoss.MissingEndpoint, LocalAiRuntimeState.Starting)]
+    public async Task Refresh_QuiescesPublishedRouteWhenEndpointOwnershipIsLost(
+        RefreshOwnershipLoss ownershipLoss,
+        LocalAiRuntimeState expectedState)
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var events = new List<string>();
+        var platform = new FakePlatform();
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_775);
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            new FakeLifecycle(events));
+        LocalAiRuntimeSnapshot started = await runtime.EnsureStartedAsync();
+        Assert.Equal(LocalAiRuntimeState.Healthy, started.State);
+        events.Clear();
+
+        switch (ownershipLoss)
+        {
+            case RefreshOwnershipLoss.Incomplete:
+                platform.Ipv4Complete = false;
+                break;
+            case RefreshOwnershipLoss.Conflict:
+                platform.Listeners[0] = platform.Listeners[0] with { Address = IPAddress.Any };
+                break;
+            case RefreshOwnershipLoss.MissingEndpoint:
+                platform.Listeners.Clear();
+                break;
+            default:
+                throw new InvalidOperationException("Unknown ownership-loss case.");
+        }
+
+        LocalAiRuntimeSnapshot refreshed = await runtime.RefreshAsync();
+
+        Assert.Equal(expectedState, refreshed.State);
+        Assert.Equal(["quiesce"], events);
+        Assert.False(host.Process!.HasExited);
+    }
+
+    [Fact]
+    public async Task Refresh_QuiesceFailureStopsUnverifiedManagedProcess()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var events = new List<string>();
+        var platform = new FakePlatform();
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_776);
+        var client = new FakeClient(events, (expectedModelPath, probeNumber) => probeNumber == 1
+            ? ReadyProbe(expectedModelPath)
+            : new(
+                false,
+                LocalAiModelAvailabilityState.Unknown,
+                null,
+                "The managed model is not ready."));
+        var lifecycle = new FakeLifecycle(events);
+        await using var runtime = CreateRuntime(paths, host, platform, client, lifecycle);
+        LocalAiRuntimeSnapshot started = await runtime.EnsureStartedAsync();
+        Assert.Equal(LocalAiRuntimeState.Healthy, started.State);
+        events.Clear();
+        lifecycle.FailQuiesce = true;
+
+        LocalAiRuntimeSnapshot refreshed = await runtime.RefreshAsync();
+
+        Assert.Equal(LocalAiRuntimeState.Failed, refreshed.State);
+        Assert.Equal(LocalAiOwnership.None, refreshed.Ownership);
+        Assert.Null(refreshed.ProcessId);
+        Assert.True(host.Process!.HasExited);
+        Assert.Equal(["probe:28776", "quiesce", "stop"], events);
+    }
+
+    [Fact]
+    public async Task Refresh_QuiesceExceptionStopsManagedProcessBeforePropagating()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var events = new List<string>();
+        var platform = new FakePlatform();
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_779);
+        var lifecycle = new FakeLifecycle(events);
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            lifecycle);
+        LocalAiRuntimeSnapshot started = await runtime.EnsureStartedAsync();
+        Assert.Equal(LocalAiRuntimeState.Healthy, started.State);
+        events.Clear();
+        platform.Listeners.Clear();
+        lifecycle.QuiesceException = new IOException("route withdrawal failed");
+
+        IOException error = await Assert.ThrowsAsync<IOException>(() => runtime.RefreshAsync());
+
+        Assert.Equal("route withdrawal failed", error.Message);
+        Assert.Equal(LocalAiRuntimeState.Failed, runtime.Snapshot.State);
+        Assert.Equal(LocalAiOwnership.None, runtime.Snapshot.Ownership);
+        Assert.Null(runtime.Snapshot.ProcessId);
+        Assert.True(host.Process!.HasExited);
+        Assert.Equal(["quiesce", "stop"], events);
+    }
+
+    [Fact]
+    public async Task Refresh_RecoveryRebindsFreshlyVerifiedEndpointBeforePublishing()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var events = new List<string>();
+        var platform = new FakePlatform();
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_777);
+        var client = new FakeClient(events, (expectedModelPath, probeNumber) => probeNumber == 2
+            ? new(
+                false,
+                LocalAiModelAvailabilityState.Unknown,
+                null,
+                "The managed model is not ready.")
+            : ReadyProbe(expectedModelPath));
+        var lifecycle = new FakeLifecycle(events);
+        await using var runtime = CreateRuntime(paths, host, platform, client, lifecycle);
+        LocalAiRuntimeSnapshot started = await runtime.EnsureStartedAsync();
+        Assert.Equal(LocalAiRuntimeState.Healthy, started.State);
+        LocalAiRuntimeSnapshot unavailable = await runtime.RefreshAsync();
+        Assert.Equal(LocalAiRuntimeState.Starting, unavailable.State);
+
+        var store = new LocalAiManifestStore(paths);
+        LocalAiResolvedInstall install = (await store.LoadAsync())!;
+        await store.SaveAsync(install.Manifest with { Endpoint = "http://127.0.0.1:29999/v1" });
+        events.Clear();
+
+        LocalAiRuntimeSnapshot recovered = await runtime.RefreshAsync();
+
+        Assert.Equal(LocalAiRuntimeState.Healthy, recovered.State);
+        Assert.Equal(28_777, recovered.Endpoint.Port);
+        Assert.Equal(["probe:28777", "publish:28777"], events);
+        LocalAiResolvedInstall rebound = (await store.LoadAsync())!;
+        Assert.Equal(28_777, rebound.Endpoint!.Port);
+    }
+
+    [Fact]
+    public async Task Refresh_RecoveryPublishFailureRemainsFailedAndQuiesced()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var events = new List<string>();
+        var platform = new FakePlatform();
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_778);
+        var client = new FakeClient(events, (expectedModelPath, probeNumber) => probeNumber == 2
+            ? new(
+                false,
+                LocalAiModelAvailabilityState.Unknown,
+                null,
+                "The managed model is not ready.")
+            : ReadyProbe(expectedModelPath));
+        var lifecycle = new FakeLifecycle(events);
+        await using var runtime = CreateRuntime(paths, host, platform, client, lifecycle);
+        LocalAiRuntimeSnapshot started = await runtime.EnsureStartedAsync();
+        Assert.Equal(LocalAiRuntimeState.Healthy, started.State);
+        LocalAiRuntimeSnapshot unavailable = await runtime.RefreshAsync();
+        Assert.Equal(LocalAiRuntimeState.Starting, unavailable.State);
+        events.Clear();
+        lifecycle.FailPublish = true;
+
+        LocalAiRuntimeSnapshot failed = await runtime.RefreshAsync();
+
+        Assert.Equal(LocalAiRuntimeState.Failed, failed.State);
+        Assert.Equal(LocalAiOwnership.CompanionManaged, failed.Ownership);
+        Assert.False(host.Process!.HasExited);
+        Assert.Equal(["probe:28778", "publish:28778"], events);
+    }
+
     [Fact]
     public async Task AutomaticPort_NeverProbesListenerWithoutMatchingProcessStartTime()
     {
@@ -442,6 +617,12 @@ public sealed class LocalAiPortLifecycleTests
         return arguments[index + 1];
     }
 
+    private static LlamaServerRouterProbeResult ReadyProbe(string expectedModelPath) => new(
+        true,
+        LocalAiModelAvailabilityState.Verified,
+        expectedModelPath,
+        "The managed model is ready.");
+
     private static LocalAiInstallManifest ValidManifest()
     {
         LlamaRuntimeVariant runtime = LlamaRuntimeCatalog.Find(
@@ -485,9 +666,10 @@ public sealed class LocalAiPortLifecycleTests
     {
         public DateTimeOffset UtcNow { get; private set; } = DateTimeOffset.Parse("2026-08-18T12:00:00Z");
         public List<WindowsTcpListenerInfo> Listeners { get; } = [];
+        public bool Ipv4Complete { get; set; } = true;
 
         public WindowsTcpListenerSnapshotResult CaptureListeners() =>
-            new([.. Listeners], Ipv4Complete: true, Ipv6Complete: true);
+            new([.. Listeners], Ipv4Complete, Ipv6Complete: true);
 
         public Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken)
         {
@@ -581,14 +763,20 @@ public sealed class LocalAiPortLifecycleTests
 
     private sealed class FakeLifecycle(List<string> events) : ILocalAiEndpointLifecycle
     {
-        public bool FailPublish { get; init; }
+        public bool FailPublish { get; set; }
+        public bool FailQuiesce { get; set; }
+        public Exception? QuiesceException { get; set; }
 
         public Task<LocalAiEndpointLifecycleResult> QuiesceAsync(
             LocalAiResolvedInstall install,
             CancellationToken cancellationToken = default)
         {
             events.Add("quiesce");
-            return Task.FromResult(LocalAiEndpointLifecycleResult.Ok());
+            if (QuiesceException is not null)
+                return Task.FromException<LocalAiEndpointLifecycleResult>(QuiesceException);
+            return Task.FromResult(FailQuiesce
+                ? LocalAiEndpointLifecycleResult.Failed("quiesce failed")
+                : LocalAiEndpointLifecycleResult.Ok());
         }
 
         public Task<LocalAiEndpointLifecycleResult> PublishAsync(
@@ -600,5 +788,12 @@ public sealed class LocalAiPortLifecycleTests
                 ? LocalAiEndpointLifecycleResult.Failed("publish failed")
                 : LocalAiEndpointLifecycleResult.Ok());
         }
+    }
+
+    public enum RefreshOwnershipLoss
+    {
+        Incomplete,
+        Conflict,
+        MissingEndpoint,
     }
 }

--- a/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
+++ b/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
@@ -148,6 +148,83 @@ public sealed class LocalAiPortLifecycleTests
         Assert.Equal(28_765, saved.Endpoint!.Port);
     }
 
+    [Theory]
+    [InlineData(LocalAiModelAvailabilityState.Unknown, true)]
+    [InlineData(LocalAiModelAvailabilityState.Loaded, false)]
+    public async Task AutomaticPort_DoesNotPersistOrPublishWithoutReadyModelEvidence(
+        LocalAiModelAvailabilityState modelState,
+        bool pathMatches)
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var events = new List<string>();
+        var platform = new FakePlatform();
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_774);
+        var client = new FakeClient(events, (expectedModelPath, _) => new(
+            true,
+            modelState,
+            pathMatches ? expectedModelPath : expectedModelPath + ".other",
+            "The managed model is not ready."));
+        var lifecycle = new FakeLifecycle(events);
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            client,
+            lifecycle,
+            startupTimeout: TimeSpan.FromMilliseconds(2));
+
+        LocalAiRuntimeSnapshot snapshot = await runtime.EnsureStartedAsync();
+
+        Assert.Equal(LocalAiRuntimeState.Failed, snapshot.State);
+        Assert.DoesNotContain(events, value => value.StartsWith("publish:", StringComparison.Ordinal));
+        Assert.True(host.Process!.StopCount > 0);
+        LocalAiResolvedInstall? saved = await new LocalAiManifestStore(paths).LoadAsync();
+        Assert.Null(saved!.Endpoint);
+    }
+
+    [Fact]
+    public async Task Refresh_UpdatesPublicationWhenManagedModelReadinessChanges()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var events = new List<string>();
+        var platform = new FakePlatform();
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_773);
+        var client = new FakeClient(events, (expectedModelPath, probeNumber) => probeNumber == 2
+            ? new(
+                true,
+                LocalAiModelAvailabilityState.Loaded,
+                expectedModelPath + ".other",
+                "The managed model path changed.")
+            : new(
+                true,
+                LocalAiModelAvailabilityState.Verified,
+                expectedModelPath,
+                "The managed model is ready."));
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            client,
+            new FakeLifecycle(events));
+        LocalAiRuntimeSnapshot started = await runtime.EnsureStartedAsync();
+        Assert.Equal(LocalAiRuntimeState.Healthy, started.State);
+        events.Clear();
+
+        LocalAiRuntimeSnapshot refreshed = await runtime.RefreshAsync();
+
+        Assert.Equal(LocalAiRuntimeState.Starting, refreshed.State);
+        Assert.Equal(LocalAiModelAvailabilityState.Unknown, refreshed.ModelEvidence.State);
+        Assert.Equal(["probe:28773", "quiesce"], events);
+        events.Clear();
+
+        LocalAiRuntimeSnapshot recovered = await runtime.RefreshAsync();
+
+        Assert.Equal(LocalAiRuntimeState.Healthy, recovered.State);
+        Assert.Equal(["probe:28773", "publish:28773"], events);
+    }
+
     [Fact]
     public async Task AutomaticPort_NeverProbesListenerWithoutMatchingProcessStartTime()
     {
@@ -328,13 +405,14 @@ public sealed class LocalAiPortLifecycleTests
         FakeProcessHost host,
         FakePlatform platform,
         FakeClient client,
-        ILocalAiEndpointLifecycle lifecycle) => new(
+        ILocalAiEndpointLifecycle lifecycle,
+        TimeSpan? startupTimeout = null) => new(
             new LlamaServerRuntimeOptions
             {
                 Paths = paths,
                 EndpointLifecycle = lifecycle,
                 HealthPollInterval = TimeSpan.FromMilliseconds(1),
-                StartupTimeout = TimeSpan.FromSeconds(1),
+                StartupTimeout = startupTimeout ?? TimeSpan.FromSeconds(1),
                 RestartDelay = TimeSpan.Zero,
             },
             NullLogger.Instance,
@@ -473,8 +551,12 @@ public sealed class LocalAiPortLifecycleTests
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 
-    private sealed class FakeClient(List<string> events) : ILlamaServerClient
+    private sealed class FakeClient(
+        List<string> events,
+        Func<string, int, LlamaServerRouterProbeResult>? probeFactory = null) : ILlamaServerClient
     {
+        private int _probeCount;
+
         public List<int> ProbedPorts { get; } = [];
 
         public Task<LlamaServerRouterProbeResult> ProbeManagedModelAsync(
@@ -486,7 +568,8 @@ public sealed class LocalAiPortLifecycleTests
             cancellationToken.ThrowIfCancellationRequested();
             ProbedPorts.Add(endpoint.Port);
             events.Add($"probe:{endpoint.Port}");
-            return Task.FromResult(new LlamaServerRouterProbeResult(
+            int probeNumber = ++_probeCount;
+            return Task.FromResult(probeFactory?.Invoke(expectedModelPath, probeNumber) ?? new LlamaServerRouterProbeResult(
                 true,
                 LocalAiModelAvailabilityState.Verified,
                 expectedModelPath,


### PR DESCRIPTION
Closes #1192

## What Problem This Solves

Fixes an issue where Local AI could be published to the gateway and reported healthy when llama-server was reachable but the configured managed model was unknown, missing, reported from the wrong path, or no longer served by a proven owned endpoint.

## Why This Change Was Made

Managed-model readiness now requires router health, a Verified or Loaded state, and an exact path match. Startup and refresh share that predicate. Every refresh branch that loses endpoint ownership or readiness quiesces the previously published route before returning. If route withdrawal fails or throws, the managed process is stopped and the runtime publishes a fail-closed state. Recovery persists and publishes the freshly verified owned endpoint rather than stale manifest data.

## User Impact

The gateway no longer routes Local AI requests to an endpoint that cannot prove it serves the configured managed model. Temporary readiness loss withdraws routing safely and routing recovers automatically only after valid model and endpoint evidence returns.

## Evidence

- Table-driven client coverage rejects timeout, invalid response, missing alias, unknown state, missing path, and wrong path; Verified and Loaded evidence pass.
- Startup coverage proves unready model evidence does not persist or publish an endpoint.
- Refresh coverage proves incomplete ownership, ownership conflict, missing endpoint, and readiness loss quiesce routing.
- Quiesce failure and exception coverage proves the managed process is stopped and runtime ownership is cleared.
- Recovery coverage proves the freshly observed endpoint is persisted and published, successful republish recovers, and publication failure remains failed.
- Final rubber-duck review confirmed the route-safety and endpoint-rebinding invariants; its cancellation/exception hardening finding was addressed before publication.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs or instructions
- [x] Tests or validation
- [x] Security hardening
- [ ] Chore or infrastructure

## Scope

- [ ] Tray or WinUI UX
- [ ] Windows node capability
- [ ] Local MCP or `winnode`
- [x] Gateway, connection, or pairing
- [ ] Setup or onboarding
- [ ] Permissions, privacy, or security
- [x] Tests, CI, or docs

## Validation

Environment: Windows 11 ARM64, .NET SDK 10.0.400. `OPENCLAW_REPO_ROOT` was set to the isolated worktree; Tray tests used an isolated `OPENCLAW_TRAY_DATA_DIR`.

- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\build.ps1`: passed. Shared, Cli, WinNodeCli, SetupEngine, and WinUI built successfully for win-arm64.
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore`: passed, 3,819 passed, 0 failed, 32 skipped.
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore`: passed, 2,749 passed, 0 failed, 0 skipped.
- `dotnet test .\tests\OpenClaw.Connection.Tests\OpenClaw.Connection.Tests.csproj --no-restore`: passed, 705 passed, 0 failed, 0 skipped.
- `dotnet test .\tests\OpenClaw.Connection.Tests\OpenClaw.Connection.Tests.csproj --no-restore --filter "FullyQualifiedName~LlamaServerClientTests|FullyQualifiedName~LocalAiPortLifecycleTests"`: passed, 40 passed, 0 failed, 0 skipped.
- `git diff --check`: passed.
- Rubber-duck review: completed. The actionable exception-path finding was fixed and focused tests rerun successfully.

## Real behavior proof

- PR head tested: `d3c1b433`.
- Rebase proof: conflict with the b10655 runtime bump was resolved by retaining `LlamaRuntimeCatalog`-driven manifest data and all readiness lifecycle cases.
- `Refresh_QuiescesPublishedRouteWhenEndpointOwnershipIsLost` observes `quiesce` before returning for incomplete ownership, conflict, and missing endpoint.
- `Refresh_QuiesceFailureStopsUnverifiedManagedProcess` observes `probe, quiesce, stop` and returns `Failed` with no runtime ownership or process ID.
- `Refresh_QuiesceExceptionStopsManagedProcessBeforePropagating` observes `quiesce, stop`, leaves a fail-closed snapshot, then propagates the lifecycle exception.
- `Refresh_RecoveryRebindsFreshlyVerifiedEndpointBeforePublishing` rewrites the persisted receipt to stale port 29999, verifies live port 28777, then observes `probe:28777, publish:28777` and confirms the receipt is rebound to 28777.
- `Refresh_UpdatesPublicationWhenManagedModelReadinessChanges` observes `probe, quiesce` followed by `probe, publish` for successful readiness recovery.
- `Refresh_RecoveryPublishFailureRemainsFailedAndQuiesced` proves a failed recovery publication does not report Healthy.
- Observed focused result: 40 passed, 0 failed, 0 skipped.
- Screenshot or artifact links verified? N/A.
- Not verified or blocked: a live managed llama-server plus WSL gateway environment was not exercised locally. Current-head deterministic HTTP and lifecycle tests directly cover the changed route mutation behavior and exact provider checks remain in `LocalAiGatewayProviderCoordinator`.

## Security Impact

- New permissions or capabilities? No
- Secrets or tokens handling changed? No
- New or changed network calls? Yes
- Command or tool execution surface changed? No
- Data access scope changed? No
- If any answer is `Yes`, explain the risk and mitigation: refresh now withdraws managed gateway routing whenever endpoint ownership or model readiness cannot be proven. Failed route withdrawal stops the managed process, and publication occurs only after the live owned endpoint and exact managed model are verified.

## Compatibility and Migration

- Backward compatible? Yes
- Config or environment changes? No
- Migration needed? No
- If yes, list the exact upgrade steps: N/A

## Review Conversations

- [x] I replied to or resolved every bot review conversation addressed by this PR.
- [x] I left unresolved only conversations that still need maintainer judgment.