### PR TITLE
fix: preserve .wslconfig encoding

### DIFF
--- a/src/OpenClaw.SetupEngine/WslGlobalConfigManager.cs
+++ b/src/OpenClaw.SetupEngine/WslGlobalConfigManager.cs
@@ -27,6 +27,8 @@ internal sealed class WslGlobalConfigManager : IWslGlobalConfigManager
     private static readonly byte[] s_utf8Bom = [.. Encoding.UTF8.Preamble];
     private static readonly byte[] s_utf16LeBom = [0xFF, 0xFE];
     private static readonly byte[] s_utf16BeBom = [0xFE, 0xFF];
+    private static readonly byte[] s_utf32LeBom = [0xFF, 0xFE, 0x00, 0x00];
+    private static readonly byte[] s_utf32BeBom = [0x00, 0x00, 0xFE, 0xFF];
 
     private readonly string _configPath;
     private readonly string _backupPath;
@@ -136,7 +138,12 @@ internal sealed class WslGlobalConfigManager : IWslGlobalConfigManager
     {
         Encoding encoding = s_utf8;
         byte[] preamble = [];
-        if (bytes.AsSpan().StartsWith(s_utf8Bom))
+        if (bytes.AsSpan().StartsWith(s_utf32LeBom) ||
+            bytes.AsSpan().StartsWith(s_utf32BeBom))
+        {
+            throw new InvalidDataException("The .wslconfig encoding is invalid or unsupported.");
+        }
+        else if (bytes.AsSpan().StartsWith(s_utf8Bom))
             preamble = s_utf8Bom;
         else if (bytes.AsSpan().StartsWith(s_utf16LeBom))
         {
@@ -159,8 +166,8 @@ internal sealed class WslGlobalConfigManager : IWslGlobalConfigManager
             throw new InvalidDataException("The .wslconfig encoding is invalid or unsupported.", ex);
         }
 
-        if (text.Any(c => char.IsControl(c) && c is not '\r' and not '\n' and not '\t'))
-            throw new InvalidDataException("The .wslconfig contains unsupported control characters.");
+        if (text.Contains('\0'))
+            throw new InvalidDataException("The .wslconfig encoding is invalid or unsupported.");
 
         var newLine = text.Contains("\r\n", StringComparison.Ordinal) ? "\r\n" : "\n";
         return new(text, encoding, preamble, newLine);

--- a/src/OpenClaw.SetupEngine/WslGlobalConfigManager.cs
+++ b/src/OpenClaw.SetupEngine/WslGlobalConfigManager.cs
@@ -21,6 +21,12 @@ internal sealed class WslGlobalConfigManager : IWslGlobalConfigManager
     private const string Wsl2Section = "wsl2";
     private const string NetworkingModeKey = "networkingMode";
     private const string MirroredValue = "mirrored";
+    private static readonly UTF8Encoding s_utf8 = new(false, true);
+    private static readonly UnicodeEncoding s_utf16Le = new(false, false, true);
+    private static readonly UnicodeEncoding s_utf16Be = new(true, false, true);
+    private static readonly byte[] s_utf8Bom = [.. Encoding.UTF8.Preamble];
+    private static readonly byte[] s_utf16LeBom = [0xFF, 0xFE];
+    private static readonly byte[] s_utf16BeBom = [0xFE, 0xFF];
 
     private readonly string _configPath;
     private readonly string _backupPath;
@@ -42,7 +48,7 @@ internal sealed class WslGlobalConfigManager : IWslGlobalConfigManager
         if (!File.Exists(_configPath))
             return new(false, false);
 
-        var document = WslConfigDocument.Parse(ReadUtf8Document(_configPath).Text);
+        var document = WslConfigDocument.Parse(ReadDocument(_configPath).Text);
         return new(true, document.IsMirrored);
     }
 
@@ -52,14 +58,14 @@ internal sealed class WslGlobalConfigManager : IWslGlobalConfigManager
         var original = originalExists
             ? File.ReadAllBytes(_configPath)
             : [];
-        var decoded = DecodeUtf8(original);
+        var decoded = Decode(original);
         var document = WslConfigDocument.Parse(decoded.Text);
 
         if (document.IsMirrored)
             return new(false, null);
 
         var updatedText = document.WithMirroredNetworking(decoded.NewLine);
