### PR TITLE
chore: use MXC SDK 0.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,13 @@
       "name": "openclaw-windows-node-mxc",
       "version": "0.0.0",
       "dependencies": {
-        "@microsoft/mxc-sdk": "^0.7.0"
+        "@microsoft/mxc-sdk": "^0.8.0"
       }
     },
     "node_modules/@microsoft/mxc-sdk": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/mxc-sdk/-/mxc-sdk-0.7.0.tgz",
-      "integrity": "sha512-EWhz2pKkcPluZHAOI1yneV+JK0NO/3hdh7nABBb0x4PjyUWMeSWPTBAjtIu+BhtMYOqlaijSPZMZ0Hs/J4ZL4A==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/mxc-sdk/-/mxc-sdk-0.8.0.tgz",
+      "integrity": "sha512-pnf5QsASwp+qtRi5uth2GDjwuyG0rHWRpxCf3RbAjQ4wDTNfBX/9l0A+RVZspU2agpF3/11uWB1JisIS7WrNYg==",
       "license": "MIT",
       "dependencies": {
         "node-pty": "^1.2.0-beta.12",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "description": "MXC sandbox dependency used by the OpenClaw tray build to copy wxc-exec.exe into the app output.",
   "dependencies": {
-    "@microsoft/mxc-sdk": "^0.7.0"
+    "@microsoft/mxc-sdk": "^0.8.0"
   }
 }

