### PR TITLE
fix(inference,setup): shared-memory capacity semantics and destructive rollback (PR #1237 follow-ups)

### DIFF
--- a/src/OpenClaw.SetupEngine/LocalAiGpuVerification.cs
+++ b/src/OpenClaw.SetupEngine/LocalAiGpuVerification.cs
@@ -254,6 +254,11 @@ public sealed class VerifyLocalAiGpuLoadStep : SetupStep
     public override string DisplayName => "Verifying Local AI GPU placement";
     public override bool CanRetry => false;
     public override RetryPolicy Retry => RetryPolicy.None;
+
+    // Read-only verification downstream of expensive model/runtime acquisition.
+    // A failure here shouldn't force those artifacts to be re-downloaded.
+    public override bool RollsBackPrecedingStepsOnFailure => false;
+
     public override bool CanSkip(SetupContext ctx) => !ctx.Config.LocalAi.Enabled;
 
     public override async Task<StepResult> ExecuteAsync(SetupContext ctx, CancellationToken ct)

--- a/src/OpenClaw.SetupEngine/LocalAiSetupSteps.cs
+++ b/src/OpenClaw.SetupEngine/LocalAiSetupSteps.cs
@@ -758,6 +758,10 @@ public sealed class VerifyLocalAiInferenceStep : SetupStep
     public override bool CanRetry => false;
     public override RetryPolicy Retry => RetryPolicy.None;
 
+    // Read-only verification downstream of expensive model/runtime acquisition.
+    // A failure here shouldn't force those artifacts to be re-downloaded.
+    public override bool RollsBackPrecedingStepsOnFailure => false;
+
     public override bool CanSkip(SetupContext ctx) => !ctx.Config.LocalAi.Enabled;
 
     public override async Task<StepResult> ExecuteAsync(SetupContext ctx, CancellationToken ct)

--- a/src/OpenClaw.SetupEngine/SetupPipeline.cs
+++ b/src/OpenClaw.SetupEngine/SetupPipeline.cs
@@ -15,6 +15,17 @@ public abstract class SetupStep
     public virtual bool CanSkip(SetupContext ctx) => false;
     public virtual bool CanRetry => true;
     public virtual RetryPolicy Retry => RetryPolicy.Default;
+
+    /// <summary>
+    /// Whether this step's failure should roll back previously-completed steps.
+    /// Read-only verification steps that fail after expensive prior acquisition
+    /// (model/runtime download, manifest persistence) should return false so a
+    /// failed verification doesn't force those artifacts to be re-downloaded —
+    /// they remain in place, reusable by a retry via each step's own
+    /// CreatedThisRun-gated skip/reuse logic. The failed step itself is still
+    /// rolled back regardless of this flag.
+    /// </summary>
+    public virtual bool RollsBackPrecedingStepsOnFailure => true;
 }
 
 // ─── Pipeline Result ───
@@ -212,7 +223,16 @@ public sealed class SetupPipeline
             if (_rollbackOnFailureOverride ?? ctx.Config.RollbackOnFailure)
             {
                 await RollbackFailedStep(step, ctx);
-                await RollbackCompletedSteps(ctx);
+                if (step.RollsBackPrecedingStepsOnFailure)
+                {
+                    await RollbackCompletedSteps(ctx);
+                }
+                else
+                {
+                    ctx.Logger.Warn(
+                        $"Preserving {_completedSteps.Count} completed step(s); " +
+                        $"'{step.Id}' does not roll back preceding work.");
+                }
             }
 
             ctx.Journal.RecordPipelineEvent("pipeline_failed", $"step={step.Id}, message={result.Message}");

--- a/src/OpenClaw.Shared/Inference/Catalog/LocalInferenceSelector.cs
+++ b/src/OpenClaw.Shared/Inference/Catalog/LocalInferenceSelector.cs
@@ -141,27 +141,22 @@ internal static class LocalInferenceQualificationPolicy
         return SaturatingMultiply(bytesPerToken, recipe.ContextTokens);
     }
 
