### PR TITLE
fix: gateway controls preserve Linux PATH in WSL

### DIFF
--- a/docs/WSL_EXE_ARGV_PITFALL.md
+++ b/docs/WSL_EXE_ARGV_PITFALL.md
@@ -128,6 +128,7 @@ All of these failed workarounds were verified empirically:
 - `src/OpenClaw.SetupEngine/CommandRunner.cs` - `RunInWslAsync` exposes the opt-in `inputViaStdin` parameter.
 - `src/OpenClaw.SetupEngine/ValidateWslLockdownStep.cs` - `ValidateWslLockdownStep` uses workaround #2, C# interpolation.
 - `src/OpenClaw.SetupEngine/WindowsNodeBootstrapContextStep.cs` - `WindowsNodeBootstrapContextStep` uses workaround #1, stdin.
+- `src/OpenClaw.Connection/WslGatewayController.cs` - gateway start, stop, and restart scripts use `bash -s` stdin so the Linux `$PATH` is not replaced by the Windows process environment.
 
 ## Related
 

--- a/src/OpenClaw.Connection/WslCommandRunner.cs
+++ b/src/OpenClaw.Connection/WslCommandRunner.cs
@@ -28,7 +28,8 @@ public interface IWslCommandRunner
     Task<WslCommandResult> RunInDistroAsync(
         string name, IReadOnlyList<string> command,
         CancellationToken cancellationToken = default,
-        IReadOnlyDictionary<string, string>? environment = null);
+        IReadOnlyDictionary<string, string>? environment = null,
+        string? standardInput = null);
 }
 
 /// <summary>
@@ -58,16 +59,27 @@ public sealed class WslExeCommandRunner : IWslCommandRunner
         IReadOnlyList<string> arguments,
         CancellationToken cancellationToken = default,
         IReadOnlyDictionary<string, string>? environment = null) =>
-        RunProcessAsync("wsl.exe", arguments, cancellationToken, environment);
+        RunProcessAsync(
+            "wsl.exe",
+            arguments,
+            cancellationToken,
+            environment,
+            standardInput: null);
 
     public Task<WslCommandResult> RunInDistroAsync(
         string name, IReadOnlyList<string> command,
         CancellationToken cancellationToken = default,
-        IReadOnlyDictionary<string, string>? environment = null)
+        IReadOnlyDictionary<string, string>? environment = null,
+        string? standardInput = null)
     {
         var args = new List<string> { "-d", name, "--" };
         args.AddRange(command);
-        return RunAsync(args, cancellationToken, environment);
+        return RunProcessAsync(
+            "wsl.exe",
+            args,
+            cancellationToken,
+            environment,
+            standardInput);
     }
 
     public Task<WslCommandResult> TerminateDistroAsync(string name, CancellationToken cancellationToken = default) =>
@@ -108,13 +120,15 @@ public sealed class WslExeCommandRunner : IWslCommandRunner
         string fileName,
         IReadOnlyList<string> arguments,
         CancellationToken cancellationToken,
