### PR TITLE
Require verified Local AI model evidence

### DIFF
--- a/src/OpenClaw.Connection/LocalAi/LlamaServerClient.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerClient.cs
@@ -6,7 +6,14 @@ public sealed record LlamaServerRouterProbeResult(
     bool IsHealthy,
     LocalAiModelAvailabilityState ModelState,
     string? ReportedModelPath,
-    string? Detail);
+    string? Detail)
+{
+    public bool HasVerifiedManagedModel =>
+        ModelState is LocalAiModelAvailabilityState.Verified or LocalAiModelAvailabilityState.Loaded &&
+        !string.IsNullOrWhiteSpace(ReportedModelPath);
+
+    public bool IsReady => IsHealthy && HasVerifiedManagedModel;
+}
 
 public sealed record LlamaServerModelStatusEvidence(
     LocalAiModelAvailabilityState State,
@@ -191,11 +198,11 @@ public sealed class LlamaServerClient : ILlamaServerClient
         }
         catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
         {
-            return new(true, LocalAiModelAvailabilityState.Unknown, null, "The model status check timed out.");
+            return new(false, LocalAiModelAvailabilityState.Unknown, null, "The model status check timed out.");
         }
         catch (Exception ex) when (ex is HttpRequestException or IOException or JsonException or InvalidDataException)
         {
-            return new(true, LocalAiModelAvailabilityState.Unknown, null, "The model status response was invalid.");
+            return new(false, LocalAiModelAvailabilityState.Unknown, null, "The model status response was invalid.");
         }
     }
 
@@ -249,9 +256,10 @@ public sealed class LlamaServerClient : ILlamaServerClient
             modelAlias,
             expectedModelPath);
         if (evidence is null)
-            return new(true, LocalAiModelAvailabilityState.NotInstalled, null, "The configured model is not registered.");
+            return new(false, LocalAiModelAvailabilityState.NotInstalled, null, "The configured model is not registered.");
+        bool hasVerifiedManagedModel = evidence.State is LocalAiModelAvailabilityState.Verified or LocalAiModelAvailabilityState.Loaded;
         return new(
-            true,
+            hasVerifiedManagedModel,
             evidence.State,
             evidence.ModelPath,
             $"llama-server reports the model as {evidence.ServerStatus}.");

--- a/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
@@ -246,7 +246,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                             install.ModelPath,
                             cancellationToken)
                         .ConfigureAwait(false);