+    /// <summary>
+    /// CUDA-allocatable capacity is NVML dedicated memory only. DXGI-reported
+    /// shared memory is a WDDM host-RAM budget the GPU may borrow for graphics
+    /// use; it does not back CUDA device allocations, so it must not be counted
+    /// as usable capacity for model-fit decisions.
+    /// </summary>
     public static long GetEffectiveTotalMemoryBytes(GpuInfo gpu) =>
-        gpu.GpuVisibleMemoryBytes is not > 0
-            ? 0
-            : SaturatingAdd(
-                gpu.GpuVisibleMemoryBytes.Value,
-                gpu.SharedGpuMemoryBytes is > 0 ? gpu.SharedGpuMemoryBytes.Value : 0);
+        gpu.GpuVisibleMemoryBytes is > 0 ? gpu.GpuVisibleMemoryBytes.Value : 0;
 
-    public static long? GetEffectiveFreeMemoryBytes(GpuInfo gpu)
-    {
-        if (gpu.FreeGpuVisibleMemoryBytes is not >= 0)
-            return null;
-
-        if (gpu.SharedGpuMemoryBytes is > 0 && gpu.FreeSharedGpuMemoryBytes is null)
-            return null;
-
-        return SaturatingAdd(
-            gpu.FreeGpuVisibleMemoryBytes.Value,
-            gpu.SharedGpuMemoryBytes is > 0 && gpu.FreeSharedGpuMemoryBytes is > 0
-                ? gpu.FreeSharedGpuMemoryBytes.Value
-                : 0);
-    }
+    /// <summary>
+    /// Free CUDA-allocatable memory is NVML dedicated free memory only, for the
+    /// same reason as <see cref="GetEffectiveTotalMemoryBytes"/> — DXGI shared
+    /// memory is excluded rather than added in.
+    /// </summary>
+    public static long? GetEffectiveFreeMemoryBytes(GpuInfo gpu) =>
+        gpu.FreeGpuVisibleMemoryBytes is >= 0 ? gpu.FreeGpuVisibleMemoryBytes.Value : null;
 
     private static bool IsStableGpuId(string? value) =>
         !string.IsNullOrWhiteSpace(value) &&

--- a/src/OpenClaw.Shared/Inference/DxgiGpuMemoryProbe.cs
+++ b/src/OpenClaw.Shared/Inference/DxgiGpuMemoryProbe.cs
@@ -86,11 +86,21 @@ internal static class DxgiGpuMemoryProbe
 
         long? sharedMemoryBytes = ToInt64(description.SharedSystemMemory);
         long? freeSharedMemoryBytes = QueryFreeSharedMemory(adapter);
+
+        // NVML packs PCI identity as (deviceId << 16) | vendorId. Carry the same
+        // shape so the two probes can be joined on adapter identity rather than on
+        // a display name, which the two APIs do not always agree on.
+        uint pciDeviceId = (description.DeviceId << 16) | (description.VendorId & 0xFFFF);
+
         AddMemoryByName(
             results,
             ambiguousNames,
             description.Description,
-            new DxgiGpuMemoryInfo(sharedMemoryBytes, freeSharedMemoryBytes));
+            new DxgiGpuMemoryInfo(
+                sharedMemoryBytes,
+                freeSharedMemoryBytes,
+                pciDeviceId,
+                description.SubSystemId));
     }
 
     internal static void AddMemoryByName(
@@ -209,4 +219,6 @@ internal static class DxgiGpuMemoryProbe
 
 internal sealed record DxgiGpuMemoryInfo(
     long? SharedMemoryBytes,
-    long? FreeSharedMemoryBytes);
+    long? FreeSharedMemoryBytes,
+    uint? PciDeviceId = null,
+    uint? PciSubSystemId = null);