-        var updated = EncodeUtf8(updatedText, decoded.HasBom);
+        var updated = Encode(updatedText, decoded.Encoding, decoded.Preamble);
         var metadata = new WslGlobalConfigRollbackMetadata(
             OriginalExisted: originalExists,
             OriginalSha256: ComputeSha256(original),
@@ -124,23 +130,48 @@ internal sealed class WslGlobalConfigManager : IWslGlobalConfigManager
         return WslGlobalConfigRestoreResult.Restored;
     }
 
-    private static Utf8Document ReadUtf8Document(string path) => DecodeUtf8(File.ReadAllBytes(path));
+    private static EncodedDocument ReadDocument(string path) => Decode(File.ReadAllBytes(path));
 
-    private static Utf8Document DecodeUtf8(byte[] bytes)
+    private static EncodedDocument Decode(byte[] bytes)
     {
-        var hasBom = bytes.AsSpan().StartsWith(Encoding.UTF8.Preamble);
-        var text = Encoding.UTF8.GetString(bytes, hasBom ? Encoding.UTF8.Preamble.Length : 0, bytes.Length - (hasBom ? Encoding.UTF8.Preamble.Length : 0));
+        Encoding encoding = s_utf8;
+        byte[] preamble = [];
+        if (bytes.AsSpan().StartsWith(s_utf8Bom))
+            preamble = s_utf8Bom;
+        else if (bytes.AsSpan().StartsWith(s_utf16LeBom))
+        {
+            encoding = s_utf16Le;
+            preamble = s_utf16LeBom;
+        }
+        else if (bytes.AsSpan().StartsWith(s_utf16BeBom))
+        {
+            encoding = s_utf16Be;
+            preamble = s_utf16BeBom;
+        }
+
+        string text;
+        try
+        {
+            text = encoding.GetString(bytes, preamble.Length, bytes.Length - preamble.Length);
+        }
+        catch (DecoderFallbackException ex)
+        {
+            throw new InvalidDataException("The .wslconfig encoding is invalid or unsupported.", ex);
+        }
+
+        if (text.Any(c => char.IsControl(c) && c is not '\r' and not '\n' and not '\t'))
+            throw new InvalidDataException("The .wslconfig contains unsupported control characters.");
+
         var newLine = text.Contains("\r\n", StringComparison.Ordinal) ? "\r\n" : "\n";
-        return new(text, hasBom, newLine);
+        return new(text, encoding, preamble, newLine);
     }
 
-    private static byte[] EncodeUtf8(string text, bool includeBom)
+    private static byte[] Encode(string text, Encoding encoding, byte[] preamble)
     {
-        var payload = Encoding.UTF8.GetBytes(text);
-        if (!includeBom)
+        var payload = encoding.GetBytes(text);
+        if (preamble.Length == 0)
             return payload;
 
-        var preamble = Encoding.UTF8.Preamble;
         var result = new byte[preamble.Length + payload.Length];
         preamble.CopyTo(result.AsSpan());
         payload.CopyTo(result, preamble.Length);
@@ -190,7 +221,11 @@ internal sealed class WslGlobalConfigManager : IWslGlobalConfigManager
         }
     }
 
-    private sealed record Utf8Document(string Text, bool HasBom, string NewLine);
+    private sealed record EncodedDocument(
+        string Text,
+        Encoding Encoding,
+        byte[] Preamble,
+        string NewLine);
 
     private sealed class WslConfigDocument
     {

--- a/tests/OpenClaw.SetupEngine.Tests/WslGlobalConfigManagerTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/WslGlobalConfigManagerTests.cs
@@ -66,23 +66,34 @@ public sealed class WslGlobalConfigManagerTests : IDisposable
     }
 
     [Theory]
