### PR TITLE
fix: render Windows notifications as plain text

### DIFF
--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -3894,7 +3894,9 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
                     openClawMetadata.TokensAfter,
                     projection.ContentParts);
 
-                if (role == "assistant")
+                if (role == "assistant" &&
+                    (string.IsNullOrWhiteSpace(state) ||
+                     string.Equals(state, "final", StringComparison.OrdinalIgnoreCase)))
                 {
                     // HIGH 4: log shape only.
                     _logger.Info($"Assistant response (legacy): role={role} state={state} len={text.Length}");

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -2760,14 +2760,15 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands, IPer
         // Agent requested a notification via node.invoke system.notify
         try
         {
+            AppNotification notification = AppNotificationMapper.FromNodeSystemNotification(args);
             AppNotificationPublisher.Publish(
                 _appNotificationService,
                 _toastService,
                 new AppNotificationPublishRequest(
-                    AppNotificationMapper.FromNodeSystemNotification(args),
+                    notification,
                     new ToastContentBuilder()
-                        .AddText(args.Title)
-                        .AddText(args.Body)));
+                        .AddText(notification.Title)
+                        .AddText(notification.Message)));
         }
         catch (Exception ex)
         {
@@ -2983,11 +2984,16 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands, IPer
         if (_settings?.ShowNotifications != true) return;
         if (!ShouldShowNotification(notification)) return;
 
+        AppNotification appNotification = AppNotificationMapper.FromGatewayNotification(
+            notification,
+            LocalizationHelper.GetString("AppNotification_ExecApprovalPending_OpenChatAction"));
+        if (notification.IsChat && string.IsNullOrWhiteSpace(appNotification.Message)) return;
+
         // Store in history
         NotificationHistoryService.AddNotification(new Services.GatewayNotification
         {
-            Title = notification.Title,
-            Message = notification.Message,
+            Title = appNotification.Title,
+            Message = appNotification.Message,
             Category = notification.Type
         });
 
@@ -2995,8 +3001,8 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands, IPer
         try
         {
             var builder = new ToastContentBuilder()
-                .AddText(notification.Title ?? "OpenClaw")
-                .AddText(notification.Message);
+                .AddText(appNotification.Title)
+                .AddText(appNotification.Message);
 
             var logoPath = GetNotificationIcon(notification.Type);
             if (!string.IsNullOrEmpty(logoPath) && System.IO.File.Exists(logoPath))
@@ -3021,9 +3027,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands, IPer
                 _appNotificationService,
                 _toastService,
                 new AppNotificationPublishRequest(
-                    AppNotificationMapper.FromGatewayNotification(
-                        notification,
-                        LocalizationHelper.GetString("AppNotification_ExecApprovalPending_OpenChatAction")),
+                    appNotification,
                     builder));
         }
         catch (Exception ex)

--- a/src/OpenClaw.Tray.WinUI/Services/AppNotificationMapper.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/AppNotificationMapper.cs
@@ -1,8 +1,10 @@
 using OpenClaw.Shared;
 using OpenClaw.Shared.Capabilities;
+using OpenClaw.Shared.Markdown;
 using System;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace OpenClawTray.Services;
 
@@ -13,7 +15,10 @@ internal static class AppNotificationMapper
         ArgumentNullException.ThrowIfNull(notification);
 
         var title = NormalizeTitle(notification.Title);
-        var message = NormalizeMessage(notification.Message, title);
+        var sourceMessage = notification.IsChat && !string.IsNullOrWhiteSpace(notification.FullMessage)
+            ? notification.FullMessage
+            : notification.Message;
+        var message = NormalizeMessage(sourceMessage, title, notification.IsChat);
         var category = NormalizeCategory(notification.Type);
         var hasChatAction = notification.IsChat && !string.IsNullOrWhiteSpace(chatActionLabel);
 
@@ -28,7 +33,7 @@ internal static class AppNotificationMapper
                 "gateway",
                 notification.Type,
                 notification.Title,
-                notification.Message,
+                message,
                 notification.SessionKey),
             ActionLabel = hasChatAction ? chatActionLabel : null,
             ActionRoute = hasChatAction ? GetChatActionRoute(notification.SessionKey) : null
@@ -48,7 +53,7 @@ internal static class AppNotificationMapper
             Message = message,
             Source = "node",
             Category = "system.notify",
-            Severity = SeverityFromText(title, message),
+            Severity = SeverityFromText(title, args.Body ?? string.Empty),
             DedupeKey = BuildDedupeKey("node-system-notify", args.Title, args.Body)
         };
     }
@@ -93,11 +98,20 @@ internal static class AppNotificationMapper
                 : AppNotificationSeverity.Informational;
     }
 
