### PR TITLE
fix(local-ai): bound default llama generation

### DIFF
--- a/src/OpenClaw.Connection/LocalAi/LlamaServerRouterConfiguration.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerRouterConfiguration.cs
@@ -119,6 +119,7 @@ public static class LlamaServerRouterConfiguration
         preset.Append("model = ").AppendLine(modelPath);
         preset.AppendLine("load-on-startup = false");
         preset.Append("ctx-size = ").AppendLine(Invariant(recipe.ContextTokens));
+        preset.Append("n-predict = ").AppendLine(Invariant(LocalAiGatewayProviderDefinition.MaximumOutputTokens));
         preset.Append("parallel = ").AppendLine(Invariant(recipe.ParallelRequests));
         preset.AppendLine("cache-type-k = f16");
         preset.AppendLine("cache-type-v = f16");

--- a/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
+++ b/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
@@ -4,6 +4,7 @@ using OpenClaw.Shared.Inference.Catalog;
 using OpenClaw.TestSupport;
 using System.Collections.Immutable;
 using System.Net;
+using System.Text.Json;
 
 namespace OpenClaw.Connection.Tests;
 
@@ -57,6 +58,29 @@ public sealed class LocalAiPortLifecycleTests
 
         Assert.Equal("retired-profile-id", saved.Manifest.HardwareProfileId);
         Assert.Equal(LocalModelCatalog.Qwen35BModelId, launch.ModelAlias);
+    }
+
+    [Fact]
+    public async Task RouterPreset_BoundsOmittedGenerationAtGatewayMaximum()
+    {
+        using var temp = new TempDirectory("local-ai-manifest-");
+        var paths = new LocalAiPaths(temp.Path);
+        var store = new LocalAiManifestStore(paths);
+        await store.SaveAsync(ValidManifest() with { Endpoint = "http://127.0.0.1:28765/v1" });
+        LocalAiResolvedInstall saved = (await store.LoadAsync())!;
+
+        LlamaServerRouterLaunchPlan launch = LlamaServerRouterConfiguration.Build(paths, saved);
+        using JsonDocument provider = JsonDocument.Parse(
+            LocalAiGatewayProviderDefinition.BuildProviderJson(saved));
+        int gatewayMaximum = provider.RootElement
+            .GetProperty("models")[0]
+            .GetProperty("maxTokens")
+            .GetInt32();
+
+        Assert.Equal(LocalAiGatewayProviderDefinition.MaximumOutputTokens, gatewayMaximum);
+        Assert.Contains(
+            $"n-predict = {gatewayMaximum}",
+            launch.PresetContent.Split(Environment.NewLine));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- add an 8,192-token `n-predict` default to the managed llama-server model preset
- reuse the existing gateway `MaximumOutputTokens` policy so server and provider limits stay aligned
- add focused coverage that verifies the generated preset against the provider definition

Closes #1240

## Validation

- `./build.ps1` passed
- `dotnet test ./tests/OpenClaw.Connection.Tests/OpenClaw.Connection.Tests.csproj --no-restore` passed: 687 passed, 0 failed, 0 skipped
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` passed: 3,817 passed, 0 failed, 32 skipped
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` passed: 2,741 passed, 0 failed, 0 skipped

## Real behavior proof

Verified on Windows ARM64 with the pinned llama.cpp b10488 runtime, the qualified Qwen 3.6 35B model, and an NVIDIA RTX Spark N1X GPU.

- the production preset generated from current head contains `n-predict = 8192`
- an isolated diagnostic copy changed only that limit to 8 so the omitted-limit behavior could be observed quickly
- a completion request without `max_tokens` generated 8 tokens and returned `finish_reason: length`
- a completion request with `max_tokens: 3` generated 3 tokens and returned `finish_reason: length`

This proves omitted request limits inherit the server default while explicit request limits remain authoritative in b10488.

## Review

- rubber-duck review: no blocking issues
- `python .agents/skills/autoreview/scripts/autoreview --mode local`: clean, no accepted or actionable findings