### PR TITLE
Preserve .wslconfig encodings

### DIFF
--- a/src/OpenClaw.SetupEngine/WslGlobalConfigManager.cs
+++ b/src/OpenClaw.SetupEngine/WslGlobalConfigManager.cs
@@ -42,7 +42,7 @@ internal sealed class WslGlobalConfigManager : IWslGlobalConfigManager
         if (!File.Exists(_configPath))
             return new(false, false);
 
-        var document = WslConfigDocument.Parse(ReadUtf8Document(_configPath).Text);
+        var document = WslConfigDocument.Parse(ReadTextDocument(_configPath).Text);
         return new(true, document.IsMirrored);
     }
 
@@ -52,14 +52,14 @@ internal sealed class WslGlobalConfigManager : IWslGlobalConfigManager
         var original = originalExists
             ? File.ReadAllBytes(_configPath)
             : [];
-        var decoded = DecodeUtf8(original);
+        var decoded = DecodeDocument(original);
         var document = WslConfigDocument.Parse(decoded.Text);
 
         if (document.IsMirrored)
             return new(false, null);
 
         var updatedText = document.WithMirroredNetworking(decoded.NewLine);
-        var updated = EncodeUtf8(updatedText, decoded.HasBom);
+        var updated = decoded.Encoding.Encode(updatedText);
         var metadata = new WslGlobalConfigRollbackMetadata(
             OriginalExisted: originalExists,
             OriginalSha256: ComputeSha256(original),
@@ -124,27 +124,61 @@ internal sealed class WslGlobalConfigManager : IWslGlobalConfigManager
         return WslGlobalConfigRestoreResult.Restored;
     }
 
-    private static Utf8Document ReadUtf8Document(string path) => DecodeUtf8(File.ReadAllBytes(path));
+    private static WslConfigTextDocument ReadTextDocument(string path) => DecodeDocument(File.ReadAllBytes(path));
 
-    private static Utf8Document DecodeUtf8(byte[] bytes)
+    private static WslConfigTextDocument DecodeDocument(byte[] bytes)
     {
-        var hasBom = bytes.AsSpan().StartsWith(Encoding.UTF8.Preamble);
-        var text = Encoding.UTF8.GetString(bytes, hasBom ? Encoding.UTF8.Preamble.Length : 0, bytes.Length - (hasBom ? Encoding.UTF8.Preamble.Length : 0));
+        var encoding = WslConfigEncoding.Detect(bytes);
+        string text;
+        try
+        {
+            text = encoding.Decode(bytes);
+        }
+        catch (DecoderFallbackException ex)
+        {
+            throw new InvalidDataException(
+                "The global .wslconfig file is not valid UTF-8 or UTF-16 with a byte order mark. OpenClaw will not modify it.",
+                ex);
+        }
+
         var newLine = text.Contains("\r\n", StringComparison.Ordinal) ? "\r\n" : "\n";
-        return new(text, hasBom, newLine);
+        return new(text, encoding, newLine);
     }
 
-    private static byte[] EncodeUtf8(string text, bool includeBom)
+    private sealed record WslConfigEncoding(Encoding Encoding, byte[] Preamble)
     {
-        var payload = Encoding.UTF8.GetBytes(text);
-        if (!includeBom)
-            return payload;
+        private static readonly UTF8Encoding StrictUtf8NoBom = new(false, true);
+        private static readonly UTF8Encoding StrictUtf8Bom = new(true, true);
+        private static readonly UnicodeEncoding StrictUtf16LittleEndian = new(false, true, true);
+        private static readonly UnicodeEncoding StrictUtf16BigEndian = new(true, true, true);
 
-        var preamble = Encoding.UTF8.Preamble;
-        var result = new byte[preamble.Length + payload.Length];
-        preamble.CopyTo(result.AsSpan());
-        payload.CopyTo(result, preamble.Length);
-        return result;
+        public static WslConfigEncoding Detect(byte[] bytes)
+        {
+            var span = bytes.AsSpan();
+            if (span.StartsWith(StrictUtf8Bom.Preamble))
+                return new(StrictUtf8Bom, StrictUtf8Bom.Preamble.ToArray());
+            if (span.StartsWith(StrictUtf16LittleEndian.Preamble))
+                return new(StrictUtf16LittleEndian, StrictUtf16LittleEndian.Preamble.ToArray());
+            if (span.StartsWith(StrictUtf16BigEndian.Preamble))
+                return new(StrictUtf16BigEndian, StrictUtf16BigEndian.Preamble.ToArray());
+
+            return new(StrictUtf8NoBom, []);
+        }
+
+        public string Decode(byte[] bytes) =>
+            Encoding.GetString(bytes, Preamble.Length, bytes.Length - Preamble.Length);
+
+        public byte[] Encode(string text)
+        {
+            var payload = Encoding.GetBytes(text);
+            if (Preamble.Length == 0)
+                return payload;
+
+            var result = new byte[Preamble.Length + payload.Length];
+            Preamble.CopyTo(result.AsSpan());
+            payload.CopyTo(result, Preamble.Length);
+            return result;
+        }
     }
 
     private static void AtomicWriteBytes(string path, byte[] contents)
@@ -190,7 +224,7 @@ internal sealed class WslGlobalConfigManager : IWslGlobalConfigManager
         }
     }
 
