### PR TITLE
Stabilize accessibility navigation readiness

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Services/AccessibilityNavigationSignal.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/AccessibilityNavigationSignal.cs
@@ -1,0 +1,45 @@
+using System.Security;
+
+namespace OpenClawTray.Services;
+
+internal static class AccessibilityNavigationSignal
+{
+    private const string SignalPathEnvironmentVariable =
+        "OPENCLAW_ACCESSIBILITY_NAVIGATION_SIGNAL";
+
+    internal static void WritePageReady(string? pageName)
+    {
+        var signalPath = Environment.GetEnvironmentVariable(
+            SignalPathEnvironmentVariable);
+        if (string.IsNullOrWhiteSpace(signalPath) ||
+            string.IsNullOrWhiteSpace(pageName))
+        {
+            return;
+        }
+
+        try
+        {
+            var directory = Path.GetDirectoryName(signalPath);
+            if (!string.IsNullOrWhiteSpace(directory))
+                Directory.CreateDirectory(directory);
+
+            using var stream = new FileStream(
+                signalPath,
+                FileMode.Append,
+                FileAccess.Write,
+                FileShare.ReadWrite);
+            using var writer = new StreamWriter(stream);
+            writer.WriteLine($"{Guid.NewGuid():N}\t{pageName}");
+        }
+        catch (Exception ex) when (
+            ex is IOException
+            or UnauthorizedAccessException
+            or ArgumentException
+            or NotSupportedException
+            or SecurityException)
+        {
+            Logger.Warn(
+                $"Accessibility navigation readiness signal failed: {ex.Message}");
+        }
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
@@ -667,6 +667,7 @@ public sealed partial class HubWindow : WindowEx
         if (ContentFrame.SourcePageType == pageType && _currentNavTag == tag)
         {
             _contentReady = CreateCompletedContentReady();
+            AccessibilityNavigationSignal.WritePageReady(pageType.Name);
             return;
         }
 
@@ -678,7 +679,7 @@ public sealed partial class HubWindow : WindowEx
         var ready = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         _contentReady = ready;
         if (!ContentFrame.Navigate(pageType, tag))
-            CompleteContentReady(ready);
+            CompleteContentReady(ready, pageName: null);
     }
 
     /// <summary>
@@ -993,7 +994,9 @@ public sealed partial class HubWindow : WindowEx
 
         InitializeCurrentPage();
         UpdateAppNotificationActionEnabledState();
-        ArmContentReady(e.Content as FrameworkElement);
+        ArmContentReady(
+            e.Content as FrameworkElement,
+            e.Content?.GetType().Name);
 
         // Navigation activation hook: resolve + assign a DI-backed view model for the
         // navigated page. Pages present in the page->view-model map (currently Settings)
@@ -1019,12 +1022,14 @@ public sealed partial class HubWindow : WindowEx
         _contentReady.TrySetResult(true);
     }
 
-    private void ArmContentReady(FrameworkElement? element)
+    private void ArmContentReady(
+        FrameworkElement? element,
+        string? pageName)
     {
         var ready = _contentReady;
         if (element == null || element.IsLoaded)
         {
-            CompleteContentReady(ready);
+            CompleteContentReady(ready, pageName);
             return;
         }
 
@@ -1032,19 +1037,24 @@ public sealed partial class HubWindow : WindowEx
         loaded = (_, _) =>
         {
             element.Loaded -= loaded;
-            CompleteContentReady(ready);
+            CompleteContentReady(ready, pageName);
         };
         element.Loaded += loaded;
     }
 
-    private void CompleteContentReady(TaskCompletionSource<bool> ready)
+    private void CompleteContentReady(
+        TaskCompletionSource<bool> ready,
+        string? pageName)
     {
         DispatcherQueue.TryEnqueue(
             Microsoft.UI.Dispatching.DispatcherQueuePriority.Low,
             () =>
             {
-                if (ReferenceEquals(_contentReady, ready))
-                    ready.TrySetResult(true);
+                if (ReferenceEquals(_contentReady, ready) &&
+                    ready.TrySetResult(true))
+                {
+                    AccessibilityNavigationSignal.WritePageReady(pageName);
+                }
             });
     }
 

