### PR TITLE
Local AI unusable on DGX Spark (Windows ARM64): shared GPU memory is not CUDA-allocatable, and a capability failure rolls back the whole setup

### DIFF
--- a/src/OpenClaw.Shared/Inference/DxgiGpuMemoryProbe.cs
+++ b/src/OpenClaw.Shared/Inference/DxgiGpuMemoryProbe.cs
@@ -86,11 +86,21 @@ internal static class DxgiGpuMemoryProbe
 
         long? sharedMemoryBytes = ToInt64(description.SharedSystemMemory);
         long? freeSharedMemoryBytes = QueryFreeSharedMemory(adapter);
+
+        // NVML packs PCI identity as (deviceId << 16) | vendorId. Carry the same
+        // shape so the two probes can be joined on adapter identity rather than on
+        // a display name, which the two APIs do not always agree on.
+        uint pciDeviceId = (description.DeviceId << 16) | (description.VendorId & 0xFFFF);
+
         AddMemoryByName(
             results,
             ambiguousNames,
             description.Description,
-            new DxgiGpuMemoryInfo(sharedMemoryBytes, freeSharedMemoryBytes));
+            new DxgiGpuMemoryInfo(
+                sharedMemoryBytes,
+                freeSharedMemoryBytes,
+                pciDeviceId,
+                description.SubSystemId));
     }
 
     internal static void AddMemoryByName(
@@ -209,4 +219,6 @@ internal static class DxgiGpuMemoryProbe
 
 internal sealed record DxgiGpuMemoryInfo(
     long? SharedMemoryBytes,
-    long? FreeSharedMemoryBytes);
+    long? FreeSharedMemoryBytes,
+    uint? PciDeviceId = null,
+    uint? PciSubSystemId = null);