-        IReadOnlyDictionary<string, string>? environment)
+        IReadOnlyDictionary<string, string>? environment,
+        string? standardInput)
     {
         var psi = new ProcessStartInfo
         {
             FileName = fileName,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
+            RedirectStandardInput = standardInput is not null,
             UseShellExecute = false,
             CreateNoWindow = true,
             StandardOutputEncoding = Encoding.UTF8,
@@ -151,6 +165,26 @@ public sealed class WslExeCommandRunner : IWslCommandRunner
         bool timedOut = false;
         try
         {
+            if (standardInput is not null)
+            {
+                try
+                {
+                    await process.StandardInput.WriteAsync(
+                        standardInput.AsMemory(),
+                        timeoutCts.Token);
+                    process.StandardInput.Close();
+                }
+                catch (IOException)
+                {
+                    // The process result below is authoritative when wsl.exe exits
+                    // before accepting the complete script.
+                }
+                catch (ObjectDisposedException)
+                {
+                    // The process closed stdin while failing. Preserve its result.
+                }
+            }
+
             await process.WaitForExitAsync(timeoutCts.Token);
         }
         catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)

--- a/src/OpenClaw.Connection/WslGatewayController.cs
+++ b/src/OpenClaw.Connection/WslGatewayController.cs
@@ -1,4 +1,3 @@
-using System.Collections.ObjectModel;
 using OpenClaw.Shared;
 
 namespace OpenClaw.Connection;
@@ -33,14 +32,10 @@ public static class WslGatewayControlCommandBuilder
 {
     internal const string OpenClawWslPathPrefix = "export PATH=\"/home/openclaw/.openclaw/bin:/opt/openclaw/bin:/usr/local/bin:$PATH\"";
 
-    public static IReadOnlyList<string> Build(WslGatewayControlAction action)
-    {
-        return new ReadOnlyCollection<string>([
-            "bash",
-            "-lc",
-            $"{OpenClawWslPathPrefix} && openclaw gateway {ToVerb(action)}"
-        ]);
-    }
+    public static IReadOnlyList<string> BuildArguments() => ["bash", "-s"];
+
+    public static string BuildStandardInput(WslGatewayControlAction action) =>
+        $"set -e\n{OpenClawWslPathPrefix}\nopenclaw gateway {ToVerb(action)}\n";
 
     public static string ToVerb(WslGatewayControlAction action)
     {
@@ -88,8 +83,10 @@ public sealed class WslGatewayController(IWslCommandRunner commandRunner, IOpenC
         logger.Info($"Running OpenClaw gateway {WslGatewayControlCommandBuilder.ToVerb(action)} in WSL distro '{normalizedDistroName}'.");
         var result = await commandRunner.RunInDistroAsync(
             normalizedDistroName,
-            WslGatewayControlCommandBuilder.Build(action),
-            cancellationToken).ConfigureAwait(false);
+            WslGatewayControlCommandBuilder.BuildArguments(),
+            cancellationToken,
+            standardInput: WslGatewayControlCommandBuilder.BuildStandardInput(action))
+            .ConfigureAwait(false);
 
         return new WslGatewayControlResult(
             normalizedDistroName,

--- a/tests/OpenClaw.Tray.Tests/LocalAiGatewayProviderCoordinatorTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalAiGatewayProviderCoordinatorTests.cs
@@ -344,7 +344,8 @@ public sealed class LocalAiGatewayProviderCoordinatorTests
             string name,
             IReadOnlyList<string> command,
             CancellationToken cancellationToken = default,
-            IReadOnlyDictionary<string, string>? environment = null)
+            IReadOnlyDictionary<string, string>? environment = null,
+            string? standardInput = null)
         {
             cancellationToken.ThrowIfCancellationRequested();
             Distros.Add(name);

--- a/tests/OpenClaw.Tray.Tests/StartupSetupStateTests.cs
+++ b/tests/OpenClaw.Tray.Tests/StartupSetupStateTests.cs
@@ -645,7 +645,7 @@ public class StartupSetupStateTests
         public Task<WslCommandResult> UnregisterDistroAsync(string name, CancellationToken cancellationToken = default) =>
             Task.FromResult(new WslCommandResult(0, "", ""));
 
-        public Task<WslCommandResult> RunInDistroAsync(string name, IReadOnlyList<string> command, CancellationToken cancellationToken = default, IReadOnlyDictionary<string, string>? environment = null) =>
+        public Task<WslCommandResult> RunInDistroAsync(string name, IReadOnlyList<string> command, CancellationToken cancellationToken = default, IReadOnlyDictionary<string, string>? environment = null, string? standardInput = null) =>
             Task.FromResult(new WslCommandResult(0, "", ""));
     }
 
@@ -663,7 +663,7 @@ public class StartupSetupStateTests
         public Task<WslCommandResult> UnregisterDistroAsync(string name, CancellationToken cancellationToken = default) =>
             Task.FromResult(new WslCommandResult(0, "", ""));
 
-        public Task<WslCommandResult> RunInDistroAsync(string name, IReadOnlyList<string> command, CancellationToken cancellationToken = default, IReadOnlyDictionary<string, string>? environment = null) =>
+        public Task<WslCommandResult> RunInDistroAsync(string name, IReadOnlyList<string> command, CancellationToken cancellationToken = default, IReadOnlyDictionary<string, string>? environment = null, string? standardInput = null) =>
             Task.FromResult(new WslCommandResult(0, "", ""));
     }
 }