-    private static string NormalizeTitle(string? title) =>
-        string.IsNullOrWhiteSpace(title) ? "OpenClaw" : title.Trim();
+    private static string NormalizeTitle(string? title)
+    {
+        string plainText = NotificationPlainTextFormatter.Format(title);
+        return string.IsNullOrWhiteSpace(plainText) ? "OpenClaw" : plainText;
+    }
 
-    private static string NormalizeMessage(string? message, string title) =>
-        string.IsNullOrWhiteSpace(message) ? title : message.Trim();
+    private static string NormalizeMessage(
+        string? message,
+        string title,
+        bool stripControlMarkers = false)
+    {
+        string plainText = NotificationPlainTextFormatter.Format(message, stripControlMarkers);
+        return string.IsNullOrWhiteSpace(plainText) && !stripControlMarkers ? title : plainText;
+    }
 
     private static string NormalizeCategory(string? category) =>
         string.IsNullOrWhiteSpace(category) ? "info" : category.Trim();
@@ -112,5 +126,99 @@ internal static class AppNotificationMapper
         var raw = string.Join("\u001f", parts.Select(part => part?.Trim() ?? string.Empty));
         var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(raw))).ToLowerInvariant();
         return $"{scope}:{hash}";
+    }
+}
+
+internal static class NotificationPlainTextFormatter
+{
+    private const int MaximumPreviewLength = 200;
+    private const int MaximumInputLength = 4_096;
+
+    private static readonly Regex s_blankLines = new(@"\n{2,}", RegexOptions.Compiled);
+    private static readonly Regex s_controlMarker = new(
+        @"^[ \t]*(?:DONE|NO_REPLY|HEARTBEAT_OK)[ \t]*(?:\n|$)|(?<=[a-z0-9.!?])DONE(?=$|[A-Z])",
+        RegexOptions.Compiled | RegexOptions.Multiline);
+
+    public static string Format(string? value, bool stripControlMarkers = false)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return string.Empty;
+
+        int inputLength = Math.Min(value.Length, MaximumInputLength);
+        if (inputLength < value.Length && char.IsHighSurrogate(value[inputLength - 1]))
+            inputLength--;
+        var document = new ChatMarkdownAstBuilder().Build(value[..inputLength]);
+        var builder = new StringBuilder(inputLength);
+        AppendBlocks(builder, document.Blocks, stripControlMarkers);
+        string text = builder.ToString()
+            .Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Replace('\r', '\n');
+        text = s_blankLines.Replace(text, "\n").Trim();
+
+        return Truncate(text);
+    }
+
+    private static void AppendBlocks(
+        StringBuilder builder,
+        IReadOnlyList<MdBlock> blocks,
+        bool stripControlMarkers)
+    {
+        foreach (MdBlock block in blocks)
+        {
+            switch (block)
+            {
+                case MdHeading heading: AppendInlines(builder, heading.Inlines, stripControlMarkers); break;
+                case MdParagraph paragraph: AppendInlines(builder, paragraph.Inlines, stripControlMarkers); break;
+                case MdBlockQuote quote: AppendBlocks(builder, quote.Children, stripControlMarkers); break;
+                case MdCodeBlock code: builder.Append(code.Code.TrimEnd()); break;
+                case MdRawTextBlock raw: builder.Append(raw.Text); break;
+                case MdList list:
+                    foreach (MdListItem item in list.Items)
+                        AppendBlocks(builder, item.Children, stripControlMarkers);
+                    break;
+                case MdListItem item: AppendBlocks(builder, item.Children, stripControlMarkers); break;
+                case MdTable table:
+                    foreach (MdTableRow row in table.HeaderRows.Concat(table.BodyRows))
+                    {
+                        for (int i = 0; i < row.Cells.Count; i++)
+                        {
+                            if (i > 0) builder.Append(" | ");
+                            AppendInlines(builder, row.Cells[i].Inlines, stripControlMarkers);
+                        }
+                        builder.AppendLine();
+                    }
+                    break;
+            }
+
+            if (builder.Length > 0 && builder[^1] != '\n') builder.AppendLine();
+        }
+    }
+
+    private static void AppendInlines(
+        StringBuilder builder,
+        IReadOnlyList<MdInline> inlines,
+        bool stripControlMarkers)
+    {
+        foreach (MdInline inline in inlines)
+        {
+            if (inline is MdInlineText text)
+            {
+                builder.Append(stripControlMarkers && !text.IsCode
+                    ? s_controlMarker.Replace(text.Text, " ")
+                    : text.Text);
+            }
+            else if (inline is MdInlineLineBreak) builder.AppendLine();
+        }
+    }
+
+    private static string Truncate(string text)
+    {
+        if (text.Length <= MaximumPreviewLength)
+            return text;
+
+        int length = MaximumPreviewLength - 1;
+        if (length > 0 && char.IsHighSurrogate(text[length - 1]))
+            length--;
+        return string.Concat(text.AsSpan(0, length).TrimEnd(), "…");
     }
 }