-                    if (probe.IsHealthy)
+                    if (probe.IsReady)
                     {
                         LocalAiInstallManifest verifiedManifest = install.Manifest with
                         {
@@ -346,7 +346,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                 install.ModelPath,
                 cancellationToken)
             .ConfigureAwait(false);
-        return probe.IsHealthy
+        return probe.IsReady
             ? PublishHealthy(probe)
             : Publish(
                 LocalAiRuntimeState.Starting,

--- a/tests/OpenClaw.Connection.Tests/LlamaServerClientTests.cs
+++ b/tests/OpenClaw.Connection.Tests/LlamaServerClientTests.cs
@@ -1,0 +1,156 @@
+using OpenClaw.Connection.LocalAi;
+using System.Net;
+using System.Text;
+
+namespace OpenClaw.Connection.Tests;
+
+public sealed class LlamaServerClientTests
+{
+    private const string Alias = "qwen3.6-35b-a3b-mtp-q4-k-m";
+    private static readonly Uri Endpoint = new("http://127.0.0.1:28765/v1");
+
+    [Fact]
+    public async Task ProbeRouterAsync_ModelStatusTimeout_ReturnsNotHealthy()
+    {
+        using var client = new LlamaServerClient(new StubHandler(request =>
+            request.RequestUri!.AbsolutePath == "/models"
+                ? throw new OperationCanceledException()
+                : JsonResponse("""{"status":"ok"}""")));
+
+        LlamaServerRouterProbeResult result = await client.ProbeRouterAsync(
+            Endpoint,
+            Alias,
+            ManagedModelPath());
+
+        Assert.False(result.IsHealthy);
+        Assert.False(result.IsReady);
+        Assert.Equal(LocalAiModelAvailabilityState.Unknown, result.ModelState);
+    }
+
+    [Fact]
+    public async Task ProbeRouterAsync_MissingConfiguredAlias_ReturnsNotHealthy()
+    {
+        using var client = new LlamaServerClient(new StubHandler(request =>
+            request.RequestUri!.AbsolutePath == "/models"
+                ? JsonResponse(ModelListJson("other-model", "unloaded", ManagedModelPath()))
+                : JsonResponse("""{"status":"ok"}""")));
+
+        LlamaServerRouterProbeResult result = await client.ProbeRouterAsync(
+            Endpoint,
+            Alias,
+            ManagedModelPath());
+
+        Assert.False(result.IsHealthy);
+        Assert.False(result.IsReady);
+        Assert.Equal(LocalAiModelAvailabilityState.NotInstalled, result.ModelState);
+    }
+
+    [Fact]
+    public async Task ProbeRouterAsync_InvalidModelsResponse_ReturnsNotHealthy()
+    {
+        using var client = new LlamaServerClient(new StubHandler(request =>
+            request.RequestUri!.AbsolutePath == "/models"
+                ? JsonResponse("""{"data":{}}""")
+                : JsonResponse("""{"status":"ok"}""")));
+
+        LlamaServerRouterProbeResult result = await client.ProbeRouterAsync(
+            Endpoint,
+            Alias,
+            ManagedModelPath());
+
+        Assert.False(result.IsHealthy);
+        Assert.False(result.IsReady);
+        Assert.Equal(LocalAiModelAvailabilityState.Unknown, result.ModelState);
+    }
+
+    [Fact]
+    public async Task ProbeRouterAsync_UnknownModelState_ReturnsNotHealthy()
+    {
+        using var client = new LlamaServerClient(new StubHandler(request =>
+            request.RequestUri!.AbsolutePath == "/models"
+                ? JsonResponse(ModelListJson(Alias, "error", ManagedModelPath()))
+                : JsonResponse("""{"status":"ok"}""")));
+
+        LlamaServerRouterProbeResult result = await client.ProbeRouterAsync(
+            Endpoint,
+            Alias,
+            ManagedModelPath());
+
+        Assert.False(result.IsHealthy);
+        Assert.False(result.IsReady);
+        Assert.Equal(LocalAiModelAvailabilityState.Unknown, result.ModelState);
+        Assert.Equal(ManagedModelPath(), result.ReportedModelPath);
+    }
+
+    [Fact]
+    public async Task ProbeRouterAsync_WrongModelPath_ReturnsNotHealthy()
+    {
+        using var client = new LlamaServerClient(new StubHandler(request =>
+            request.RequestUri!.AbsolutePath == "/models"
+                ? JsonResponse(ModelListJson(Alias, "unloaded", ManagedModelPath("wrong.gguf")))
+                : JsonResponse("""{"status":"ok"}""")));
+
+        LlamaServerRouterProbeResult result = await client.ProbeRouterAsync(
+            Endpoint,
+            Alias,
+            ManagedModelPath());
+
+        Assert.False(result.IsHealthy);
+        Assert.False(result.IsReady);
+        Assert.Equal(LocalAiModelAvailabilityState.Unknown, result.ModelState);
+    }
+
+    [Theory]
+    [InlineData("unloaded", LocalAiModelAvailabilityState.Verified)]
+    [InlineData("loaded", LocalAiModelAvailabilityState.Loaded)]
+    public async Task ProbeRouterAsync_VerifiedManagedModel_ReturnsHealthy(string serverStatus, LocalAiModelAvailabilityState expectedState)
+    {
+        using var client = new LlamaServerClient(new StubHandler(request =>
+            request.RequestUri!.AbsolutePath == "/models"
+                ? JsonResponse(ModelListJson(Alias, serverStatus, ManagedModelPath()))
+                : JsonResponse("""{"status":"ok"}""")));
+
+        LlamaServerRouterProbeResult result = await client.ProbeRouterAsync(
+            Endpoint,
+            Alias,
+            ManagedModelPath());
+
+        Assert.True(result.IsHealthy);
+        Assert.True(result.IsReady);
+        Assert.Equal(expectedState, result.ModelState);
+        Assert.Equal(ManagedModelPath(), result.ReportedModelPath);
+    }
+
+    private static string ModelListJson(string alias, string status, string modelPath) =>
+        $$"""
+        {
+          "data": [
+            {
+              "id": "{{alias}}",
+              "status": {
+                "value": "{{status}}",
+                "args": ["--model", "{{JsonEscape(modelPath)}}"]
+              }
+            }
+          ]
+        }
+        """;
+
+    private static HttpResponseMessage JsonResponse(string json) =>
+        new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json"),
+        };
+
+    private static string ManagedModelPath(string fileName = "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf") =>
+        Path.Combine("C:\\", "OpenClaw", "models", fileName);
+
+    private static string JsonEscape(string value) =>
+        value.Replace("\\", "\\\\", StringComparison.Ordinal).Replace("\"", "\\\"", StringComparison.Ordinal);
+
+    private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> respond) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(respond(request));
+    }
+}