--- a/tests/OpenClaw.Tray.UITests/AccessibilityAppFixture.cs
+++ b/tests/OpenClaw.Tray.UITests/AccessibilityAppFixture.cs
@@ -31,6 +31,7 @@ public sealed class AccessibilityAppFixture : IDisposable
     private readonly string _executablePath;
     private readonly string? _nativeChatProofSignalPath;
     private readonly string? _nativeChatProofVisualDirectory;
+    private readonly string _navigationSignalPath;
     private readonly Process _process;
 
     public IntPtr HubWindowHandle { get; }
@@ -54,6 +55,9 @@ public sealed class AccessibilityAppFixture : IDisposable
             Path.GetTempPath(),
             $"OpenClaw.Tray.Axe.{Guid.NewGuid():N}");
         Directory.CreateDirectory(_dataDirectory);
+        _navigationSignalPath = Path.Combine(
+            _dataDirectory,
+            "accessibility-navigation.ready");
         if (!initializeAxe
             && Environment.GetEnvironmentVariable("OPENCLAW_UI_SCREENSHOT_PATH")
                 is { Length: > 0 })
@@ -82,9 +86,13 @@ public sealed class AccessibilityAppFixture : IDisposable
             AxeHelper.Initialize(_process.Id);
     }
 
-    public async Task NavigateAsync(string pageTag, string pageMarkerAutomationId)
+    public async Task NavigateAsync(
+        string pageTag,
+        string expectedPageName,
+        string pageMarkerAutomationId)
     {
         EnsureTargetIsAlive();
+        var baselineSignalCount = ReadNavigationSignals().Count;
 
         using var sender = StartProcess($"{OpenClawTray.AppIdentity.ProtocolScheme}://hub/{pageTag}");
         using var timeout = new CancellationTokenSource(DeepLinkTimeout);
@@ -101,6 +109,10 @@ public sealed class AccessibilityAppFixture : IDisposable
         }
 
         EnsureTargetIsAlive();
+        await WaitForNavigationSignalAsync(
+            pageTag,
+            expectedPageName,
+            baselineSignalCount);
         await WaitForPageMarkerAsync(pageTag, pageMarkerAutomationId);
     }
 
@@ -237,6 +249,70 @@ public sealed class AccessibilityAppFixture : IDisposable
         return path;
     }
 
+    private async Task WaitForNavigationSignalAsync(
+        string pageTag,
+        string expectedPageName,
+        int baselineSignalCount)
+    {
+        var stopwatch = Stopwatch.StartNew();
+
+        while (stopwatch.Elapsed < NavigationTimeout)
+        {
+            EnsureTargetIsAlive();
+            var signals = ReadNavigationSignals();
+            if (signals
+                .Skip(Math.Min(baselineSignalCount, signals.Count))
+                .Any(signal => string.Equals(
+                    signal,
+                    expectedPageName,
+                    StringComparison.Ordinal)))
+            {
+                return;
+            }
+
+            await Task.Delay(100);
+        }
+
+        throw new TimeoutException(
+            $"The '{pageTag}' page did not publish its app-owned readiness acknowledgement " +
+            $"within {NavigationTimeout.TotalSeconds:0} seconds.");
+    }
+
+    private IReadOnlyList<string> ReadNavigationSignals()
+    {
+        for (var attempt = 0; attempt < 5; attempt++)
+        {
+            try
+            {
+                if (!File.Exists(_navigationSignalPath))
+                    return [];
+
+                using var stream = new FileStream(
+                    _navigationSignalPath,
+                    FileMode.Open,
+                    FileAccess.Read,
+                    FileShare.ReadWrite);
+                using var reader = new StreamReader(stream);
+                var signals = new List<string>();
+                while (reader.ReadLine() is { } line)
+                {
+                    var parts = line.Split('\t', 2);
+                    if (parts.Length == 2)
+                        signals.Add(parts[1]);
+                }
+
+                return signals;
+            }
+            catch (IOException) when (attempt < 4)
+            {
+                Thread.Sleep(20);
+            }
+        }
+
+        throw new IOException(
+            "Could not read the accessibility navigation acknowledgement file.");
+    }
+
     private async Task WaitForPageMarkerAsync(string pageTag, string automationId)
     {
         var stopwatch = Stopwatch.StartNew();
@@ -255,7 +331,7 @@ public sealed class AccessibilityAppFixture : IDisposable
         }
 
         throw new TimeoutException(
-            $"The '{pageTag}' page did not expose its '{automationId}' marker " +
+            $"The app acknowledged '{pageTag}' as ready, but its '{automationId}' marker was not visible " +
             $"within {NavigationTimeout.TotalSeconds:0} seconds.");
     }
 