--- a/src/OpenClaw.Shared/Mxc/MxcPolicyBuilder.cs
+++ b/src/OpenClaw.Shared/Mxc/MxcPolicyBuilder.cs
@@ -31,8 +31,9 @@ public static class MxcPolicyBuilder
 {
     /// <summary>
     /// Policy schema version emitted to <c>wxc-exec</c>. @microsoft/mxc-sdk
-    /// 0.7.0 emits and accepts the 0.7.0-alpha contract used by
-    /// processcontainer/AppContainer execution on Windows build 26100+.
+    /// 0.8.0 continues to accept the 0.7.0-alpha contract used by OpenClaw.
+    /// Keep the policy contract stable while taking native executor fixes;
+    /// adopting the 0.8 directional network schema is a separate behavior change.
     /// </summary>
     public const string SupportedPolicyVersion = "0.7.0-alpha";
 

--- a/src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj
+++ b/src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj
@@ -118,7 +118,7 @@
     <MxcArch Condition="'$(MxcArch)' == '' And '$(PlatformTarget)' == 'ARM64'">arm64</MxcArch>
     <MxcArch Condition="'$(MxcArch)' == '' And '$(RuntimeIdentifier)' == ''">x64</MxcArch>
     <MxcSdkBinDir>$(OpenClawRepoRoot)node_modules\@microsoft\mxc-sdk\bin\$(MxcArch)\</MxcSdkBinDir>
-    <MxcSdkExpectedVersion>0.7.0</MxcSdkExpectedVersion>
+    <MxcSdkExpectedVersion>0.8.0</MxcSdkExpectedVersion>
     <MxcSdkPackageJson>$(OpenClawRepoRoot)node_modules\@microsoft\mxc-sdk\package.json</MxcSdkPackageJson>
     <MxcSdkRestoreStamp>$(OpenClawRepoRoot)node_modules\.openclaw-mxc-sdk-$(MxcSdkExpectedVersion).stamp</MxcSdkRestoreStamp>
   </PropertyGroup>

--- a/tests/OpenClaw.Tray.Tests/InstallerIssAssertionTests.cs
+++ b/tests/OpenClaw.Tray.Tests/InstallerIssAssertionTests.cs
@@ -347,9 +347,9 @@ public sealed class InstallerIssAssertionTests
         var iss = File.ReadAllText(Path.Combine(repositoryRoot, "installer.iss"));
 
         Assert.Contains(@"""@microsoft/mxc-sdk""", packageJson);
-        Assert.Contains(@"""@microsoft/mxc-sdk"": ""^0.7.0""", packageJson);
+        Assert.Contains(@"""@microsoft/mxc-sdk"": ""^0.8.0""", packageJson);
         Assert.Contains(@"""node_modules/@microsoft/mxc-sdk""", packageLock);
-        Assert.Contains(@"""version"": ""0.7.0""", packageLock);
+        Assert.Contains(@"""version"": ""0.8.0""", packageLock);
         Assert.Contains("RestoreMxcNodeBridge", trayProject);
         Assert.Contains(@"Inputs=""$(OpenClawRepoRoot)package-lock.json""", trayProject);
         Assert.Contains(@"<MxcSdkRestoreStamp>$(OpenClawRepoRoot)node_modules\.openclaw-mxc-sdk-$(MxcSdkExpectedVersion).stamp</MxcSdkRestoreStamp>", trayProject);


### PR DESCRIPTION
@karkarl please review this MXC executor upgrade.

## What Problem This Solves

OpenClaw shipped the older MXC 0.7 executor even though MXC 0.8 is now the supported npm release with native executor fixes and stronger fail-closed behavior.

## Why This Change Was Made

Upgrade the packaged `@microsoft/mxc-sdk` and shipped `wxc-exec.exe` to 0.8.0. OpenClaw intentionally retains the supported `0.7.0-alpha` policy contract so this PR does not also introduce schema 0.8 directional-network behavior changes.

## User Impact

Sandboxed `system.run` uses the MXC 0.8 native executor while preserving the existing OpenClaw policy and permission behavior.

## Evidence

- `npm ls @microsoft/mxc-sdk --depth=0` resolves `@microsoft/mxc-sdk@0.8.0`.
- The built tray `tools\mxc\x64\wxc-exec.exe` SHA-256 matches the npm 0.8.0 package binary: `6049C64723AF1173C3739DC6CD6B2F33F6C021BB2832C4216233CBA7F71AEE9A`.
- Structured autoreview was clean with no actionable findings.
- Rubber-duck review found no blocking issues and confirmed the build guard, binary hash, and live containment proof form a coherent evidence chain.

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs or instructions
- [x] Tests or validation
- [ ] Security hardening
- [x] Chore or infrastructure

## Scope

- [ ] Tray or WinUI UX
- [x] Windows node capability
- [ ] Local MCP or `winnode`
- [x] Gateway, connection, or pairing
- [ ] Setup or onboarding
- [ ] Permissions, privacy, or security
- [x] Tests, CI, or docs

## Validation

- `./build.ps1`: passed, all five projects built successfully.
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore`: 3,813 passed, 32 skipped, 0 failed.
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore`: 2,724 passed, 0 failed.
- `./scripts/validate-mxc-e2e.ps1 -NoBuild`: passed all required non-skipping MXC proofs.

## Real Behavior Proof

- Environment tested: Windows x64, Windows SDK 10.0.26100, local WSL Gateway.
- PR head or commit tested: `5f2f7f6b`.
- Exact steps or command run: `./scripts/validate-mxc-e2e.ps1 -NoBuild`.
- Evidence after fix: Gateway `system.run` returned `OPENCLAW_GATEWAY_SYSTEM_RUN_MXC_OK` with exit code 0 and runtime diagnostics reported `executor=mxc-direct-appc`, `contained=True`, and `containment=mxc`.
- Observed result: `RealGateway_SystemRun_ExecutesThroughWindowsNodeMxcSandbox`, `RealGateway_SystemRun_BlocksWritesToTrayDataDirectoryInMxcSandbox`, and `MirroredWslSafeGatewayPort_IsListeningAndRecorded` all passed. The denied-write proof returned non-zero and left the protected file absent.
- Screenshot or artifact links verified? (`Yes`/`No`/`N/A`): N/A
- Not verified or blocked: None.

## Security Impact

- New permissions or capabilities? (`Yes`/`No`): No
- Secrets or tokens handling changed? (`Yes`/`No`): No
- New or changed network calls? (`Yes`/`No`): No
- Command or tool execution surface changed? (`Yes`/`No`): Yes
- Data access scope changed? (`Yes`/`No`): No
- If any answer is `Yes`, explain the risk and mitigation: The native MXC executor changed from 0.7.0 to 0.8.0. OpenClaw retains its 0.7 policy contract, build-time version enforcement verifies the package, the shipped binary hash matches the dependency, and real Gateway execution plus denied-write containment passed.

## Compatibility and Migration

- Backward compatible? (`Yes`/`No`): Yes
- Config or environment changes? (`Yes`/`No`): No
- Migration needed? (`Yes`/`No`): No
- If yes, list the exact upgrade steps: N/A

## Review Conversations

- [ ] I replied to or resolved every bot review conversation addressed by this PR.
- [ ] I left unresolved only conversations that still need maintainer judgment.