--- a/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
+++ b/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
@@ -287,6 +287,32 @@ public sealed class LocalAiPortLifecycleTests
         Assert.Equal(28_768, recovered.Endpoint.Port);
     }
 
+    [Fact]
+    public async Task Startup_DoesNotPublishWhenModelEvidenceIsNotVerified()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var events = new List<string>();
+        var platform = new FakePlatform();
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_773);
+        var client = new FakeClient(events)
+        {
+            Result = new LlamaServerRouterProbeResult(
+                true,
+                LocalAiModelAvailabilityState.NotInstalled,
+                null,
+                "The configured model is not registered."),
+        };
+        await using var runtime = CreateRuntime(paths, host, platform, client, new FakeLifecycle(events));
+
+        LocalAiRuntimeSnapshot snapshot = await runtime.EnsureStartedAsync();
+
+        Assert.Equal(LocalAiRuntimeState.Failed, snapshot.State);
+        Assert.DoesNotContain("publish:28773", events);
+        LocalAiResolvedInstall? saved = await new LocalAiManifestStore(paths).LoadAsync();
+        Assert.Null(saved!.Endpoint);
+    }
+
     private static LlamaServerRuntimeService CreateRuntime(
         LocalAiPaths paths,
         FakeProcessHost host,
@@ -442,6 +468,7 @@ public sealed class LocalAiPortLifecycleTests
     private sealed class FakeClient(List<string> events) : ILlamaServerClient
     {
         public List<int> ProbedPorts { get; } = [];
+        public LlamaServerRouterProbeResult? Result { get; init; }
 
         public Task<LlamaServerRouterProbeResult> ProbeRouterAsync(
             Uri endpoint,
@@ -452,7 +479,7 @@ public sealed class LocalAiPortLifecycleTests
             cancellationToken.ThrowIfCancellationRequested();
             ProbedPorts.Add(endpoint.Port);
             events.Add($"probe:{endpoint.Port}");
-            return Task.FromResult(new LlamaServerRouterProbeResult(
+            return Task.FromResult(Result ?? new LlamaServerRouterProbeResult(
                 true,
                 LocalAiModelAvailabilityState.Verified,
                 expectedModelPath,


### PR DESCRIPTION
Fixes #1192

## Summary
- Require the managed llama-server probe to report healthy only when `/health` succeeds and `/models` verifies the configured managed model.
- Treat `/models` timeout, invalid data, missing alias, unknown state, and wrong path as not ready.
- Use the same readiness predicate before startup publication and during refresh.

## Validation
- PASS: `dotnet test .\tests\OpenClaw.Connection.Tests\OpenClaw.Connection.Tests.csproj --no-restore --filter "FullyQualifiedName~LlamaServerClientTests|FullyQualifiedName~Startup_DoesNotPublishWhenModelEvidenceIsNotVerified"` (8 passed)
- PASS: `dotnet test .\tests\OpenClaw.Connection.Tests\OpenClaw.Connection.Tests.csproj --no-restore --filter "FullyQualifiedName!~ManagedLocalGatewayPortProvenanceServiceTests.VerifyMicrosoftSignedFile_AcceptsWindowsWslBinary"` (687 passed)
- PASS: `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore` (3812 passed, 32 skipped)
- PASS: `git diff --check`
- BLOCKED: `.\build.ps1` builds Shared, Cli, WinNodeCli, and SetupEngine, then fails WinUI restore because `Microsoft.WindowsAppSDK` and `WinUIEx` cannot be resolved locally while nuget.org is disabled.
- BLOCKED: `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore` cannot run because restore assets for the Tray test project are missing and local package restore cannot load nuget.org.
- BLOCKED: full `dotnet test .\tests\OpenClaw.Connection.Tests\OpenClaw.Connection.Tests.csproj --no-restore` has one environment failure: `VerifyMicrosoftSignedFile_AcceptsWindowsWslBinary` reports local `wsl.exe` as unsigned. The full suite otherwise passes when that environment-specific test is excluded.
- PASS: `.\scripts\setup-dev.ps1 -CheckOnly`

## Real behavior proof
- Focused client tests prove `/models` timeout, invalid response, missing alias, unknown model state, and wrong model path all return not healthy.
- Focused client tests prove verified and loaded managed-model evidence returns healthy.
- Runtime test proves a probe with process health but unverified model evidence does not save the endpoint or publish the provider.