### PR TITLE
fix: preserve Core updates across restart timeouts

### DIFF
--- a/src/OpenClaw.Connection/WslCommandRunner.cs
+++ b/src/OpenClaw.Connection/WslCommandRunner.cs
@@ -5,9 +5,15 @@ using System.Text;
 
 namespace OpenClaw.Connection;
 
-public sealed record WslCommandResult(int ExitCode, string StandardOutput, string StandardError)
+public sealed record WslCommandResult(
+    int ExitCode,
+    string StandardOutput,
+    string StandardError,
+    bool TimedOut = false,
+    bool OutcomeIndeterminate = false)
 {
     public bool Success => ExitCode == 0;
+    public bool IsIndeterminate => TimedOut || OutcomeIndeterminate;
 }
 
 public sealed record WslDistroInfo(string Name, string State, int Version);
@@ -153,7 +159,11 @@ public sealed class WslExeCommandRunner : IWslCommandRunner
         }
         catch (Exception ex)
         {
-            return new WslCommandResult(-1, string.Empty, $"Failed to start wsl.exe: {ex.Message}");
+            return new WslCommandResult(
+                -1,
+                string.Empty,
+                $"Failed to start wsl.exe: {ex.Message}",
+                OutcomeIndeterminate: true);
         }
 
         using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -172,7 +182,6 @@ public sealed class WslExeCommandRunner : IWslCommandRunner
                     await process.StandardInput.WriteAsync(
                         standardInput.AsMemory(),
                         timeoutCts.Token);
-                    process.StandardInput.Close();
                 }
                 catch (IOException)
                 {
@@ -182,6 +191,12 @@ public sealed class WslExeCommandRunner : IWslCommandRunner
                 catch (ObjectDisposedException)
                 {
                     // The process closed stdin while failing. Preserve its result.
+                }
+                finally
+                {
+                    try { process.StandardInput.Close(); }
+                    catch (IOException) { }
+                    catch (ObjectDisposedException) { }
                 }
             }
 
@@ -205,7 +220,7 @@ public sealed class WslExeCommandRunner : IWslCommandRunner
         try { stderr = await stderrTask; } catch { stderr = string.Empty; }
 
         return timedOut
-            ? new WslCommandResult(-1, stdout, "wsl.exe timed out")
+            ? new WslCommandResult(-1, stdout, "wsl.exe timed out", TimedOut: true)
             : new WslCommandResult(process.ExitCode, stdout, stderr);
     }
 }

--- a/src/OpenClaw.Connection/WslGatewayController.cs
+++ b/src/OpenClaw.Connection/WslGatewayController.cs
@@ -14,9 +14,12 @@ public sealed record WslGatewayControlResult(
     WslGatewayControlAction Action,
     int ExitCode,
     string StandardOutput,
-    string StandardError)
+    string StandardError,
+    bool TimedOut = false,
+    bool OutcomeIndeterminate = false)
 {
     public bool Success => ExitCode == 0;
+    public bool IsIndeterminate => TimedOut || OutcomeIndeterminate;
 
     public string OutputSummary
     {
@@ -93,7 +96,9 @@ public sealed class WslGatewayController(IWslCommandRunner commandRunner, IOpenC
             action,
             result.ExitCode,
             result.StandardOutput,
-            result.StandardError);
+            result.StandardError,
+            result.TimedOut,
+            result.OutcomeIndeterminate);
     }
 
     /// <summary>
@@ -113,12 +118,17 @@ public sealed class WslGatewayController(IWslCommandRunner commandRunner, IOpenC
         }
 
         var normalizedDistroName = distroName.Trim();
+        cancellationToken.ThrowIfCancellationRequested();
         logger.Info($"Force-terminating WSL distro '{normalizedDistroName}' before restart (in-place restart failed).");
 
         // Terminate is best-effort: a "not running" distro still returns success, and any failure here
         // should not stop the cold restart below from surfacing the real error.
         // slopwatch-ignore: SW003 Terminate is best-effort; its failure cannot improve the caller state and the restart below is authoritative.
