### PR TITLE
fix(setup): block unsafe Local AI archive destinations

### DIFF
--- a/src/OpenClaw.SetupEngine/LocalAiPathPolicy.cs
+++ b/src/OpenClaw.SetupEngine/LocalAiPathPolicy.cs
@@ -436,10 +436,11 @@ internal static class LocalAiPathPolicy
         }
 
         string root;
+        string candidatePath;
         try
         {
             root = NormalizePath(stagingDirectory);
-            destinationPath = NormalizePath(Path.Combine(
+            candidatePath = NormalizePath(Path.Combine(
                 root,
                 entryName
                     .Replace('/', Path.DirectorySeparatorChar)
@@ -451,19 +452,17 @@ internal static class LocalAiPathPolicy
             return false;
         }
 
-        if (!IsStrictDescendant(destinationPath, root))
+        // Keep the untrusted candidate local until containment and reparse checks establish ownership.
+        if (!candidatePath.StartsWith(EnsureTrailingDirectorySeparator(root), PathComparison))
         {
-            destinationPath = "";
             error = $"Local AI archive entry '{entryName}' escapes its staging directory.";
             return false;
         }
 
-        if (!TryValidateExistingPathChain(root, destinationPath, out error))
-        {
-            destinationPath = "";
+        if (!TryValidateExistingPathChain(root, candidatePath, out error))
             return false;
-        }
 
+        destinationPath = candidatePath;
         error = "";
         return true;
     }

--- a/tests/OpenClaw.SetupEngine.Tests/LocalAiInstallRecoveryTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/LocalAiInstallRecoveryTests.cs
@@ -268,6 +268,139 @@ public sealed class LocalAiInstallRecoveryTests
     }
 
     [Fact]
+    public async Task ArtifactInstall_RejectsPinnedZipUnsafeEntryNameWithoutWritingOutsideRoot()
+    {
+        using var temp = new TempDirectory();
+        byte[] archiveBytes = CreateZip(("../../../outside.txt", "outside"u8.ToArray()));
+        var archive = new LocalAiPinnedArchive(
+            "runtime.zip",
+            new Uri("https://github.com/owner/repo/releases/download/v1/runtime.zip"),
+            archiveBytes.Length,
+            Sha256(archiveBytes));
+        using var client = new HttpClient(new DelegateHandler(_ =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(archiveBytes),
+            }));
+        string outsidePath = Path.Combine(temp.Path, "outside.txt");
+
+        LocalAiArtifactInstallException exception =
+            await Assert.ThrowsAsync<LocalAiArtifactInstallException>(() =>
+                new LocalAiArtifactInstaller(client).InstallAsync(
+                    temp.Path,
+                    TestComponent(),
+                    [archive],
+                    progress: null,
+                    CancellationToken.None));
+
+        Assert.Contains("unsafe path segment", exception.Message, StringComparison.Ordinal);
+        Assert.False(File.Exists(outsidePath));
+    }
+
+    [Theory]
+    [InlineData("../outside.txt")]
+    [InlineData("..\\outside.txt")]
+    public void ArchiveDestination_RejectsTraversalWithEitherSeparator(string entryName)
+    {
+        using var temp = new TempDirectory();
+        string stagingDirectory = Path.Combine(temp.Path, "staging");
+
+        bool resolved = LocalAiPathPolicy.TryResolveArchiveEntryDestination(
+            stagingDirectory,
+            entryName,
+            out string destinationPath,
+            out string error);
+
+        Assert.False(resolved);
+        Assert.Empty(destinationPath);
+        Assert.Contains("escapes its staging directory", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ArchiveDestination_RejectsCanonicalizedPrefixCollision()
+    {
+        using var temp = new TempDirectory();
+        string stagingDirectory = Path.Combine(temp.Path, "staging");
+
+        bool resolved = LocalAiPathPolicy.TryResolveArchiveEntryDestination(
+            stagingDirectory,
+            "../staging-sibling/outside.txt",
+            out string destinationPath,
+            out string error);
+
+        Assert.False(resolved);
+        Assert.Empty(destinationPath);
+        Assert.Contains("escapes its staging directory", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ArchiveDestination_RejectsRootedPath()
+    {
+        using var temp = new TempDirectory();
+        string stagingDirectory = Path.Combine(temp.Path, "staging");
+        string rootedEntry = Path.Combine(
+            Path.GetPathRoot(temp.Path)!,
+            $"openclaw-rooted-{Guid.NewGuid():N}.txt");
+
+        bool resolved = LocalAiPathPolicy.TryResolveArchiveEntryDestination(
+            stagingDirectory,
+            rootedEntry,
+            out string destinationPath,
+            out string error);
+
+        Assert.False(resolved);
+        Assert.Empty(destinationPath);
+        Assert.Contains("escapes its staging directory", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ArchiveDestination_RejectsDescendantJunction()
+    {
+        using var temp = new TempDirectory();
+        using var outside = new TempDirectory();
+        string stagingDirectory = Path.Combine(temp.Path, "staging");
+        Directory.CreateDirectory(stagingDirectory);
+        string junction = Path.Combine(stagingDirectory, "linked");
+        CreateJunction(junction, outside.Path);
+        try
+        {
+            bool resolved = LocalAiPathPolicy.TryResolveArchiveEntryDestination(
+                stagingDirectory,
+                "linked/outside.txt",
+                out string destinationPath,
+                out string error);
+
+            Assert.False(resolved);
+            Assert.Empty(destinationPath);
+            Assert.Contains("reparse point", error, StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (Directory.Exists(junction))
+                Directory.Delete(junction);
+        }
+    }
+
+    [Fact]
+    public void ArchiveDestination_ResolvesValidNestedEntry()
+    {
+        using var temp = new TempDirectory();
+        string stagingDirectory = Path.Combine(temp.Path, "staging");
+
+        bool resolved = LocalAiPathPolicy.TryResolveArchiveEntryDestination(
+            stagingDirectory,
+            "bin/tools/llama-server.exe",
+            out string destinationPath,
+            out string error);
+
+        Assert.True(resolved, error);
+        Assert.Equal(
+            Path.GetFullPath(Path.Combine(stagingDirectory, "bin", "tools", "llama-server.exe")),
+            destinationPath);
+        Assert.Empty(error);
+    }
+
+    [Fact]
     public async Task Reconciler_ReusesOnlyMatchingManifestWithoutMutation()
     {
         using var temp = new TempDirectory();


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw-windows-node/pull/1225

## What Problem This Solves

Fixes an issue where a Local AI runtime archive destination remained modeled as untrusted after validation, leaving archive extraction flagged by CodeQL as a path-traversal sink.

## Why This Change Was Made

The archive path policy now keeps the normalized candidate private until root containment and existing reparse-point checks both succeed. It then publishes the validated destination to the extraction caller. Scope is limited to archive destination validation and focused proof.

This replacement preserves useful source work from https://github.com/openclaw/openclaw-windows-node/pull/1225 by Vincent Koc and Scott Hanselman. Scott is credited as a co-author. The existing draft was not changed because it contains external contributor work and is not campaign-exclusive.

## User Impact

Local AI archive extraction retains its current fail-closed behavior for unsafe entry names while making the validated destination ownership explicit to callers and CodeQL.

## Evidence

- Pre-fix regression: CodeQL alert 20 is open on exact `main` analysis `911f36860b2d9f45c4c7ccddfb94ddb60b3ee2b0`.
- Pre-fix native Windows characterization: 13 recovery tests passed, confirming ordinary traversal strings were already rejected at runtime.
- After-fix native Windows extraction proof: 20 recovery tests passed, including `/` and `\` traversal, rooted paths, sibling-prefix collision, descendant junction, valid nested destination, and archive-boundary no-write behavior.
- Independent Sol/high autoreview, security rubber-duck, and test-audit: clean, no actionable findings, 0.96 confidence.
- Production LOC: `+6/-7` (net `-1`). Test LOC: `+133/-0`.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs or instructions
- [x] Tests or validation
- [x] Security hardening
- [ ] Chore or infrastructure

## Scope

- [ ] Tray or WinUI UX
- [ ] Windows node capability
- [ ] Local MCP or `winnode`
- [ ] Gateway, connection, or pairing
- [x] Setup or onboarding
- [x] Permissions, privacy, or security
- [x] Tests, CI, or docs

## Validation

- `./build.ps1`: passed; Shared, CLI, WinNode CLI, SetupEngine, and WinUI built successfully.
- `dotnet test tests/OpenClaw.SetupEngine.Tests/OpenClaw.SetupEngine.Tests.csproj --no-restore`: 1,005 passed, 0 failed, 0 skipped.
- `dotnet test tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore`: 3,817 passed, 0 failed, 32 environment-gated skips.
- `dotnet test tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore`: 2,741 passed, 0 failed, 0 skipped.
- Focused `LocalAiInstallRecoveryTests`: 20 passed, 0 failed.
- `git diff --check`: passed.
- Sol/high autoreview with security and test-audit focus: clean.

## Real Behavior Proof

- Environment tested: clean native Windows Server 2022 Crabbox lease, full non-promisor public clone.
- PR head or commit tested: `2dbe68751890b5f3f5a14562ab5c46b58a6a01cd`; changed files verified byte-for-byte by SHA-256.
- Exact steps or command run: built the full repository, ran all SetupEngine tests, then ran the required Shared and Tray test projects with `--no-restore`.
- Evidence after fix: unsafe archive destinations returned no path; archive extraction wrote no file outside the staging owner; valid nested extraction remained accepted.
- Observed result: all focused and repository-required native Windows checks passed.
- Screenshot or artifact links verified? (`Yes`/`No`/`N/A`): N/A
- Exact-head GitHub result: 16 checks passed, 7 policy-skipped, 0 failed or pending, including C# CodeQL, repository tests, all three E2E lanes, and win-x64/win-arm64 packaging.

## Security Impact

- New permissions or capabilities? (`Yes`/`No`): No
- Secrets or tokens handling changed? (`Yes`/`No`): No
- New or changed network calls? (`Yes`/`No`): No
- Command or tool execution surface changed? (`Yes`/`No`): No
- Data access scope changed? (`Yes`/`No`): No
- If any answer is `Yes`, explain the risk and mitigation: N/A

## Compatibility and Migration

- Backward compatible? (`Yes`/`No`): Yes
- Config or environment changes? (`Yes`/`No`): No
- Migration needed? (`Yes`/`No`): No
- If yes, list the exact upgrade steps: N/A

## Review Conversations

- [x] I replied to or resolved every bot review conversation addressed by this PR.
- [ ] I left unresolved only conversations that still need maintainer judgment.
