### PR TITLE
Make telemetry test collectors thread-safe

### DIFF
--- a/tests/OpenClaw.Shared.Tests/Telemetry/OpenClawTelemetryTests.cs
+++ b/tests/OpenClaw.Shared.Tests/Telemetry/OpenClawTelemetryTests.cs
@@ -366,14 +366,14 @@ public sealed class OpenClawTelemetryTests
                 }
             };
             _listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, _) =>
-                LongMeasurements.Add(new MetricMeasurement<long>(instrument.Name, measurement, tags.ToArray())));
+                LongMeasurements.Enqueue(new MetricMeasurement<long>(instrument.Name, measurement, tags.ToArray())));
             _listener.SetMeasurementEventCallback<double>((instrument, measurement, tags, _) =>
-                DoubleMeasurements.Add(new MetricMeasurement<double>(instrument.Name, measurement, tags.ToArray())));
+                DoubleMeasurements.Enqueue(new MetricMeasurement<double>(instrument.Name, measurement, tags.ToArray())));
             _listener.Start();
         }
 
-        public List<MetricMeasurement<long>> LongMeasurements { get; } = new();
-        public List<MetricMeasurement<double>> DoubleMeasurements { get; } = new();
+        public ConcurrentQueue<MetricMeasurement<long>> LongMeasurements { get; } = new();
+        public ConcurrentQueue<MetricMeasurement<double>> DoubleMeasurements { get; } = new();
 
         public static MetricCollector Listen(string meterName) => new(meterName);
 


### PR DESCRIPTION
Replace callback-mutated `List<T>` collections in `OpenClawTelemetryTests` with `ConcurrentQueue<T>` and enqueue measurements from `MeterListener` callbacks. This prevents concurrent callback races without changing production telemetry behavior.

## Validation

- `OpenClawTelemetryTests`: 20 passed
- `.\build.ps1`: passed
- Shared tests: 3,813 passed, 32 skipped
- Tray tests: 2,712 passed

## Real behavior proof

The focused telemetry suite exercises both counter and histogram listener callbacks using the thread-safe collector implementation. All 20 telemetry tests pass, and the PR diff contains only `tests/OpenClaw.Shared.Tests/Telemetry/OpenClawTelemetryTests.cs`.