--- a/tests/OpenClaw.Tray.Tests/WslGatewayControllerTests.cs
+++ b/tests/OpenClaw.Tray.Tests/WslGatewayControllerTests.cs
@@ -9,14 +9,15 @@ public class WslGatewayControllerTests
     [InlineData(WslGatewayControlAction.Start, "start")]
     [InlineData(WslGatewayControlAction.Stop, "stop")]
     [InlineData(WslGatewayControlAction.Restart, "restart")]
-    public void Build_UsesBashLoginShellPathPrefixAndGatewayCommand(WslGatewayControlAction action, string verb)
+    public void Build_UsesStdinScriptWithLinuxPathAndGatewayCommand(WslGatewayControlAction action, string verb)
     {
-        var command = WslGatewayControlCommandBuilder.Build(action);
+        var arguments = WslGatewayControlCommandBuilder.BuildArguments();
+        var standardInput = WslGatewayControlCommandBuilder.BuildStandardInput(action);
 
-        Assert.Equal(["bash", "-lc"], command.Take(2).ToArray());
-        Assert.Equal(
-            $"{WslGatewayControlCommandBuilder.OpenClawWslPathPrefix} && openclaw gateway {verb}",
-            command[2]);
+        Assert.Equal(["bash", "-s"], arguments);
+        Assert.Contains(WslGatewayControlCommandBuilder.OpenClawWslPathPrefix, standardInput);
+        Assert.Contains($"openclaw gateway {verb}", standardInput);
+        Assert.Contains("$PATH", standardInput);
     }
 
     [Fact]
@@ -33,7 +34,10 @@ public class WslGatewayControllerTests
 
         Assert.True(result.Success);
         Assert.Equal("OpenClawGateway", runner.LastDistroName);
-        Assert.Equal(WslGatewayControlCommandBuilder.Build(WslGatewayControlAction.Start), runner.LastDistroCommand);
+        Assert.Equal(WslGatewayControlCommandBuilder.BuildArguments(), runner.LastDistroCommand);
+        Assert.Equal(
+            WslGatewayControlCommandBuilder.BuildStandardInput(WslGatewayControlAction.Start),
+            runner.LastStandardInput);
     }
 
     [Fact]
@@ -70,7 +74,10 @@ public class WslGatewayControllerTests
 
         Assert.True(result.Success);
         Assert.Equal("OpenClawGateway", runner.LastDistroName);
-        Assert.Equal(WslGatewayControlCommandBuilder.Build(WslGatewayControlAction.Restart), runner.LastDistroCommand);
+        Assert.Equal(WslGatewayControlCommandBuilder.BuildArguments(), runner.LastDistroCommand);
+        Assert.Equal(
+            WslGatewayControlCommandBuilder.BuildStandardInput(WslGatewayControlAction.Restart),
+            runner.LastStandardInput);
         Assert.DoesNotContain("not registered", result.StandardError);
     }
 
@@ -90,8 +97,11 @@ public class WslGatewayControllerTests
         Assert.Equal(1, runner.TerminateCount);                      // host-side terminate happened first
         Assert.Equal("OpenClawGateway", runner.LastTerminatedDistro);
         Assert.Equal(                                                 // then a cold in-distro restart
-            WslGatewayControlCommandBuilder.Build(WslGatewayControlAction.Restart),
+            WslGatewayControlCommandBuilder.BuildArguments(),
             runner.LastDistroCommand);
+        Assert.Equal(
+            WslGatewayControlCommandBuilder.BuildStandardInput(WslGatewayControlAction.Restart),
+            runner.LastStandardInput);
     }
 
     [Fact]
@@ -169,6 +179,7 @@ public class WslGatewayControllerTests
         public Queue<WslCommandResult>? InDistroResults { get; init; }
         public string? LastDistroName { get; private set; }
         public IReadOnlyList<string>? LastDistroCommand { get; private set; }
+        public string? LastStandardInput { get; private set; }
         public int InDistroCount { get; private set; }
         public int TerminateCount { get; private set; }
         public string? LastTerminatedDistro { get; private set; }
@@ -202,10 +213,12 @@ public class WslGatewayControllerTests
             string name,
             IReadOnlyList<string> command,
             CancellationToken cancellationToken = default,