-    private sealed record Utf8Document(string Text, bool HasBom, string NewLine);
+    private sealed record WslConfigTextDocument(string Text, WslConfigEncoding Encoding, string NewLine);
 
     private sealed class WslConfigDocument
     {

--- a/tests/OpenClaw.SetupEngine.Tests/WslGlobalConfigManagerTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/WslGlobalConfigManagerTests.cs
@@ -17,7 +17,7 @@ public sealed class WslGlobalConfigManagerTests : IDisposable
     [InlineData("\r\n", false, true)]
     [InlineData("\r\n", true, false)]
     [InlineData("\r\n", true, true)]
-    public void ApplyMirroredNetworking_PreservesLineBoundariesAndEncoding(
+    public void ApplyMirroredNetworking_PreservesLineBoundariesAndUtf8Bom(
         string newLine,
         bool includeBom,
         bool includeFinalNewLine)
@@ -45,6 +45,54 @@ public sealed class WslGlobalConfigManagerTests : IDisposable
 
         Assert.Equal(WslGlobalConfigRestoreResult.Restored, manager.RestoreIfUnchanged());
         Assert.Equal(originalBytes, File.ReadAllBytes(configPath));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ApplyMirroredNetworking_PreservesUtf16BomEncoding(bool littleEndian)
+    {
+        Directory.CreateDirectory(_root);
+        var configPath = Path.Combine(_root, "wslconfig");
+        var backupPath = Path.Combine(_root, "backup");
+        var encoding = new UnicodeEncoding(
+            bigEndian: !littleEndian,
+            byteOrderMark: true,
+            throwOnInvalidBytes: true);
+        var originalText = "[wsl2]\r\nmemory=8GB\r\n";
+        byte[] originalBytes = [.. encoding.GetPreamble(), .. encoding.GetBytes(originalText)];
+        File.WriteAllBytes(configPath, originalBytes);
+
+        var manager = new WslGlobalConfigManager(configPath, backupPath);
+        var result = manager.ApplyMirroredNetworking();
+
+        Assert.True(result.Changed);
+        var updatedBytes = File.ReadAllBytes(configPath);
+        Assert.True(updatedBytes.AsSpan().StartsWith(encoding.GetPreamble()));
+        Assert.Contains(
+            "memory=8GB\r\nnetworkingMode=mirrored",
+            encoding.GetString(updatedBytes, encoding.GetPreamble().Length, updatedBytes.Length - encoding.GetPreamble().Length));
+
+        Assert.Equal(WslGlobalConfigRestoreResult.Restored, manager.RestoreIfUnchanged());
+        Assert.Equal(originalBytes, File.ReadAllBytes(configPath));
+    }
+
+    [Fact]
+    public void ApplyMirroredNetworking_RejectsInvalidUtf8WithoutMutating()
+    {
+        Directory.CreateDirectory(_root);
+        var configPath = Path.Combine(_root, "wslconfig");
+        var backupPath = Path.Combine(_root, "backup");
+        byte[] originalBytes = [0x5B, 0x77, 0x73, 0x6C, 0x32, 0x5D, 0x0A, 0xFF, 0x0A];
+        File.WriteAllBytes(configPath, originalBytes);
+
+        var manager = new WslGlobalConfigManager(configPath, backupPath);
+        var ex = Assert.Throws<InvalidDataException>(() => manager.ApplyMirroredNetworking());
+
+        Assert.Contains("OpenClaw will not modify it", ex.Message);
+        Assert.Equal(originalBytes, File.ReadAllBytes(configPath));
+        Assert.False(File.Exists(Path.Combine(backupPath, "wslconfig.original")));
+        Assert.False(File.Exists(Path.Combine(backupPath, "wslconfig.rollback.json")));
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #1193

## Summary
- Detect UTF-8, UTF-8 BOM, UTF-16 LE BOM, and UTF-16 BE BOM before parsing `.wslconfig`.
- Preserve the detected encoding when rewriting mirrored networking settings.
- Reject invalid UTF-8 input before writing backups or modifying the user file.

## Validation
- `dotnet test .\tests\OpenClaw.SetupEngine.Tests\OpenClaw.SetupEngine.Tests.csproj --filter WslGlobalConfigManagerTests` - passed, 13 tests.
- `dotnet test .\tests\OpenClaw.SetupEngine.Tests\OpenClaw.SetupEngine.Tests.csproj --no-restore` - passed, 950 tests.
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore` - passed, 3812 passed, 32 skipped.
- `.\scripts\setup-dev.ps1 -CheckOnly` - passed prerequisite checks.
- `.\build.ps1` - blocked in WinUI restore/build because `Microsoft.WindowsAppSDK (>= 2.4.0)` could not be resolved for the WinUI projects.
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore` - blocked because the test project restore could not access `https://api.nuget.org/v3/index.json` and runtime packs were unavailable in the generated assets.

## Real behavior proof
- Focused `WslGlobalConfigManagerTests` verify UTF-16 LE and UTF-16 BE BOM files keep their original BOM and encoding after mirrored networking is applied, then restore to the exact original bytes.
- Focused tests verify invalid UTF-8 without a BOM throws `InvalidDataException`, leaves the original bytes unchanged, and creates no rollback artifacts.
- Existing UTF-8 round-trip coverage still passes for LF/CRLF, BOM/no BOM, final newline/no final newline, idempotence, and restore behavior.