### PR TITLE
fix: prevent .NET 10 COM wrapper memory leak in production

### DIFF
--- a/src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj
+++ b/src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj
@@ -32,6 +32,14 @@
     <AppIdentityMarker>release</AppIdentityMarker>
   </PropertyGroup>
 
+  <!-- Work around dotnet/runtime#129191 in production builds. Explicit DevBuild
+       builds retain debugger support for managed/native interop diagnostics. -->
+  <ItemGroup Condition="'$(Configuration)' == 'Release' and '$(DevBuild)' != 'true'">
+    <RuntimeHostConfigurationOption Include="System.Diagnostics.Debugger.IsSupported"
+                                    Value="false"
+                                    Trim="true" />
+  </ItemGroup>
+
   <!-- Map $(Platform) to $(RuntimeIdentifier) so self-contained WinUI F5/debug produces a launchable EXE. -->
   <PropertyGroup Condition="'$(RuntimeIdentifier)' == '' and '$(Platform)' == 'x64'">
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>

--- a/tests/OpenClaw.Tray.Tests/InstallerIssAssertionTests.cs
+++ b/tests/OpenClaw.Tray.Tests/InstallerIssAssertionTests.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+
 namespace OpenClaw.Tray.Tests;
 
 /// <summary>
@@ -198,28 +200,105 @@ public sealed class InstallerIssAssertionTests
         Assert.DoesNotContain("<DevBuild>true</DevBuild>", project);
     }
 
-    [Fact]
-    public void ProductionBuild_DisablesComWrapperDiagnosticsWithoutChangingDevBuilds()
+    [Theory]
+    [InlineData("Release", false, false, "win-x64", true)]
+    [InlineData("Release", false, true, "win-x64", true)]
+    [InlineData("Release", false, false, "win-arm64", true)]
+    [InlineData("Release", false, true, "win-arm64", true)]
+    [InlineData("Release", true, false, "win-x64", false)]
+    [InlineData("Debug", false, false, "win-x64", false)]
+    public async Task ComWrapperDiagnosticsSwitch_EvaluatesOnlyForProductionBuilds(
+        string configuration,
+        bool devBuild,
+        bool packageMsix,
+        string runtimeIdentifier,
+        bool expected)
     {
+        var repositoryRoot = TestRepositoryPaths.GetRepositoryRoot();
         var projectPath = Path.Combine(
-            TestRepositoryPaths.GetRepositoryRoot(),
+            repositoryRoot,
             "src",
             "OpenClaw.Tray.WinUI",
             "OpenClaw.Tray.WinUI.csproj");
-        var project = System.Xml.Linq.XDocument.Load(projectPath);
-        var option = Assert.Single(
-            project.Descendants("RuntimeHostConfigurationOption"),
-            element =>
-                string.Equals(
-                    element.Attribute("Include")?.Value,
-                    "System.Diagnostics.Debugger.IsSupported",
-                    StringComparison.Ordinal));
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            WorkingDirectory = repositoryRoot,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        startInfo.ArgumentList.Add("msbuild");
+        startInfo.ArgumentList.Add(projectPath);
+        startInfo.ArgumentList.Add("-nologo");
+        startInfo.ArgumentList.Add("-v:q");
+        startInfo.ArgumentList.Add("-getItem:RuntimeHostConfigurationOption");
+        startInfo.ArgumentList.Add($"-p:Configuration={configuration}");
+        startInfo.ArgumentList.Add($"-p:DevBuild={devBuild.ToString().ToLowerInvariant()}");
+        startInfo.ArgumentList.Add($"-p:PackageMsix={packageMsix.ToString().ToLowerInvariant()}");
+        startInfo.ArgumentList.Add($"-p:RuntimeIdentifier={runtimeIdentifier}");
 
-        Assert.Equal("false", option.Attribute("Value")?.Value);
-        Assert.Equal("true", option.Attribute("Trim")?.Value);
-        Assert.Equal(
-            "'$(Configuration)' == 'Release' and '$(DevBuild)' != 'true'",
-            option.Parent?.Attribute("Condition")?.Value);
+        using var process = Process.Start(startInfo);
+        Assert.NotNull(process);
+        var standardOutput = process.StandardOutput.ReadToEndAsync();
+        var standardError = process.StandardError.ReadToEndAsync();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+        try
+        {
+            await process.WaitForExitAsync(timeout.Token);
+        }
+        catch (OperationCanceledException) when (timeout.IsCancellationRequested)
+        {
+            if (!process.HasExited)
+                process.Kill(entireProcessTree: true);
+            await process.WaitForExitAsync();
+
+            throw new TimeoutException(
+                $"MSBuild evaluation timed out.{Environment.NewLine}" +
+                $"Standard output:{Environment.NewLine}{await standardOutput}{Environment.NewLine}" +
+                $"Standard error:{Environment.NewLine}{await standardError}");
+        }
+
+        var output = await standardOutput;
+        var error = await standardError;
+
+        Assert.True(
+            process.ExitCode == 0,
+            $"MSBuild evaluation failed with exit code {process.ExitCode}.{Environment.NewLine}" +
+            $"Standard output:{Environment.NewLine}{output}{Environment.NewLine}" +
+            $"Standard error:{Environment.NewLine}{error}");
+
+        JsonNode? result;
+        try
+        {
+            result = JsonNode.Parse(output);
+        }
+        catch (System.Text.Json.JsonException exception)
+        {
+            throw new InvalidDataException(
+                $"MSBuild evaluation returned invalid JSON:{Environment.NewLine}{output}",
+                exception);
+        }
+
+        var options = result?["Items"]?["RuntimeHostConfigurationOption"]?.AsArray();
+        Assert.NotNull(options);
+        var matchingOptions = options
+            .Where(option =>
+                string.Equals(
+                    option?["Identity"]?.GetValue<string>(),
+                    "System.Diagnostics.Debugger.IsSupported",
+                    StringComparison.Ordinal))
+            .ToArray();
+
+        if (!expected)
+        {
+            Assert.Empty(matchingOptions);
+            return;
+        }
+
+        var matchingOption = Assert.Single(matchingOptions);
+        Assert.Equal("false", matchingOption?["Value"]?.GetValue<string>());
+        Assert.Equal("true", matchingOption?["Trim"]?.GetValue<string>());
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/InstallerIssAssertionTests.cs
+++ b/tests/OpenClaw.Tray.Tests/InstallerIssAssertionTests.cs
@@ -199,6 +199,30 @@ public sealed class InstallerIssAssertionTests
     }
 
     [Fact]