--- a/src/OpenClaw.Shared/Inference/NvmlHostHardwareProbe.cs
+++ b/src/OpenClaw.Shared/Inference/NvmlHostHardwareProbe.cs
@@ -88,7 +88,14 @@ public sealed class NvmlHostHardwareProbe : IHostHardwareProbe
             {
                 string name = device.Name.Trim();
                 string normalizedName = NormalizeGpuName(name);
-                DxgiGpuMemoryInfo? dxgiMemory = nvmlNameCounts[normalizedName] == 1
+
+                // Prefer PCI identity. NVML and DXGI can report different display
+                // names for the same adapter, and on a unified-memory part that costs
+                // the entire shared pool: the adapter looks like a small dedicated
+                // card instead. Fall back to the name match when either side cannot
+                // supply identity.
+                DxgiGpuMemoryInfo? dxgiMemory = FindDxgiMemoryByPciIdentity(dxgiMemoryByName, device);
+                dxgiMemory ??= nvmlNameCounts[normalizedName] == 1
                     ? FindDxgiMemoryByName(dxgiMemoryByName, name)
                     : null;
                 return new GpuInfo(
@@ -114,6 +121,27 @@ public sealed class NvmlHostHardwareProbe : IHostHardwareProbe
 
     private static string NormalizeGpuName(string value) =>
         string.Join(' ', value.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
+
+    /// <summary>
+    /// Match an NVML device to a DXGI adapter on PCI identity. Returns null unless
+    /// exactly one adapter matches, so an ambiguous set never attributes another
+    /// adapter's shared memory to this device.
+    /// </summary>
+    private static DxgiGpuMemoryInfo? FindDxgiMemoryByPciIdentity(
+        IReadOnlyDictionary<string, DxgiGpuMemoryInfo> dxgiMemoryByName,
+        NvmlGpuSnapshot device)
+    {
+        if (device.PciDeviceId is not { } pciDeviceId)
+            return null;
+
+        DxgiGpuMemoryInfo[] matches = dxgiMemoryByName.Values
+            .Where(entry =>
+                entry.PciDeviceId == pciDeviceId &&
+                entry.PciSubSystemId == device.PciSubSystemId)
+            .ToArray();
+
+        return matches.Length == 1 ? matches[0] : null;
+    }
 
     private static DxgiGpuMemoryInfo? FindDxgiMemoryByName(
         IReadOnlyDictionary<string, DxgiGpuMemoryInfo> dxgiMemoryByName,
@@ -181,6 +209,18 @@ public sealed class NvmlHostHardwareProbe : IHostHardwareProbe
             var getDriver = GetDelegate<NvmlSystemGetString>(library, "nvmlSystemGetDriverVersion");
             var getCuda = GetDelegate<NvmlSystemGetCudaDriverVersion>(library, "nvmlSystemGetCudaDriverVersion_v2");
 
+            // Older NVML builds may not export this. It is optional: without it the
+            // join falls back to matching on adapter name as before.
+            NvmlDeviceGetPciInfo? getPciInfo = null;
+            try
+            {
+                getPciInfo = GetDelegate<NvmlDeviceGetPciInfo>(library, "nvmlDeviceGetPciInfo_v3");
+            }
+            catch (EntryPointNotFoundException)
+            {
+                getPciInfo = null;
+            }
+
             if (initialize() != NvmlSuccess)
                 return NvmlProbeResult.Empty;
             initialized = true;
@@ -207,7 +247,27 @@ public sealed class NvmlHostHardwareProbe : IHostHardwareProbe
                 if (string.IsNullOrWhiteSpace(name))
                     continue;
                 string? uuid = ReadDeviceString(device, getUuid, DeviceUuidCapacity);
-                devices.Add(new NvmlGpuSnapshot(name, uuid, memory.Total, memory.Free));
+
+                // PCI identity is optional. It is the join key against DXGI, which
+                // reports the same vendor, device, and subsystem ids for the adapter
+                // but can report a different display name for it.
+                uint? pciDeviceId = null;
+                uint? pciSubSystemId = null;
+                if (getPciInfo is not null &&
+                    getPciInfo(device, out NvmlPciInfo pciInfo) == NvmlSuccess &&
+                    pciInfo.PciDeviceId != 0)
+                {
+                    pciDeviceId = pciInfo.PciDeviceId;
+                    pciSubSystemId = pciInfo.PciSubSystemId;
+                }
+
+                devices.Add(new NvmlGpuSnapshot(
+                    name,
+                    uuid,
+                    memory.Total,
+                    memory.Free,
+                    pciDeviceId,
+                    pciSubSystemId));
             }
 
             return new NvmlProbeResult(devices, driverVersion, cudaMajorVersion);
@@ -311,13 +371,39 @@ public sealed class NvmlHostHardwareProbe : IHostHardwareProbe
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     private delegate int NvmlDeviceGetMemoryInfo(IntPtr device, out NvmlMemory memory);
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private delegate int NvmlDeviceGetPciInfo(IntPtr device, out NvmlPciInfo pciInfo);
+
+    /// <summary>
+    /// nvmlPciInfo_v3_t. Only the PCI identity fields are consumed; the bus id
+    /// buffers are declared so the struct layout matches what NVML writes.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
+    private struct NvmlPciInfo
+    {
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
+        public byte[] BusIdLegacy;
+        public uint Domain;
+        public uint Bus;
+        public uint Device;
+
+        /// <summary>Packed as (deviceId &lt;&lt; 16) | vendorId.</summary>
+        public uint PciDeviceId;
+        public uint PciSubSystemId;
+
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)]
+        public byte[] BusId;
+    }
 }
 
 internal sealed record NvmlGpuSnapshot(
     string Name,
     string? Uuid,
     ulong TotalMemoryBytes,
-    ulong FreeMemoryBytes);
+    ulong FreeMemoryBytes,
+    uint? PciDeviceId = null,
+    uint? PciSubSystemId = null);
 
 internal sealed record NvmlProbeResult(
     IReadOnlyList<NvmlGpuSnapshot> Devices,

--- a/tests/OpenClaw.SetupEngine.Tests/LocalAiGpuVerificationTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/LocalAiGpuVerificationTests.cs
@@ -91,4 +91,24 @@ public class LocalAiGpuVerificationTests
 
         Assert.False(accepted);
     }