@@ -273,6 +349,8 @@ public sealed class AccessibilityAppFixture : IDisposable
         startInfo.Environment["OPENCLAW_LANGUAGE"] = "en-US";
         startInfo.Environment["OPENCLAW_ACCESSIBILITY_TEST_CHAT"] = "1";
         startInfo.Environment["OPENCLAW_ACCESSIBILITY_TEST_SESSIONS"] = "1";
+        startInfo.Environment["OPENCLAW_ACCESSIBILITY_NAVIGATION_SIGNAL"] =
+            _navigationSignalPath;
         if (_nativeChatProofSignalPath is not null
             && _nativeChatProofVisualDirectory is not null)
         {

--- a/tests/OpenClaw.Tray.UITests/AccessibilityScanTests.cs
+++ b/tests/OpenClaw.Tray.UITests/AccessibilityScanTests.cs
@@ -66,7 +66,10 @@ public sealed class AccessibilityScanTests
         string pageTag,
         string pageMarkerAutomationId)
     {
-        await _app.NavigateAsync(pageTag, pageMarkerAutomationId);
+        await _app.NavigateAsync(
+            pageTag,
+            pageName,
+            pageMarkerAutomationId);
         PageRuleExclusions.TryGetValue(pageName, out var exclusions);
         AxeHelper.AssertNoAccessibilityErrors(
             _app.HubWindowHandle,
@@ -78,7 +81,10 @@ public sealed class AccessibilityScanTests
     [Trait("Category", "Accessibility")]
     public async Task ChatComposerControls_ExposeOnscreenLayoutThroughUia()
     {
-        await _app.NavigateAsync("chat", "ChatComposerInput");
+        await _app.NavigateAsync(
+            "chat",
+            "ChatPage",
+            "ChatComposerInput");
         var hub = AutomationElement.FromHandle(_app.HubWindowHandle);
         foreach (var automationId in new[]
         {

--- a/tests/OpenClaw.Tray.UITests/NativeToolIdentityScreenshotProofTests.cs
+++ b/tests/OpenClaw.Tray.UITests/NativeToolIdentityScreenshotProofTests.cs
@@ -23,8 +23,14 @@ public sealed class NativeToolIdentityScreenshotFixture : IDisposable
 
     public IntPtr HubWindowHandle => _app.HubWindowHandle;
 
-    public Task NavigateAsync(string pageTag, string pageMarkerAutomationId) =>
-        _app.NavigateAsync(pageTag, pageMarkerAutomationId);
+    public Task NavigateAsync(
+        string pageTag,
+        string expectedPageName,
+        string pageMarkerAutomationId) =>
+        _app.NavigateAsync(
+            pageTag,
+            expectedPageName,
+            pageMarkerAutomationId);
 
     public string? CaptureNativeChatVisualIfRequested() =>
         _app.CaptureNativeChatVisualIfRequested();
@@ -52,7 +58,10 @@ public sealed class NativeToolIdentityScreenshotProofTests
     [Trait("Category", "Accessibility")]
     public async Task SyntheticNativeRows_RenderTrustedIdentitySafeInputAndTruthfulFallback()
     {
-        await _app.NavigateAsync("chat", "ChatComposerInput");
+        await _app.NavigateAsync(
+            "chat",
+            "ChatPage",
+            "ChatComposerInput");
 
         var proof = new List<string>
         {

--- a/tests/OpenClaw.Tray.UITests/SessionTitleBehaviorProofTests.cs
+++ b/tests/OpenClaw.Tray.UITests/SessionTitleBehaviorProofTests.cs
@@ -39,7 +39,10 @@ public sealed class SessionTitleBehaviorProofTests
             $"input key=agent:main:fork displayName=\"{RawTitle}\"",
         };
 
-        await _app.NavigateAsync("sessions", "SessionsPageMarker");
+        await _app.NavigateAsync(
+            "sessions",
+            "SessionsPage",
+            "SessionsPageMarker");
         var observedMainTitle = WaitForTitleCount(RawTitle, expectedCount: 1);
         var observedForkTitle = WaitForTitleCount(ForkTitle, expectedCount: 1);
         proof.Add($"UIA title key=agent:main:main value=\"{observedMainTitle}\"");
@@ -52,7 +55,10 @@ public sealed class SessionTitleBehaviorProofTests
         }
 
         AssertOpenChatRoute(RawTitle, "agent:main:main", proof);
-        await _app.NavigateAsync("sessions", "SessionsPageMarker");
+        await _app.NavigateAsync(
+            "sessions",
+            "SessionsPage",
+            "SessionsPageMarker");
         _ = WaitForTitleCount(ForkTitle, expectedCount: 1);
         AssertOpenChatRoute(ForkTitle, "agent:main:fork", proof);
 


### PR DESCRIPTION
Fixes #1137

## Summary

- add an app-owned accessibility navigation readiness acknowledgement carrying the resolved page type
- require the readiness acknowledgement before the existing UIA marker check
- baseline acknowledgement counts so stale signals cannot satisfy a later navigation
- preserve agent-normalized navigation tags through `HubPageRegistry`

This is the exact six-file snapshot from `afa4ed08b8555b0fc230df990d33f132a914f2b2` on `origin/recover-maintainer-patches`. `HubPageRegistry` remains the authoritative owner of tag-to-page resolution. `HubWindow` only publishes readiness after applying the resolved navigation.

## Validation

- `./build.ps1`: passed, all 5 build targets succeeded
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore`: passed, 3,813 passed, 32 skipped, 0 failed
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore`: passed, 2,712 passed, 0 skipped, 0 failed
- `dotnet build tests\OpenClaw.Tray.UITests -c Debug -r win-x64`: passed, 0 warnings, 0 errors
- `dotnet test tests\OpenClaw.Tray.UITests -c Debug -r win-x64 --no-build --filter Category=Accessibility`: passed, 21 passed, 0 skipped, 0 failed
- blocker-only rubber-duck review: no blockers

## Real behavior proof

Current-head x64 accessibility lane output:

```text
Test run for tests\OpenClaw.Tray.UITests\bin\Debug\net10.0-windows10.0.22621.0\win-x64\OpenClaw.Tray.UITests.dll (.NETCoreApp,Version=v10.0)
A total of 1 test files matched the specified pattern.

Passed!  - Failed:     0, Passed:    21, Skipped:     0, Total:    21, Duration: 2 m 33 s - OpenClaw.Tray.UITests.dll (net10.0)
```

The lane exercised the real WinUI process. Each navigation now waits for a newly appended app-owned acknowledgement matching the resolved page type, then independently requires the expected UIA marker before scanning or collecting proof.