-        try { await commandRunner.TerminateDistroAsync(normalizedDistroName, cancellationToken).ConfigureAwait(false); }
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await commandRunner.TerminateDistroAsync(normalizedDistroName, cancellationToken).ConfigureAwait(false);
+        }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
         catch (Exception ex) { logger.Warn($"Force-terminate of '{normalizedDistroName}' failed (continuing to restart): {ex.Message}"); }
 

--- a/src/OpenClaw.Tray.WinUI/Services/ManagedLocalGatewayRepairAdapters.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/ManagedLocalGatewayRepairAdapters.cs
@@ -31,13 +31,27 @@ public sealed class WslManagedLocalGatewayRestarter(WslGatewayController control
         if (result.Success)
             return new ManagedLocalGatewayRestartResult(true);
 
+        // An indeterminate result only proves that the host-side wsl.exe client stopped waiting or
+        // could not start. The in-distro restart (or a detached update handoff that triggered it)
+        // may still be running. Terminating the whole distro here can kill healthy, long-running
+        // maintenance, so fail closed and let the normal reconnect/repair loop observe the outcome.
+        if (result.IsIndeterminate)
+        {
+            var unknownDetail = result.TimedOut
+                ? "Gateway restart timed out"
+                : "Gateway restart outcome is unknown";
+            return new ManagedLocalGatewayRestartResult(
+                false,
+                $"{unknownDetail}; skipped forced distro termination because completion is unknown.");
+        }
+
         if (!canContinue())
             return new ManagedLocalGatewayRestartResult(false, "Gateway changed before forced restart.");
 
-        // The in-place restart failed — the distro/VM may be wedged and unable to run an in-distro
-        // command (an in-distro command also times out to a failure rather than hanging forever).
-        // Escalate to a host-side terminate + cold restart, which recovers a hung WSL instance
-        // (ForceRestartAsync logs the terminate).
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // The in-place restart returned a definitive failure. Escalate to a host-side terminate +
+        // cold restart (ForceRestartAsync logs the terminate).
         result = await _controller
             .ForceRestartAsync(distroName, cancellationToken)
             .ConfigureAwait(false);

--- a/tests/OpenClaw.Tray.Tests/WslGatewayControllerTests.cs
+++ b/tests/OpenClaw.Tray.Tests/WslGatewayControllerTests.cs
@@ -129,6 +129,52 @@ public class WslGatewayControllerTests
     }
 
     [Fact]