-    [InlineData(false, "\r\n")]
-    [InlineData(true, "\n")]
+    [InlineData(false, "\n", false)]
+    [InlineData(false, "\n", true)]
+    [InlineData(false, "\r\n", false)]
+    [InlineData(false, "\r\n", true)]
+    [InlineData(true, "\n", false)]
+    [InlineData(true, "\n", true)]
+    [InlineData(true, "\r\n", false)]
+    [InlineData(true, "\r\n", true)]
     public void ApplyMirroredNetworking_PreservesUtf16EncodingAndRollback(
         bool bigEndian,
-        string newLine)
+        string newLine,
+        bool includeFinalNewLine)
     {
         Directory.CreateDirectory(_root);
         var configPath = Path.Combine(_root, "wslconfig");
         var encoding = new UnicodeEncoding(bigEndian, byteOrderMark: true, throwOnInvalidBytes: true);
-        var original = Encode($"[wsl2]{newLine}memory=8GB{newLine}", encoding);
+        var originalText = $"[wsl2]{newLine}memory=8GB" +
+            (includeFinalNewLine ? newLine : string.Empty);
+        var original = Encode(originalText, encoding);
         File.WriteAllBytes(configPath, original);
         var manager = new WslGlobalConfigManager(configPath, Path.Combine(_root, "backup"));
 
         Assert.True(manager.ApplyMirroredNetworking().Changed);
         var updated = File.ReadAllBytes(configPath);
         Assert.True(updated.AsSpan().StartsWith(encoding.Preamble));
-        Assert.Contains($"memory=8GB{newLine}networkingMode=mirrored", encoding.GetString(updated[encoding.Preamble.Length..]));
+        var updatedText = encoding.GetString(updated[encoding.Preamble.Length..]);
+        Assert.Contains($"memory=8GB{newLine}networkingMode=mirrored", updatedText);
+        Assert.Equal(includeFinalNewLine, updatedText.EndsWith(newLine, StringComparison.Ordinal));
         Assert.Equal(WslGlobalConfigRestoreResult.Restored, manager.RestoreIfUnchanged());
         Assert.Equal(original, File.ReadAllBytes(configPath));
     }
@@ -101,6 +112,121 @@ public sealed class WslGlobalConfigManagerTests : IDisposable
         Assert.Throws<InvalidDataException>(() => manager.ApplyMirroredNetworking());
         Assert.Equal(original, File.ReadAllBytes(configPath));
         Assert.False(Directory.Exists(backupPath));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ApplyMirroredNetworking_UnsupportedUtf32DoesNotModifyFiles(bool bigEndian)