--- a/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
@@ -2385,6 +2385,33 @@ public class OpenClawGatewayClientTests
         Assert.Equal(fullMessage, notification.FullMessage);
     }
 
+    [Theory]
+    [InlineData("streaming", false)]
+    [InlineData("final", true)]
+    public void ProcessRawMessage_LegacyAssistantNotification_DependsOnFinalState(
+        string state,
+        bool expectNotification)
+    {
+        var helper = new GatewayClientTestHelper();
+        var notifications = new List<OpenClawNotification>();
+        helper.Client.NotificationReceived += (_, value) => notifications.Add(value);
+
+        helper.ProcessRawMessage($$"""
+        {
+          "type": "event",
+          "event": "session.message",
+          "payload": {
+            "sessionKey": "main",
+            "role": "assistant",
+            "text": "legacy reply",
+            "state": "{{state}}"
+          }
+        }
+        """);
+
+        Assert.Equal(expectNotification ? 1 : 0, notifications.Count);
+    }
+
     [Fact]
     public void ProcessRawMessage_AgentEventLogsRawLengthWithoutPayloadContent()
     {

--- a/tests/OpenClaw.Tray.Tests/Services/AppNotificationMapperTests.cs
+++ b/tests/OpenClaw.Tray.Tests/Services/AppNotificationMapperTests.cs
@@ -82,6 +82,44 @@ public sealed class AppNotificationMapperTests
     }
 
     [Fact]
+    public void FromGatewayNotification_FormatsChatMarkdownAndRemovesTrailingControlMarker()
+    {
+        var mapped = AppNotificationMapper.FromGatewayNotification(new OpenClawNotification
+        {
+            Title = "# Build **complete**",
+            Message = "truncated",
+            FullMessage = "## Result\n- **Build** [passed](https://example.com) with `zero` failures.\n```text\n# Tests: **42**\nDONE\n```\nStatus is DONE. Use <https://example.com> with <requestId>.\nfinishedDONENext stepDONE",
+            IsChat = true
+        });
+
+        Assert.Equal("Build complete", mapped.Title);
+        Assert.Equal(
+            "Result\nBuild passed (https://example.com) with zero failures.\n# Tests: **42**\nDONE\nStatus is DONE. Use https://example.com with <requestId>.\nfinished Next step",
+            mapped.Message);
+
+        var controlOnly = AppNotificationMapper.FromGatewayNotification(new OpenClawNotification
+        {
+            Title = "Chat response",
+            FullMessage = "DONE",
+            IsChat = true
+        });
+        Assert.Empty(controlOnly.Message);
+    }
+
+    [Fact]
+    public void FromNodeSystemNotification_FormatsMarkdownWithoutChangingMarkerLikeProse()
+    {
+        var mapped = AppNotificationMapper.FromNodeSystemNotification(new SystemNotifyArgs
+        {
+            Title = "**Deploy** notice",
+            Body = "- Review [details](https://example.com) when DONE"
+        });
+
+        Assert.Equal("Deploy notice", mapped.Title);
+        Assert.Equal("Review details (https://example.com) when DONE", mapped.Message);
+    }
+
+    [Fact]
     public void FromNodeActivity_UsesExplicitMetadata()
     {
         var mapped = AppNotificationMapper.FromNodeActivity(


### PR DESCRIPTION
## Summary
- Render Windows notification titles and bodies as bounded plain text using the existing Markdown parser.
- Remove response-boundary markers such as glued `DONE` without changing ordinary prose or code examples.
- Suppress control-only chat popups and emit legacy assistant notifications only for final frames.
- Use the normalized displayed preview for notification history, toast content, publishing, and deduplication.

## Root cause
Windows toast text controls do not render Markdown. Gateway chat text was passed through directly, and the legacy assistant event path emitted notifications for explicitly non-final streaming frames. Modern array content is already joined with newlines, so the Windows toast API was not concatenating those blocks.

## Validation
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\build.ps1` (passed, ARM64)
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore` (3,814 passed, 32 skipped, 0 failed)
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore` (2,705 passed, 0 skipped, 0 failed)
- Local autoreview (clean, no actionable findings)

## Real behavior proof
- Current-head mapper tests prove headings, emphasis, lists, links, and code fences become safe plain text while code content and ordinary `DONE` prose remain intact.
- Current-head gateway tests prove explicitly streaming legacy assistant frames emit no notification and final frames emit exactly one.
- Visible Windows toast screenshot: Not verified / blocked because this session does not provide computer-use screenshot capture.

Closes #1221