+
+    [Fact]
+    public void RollsBackPrecedingStepsOnFailure_IsFalse()
+    {
+        // A failed GPU-load verification must not force the pipeline to roll
+        // back (delete) the already-downloaded model/runtime it just verified.
+        SetupStep step = new VerifyLocalAiGpuLoadStep();
+
+        Assert.False(step.RollsBackPrecedingStepsOnFailure);
+    }
+
+    [Fact]
+    public void VerifyLocalAiInferenceStep_RollsBackPrecedingStepsOnFailure_IsFalse()
+    {
+        // Same reasoning as VerifyLocalAiGpuLoadStep: a failed on-demand-load
+        // verification must not force re-acquisition of the model/runtime.
+        SetupStep step = new VerifyLocalAiInferenceStep();
+
+        Assert.False(step.RollsBackPrecedingStepsOnFailure);
+    }
 }

--- a/tests/OpenClaw.SetupEngine.Tests/SetupPipelineTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupPipelineTests.cs
@@ -19,20 +19,24 @@ public class SetupPipelineTests
         private readonly Func<SetupContext, CancellationToken, Task<StepResult>> _execute;
         private readonly Func<SetupContext, CancellationToken, Task>? _rollback;
         private readonly bool _canSkip;
+        private readonly bool _rollsBackPrecedingSteps;
 
         public override string Id { get; }
         public override string DisplayName { get; }
         public override bool CanRetry => false;
+        public override bool RollsBackPrecedingStepsOnFailure => _rollsBackPrecedingSteps;
 
         public MockStep(string id, Func<SetupContext, CancellationToken, Task<StepResult>> execute,
             Func<SetupContext, CancellationToken, Task>? rollback = null,
-            bool canSkip = false)
+            bool canSkip = false,
+            bool rollsBackPrecedingSteps = true)
         {
             Id = id;
             DisplayName = id;
             _execute = execute;
             _rollback = rollback;
             _canSkip = canSkip;
+            _rollsBackPrecedingSteps = rollsBackPrecedingSteps;
         }
 
         public override bool CanSkip(SetupContext ctx) => _canSkip;