--- a/src/OpenClaw.Shared/Inference/NvmlHostHardwareProbe.cs
+++ b/src/OpenClaw.Shared/Inference/NvmlHostHardwareProbe.cs
@@ -88,7 +88,14 @@ public sealed class NvmlHostHardwareProbe : IHostHardwareProbe
             {
                 string name = device.Name.Trim();
                 string normalizedName = NormalizeGpuName(name);
-                DxgiGpuMemoryInfo? dxgiMemory = nvmlNameCounts[normalizedName] == 1
+
+                // Prefer PCI identity. NVML and DXGI can report different display
+                // names for the same adapter, and on a unified-memory part that costs
+                // the entire shared pool: the adapter looks like a small dedicated
+                // card instead. Fall back to the name match when either side cannot
+                // supply identity.
+                DxgiGpuMemoryInfo? dxgiMemory = FindDxgiMemoryByPciIdentity(dxgiMemoryByName, device);
+                dxgiMemory ??= nvmlNameCounts[normalizedName] == 1
                     ? FindDxgiMemoryByName(dxgiMemoryByName, name)
                     : null;
                 return new GpuInfo(
@@ -114,6 +121,27 @@ public sealed class NvmlHostHardwareProbe : IHostHardwareProbe
 
     private static string NormalizeGpuName(string value) =>
         string.Join(' ', value.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
+
+    /// <summary>
+    /// Match an NVML device to a DXGI adapter on PCI identity. Returns null unless
+    /// exactly one adapter matches, so an ambiguous set never attributes another
+    /// adapter's shared memory to this device.
+    /// </summary>
+    private static DxgiGpuMemoryInfo? FindDxgiMemoryByPciIdentity(
+        IReadOnlyDictionary<string, DxgiGpuMemoryInfo> dxgiMemoryByName,
+        NvmlGpuSnapshot device)
+    {
+        if (device.PciDeviceId is not { } pciDeviceId)
+            return null;
+
+        DxgiGpuMemoryInfo[] matches = dxgiMemoryByName.Values
+            .Where(entry =>
+                entry.PciDeviceId == pciDeviceId &&
+                entry.PciSubSystemId == device.PciSubSystemId)
+            .ToArray();
+
+        return matches.Length == 1 ? matches[0] : null;
+    }
 
     private static DxgiGpuMemoryInfo? FindDxgiMemoryByName(
         IReadOnlyDictionary<string, DxgiGpuMemoryInfo> dxgiMemoryByName,
@@ -181,6 +209,18 @@ public sealed class NvmlHostHardwareProbe : IHostHardwareProbe
             var getDriver = GetDelegate<NvmlSystemGetString>(library, "nvmlSystemGetDriverVersion");
             var getCuda = GetDelegate<NvmlSystemGetCudaDriverVersion>(library, "nvmlSystemGetCudaDriverVersion_v2");
 
+            // Older NVML builds may not export this. It is optional: without it the
+            // join falls back to matching on adapter name as before.
+            NvmlDeviceGetPciInfo? getPciInfo = null;
+            try
+            {
+                getPciInfo = GetDelegate<NvmlDeviceGetPciInfo>(library, "nvmlDeviceGetPciInfo_v3");
+            }
+            catch (EntryPointNotFoundException)
+            {
+                getPciInfo = null;
+            }
+
             if (initialize() != NvmlSuccess)
                 return NvmlProbeResult.Empty;
             initialized = true;
@@ -207,7 +247,27 @@ public sealed class NvmlHostHardwareProbe : IHostHardwareProbe
                 if (string.IsNullOrWhiteSpace(name))
                     continue;
                 string? uuid = ReadDeviceString(device, getUuid, DeviceUuidCapacity);
-                devices.Add(new NvmlGpuSnapshot(name, uuid, memory.Total, memory.Free));
+
+                // PCI identity is optional. It is the join key against DXGI, which
+                // reports the same vendor, device, and subsystem ids for the adapter
+                // but can report a different display name for it.
+                uint? pciDeviceId = null;
+                uint? pciSubSystemId = null;
+                if (getPciInfo is not null &&
+                    getPciInfo(device, out NvmlPciInfo pciInfo) == NvmlSuccess &&
+                    pciInfo.PciDeviceId != 0)
+                {
+                    pciDeviceId = pciInfo.PciDeviceId;
+                    pciSubSystemId = pciInfo.PciSubSystemId;
+                }
+
+                devices.Add(new NvmlGpuSnapshot(
+                    name,
+                    uuid,
+                    memory.Total,
+                    memory.Free,
+                    pciDeviceId,
+                    pciSubSystemId));
             }
 
             return new NvmlProbeResult(devices, driverVersion, cudaMajorVersion);
@@ -311,13 +371,39 @@ public sealed class NvmlHostHardwareProbe : IHostHardwareProbe
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     private delegate int NvmlDeviceGetMemoryInfo(IntPtr device, out NvmlMemory memory);
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private delegate int NvmlDeviceGetPciInfo(IntPtr device, out NvmlPciInfo pciInfo);
+
+    /// <summary>
+    /// nvmlPciInfo_v3_t. Only the PCI identity fields are consumed; the bus id
+    /// buffers are declared so the struct layout matches what NVML writes.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
+    private struct NvmlPciInfo
+    {
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
+        public byte[] BusIdLegacy;
+        public uint Domain;
+        public uint Bus;
+        public uint Device;
+
+        /// <summary>Packed as (deviceId &lt;&lt; 16) | vendorId.</summary>
+        public uint PciDeviceId;
+        public uint PciSubSystemId;
+
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)]
+        public byte[] BusId;
+    }
 }
 
 internal sealed record NvmlGpuSnapshot(
     string Name,
     string? Uuid,
     ulong TotalMemoryBytes,
-    ulong FreeMemoryBytes);
+    ulong FreeMemoryBytes,
+    uint? PciDeviceId = null,
+    uint? PciSubSystemId = null);
 
 internal sealed record NvmlProbeResult(
     IReadOnlyList<NvmlGpuSnapshot> Devices,


### PR DESCRIPTION
> **Bug report, not a merge candidate.** The commit on this branch is retained only to show what
> was tried and why it is the wrong fix. Please do not merge it. See "Why the obvious fix is wrong".

## Summary

On a DGX Spark (GB10) running Windows ARM64, Local AI is unusable and the failure is expensive:
setup runs to completion, downloads a multi-GB model, then fails at the very last step with an
opaque `HTTP 500`, and rolls back everything including the gateway.

Underneath are three separate issues. Only the first is a straightforward bug.

## 1. NVML and DXGI are joined on adapter name, and the names disagree

`NvmlHostHardwareProbe` attaches DXGI shared memory to an NVML device by matching adapter **name**:

```csharp
DxgiGpuMemoryInfo? dxgiMemory = nvmlNameCounts[normalizedName] == 1
    ? FindDxgiMemoryByName(dxgiMemoryByName, name)
    : null;
```

On this hardware the two APIs report different names for the same adapter, so the match fails
silently:

```
NVML name : 'JMJWOA-Generic-GPU'    shared            : null
DXGI name : 'RTX Spark GPU'         SharedSystemMemory: 30.07 GiB
=> JOIN RESULT: NO MATCH - shared memory dropped
```

This part is a genuine defect: a silent no-match is indistinguishable from an adapter that has no
shared memory, and nothing is logged.

## 2. Why the obvious fix is wrong

The commit here joins on PCI identity instead (`nvmlDeviceGetPciInfo_v3` against the `VendorId` /
`DeviceId` / `SubSystemId` that `DXGI_ADAPTER_DESC1` already reads and discards). It works: the
adapter then reports 46.01 GiB instead of 15.94 GiB, and every catalog model becomes `Eligible`.

**That is the wrong outcome.** Measured with the patched build:

`llama-server` reports the same optimistic figure and then cannot honour it.

```
CUDA0 : JMJWOA-Generic-GPU (46332 MiB, 46114 MiB free)
```

Qwen3.5 9B, the smallest model in the catalog, allocates:

| Buffer | Size |
|---|---|
| model | 5040.86 MiB |
| KV | 8192.00 MiB |
| RS | 201.00 MiB |
| compute | 2752.13 MiB |
| **total on CUDA0** | **16186.0 MiB (15.81 GiB)** |

```
ggml-cuda.cu:106: CUDA error
CUDA error: out of memory
```

It dies at **15.81 GiB**, against NVML's dedicated figure of **15.94 GiB** (16320 MiB). Qwen3.6 35B
fails the same way earlier, on a single 21087.70 MiB model-buffer request.

So CUDA advertises 46.3 GiB but can only allocate about 15.9 GiB of device memory here. The shared
portion is host memory that DXGI reports and CUDA surfaces, but it does not back device allocations
under WDDM. **NVML's dedicated figure is the one that predicts real behaviour, and the current
name-join failure accidentally produces the correct answer on this machine.**

Fixing the join without changing capacity semantics would make eligibility *worse*: models are
selected that cannot load, and the user finds out only after a multi-GB download.

Worth noting the platform context: the unified memory that makes Spark good at local inference is
addressable under DGX OS / Linux, not through WDDM. With about 15.9 GiB usable, no model in the
catalog fits (the smallest requires 21.47 GiB).

## 3. A capability failure destroys the whole setup

`verify-local-ai-inference` is terminal, so its failure rolls back all completed steps:

```
verify-local-ai-inference -> rollback_ok
capture-local-ai-gpu-baseline -> rollback_ok
start-local-ai-runtime -> rollback_ok
persist-local-ai-manifest -> rollback_ok
acquire-local-ai-model -> rollback_ok      <- deletes the downloaded model
acquire-local-ai-runtime -> rollback_ok
reconcile-local-ai-installation -> rollback_ok
ensure-wsl-platform -> rollback_ok
...
_pipeline -> pipeline_failed
```

Local AI is one capability, but its verification failure takes down the WSL gateway too, and
discards a 12 GB download. The failure screen then offers only **Close**: no retry, and no way back
to the model dropdown one step earlier, even though choosing a smaller model is the obvious next
move. Repeating the attempt means re-downloading.

## Suggested direction

1. Join on stable identity, but keep the reported capacity honest. Shared/non-local memory should
   not count toward CUDA-allocatable capacity on WDDM. If it is surfaced at all it should be
   separate from the number eligibility is judged against.
2. Log an explicit warning when NVML and DXGI each see exactly one NVIDIA adapter but fail to match.
   That single line would have made this diagnosable in minutes.
3. Verify inference capability, or at least attempt a small allocation, **before** downloading
   gigabytes.
4. Do not roll back the gateway when an optional capability fails. Offer retry and model selection
   from the failure screen, and keep verified downloads.

## Environment

- NVIDIA DGX Spark (GB10), Windows 11 Pro 10.0.28000, ARM64
- Driver 592.96, CUDA 13.1, NVML dedicated 16320 MiB, DXGI shared 30.07 GiB, 46.07 GiB system RAM
- llama-server b10488 (`b10488-cuda13-arm64`), ARCHS include 1210, `BLACKWELL_NATIVE_FP4 = 1`
- Reproduced with both `qwen3.6-35b-a3b-mtp-q4-k-m` and `qwen3.5-9b-mtp-q4-k-m`

Note: reaching the failure at all required lowering `MinimumNvidiaDriverVersion` from 615.0 to 580.0
locally, since this host has driver 592.96 and no 615+ Windows ARM64 driver appears to be published
for this SKU. That local change is not part of this branch. Related: #1235.
