### PR TITLE
fix(setup): stop WSL inspection flake from dead-ending onboarding

### DIFF
--- a/src/OpenClaw.SetupEngine.UI/Pages/WelcomePage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/WelcomePage.xaml.cs
@@ -13,8 +13,6 @@ namespace OpenClaw.SetupEngine.UI.Pages;
 
 public sealed partial class WelcomePage : Page
 {
-    private const string InstallButtonText = "Install a local gateway (WSL)";
-    private const string CheckingButtonText = "Checking existing setup...";
     private SetupConfig? _config;
     private bool _installSelected = true; // default selection
     private bool _suppressSelectionWrite;
@@ -145,42 +143,53 @@ public sealed partial class WelcomePage : Page
         var setupWindow = SetupWindow.Active;
         var dataDir = setupWindow?.DataDir ?? SetupContext.ResolveDataDir();
 
+        // The progress ring carries the checking state (its automation name is
+        // "Checking existing WSL setup"). Leave the option title alone: replacing it
+        // hides which option is being acted on for as long as the check runs.
         NextButton.IsEnabled = false;
-        InstallTitle.Text = CheckingButtonText;
         InstallCheckProgress.IsActive = true;
         InstallCheckProgress.Visibility = Visibility.Visible;
         var navigating = false;
         try
         {
             ExistingConfigDetector.ExistingConfig existing;
-            try
+            while (true)
             {
-                existing = await Task.Run(() => ExistingConfigDetector.Detect(
-                    dataDir,
-                    config.DistroName,
-                    setupWindow?.LocalDataDir));
-            }
-            catch (InvalidOperationException ex)
-            {
-                var errorRoot = XamlRoot;
-                if (setupWindow is not null and { IsClosed: false } && errorRoot is not null)
+                try
                 {
-                    await new ContentDialog
+                    existing = await Task.Run(() => ExistingConfigDetector.Detect(
+                        dataDir,
+                        config.DistroName,
+                        setupWindow?.LocalDataDir));
+                    break;
+                }
+                catch (InvalidOperationException ex)
+                {
+                    var errorRoot = XamlRoot;
+                    if (setupWindow is null or { IsClosed: true } || errorRoot is null)
+                        return;
+
+                    // Inspection failure is usually transient, so offer a way forward
+                    // instead of ending the flow on the recommended option.
+                    var retry = await new ContentDialog
                     {
                         Title = "Could not inspect WSL",
                         Content = ex.Message,
-                        CloseButtonText = "Close",
+                        PrimaryButtonText = "Try again",
+                        CloseButtonText = "Cancel",
+                        DefaultButton = ContentDialogButton.Primary,
                         XamlRoot = errorRoot,
                     }.ShowAsync();
+
+                    if (retry != ContentDialogResult.Primary)
+                        return;
                 }
-                return;
             }
 
             var xamlRoot = XamlRoot;
             if (setupWindow is null or { IsClosed: true } || xamlRoot is null)
                 return;
 
-            InstallTitle.Text = InstallButtonText;
             InstallCheckProgress.IsActive = false;
             InstallCheckProgress.Visibility = Visibility.Collapsed;
             var summary = ExistingConfigDetector.BuildReplacementSummary(existing);
@@ -218,7 +227,6 @@ public sealed partial class WelcomePage : Page
         {
             if (!navigating && setupWindow is { IsClosed: false })
             {
-                InstallTitle.Text = InstallButtonText;
                 InstallCheckProgress.IsActive = false;
                 InstallCheckProgress.Visibility = Visibility.Collapsed;
                 NextButton.IsEnabled = true;

--- a/src/OpenClaw.SetupEngine/CommandRunner.cs
+++ b/src/OpenClaw.SetupEngine/CommandRunner.cs
@@ -71,6 +71,14 @@ public sealed class CommandRunner : ICommandRunner
 {
     private readonly SetupLogger _logger;
     private static readonly TimeSpan s_outputDrainGrace = TimeSpan.FromMilliseconds(250);
+
+    /// <summary>
+    /// Upper bound on how long an exited process is given to reach EOF on its redirected
+    /// pipes. Large enough that a saturated thread pool cannot make a process that did
+    /// write output look silent, small enough that a descendant holding the pipes open
+    /// cannot stall the caller.
+    /// </summary>
+    private static readonly TimeSpan s_outputDrainCap = TimeSpan.FromSeconds(3);
     private const int MaxCapturedStreamChars = 1_048_576;
 
     public CommandRunner(SetupLogger logger) => _logger = logger;
@@ -193,11 +201,29 @@ public sealed class CommandRunner : ICommandRunner
         }
 
         // A surviving descendant can keep inherited pipe handles open after the child
-        // exits. Preserve output already in flight without charging the command's full
-        // timeout to an EOF that may never arrive.
+        // exits, so the EOF wait must stay bounded and cannot simply run to the command
+        // timeout. It also cannot be as tight as a few hundred milliseconds: the
+        // OutputDataReceived callbacks are queued to the thread pool, and on a saturated
+        // pool they can miss that window even though the process already exited and
+        // wrote its output. That surfaced as an exited process being reported with empty
+        // stdout and stderr, which every caller that classifies command output then
+        // misreads as silence. Wait up to a short cap instead, clamped by whatever
+        // remains of the caller's own deadline so the accepted timeout is never exceeded.
+        TimeSpan drainBudget = s_outputDrainGrace;
+        if (!timedOut)
+        {
+            TimeSpan remaining = timeout - sw.Elapsed;
+            if (remaining < TimeSpan.Zero)
+                remaining = TimeSpan.Zero;
+
+            TimeSpan bounded = remaining < s_outputDrainCap ? remaining : s_outputDrainCap;
+            if (bounded > drainBudget)
+                drainBudget = bounded;
+        }
+
         await Task.WhenAny(
             Task.WhenAll(stdoutClosed.Task, stderrClosed.Task),
-            Task.Delay(s_outputDrainGrace));
+            Task.Delay(drainBudget));
 
         sw.Stop();
         var result = new CommandResult(

--- a/src/OpenClaw.SetupEngine/CommandRunner.cs
+++ b/src/OpenClaw.SetupEngine/CommandRunner.cs
@@ -209,17 +209,7 @@ public sealed class CommandRunner : ICommandRunner
         // stdout and stderr, which every caller that classifies command output then
         // misreads as silence. Wait up to a short cap instead, clamped by whatever
         // remains of the caller's own deadline so the accepted timeout is never exceeded.
-        TimeSpan drainBudget = s_outputDrainGrace;
-        if (!timedOut)
-        {
-            TimeSpan remaining = timeout - sw.Elapsed;
-            if (remaining < TimeSpan.Zero)
-                remaining = TimeSpan.Zero;
-
-            TimeSpan bounded = remaining < s_outputDrainCap ? remaining : s_outputDrainCap;
-            if (bounded > drainBudget)
-                drainBudget = bounded;
-        }
+        TimeSpan drainBudget = GetOutputDrainBudget(timeout, sw.Elapsed, timedOut);
 
         await Task.WhenAny(
             Task.WhenAll(stdoutClosed.Task, stderrClosed.Task),
@@ -235,6 +225,21 @@ public sealed class CommandRunner : ICommandRunner
 
         _logger.CommandCompleted(executable, result, sw.Elapsed);
         return result;
+    }
+
+    internal static TimeSpan GetOutputDrainBudget(
+        TimeSpan timeout,
+        TimeSpan elapsed,
+        bool timedOut)
+    {
+        if (timedOut)
+            return s_outputDrainGrace;
+
+        TimeSpan remaining = timeout - elapsed;
+        if (remaining <= TimeSpan.Zero)
+            return TimeSpan.Zero;
+
+        return remaining < s_outputDrainCap ? remaining : s_outputDrainCap;
     }
 
     /// <summary>

--- a/src/OpenClaw.SetupEngine/ExistingConfigDetector.cs
+++ b/src/OpenClaw.SetupEngine/ExistingConfigDetector.cs
@@ -86,7 +86,11 @@ public sealed class ExistingConfigDetector
         if (!result.TimedOut && result.ExitCode == 0)
             return WslInstallSupport.ContainsDistro(result.Stdout, targetDistroName);
 
-        if (!result.TimedOut && WslViabilityInspector.LooksUnavailable(result))
+        // A conclusive "WSL is not installed" answer stays usable even when the run
+        // also timed out. The output already proves no distro can exist, so failing
+        // closed here would reject evidence the inspector itself treats as the
+        // installable path rather than a blocker.
+        if (WslViabilityInspector.LooksUnavailable(result))
             return false;
 
         throw new InvalidOperationException(

--- a/tests/OpenClaw.SetupEngine.Tests/CommandRunnerTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/CommandRunnerTests.cs
@@ -94,6 +94,25 @@ public class CommandRunnerTests
         Assert.InRange(stopwatch.Elapsed, TimeSpan.Zero, TimeSpan.FromSeconds(5));
     }
 
+    [Theory]
+    [InlineData(200, 175, false, 25)]
+    [InlineData(200, 250, false, 0)]
+    [InlineData(5_000, 1_000, false, 3_000)]
+    [InlineData(200, 250, true, 250)]
+    public void OutputDrainBudget_ClampsToDeadlineAndCap(
+        int timeoutMilliseconds,
+        int elapsedMilliseconds,
+        bool timedOut,
+        int expectedMilliseconds)
+    {
+        TimeSpan budget = CommandRunner.GetOutputDrainBudget(
+            TimeSpan.FromMilliseconds(timeoutMilliseconds),
+            TimeSpan.FromMilliseconds(elapsedMilliseconds),
+            timedOut);
+
+        Assert.Equal(TimeSpan.FromMilliseconds(expectedMilliseconds), budget);
+    }
+
     private static CommandRunner CreateRunner()
         => new(new SetupLogger(filePath: null, LogLevel.Trace));
 

--- a/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
@@ -3672,6 +3672,22 @@ public class SetupStepsTests : IDisposable
         Assert.False(ExistingConfigDetector.InterpretDistroList(result, "OpenClawGateway"));
     }
 
+    [Fact]
+    public void ExistingConfigDetector_KeepsConclusiveUnavailableAnswerWhenRunAlsoTimedOut()
+    {
+        // A run can time out after wsl.exe already reported that WSL is not installed.
+        // That output still proves no distro can exist, so the answer stays usable
+        // instead of failing closed and dead-ending the setup flow.
+        var result = new CommandResult(
+            -1,
+            "",
+            "WSL is not installed. See https://aka.ms/wslinstall",
+            TimeSpan.FromSeconds(5),
+            TimedOut: true);
+
+        Assert.False(ExistingConfigDetector.InterpretDistroList(result, "OpenClawGateway"));
+    }
+
     [Theory]
     [InlineData(true, 1, "")]
     [InlineData(false, 1, "unexpected failure")]

--- a/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
@@ -1584,18 +1584,24 @@ public sealed class AppRefactorContractTests
         var method = ExtractMethod(source, "StartInstallAsync");
 
         Assert.Contains("NextButton.IsEnabled = false", method);
-        Assert.Contains("InstallTitle.Text = CheckingButtonText", method);
         Assert.Contains("InstallCheckProgress.IsActive = true", method);
         Assert.Contains("InstallCheckProgress.Visibility = Visibility.Visible", method);
-        Assert.Contains("CheckingButtonText", method);
         Assert.Contains("var setupWindow = SetupWindow.Active", method);
         Assert.Contains("await Task.Run(() => ExistingConfigDetector.Detect", method);
         Assert.Contains("setupWindow is null or { IsClosed: true } || xamlRoot is null", method);
         Assert.Contains("setupWindow is { IsClosed: false }", method);
-        Assert.Contains("InstallTitle.Text = InstallButtonText", method);
         Assert.Contains("InstallCheckProgress.IsActive = false", method);
         Assert.Contains("InstallCheckProgress.Visibility = Visibility.Collapsed", method);
         Assert.Contains("NextButton.IsEnabled = true", method);
+
+        // The busy state is carried by the progress ring alone. Overwriting the option
+        // title hid which option was being acted on for as long as the check ran.
+        Assert.DoesNotContain("InstallTitle.Text", method);
+
+        // A failed inspection must stay recoverable instead of ending the flow on the
+        // recommended option with no way forward.
+        Assert.Contains("PrimaryButtonText = \"Try again\"", method);
+
         Assert.Contains("AutomationProperties.AutomationId=\"WelcomeInstallCheckProgress\"", File.ReadAllText(
             Path.Combine(root, "src", "OpenClaw.SetupEngine.UI", "Pages", "WelcomePage.xaml")));
         AssertInOrder(


### PR DESCRIPTION
## Problem  Selecting the recommended **Install a local gateway (WSL)** option could end the setup flow with a `Could not inspect WSL` dialog whose only action was **Close**, telling the user to run `wsl --list --quiet` by hand. There is no way forward from that state on the recommended path.  It reproduces on a machine where that exact command succeeds every time when run manually, which is what makes it confusing to diagnose from a bug report.  Three separate defects combine to produce it.  ### 1. `CommandRunner` can report a process that wrote output as silent  After the child exits, the redirected pipes were given a flat 250 ms grace to reach EOF. The `OutputDataReceived` / `ErrorDataReceived` callbacks are queued to the thread pool, so on a saturated pool (a WinUI cold start is exactly that) they can miss that window even though the process already exited and wrote its output. The command is then reported with an exit code but **empty stdout and stderr**.  Every caller that classifies command output shares this exposure, so this is fixed at the runner.  Reproduced by starving the thread pool and looping the call:  ``` iter 0: THREW exit=1 timedOut=False outLen=0 errLen=0 elapsed=1916ms ok=39 threw=1 emptyOutput=1 ```  The EOF wait is now bounded by a short cap instead of a flat grace, clamped by whatever remains of the caller's own deadline so the accepted timeout is never exceeded. The cap preserves the existing protection against a surviving descendant holding inherited pipe handles open, which `RunAsync_ReturnsWhenDescendantKeepsOutputPipesOpen` covers.  ### 2. `InterpretDistroList` discarded a conclusive answer  Both success paths were gated behind `!result.TimedOut`:  ```csharp if (!result.TimedOut && result.ExitCode == 0) return ContainsDistro(...); if (!result.TimedOut && LooksUnavailable(result)) return false; throw new InvalidOperationException(...); ```  A run that timed out *after* `wsl.exe` had already reported that WSL is not installed therefore threw, while holding stderr that reads `The Windows Subsystem for Linux is not installed` and with `LooksUnavailable` returning `true`. Observed directly:  ``` ExitCode : -1 TimedOut : True Stderr   : len=332   (fully captured) LooksUnavailable => True Detect   => THREW InvalidOperationException ```  That output proves no distro can exist, and `WslViabilityInspector` already classifies the state as `Installable` rather than a blocker (`PreflightWslStep.cs`), so the conclusive answer is now kept. Fail-closed behaviour is unchanged when the output is empty or genuinely unrecognised.  ### 3. The wizard destroyed context and offered no way forward  `WelcomePage` replaced the option's title with `Checking existing setup...` for the duration of the check, so the user could not see which option was being acted on, and offered only **Close** when inspection failed.  The progress ring beside the title already carries the busy state (its automation name is `Checking existing WSL setup`), so the title now stays put, and a failed inspection offers **Try again** instead of ending the flow.  ## Validation  Required closeout subset from `AGENTS.md`, all run on this branch's content:  | Check | Result | |---|---| | `./build.ps1` | Pass (Shared, Cli, WinNodeCli, SetupEngine, WinUI) | | `dotnet test ./tests/OpenClaw.Shared.Tests` | **3813 passed**, 0 failed, 32 skipped | | `dotnet test ./tests/OpenClaw.Tray.Tests` | Prior head: **2724 passed**. Current-head local rerun was blocked by a pre-existing Windows TCP-listener enumeration hang; the GitHub Build and Test workflow passed on rerun. | | `dotnet test ./tests/OpenClaw.SetupEngine.Tests` | **1003 passed**, 0 failed |  Targeted tests added or updated:  - `OutputDrainBudget_ClampsToDeadlineAndCap` (new maintainer follow-up) covers the remaining review finding by proving the drain wait uses the caller's actual remaining deadline, including the under-250 ms and exhausted-deadline boundaries.  - `ExistingConfigDetector_KeepsConclusiveUnavailableAnswerWhenRunAlsoTimedOut` (new) covers defect 2.   The existing `ExistingConfigDetector_FailsClosedWhenDistroStateIsUnknown` cases still throw, so the   fail-closed contract is intact. - `SetupWelcomePage_RunsExistingConfigDetectionOffUiThread` updated for the new busy-state contract,   with regression guards added: `Assert.DoesNotContain("InstallTitle.Text", method)` and a required   `PrimaryButtonText = "Try again"`. - `RunAsync_ReturnsWhenDescendantKeepsOutputPipesOpen` is unchanged and still passes, which is what   bounds the cap in defect 1. An earlier attempt that charged the full remaining timeout to the EOF   wait failed this test at 20.28s against its 5s budget.  Environment: Windows 11 ARM64 (NVIDIA GB10 class), .NET SDK 10.0.400, Windows SDK 10.0.26100.  ## Real behavior proof  Captured from a build of this branch's content, launched isolated with `OPENCLAW_TRAY_DATA_DIR` and `OPENCLAW_FORCE_ONBOARDING=1`, on a machine with WSL not installed (`Microsoft-Windows-Subsystem-Linux` and `VirtualMachinePlatform` both disabled), which is the configuration that triggers the bug.  **Before** (release build, same machine): selecting the recommended option and pressing Next left the wizard on a dialog reading `Could not inspect WSL` with the option title stuck at `Checking existing setup...` and `Next` disabled. UI Automation, sampled at 1s, 3s, 6s and 10s after the click, showed no change at any point:  ``` [Text]   'Could not inspect WSL' [Text]   'OpenClaw could not safely inspect existing WSL distributions. Run `wsl --list --quiet` in ...' [Text]   'Checking existing setup...' [Button] 'Next'      IsEnabled = False ```  **After** (this branch): the same flow proceeds past WSL inspection to the next step rather than dead-ending, and the option title is preserved throughout:  ``` [Text]     'Set up OpenClaw' [ListItem] 'Install a local gateway (WSL), recommended' [Text]     'Install a local gateway (WSL)'          <- title intact, not clobbered [Button]   'Next' ... [Text]     'Set up the WSL gateway'                 <- advanced past inspection [Text]     'Windows permissions' ```  Runner timing after the fix, from the app log:  ``` cmd.done: C:\Windows\System32\wsl.exe exit=1 (67ms) ```  Not verified / blocked: the end-to-end WSL gateway install itself is not exercised here, because WSL is not installed on this host and installing it is out of scope for this fix. The change is scoped to inspection and its failure handling. 