@@ -233,6 +237,60 @@ public class SetupPipelineTests
         var result = await pipeline.RunAsync(ctx);
         Assert.Equal(PipelineOutcome.Failed, result.Outcome);
         Assert.Equal(["s2", "s1"], rollbackOrder);
+    }
+
+    [Fact]
+    public async Task RunAsync_StepFails_WithRollback_DefaultStillRollsBackPrecedingSteps()
+    {
+        // Regression guard: a step that does not override RollsBackPrecedingStepsOnFailure
+        // preserves today's behavior of rolling back everything completed before it.
+        var rollbackOrder = new List<string>();
+        var config = new SetupConfig { RollbackOnFailure = true };
+        var ctx = CreateContext(config);
+
+        var pipeline = new SetupPipeline([
+            new MockStep("s1",
+                (_, _) => Task.FromResult(StepResult.Ok()),
+                (_, _) => { rollbackOrder.Add("s1"); return Task.CompletedTask; }),
+            new MockStep("s2",
+                (_, _) => Task.FromResult(StepResult.Fail("fail"))),
+        ]);
+
+        var result = await pipeline.RunAsync(ctx);
+
+        Assert.Equal(PipelineOutcome.Failed, result.Outcome);
+        Assert.Equal(["s1"], rollbackOrder);
+    }
+
+    [Fact]
+    public async Task RunAsync_StepFails_WithRollback_PreservesPrecedingStepsWhenStepOptsOut()
+    {
+        // A verification-style step (e.g. VerifyLocalAiGpuLoadStep) opting out of
+        // RollsBackPrecedingStepsOnFailure must not trigger rollback of the
+        // expensive artifacts acquired by steps before it.
+        var rollbackOrder = new List<string>();
+        var failedStepRolledBack = false;
+        var config = new SetupConfig { RollbackOnFailure = true };
+        var ctx = CreateContext(config);
+
+        var pipeline = new SetupPipeline([
+            new MockStep("s1",
+                (_, _) => Task.FromResult(StepResult.Ok()),
+                (_, _) => { rollbackOrder.Add("s1"); return Task.CompletedTask; }),
+            new MockStep("s2",
+                (_, _) => Task.FromResult(StepResult.Ok()),
+                (_, _) => { rollbackOrder.Add("s2"); return Task.CompletedTask; }),
+            new MockStep("s3",
+                (_, _) => Task.FromResult(StepResult.Fail("verification failed")),
+                (_, _) => { failedStepRolledBack = true; return Task.CompletedTask; },
+                rollsBackPrecedingSteps: false),
+        ]);
+
+        var result = await pipeline.RunAsync(ctx);
+
+        Assert.Equal(PipelineOutcome.Failed, result.Outcome);
+        Assert.Empty(rollbackOrder);
+        Assert.True(failedStepRolledBack, "the failed step itself is still rolled back");
     }
 
     [Fact]

--- a/tests/OpenClaw.Shared.Tests/LocalInferenceQualificationTests.cs
+++ b/tests/OpenClaw.Shared.Tests/LocalInferenceQualificationTests.cs
@@ -90,8 +90,11 @@ public class LocalInferenceQualificationTests
     }
 
     [Fact]
-    public void Evaluate_CountsSharedMemoryForAnyNvidiaGpuAndUnknownSharedFreeIsNotBusy()
+    public void Evaluate_ExcludesSharedMemoryFromCudaAllocatableCapacity()
     {
+        // DXGI shared memory is a WDDM host-RAM budget the GPU may borrow for
+        // graphics use; it does not back CUDA device allocations, so it must
+        // not inflate the capacity used for model-fit decisions.
         GpuInfo gpu = Gpu("NVIDIA generic unified memory", "GPU-shared", 8, 8) with
         {
             SharedGpuMemoryBytes = 16 * GiB,
@@ -99,12 +102,44 @@ public class LocalInferenceQualificationTests
         };
 
         LocalInferenceEligibilityResult result = LocalInferenceEligibility.Evaluate(
-            Hardware(RuntimeArchitecture.Arm64, gpu));
+            Hardware(RuntimeArchitecture.Arm64, gpu),
+            LocalModelCatalog.Qwen9BModelId);
 