+    public async Task Restarter_WhenInPlaceRestartTimesOut_DoesNotForceTerminate()
+    {
+        var runner = new FakeWslCommandRunner
+        {
+            Distros = [new WslDistroInfo("OpenClawGateway", "Running", 2)],
+            Result = new WslCommandResult(
+                -1,
+                string.Empty,
+                "wsl.exe timed out",
+                TimedOut: true),
+        };
+        var controller = new WslGatewayController(runner, NullLogger.Instance);
+        var restarter = new OpenClawTray.Services.WslManagedLocalGatewayRestarter(controller);
+
+        var result = await restarter.RestartAsync("OpenClawGateway", CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Contains("completion is unknown", result.Detail, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(0, runner.TerminateCount);
+        Assert.Equal(1, runner.InDistroCount);
+    }
+
+    [Fact]
+    public async Task Restarter_WhenInPlaceRestartIsIndeterminate_DoesNotForceTerminate()
+    {
+        var runner = new FakeWslCommandRunner
+        {
+            Distros = [new WslDistroInfo("OpenClawGateway", "Running", 2)],
+            Result = new WslCommandResult(
+                -1,
+                string.Empty,
+                "Failed to start wsl.exe",
+                OutcomeIndeterminate: true),
+        };
+        var controller = new WslGatewayController(runner, NullLogger.Instance);
+        var restarter = new OpenClawTray.Services.WslManagedLocalGatewayRestarter(controller);
+
+        var result = await restarter.RestartAsync("OpenClawGateway", CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Contains("outcome is unknown", result.Detail, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(0, runner.TerminateCount);
+        Assert.Equal(1, runner.InDistroCount);
+    }
+
+    [Fact]
     public async Task Restarter_WhenBothRestartsFail_ReportsFailure()
     {
         var runner = new FakeWslCommandRunner
@@ -168,6 +214,34 @@ public class WslGatewayControllerTests
 
         Assert.False(result.Success);
         Assert.Contains("changed", result.Detail, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(0, runner.TerminateCount);
+        Assert.Equal(1, runner.InDistroCount);
+    }
+
+    [Fact]
+    public async Task Restarter_CancelledBeforeForcedRestart_DoesNotForceTerminate()
+    {
+        using var cts = new CancellationTokenSource();
+        var runner = new FakeWslCommandRunner
+        {
+            Distros = [new WslDistroInfo("OpenClawGateway", "Running", 2)],
+            Result = new WslCommandResult(1, string.Empty, "wedged"),
+        };
+        var controller = new WslGatewayController(runner, NullLogger.Instance);
+        var restarter = new OpenClawTray.Services.WslManagedLocalGatewayRestarter(controller);
+        var checks = 0;
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => restarter.RestartAsync(
+                "OpenClawGateway",
+                cts.Token,
+                canContinue: () =>
+                {
+                    if (++checks == 2)
+                        cts.Cancel();
+                    return true;
+                }));
+
         Assert.Equal(0, runner.TerminateCount);
         Assert.Equal(1, runner.InDistroCount);
     }


### PR DESCRIPTION
Supersedes #1181 because the contributor branch cannot be updated after `main` changed a workflow file and the available OAuth token lacks workflow scope.

This app-owned replacement preserves the final validated implementation from source commit `3aebd2fe` while rebasing it cleanly onto current `main`. Original design, investigation, and contribution credit belong to @TheAngryPit; the replacement commit also retains co-author attribution.

## What Problem This Solves

Automatic gateway repair previously treated a 30-second in-distro restart timeout as a definitive failure and force-terminated the WSL distro. That could kill a supported detached OpenClaw Core updater that was still running.

The WSL runner now carries explicit timeout and indeterminate outcome signals through the gateway controller. Automatic repair fails closed for ambiguous outcomes and skips destructive distro termination. Definitive non-timeout failures retain terminate plus cold restart.

The existing #1227 bash-stdin behavior is preserved and strengthened: stdin closure remains in `finally`, so `bash -s` receives EOF even when the write path fails.

## Validation

- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --filter "FullyQualifiedName~WslGatewayControllerTests"`: 13 passed, 0 failed, 0 skipped.
- `.\build.ps1`: all 5 projects built; documentation validation passed for 46 files.
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore`: 3,813 passed, 0 failed, 32 intentional integration/environment skips.
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore`: 2,722 passed, 0 failed, 0 skipped.
- `git diff --check`: clean.
- All four changed file blobs were verified byte-for-byte against `3aebd2fe` before commit.
- Hanselman adversarial review: Claude Opus 5 and GPT-5.3-Codex found no blockers after proof; final merge-readiness confidence was 98% and 97%.

## Real behavior proof

Current-head proof used the production `WslExeCommandRunner` against Ubuntu on WSL 2 with read-only commands only. No terminate, restart, update, or gateway mutation command was invoked.

```text
stdin.exit=0
stdin.timedOut=False
stdin.indeterminate=False
OPENCLAW_RUNNER_STDIN_PROOF=ok

timeout.exit=-1
timeout.timedOut=True
timeout.outcomeIndeterminate=False
timeout.isIndeterminate=True
timeout.stderr=wsl.exe timed out

definitive.exit=7
definitive.timedOut=False
definitive.indeterminate=False
cancellation.threw=True
```

Focused tests prove the consumption side of those outcomes:

- Timed-out or otherwise indeterminate restart: failure is reported, with zero distro termination calls.
- Definitive in-place failure: one termination and a subsequent cold restart are retained.
- Cancellation before escalation: `OperationCanceledException` is propagated, with zero termination calls.

Not verified / blocked: no destructive real-gateway outage was induced because proof was intentionally constrained to safe read-only WSL behavior.