+    public void ProductionBuild_DisablesComWrapperDiagnosticsWithoutChangingDevBuilds()
+    {
+        var projectPath = Path.Combine(
+            TestRepositoryPaths.GetRepositoryRoot(),
+            "src",
+            "OpenClaw.Tray.WinUI",
+            "OpenClaw.Tray.WinUI.csproj");
+        var project = System.Xml.Linq.XDocument.Load(projectPath);
+        var option = Assert.Single(
+            project.Descendants("RuntimeHostConfigurationOption"),
+            element =>
+                string.Equals(
+                    element.Attribute("Include")?.Value,
+                    "System.Diagnostics.Debugger.IsSupported",
+                    StringComparison.Ordinal));
+
+        Assert.Equal("false", option.Attribute("Value")?.Value);
+        Assert.Equal("true", option.Attribute("Trim")?.Value);
+        Assert.Equal(
+            "'$(Configuration)' == 'Release' and '$(DevBuild)' != 'true'",
+            option.Parent?.Attribute("Condition")?.Value);
+    }
+
+    [Fact]
     public void MsixManifest_IsGeneratedUnderObjWithoutMutatingTrackedSource()
     {
         var root = TestRepositoryPaths.GetRepositoryRoot();


### PR DESCRIPTION
## Summary

- disable `System.Diagnostics.Debugger.IsSupported` only for non-dev Release builds
- preserve managed debugger support for ordinary Debug/F5 and explicit `DevBuild=true` builds
- add a contract test that pins the configuration and identity condition

## Why

A live OpenClaw Companion process reached about 13.5 GB private memory. Heap analysis found 13.76 GB retained by duplicate `System.Runtime.InteropServices.ComWrappers+ManagedObjectWrapperHolder[]` entries, including two 4 GB arrays rooted through `ChatPage` and `ReactorHostControl`.

This matches the open [.NET 10 runtime regression dotnet/runtime#129191](https://github.com/dotnet/runtime/issues/129191). The runtime's diagnostics-only CCW registry appends duplicate wrapper references on every managed-to-native crossing. Setting `System.Diagnostics.Debugger.IsSupported=false` bypasses that registry. This PR scopes the workaround to production Release artifacts so local debugging remains available.

## Validation

- `./build.ps1`
  - all builds succeeded
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore`
  - 3,812 passed, 32 skipped, 0 failed
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore`
  - 2,704 passed, 0 skipped, 0 failed
- focused contract test
  - 1 passed, 0 failed
- autoreview with Codex `gpt-5.6-sol`, high reasoning
  - clean, no accepted/actionable findings

## Real behavior proof

Generated `OpenClaw.Tray.WinUI.runtimeconfig.json` and `app-identity.txt` from current-head ARM64 builds:

| Configuration | DevBuild | Identity | `System.Diagnostics.Debugger.IsSupported` |
|---|---:|---|---|
| Release | false | release | `false` |
| Release | true | dev | omitted |
| Debug | false | release | omitted |

This is a build/runtime configuration change with no user-visible UI state, so screenshot proof is not applicable.