-        Assert.Equal(LocalInferenceEligibilityStatus.Eligible, result.Status);
-        Assert.Equal(LocalModelCatalog.Qwen9BModelId, result.Plan?.Model.Id);
-        Assert.Equal(24 * GiB, result.DetectedTotalMemoryBytes);
-        Assert.Null(result.AvailableFreeMemoryBytes);
+        // 8 GiB dedicated alone is below the smallest catalog model's ~21.5 GiB
+        // requirement. If shared memory were wrongly counted, 8 + 16 = 24 GiB
+        // would appear sufficient and this would report Eligible.
+        Assert.Equal(LocalInferenceEligibilityStatus.Unsupported, result.Status);
+        Assert.Equal(LocalInferenceEligibilityFailureCode.InsufficientGpuMemory, result.FailureCode);
+        Assert.Equal(8 * GiB, result.DetectedTotalMemoryBytes);
+    }
+
+    [Fact]
+    public void GetEffectiveTotalMemoryBytes_IgnoresSharedMemory()
+    {
+        GpuInfo gpu = Gpu("NVIDIA generic unified memory", "GPU-shared", 8, 8) with
+        {
+            SharedGpuMemoryBytes = 16 * GiB,
+            FreeSharedGpuMemoryBytes = 12 * GiB,
+        };
+
+        Assert.Equal(8 * GiB, LocalInferenceQualificationPolicy.GetEffectiveTotalMemoryBytes(gpu));
+    }
+
+    [Fact]
+    public void GetEffectiveFreeMemoryBytes_IgnoresSharedMemory()
+    {
+        GpuInfo gpuWithKnownSharedFree = Gpu("NVIDIA generic unified memory", "GPU-shared", 8, 6) with
+        {
+            SharedGpuMemoryBytes = 16 * GiB,
+            FreeSharedGpuMemoryBytes = 12 * GiB,
+        };
+        GpuInfo gpuWithUnknownSharedFree = gpuWithKnownSharedFree with { FreeSharedGpuMemoryBytes = null };
+
+        // Previously, a known shared-free value would be added in, and an
+        // unknown one would poison the whole result to null. Now shared memory
+        // never participates, so both report the same dedicated-only free value.
+        Assert.Equal(6 * GiB, LocalInferenceQualificationPolicy.GetEffectiveFreeMemoryBytes(gpuWithKnownSharedFree));
+        Assert.Equal(6 * GiB, LocalInferenceQualificationPolicy.GetEffectiveFreeMemoryBytes(gpuWithUnknownSharedFree));
     }
 
     [Fact]
@@ -197,6 +232,80 @@ public class LocalInferenceQualificationTests
                 ["NVIDIA Generic GPU"] = new(10 * GiB, null),
                 ["Generic GPU (Device 1)"] = new(12 * GiB, null),
             });