-            IReadOnlyDictionary<string, string>? environment = null)
+            IReadOnlyDictionary<string, string>? environment = null,
+            string? standardInput = null)
         {
             LastDistroName = name;
             LastDistroCommand = command;
+            LastStandardInput = standardInput;
             InDistroCount++;
             var result = InDistroResults is { Count: > 0 } ? InDistroResults.Dequeue() : Result;
             return Task.FromResult(result);


### PR DESCRIPTION
Closes #911

## What Problem This Solves

Fixes an issue where users controlling the local gateway in WSL could have Linux shell variables such as `$PATH` rewritten by `wsl.exe`, causing gateway start, stop, or restart commands to run with Windows path semantics.

## Why This Change Was Made

Gateway control scripts now run through `bash -s` and are sent over stdin, which `wsl.exe` does not rewrite. The WSL command runner accepts optional stdin while preserving authoritative process exit/stderr results and existing cancellation and timeout behavior.

## User Impact

Local WSL gateway start, stop, and restart operations retain the intended Linux executable search path instead of inheriting a rewritten Windows `$PATH`.

## Evidence

- Focused tests assert all three gateway verbs use `bash -s`, keep `$PATH` in stdin, and pass the script through `IWslCommandRunner`.
- Full repository build and required Shared/Tray suites pass.
- Blocker-only rubber-duck review found no blockers.
- The six changed files are byte-for-byte identical to source snapshot commit `afa4ed08b8555b0fc230df990d33f132a914f2b2`; no unrelated paths are present.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs or instructions
- [x] Tests or validation
- [ ] Security hardening
- [ ] Chore or infrastructure

## Scope

- [ ] Tray or WinUI UX
- [ ] Windows node capability
- [ ] Local MCP or `winnode`
- [x] Gateway, connection, or pairing
- [ ] Setup or onboarding
- [ ] Permissions, privacy, or security
- [x] Tests, CI, or docs

## Validation

- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --filter "FullyQualifiedName~WslGatewayControllerTests|FullyQualifiedName~StartupSetupStateTests|FullyQualifiedName~LocalAiGatewayProviderCoordinatorTests" --logger "console;verbosity=normal"`: 58 passed, 0 failed, 0 skipped.
- `.\build.ps1`: passed; documentation validation and all five Debug build targets succeeded.
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore --logger "console;verbosity=minimal"`: 3,813 passed, 0 failed, 32 skipped, 3,845 total.
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore --logger "console;verbosity=minimal"`: 2,712 passed, 0 failed, 0 skipped.

A fresh-worktree Shared test invocation initially lacked `project.assets.json`; the project was restored once, then the complete required build and both `--no-restore` suites were rerun successfully.

## Real Behavior Proof

- Environment tested: Windows 11, WSL 2 available.
- PR head or commit tested: `6bcb6c63`.
- Exact steps or command run: `wsl.exe --list --verbose` after current-head automated validation.
- Evidence after fix: current-head focused tests verify `bash -s` argv plus an stdin script containing the Linux `$PATH` prefix for start, stop, and restart.
- Observed result: automated command-contract proof passed for all three verbs.
- Screenshot or artifact links verified? (`Yes`/`No`/`N/A`): N/A.
- Not verified or blocked: real gateway invocation is blocked because this host has Ubuntu, AlmaLinux-9, MacComfort, and docker-desktop WSL distros, but no `OpenClawGateway` distro. No live gateway result is claimed.

## Security Impact

- New permissions or capabilities? (`Yes`/`No`): No.
- Secrets or tokens handling changed? (`Yes`/`No`): No.
- New or changed network calls? (`Yes`/`No`): No.
- Command or tool execution surface changed? (`Yes`/`No`): Yes.
- Data access scope changed? (`Yes`/`No`): No.
- If any answer is `Yes`, explain the risk and mitigation: the existing WSL process runner can now receive explicit stdin. Only the fixed gateway control script uses it; arguments remain structured, timeout and cancellation still kill the process tree, and broken-pipe failures preserve the process exit code and stderr.

## Compatibility and Migration

- Backward compatible? (`Yes`/`No`): Yes.
- Config or environment changes? (`Yes`/`No`): No.
- Migration needed? (`Yes`/`No`): No.
- If yes, list the exact upgrade steps: N/A.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation addressed by this PR.
- [ ] I left unresolved only conversations that still need maintainer judgment.