+    {
+        Directory.CreateDirectory(_root);
+        var configPath = Path.Combine(_root, "wslconfig");
+        var backupPath = Path.Combine(_root, "backup");
+        var encoding = new UTF32Encoding(bigEndian, byteOrderMark: true, throwOnInvalidCharacters: true);
+        var original = Encode("# existing comment\n", encoding);
+        File.WriteAllBytes(configPath, original);
+
+        var manager = new WslGlobalConfigManager(configPath, backupPath);
+
+        Assert.Throws<InvalidDataException>(() => manager.ApplyMirroredNetworking());
+        Assert.Equal(original, File.ReadAllBytes(configPath));
+        Assert.False(Directory.Exists(backupPath));
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public void ApplyMirroredNetworking_MalformedUtf16DoesNotModifyFiles(
+        bool bigEndian,
+        bool unpairedSurrogate)
+    {
+        Directory.CreateDirectory(_root);
+        var configPath = Path.Combine(_root, "wslconfig");
+        var backupPath = Path.Combine(_root, "backup");
+        var encoding = new UnicodeEncoding(bigEndian, byteOrderMark: true, throwOnInvalidBytes: true);
+        byte[] malformedPayload = unpairedSurrogate
+            ? bigEndian ? [0xD8, 0x00] : [0x00, 0xD8]
+            : [0x5B];
+        byte[] original = [.. encoding.Preamble, .. malformedPayload];
+        File.WriteAllBytes(configPath, original);
+
+        var manager = new WslGlobalConfigManager(configPath, backupPath);
+
+        Assert.Throws<InvalidDataException>(() => manager.ApplyMirroredNetworking());
+        Assert.Equal(original, File.ReadAllBytes(configPath));
+        Assert.False(Directory.Exists(backupPath));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ApplyMirroredNetworking_BomlessUtf16DoesNotModifyFiles(bool bigEndian)
+    {
+        Directory.CreateDirectory(_root);
+        var configPath = Path.Combine(_root, "wslconfig");
+        var backupPath = Path.Combine(_root, "backup");
+        var encoding = new UnicodeEncoding(bigEndian, byteOrderMark: false, throwOnInvalidBytes: true);
+        var original = encoding.GetBytes("[wsl2]\nmemory=8GB\n");
+        File.WriteAllBytes(configPath, original);
+
+        var manager = new WslGlobalConfigManager(configPath, backupPath);
+
+        Assert.Throws<InvalidDataException>(() => manager.ApplyMirroredNetworking());
+        Assert.Equal(original, File.ReadAllBytes(configPath));
+        Assert.False(Directory.Exists(backupPath));
+    }
+
+    [Fact]
+    public void ApplyMirroredNetworking_PreservesValidControlCharactersInUnknownContent()
+    {
+        Directory.CreateDirectory(_root);
+        var configPath = Path.Combine(_root, "wslconfig");
+        var backupPath = Path.Combine(_root, "backup");
+        const string unknownContent = "[experimental]\n# legacy separator: \u001A\n";
+        var original = Encoding.UTF8.GetBytes($"{unknownContent}[wsl2]\nmemory=8GB\n");
+        File.WriteAllBytes(configPath, original);
+
+        var manager = new WslGlobalConfigManager(configPath, backupPath);
+
+        Assert.True(manager.ApplyMirroredNetworking().Changed);
+        Assert.StartsWith(unknownContent, File.ReadAllText(configPath));
+        Assert.Equal(WslGlobalConfigRestoreResult.Restored, manager.RestoreIfUnchanged());
+        Assert.Equal(original, File.ReadAllBytes(configPath));
+    }
+
+    [Fact]
+    public void ApplyMirroredNetworking_AppendsSectionWithoutReplacingUnknownContent()
+    {
+        Directory.CreateDirectory(_root);
+        var configPath = Path.Combine(_root, "wslconfig");
+        var backupPath = Path.Combine(_root, "backup");
+        const string originalText = "[experimental]\nautoMemoryReclaim=gradual";
+        var original = Encoding.UTF8.GetBytes(originalText);
+        File.WriteAllBytes(configPath, original);
+
+        var manager = new WslGlobalConfigManager(configPath, backupPath);
+
+        Assert.True(manager.ApplyMirroredNetworking().Changed);
+        Assert.Equal(
+            $"{originalText}\n[wsl2]\nnetworkingMode=mirrored\n",
+            File.ReadAllText(configPath));
+        Assert.Equal(WslGlobalConfigRestoreResult.Restored, manager.RestoreIfUnchanged());
+        Assert.Equal(original, File.ReadAllBytes(configPath));
+    }
+
+    [Fact]
+    public void ApplyMirroredNetworking_CreatesAndRollsBackMissingFile()
+    {
+        Directory.CreateDirectory(_root);
+        var configPath = Path.Combine(_root, "wslconfig");
+        var manager = new WslGlobalConfigManager(configPath, Path.Combine(_root, "backup"));
+
+        Assert.True(manager.ApplyMirroredNetworking().Changed);
+        Assert.Equal("[wsl2]\nnetworkingMode=mirrored\n", File.ReadAllText(configPath));
+        Assert.Equal(WslGlobalConfigRestoreResult.Restored, manager.RestoreIfUnchanged());
+        Assert.False(File.Exists(configPath));
     }
 
     [Fact]

--- a/tests/OpenClaw.SetupEngine.Tests/WslGlobalConfigManagerTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/WslGlobalConfigManagerTests.cs
@@ -65,6 +65,44 @@ public sealed class WslGlobalConfigManagerTests : IDisposable
         Assert.False(manager.ApplyMirroredNetworking().Changed);
     }
 
+    [Theory]
+    [InlineData(false, "\r\n")]
+    [InlineData(true, "\n")]
+    public void ApplyMirroredNetworking_PreservesUtf16EncodingAndRollback(
+        bool bigEndian,
+        string newLine)
+    {
+        Directory.CreateDirectory(_root);
+        var configPath = Path.Combine(_root, "wslconfig");
+        var encoding = new UnicodeEncoding(bigEndian, byteOrderMark: true, throwOnInvalidBytes: true);
+        var original = Encode($"[wsl2]{newLine}memory=8GB{newLine}", encoding);
+        File.WriteAllBytes(configPath, original);
+        var manager = new WslGlobalConfigManager(configPath, Path.Combine(_root, "backup"));
+
+        Assert.True(manager.ApplyMirroredNetworking().Changed);
+        var updated = File.ReadAllBytes(configPath);
+        Assert.True(updated.AsSpan().StartsWith(encoding.Preamble));
+        Assert.Contains($"memory=8GB{newLine}networkingMode=mirrored", encoding.GetString(updated[encoding.Preamble.Length..]));
+        Assert.Equal(WslGlobalConfigRestoreResult.Restored, manager.RestoreIfUnchanged());
+        Assert.Equal(original, File.ReadAllBytes(configPath));
+    }
+
+    [Fact]
+    public void ApplyMirroredNetworking_InvalidEncodingDoesNotModifyFiles()
+    {
+        Directory.CreateDirectory(_root);
+        var configPath = Path.Combine(_root, "wslconfig");
+        var backupPath = Path.Combine(_root, "backup");
+        byte[] original = [.. Encoding.UTF8.GetBytes("[wsl2]\nmemory=8GB\n"), 0xFF];
+        File.WriteAllBytes(configPath, original);
+
+        var manager = new WslGlobalConfigManager(configPath, backupPath);
+
+        Assert.Throws<InvalidDataException>(() => manager.ApplyMirroredNetworking());
+        Assert.Equal(original, File.ReadAllBytes(configPath));
+        Assert.False(Directory.Exists(backupPath));
+    }
+
     [Fact]
     public void RestoreIfUnchanged_PreservesAConcurrentUserEdit()
     {
@@ -97,6 +135,9 @@ public sealed class WslGlobalConfigManagerTests : IDisposable
         var payload = Encoding.UTF8.GetBytes(text);
         return includeBom ? [.. Encoding.UTF8.Preamble, .. payload] : payload;
     }
+
+    private static byte[] Encode(string text, Encoding encoding) =>
+        [.. encoding.Preamble, .. encoding.GetBytes(text)];
 
     private static string Decode(byte[] bytes)
     {


### PR DESCRIPTION
## Summary
- Detect UTF-8, UTF-8 BOM, UTF-16 LE BOM, and UTF-16 BE BOM before parsing `.wslconfig`.
- Decode strictly and reject malformed, UTF-32, NUL-bearing, and BOM-less UTF-16 input before creating backup or rollback files.
- Preserve valid decoded control characters, unknown content, the original encoding/BOM, newline convention, and byte-exact rollback behavior.

## Validation
- `.\build.ps1` (passed on AMD64; Shared, CLI, WinNode CLI, SetupEngine, and WinUI built)
- `dotnet test .\tests\OpenClaw.SetupEngine.Tests\OpenClaw.SetupEngine.Tests.csproj --filter FullyQualifiedName~WslGlobalConfigManagerTests --no-restore` (30 passed, 0 failed)
- `dotnet test .\tests\OpenClaw.SetupEngine.Tests\OpenClaw.SetupEngine.Tests.csproj --no-restore` (967 passed, 0 failed)
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore` (3,812 passed, 32 skipped, 0 failed)
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore` (2,703 passed, 0 failed)
- Hanselman adversarial review: no remaining correctness defects; Opus 97% and Codex 98% merge confidence.

## Real behavior proof
Current-head proof loaded the built `OpenClaw.SetupEngine.dll` and invoked `WslGlobalConfigManager` against an isolated CRLF UTF-16 LE BOM file containing unrelated `[experimental]` content.

```json
{
  "encoding": "UTF-16 LE with BOM",
  "applyChanged": true,
  "bomPreserved": true,
  "mirroredSettingPresent": true,
  "unknownContentPreserved": true,
  "rollbackResult": "Restored",
  "originalSha256": "3a95220877974453a6475a51cdb8944aae960bd010c6148d44c96bec1bc98c4f",
  "restoredSha256": "3a95220877974453a6475a51cdb8944aae960bd010c6148d44c96bec1bc98c4f",
  "rollbackByteIdentical": true
}
```

Malformed UTF-8/UTF-16, UTF-32 BOM, and BOM-less UTF-16 cases also assert that the original bytes remain unchanged and the backup directory is never created.

Closes #1193