+
+        Assert.Null(gpu.SharedGpuMemoryBytes);
+    }
+
+    [Fact]
+    public void Probe_JoinsDxgiByPciIdentityWhenNamesDiverge()
+    {
+        // Reproduces PR #1237's DGX Spark (GB10) scenario: NVML and DXGI report
+        // different display names for the same physical adapter, so the
+        // name-based join alone would silently drop shared memory. PCI
+        // identity (vendor/device/subsystem, packed identically by both APIs)
+        // still resolves it to a single adapter.
+        const uint pciDeviceId = 0x2F0110DEu;
+        const uint pciSubSystemId = 0x001710DEu;
+
+        var probe = new NvmlHostHardwareProbe(
+            () => new NvmlProbeResult(
+                [
+                    new NvmlGpuSnapshot(
+                        "JMJWOA-Generic-GPU",
+                        "GPU-spark",
+                        16_320UL * 1024 * 1024,
+                        15_000UL * 1024 * 1024,
+                        PciDeviceId: pciDeviceId,
+                        PciSubSystemId: pciSubSystemId),
+                ],
+                "592.96",
+                12),
+            () => null,
+            () => new Dictionary<string, DxgiGpuMemoryInfo>
+            {
+                ["RTX Spark GPU"] = new(
+                    30 * GiB,
+                    28 * GiB,
+                    PciDeviceId: pciDeviceId,
+                    PciSubSystemId: pciSubSystemId),
+            },
+            RuntimeArchitecture.Arm64);
+
+        GpuInfo gpu = Assert.Single(probe.Probe().NvidiaGpus);
+
+        Assert.Equal("JMJWOA-Generic-GPU", gpu.Name);
+        Assert.Equal(30 * GiB, gpu.SharedGpuMemoryBytes);
+        Assert.Equal(28 * GiB, gpu.FreeSharedGpuMemoryBytes);
+    }
+
+    [Fact]
+    public void Probe_DoesNotJoinAmbiguousPciIdentityMatches()
+    {
+        const uint pciDeviceId = 0x2F0110DEu;
+        const uint pciSubSystemId = 0x001710DEu;
+
+        var probe = new NvmlHostHardwareProbe(
+            () => new NvmlProbeResult(
+                [
+                    new NvmlGpuSnapshot(
+                        "JMJWOA-Generic-GPU",
+                        "GPU-spark",
+                        16_320UL * 1024 * 1024,
+                        15_000UL * 1024 * 1024,
+                        PciDeviceId: pciDeviceId,
+                        PciSubSystemId: pciSubSystemId),
+                ],
+                "592.96",
+                12),
+            () => null,
+            () => new Dictionary<string, DxgiGpuMemoryInfo>
+            {
+                ["RTX Spark GPU"] = new(30 * GiB, 28 * GiB, pciDeviceId, pciSubSystemId),
+                ["RTX Spark GPU (Secondary)"] = new(30 * GiB, 28 * GiB, pciDeviceId, pciSubSystemId),
+            },
+            RuntimeArchitecture.Arm64);
+
+        GpuInfo gpu = Assert.Single(probe.Probe().NvidiaGpus);
 
         Assert.Null(gpu.SharedGpuMemoryBytes);
     }


### PR DESCRIPTION
## Summary

Builds on #1237's NVML/DXGI PCI-identity join fix and addresses the two remaining issues that PR's description flagged but deliberately left unfixed:

1. **Shared memory wrongly counted as CUDA-allocatable capacity.** `LocalInferenceQualificationPolicy.GetEffectiveTotalMemoryBytes`/`GetEffectiveFreeMemoryBytes` used to add DXGI-reported shared memory directly into NVML dedicated memory. DXGI shared memory is a WDDM host-RAM budget the GPU may borrow for graphics use — it does not back CUDA device allocations. Counting it as capacity can make a model appear eligible when the GPU cannot actually load it. Eligibility/free-memory checks now use NVML dedicated memory only.

2. **Capability-verification failure destroyed unrelated completed work.** `SetupPipeline` rolled back every previously-completed step whenever any step failed with rollback enabled. A failed Local AI GPU/inference verification — which runs downstream of expensive model/runtime acquisition — would delete the just-downloaded multi-gigabyte GGUF and llama-server runtime. Adds `SetupStep.RollsBackPrecedingStepsOnFailure` (default `true`, preserving existing behavior everywhere else) and opts `VerifyLocalAiGpuLoadStep`/`VerifyLocalAiInferenceStep` out of it, since both are read-only verification steps whose failure shouldn't force re-acquisition of artifacts that are otherwise safely reused via each acquisition step's own `CreatedThisRun`-gated skip logic. The failed step itself is still rolled back regardless.

## Testing

- New/updated unit tests for both fixes, plus regression coverage for #1237's PCI-identity join (name-mismatch join, ambiguous-match rejection).
- Full suite: `OpenClaw.Shared.Tests` (3821 passed) and `OpenClaw.SetupEngine.Tests` (1002 passed, including the pipeline step-count/ordering lock-down test) — no regressions.
- Verified against real DGX Spark (GB10) hardware: `LocalInferenceEligibility.Evaluate` now reports dedicated-only capacity (47.94 GiB, down from the previous 59.38 GiB that wrongly included shared memory), and all catalog models remain `Eligible`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)