### PR TITLE
chore(local-ai): bump llama.cpp runtime to b10655

### DIFF
--- a/src/OpenClaw.SetupEngine/LlamaRuntimeInstaller.cs
+++ b/src/OpenClaw.SetupEngine/LlamaRuntimeInstaller.cs
@@ -277,7 +277,9 @@ internal sealed class WindowsLlamaRuntimeInspector : ILlamaRuntimeInspector
 
     internal static LlamaRuntimeInspection ValidateVersionOutput(string output)
     {
-        bool buildMatches = output.Contains("build 10488", StringComparison.OrdinalIgnoreCase);
+        bool buildMatches = output.Contains(
+            $"build {LlamaRuntimeCatalog.ReleaseTag[1..]}",
+            StringComparison.OrdinalIgnoreCase);
         bool commitMatches = output.Contains(
             LlamaRuntimeCatalog.ReleaseCommitSha[..9],
             StringComparison.OrdinalIgnoreCase);
@@ -286,7 +288,7 @@ internal sealed class WindowsLlamaRuntimeInspector : ILlamaRuntimeInspector
             : new LlamaRuntimeInspection(
                 false,
                 output,
-                "llama-server did not report the pinned b10488 build and source commit.");
+                $"llama-server did not report the pinned {LlamaRuntimeCatalog.ReleaseTag} build and source commit.");
     }
 
     private static void KillProcessTree(Process process)

--- a/src/OpenClaw.Shared/Inference/Catalog/LlamaRuntimeCatalog.cs
+++ b/src/OpenClaw.Shared/Inference/Catalog/LlamaRuntimeCatalog.cs
@@ -47,11 +47,11 @@ public sealed record LlamaRuntimeVariant
 /// </summary>
 public static class LlamaRuntimeCatalog
 {
-    public const string ReleaseTag = "b10488";
-    public const string ReleaseCommitSha = "9d77fa17254e1dee4b9e92504c91611a60b1359f";
+    public const string ReleaseTag = "b10655";
+    public const string ReleaseCommitSha = "cb300598d5f90189cb69d2702f4930aaf99d32a2";
     public const string ServerExecutableName = "llama-server.exe";
-    public const string X64RuntimeId = "b10488-cuda13-x64";
-    public const string Arm64RuntimeId = "b10488-cuda13-arm64";
+    public const string X64RuntimeId = "b10655-cuda13-x64";
+    public const string Arm64RuntimeId = "b10655-cuda13-arm64";
 
     public static GitHubReleaseSource Source { get; } = new(
         "ggml-org/llama.cpp",
@@ -69,13 +69,13 @@ public static class LlamaRuntimeCatalog
                     new[]
                     {
                         RuntimeArtifact(
-                            "llama-b10488-cuda13-x64",
+                            "llama-b10655-cuda13-x64",
                             ArtifactRole.RuntimeBinary,
-                            "llama-b10488-bin-win-cuda-13.3-x64.zip",
-                            146_824_581,
-                            "f4ea53c2e7f3d295cb9fd092515d50af4969266b4cdae01f03a1cbaa8b4d9af0"),
+                            "llama-b10655-bin-win-cuda-13.3-x64.zip",
+                            146_478_045,
+                            "be61636141327b3ca4d437c17489fd69964838a31a5fe3e97400f0dcd9f669dc"),
                         RuntimeArtifact(
-                            "cudart-b10488-cuda13-x64",
+                            "cudart-b10655-cuda13-x64",
                             ArtifactRole.RuntimeDependency,
                             "cudart-llama-bin-win-cuda-13.3-x64.zip",
                             390_970_417,
@@ -89,13 +89,13 @@ public static class LlamaRuntimeCatalog
                     new[]
                     {
                         RuntimeArtifact(
-                            "llama-b10488-cuda13-arm64",
+                            "llama-b10655-cuda13-arm64",
                             ArtifactRole.RuntimeBinary,
-                            "llama-b10488-bin-win-cuda-13.4-arm64.zip",
-                            140_379_054,
-                            "75554d62f4af8f4150d3b4b0cca7df62d44105e98fb7cd92ab2d177e382b441d"),
+                            "llama-b10655-bin-win-cuda-13.4-arm64.zip",
+                            140_055_278,
+                            "567e61b4129e0d5b0580e5d3ea86b82ab5b6bee745ee02f69b58af799b49a582"),
                         RuntimeArtifact(
-                            "cudart-b10488-cuda13-arm64",
+                            "cudart-b10655-cuda13-arm64",
                             ArtifactRole.RuntimeDependency,
                             "cudart-llama-bin-win-cuda-13.4-arm64.zip",
                             153_318_797,

--- a/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
+++ b/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
@@ -340,46 +340,44 @@ public sealed class LocalAiPortLifecycleTests
         return arguments[index + 1];
     }
 
-    private static LocalAiInstallManifest ValidManifest() => new()
+    private static LocalAiInstallManifest ValidManifest()
     {
-        EngineVersion = "b10488",
-        Architecture = "arm64",
-        RuntimeId = "b10488-cuda13-arm64",
-        ModelCatalogId = "qwen3.6-35b-a3b-mtp-q4-k-m",
-        SelectedGpuId = "GPU-01234567-89ab-cdef-0123-456789abcdef",
-        ExecutablePath = Path.Combine("engines", "llama-b10488", "llama-server.exe"),
-        RuntimeAssets =
-        [
-            new LocalAiAssetReceipt
-            {
-                FileName = "llama-b10488-bin-win-cuda-13.4-arm64.zip",
-                SourceUrl = "https://github.com/ggml-org/llama.cpp/releases/download/b10488/llama-b10488-bin-win-cuda-13.4-arm64.zip",
-                SizeBytes = 140_379_054,
-                Sha256 = "75554d62f4af8f4150d3b4b0cca7df62d44105e98fb7cd92ab2d177e382b441d",
-            },
-            new LocalAiAssetReceipt
-            {
-                FileName = "cudart-llama-bin-win-cuda-13.4-arm64.zip",
-                SourceUrl = "https://github.com/ggml-org/llama.cpp/releases/download/b10488/cudart-llama-bin-win-cuda-13.4-arm64.zip",
-                SizeBytes = 153_318_797,
-                Sha256 = "5a40dc7c5fa3d0a80ceeba4f16f9e8d25d87bcf1399c9233588953c43436c33c",
-            },
-        ],
-        ModelPath = Path.Combine("models", "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf"),
-        ModelId = "unsloth/Qwen3.6-35B-A3B-MTP-GGUF@5bc3e238d916f48a861bac2f8a1990a0e9b7e98d",
-        ModelAlias = "qwen3.6-35b-a3b-mtp-q4-k-m",
-        ModelAsset = new LocalAiAssetReceipt
+        LlamaRuntimeVariant runtime = LlamaRuntimeCatalog.Find(
+            System.Runtime.InteropServices.Architecture.Arm64)!;
+        return new LocalAiInstallManifest
         {
-            FileName = "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
-            SourceUrl = "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-MTP-GGUF/resolve/5bc3e238d916f48a861bac2f8a1990a0e9b7e98d/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf?download=true",
-            SizeBytes = 22_663_387_424,
-            Sha256 = "0b21525e972670ed59e1812e170b27c26355381f0656ecc4e25617ece7dac58b",
-        },
-        RequestedPort = 0,
-        Endpoint = null,
-        ContextLength = 262_144,
-        InstalledAtUtc = DateTimeOffset.Parse("2026-08-18T12:00:00Z"),
-    };
+            EngineVersion = LlamaRuntimeCatalog.ReleaseTag,
+            Architecture = "arm64",
+            RuntimeId = runtime.Id,
+            ModelCatalogId = "qwen3.6-35b-a3b-mtp-q4-k-m",
+            SelectedGpuId = "GPU-01234567-89ab-cdef-0123-456789abcdef",
+            ExecutablePath = Path.Combine(
+                "engines",
+                $"llama-{LlamaRuntimeCatalog.ReleaseTag}",
+                LlamaRuntimeCatalog.ServerExecutableName),
+            RuntimeAssets = runtime.Artifacts.Select(artifact => new LocalAiAssetReceipt
+            {
+                FileName = Path.GetFileName(artifact.RelativePath),
+                SourceUrl = artifact.DownloadUri.AbsoluteUri,
+                SizeBytes = artifact.SizeBytes,
+                Sha256 = artifact.Sha256.Value,
+            }).ToImmutableArray(),
+            ModelPath = Path.Combine("models", "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf"),
+            ModelId = "unsloth/Qwen3.6-35B-A3B-MTP-GGUF@5bc3e238d916f48a861bac2f8a1990a0e9b7e98d",
+            ModelAlias = "qwen3.6-35b-a3b-mtp-q4-k-m",
+            ModelAsset = new LocalAiAssetReceipt
+            {
+                FileName = "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
+                SourceUrl = "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-MTP-GGUF/resolve/5bc3e238d916f48a861bac2f8a1990a0e9b7e98d/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf?download=true",
+                SizeBytes = 22_663_387_424,
+                Sha256 = "0b21525e972670ed59e1812e170b27c26355381f0656ecc4e25617ece7dac58b",
+            },
+            RequestedPort = 0,
+            Endpoint = null,
+            ContextLength = 262_144,
+            InstalledAtUtc = DateTimeOffset.Parse("2026-08-18T12:00:00Z"),
+        };
+    }
 
     private sealed class FakePlatform : ILlamaServerRuntimePlatform
     {


### PR DESCRIPTION
## Summary

Bumps the pinned llama-server runtime from `b10488` to `b10655` (`ggml-org/llama.cpp` commit `cb300598d`) and updates the pinned SHA-256 hashes/sizes for the x64 and arm64 CUDA runtime binaries. The `cudart` dependency archives are byte-identical between the two releases, so their hashes are unchanged.

## Motivation

Closes/addresses #1242: on the RTX Spark N1X (Blackwell, sm_121), `b10488` crashes with a fatal CUDA error (`cudaErrorSharedObjectInitFailed`) inside the flash-attention kernel's shared-memory setup during model warm-up. This surfaces during setup as `verify-local-ai-inference` failing with HTTP 500.

I reproduced the crash manually by running `llama-server.exe` directly with the same flags/model as the failing setup run, against both b10488 (crashes, confirming the report) and b10655 (does not crash — loading completes and a real chat-completion round-trips successfully). Full details and logs are in the issue and its comment thread.

Note: at the full `--ctx-size 262144` used in the original failing run, b10655 now gets further in loading but hits an unrelated CUDA OOM allocating the speculative/MTP draft buffers — plausibly related to the GPU-capacity/DXGI-shared-memory misdetection already being addressed elsewhere in this repo (`ba487943`, `05994b93`). That's a separate follow-up, not blocking this bump — it's an improvement either way, and worth re-checking against whatever context size the app's own capacity planner actually selects on this hardware.

## Changes

- `LlamaRuntimeCatalog`: `ReleaseTag` → `b10655`, `ReleaseCommitSha` → `cb300598d5f90189cb69d2702f4930aaf99d32a2`, runtime ids, artifact filenames/sizes/hashes for both x64 (CUDA 13.3) and arm64 (CUDA 13.4) variants.
- `LlamaRuntimeInstaller.ValidateVersionOutput`: was checking for the hardcoded literal `"build 10488"` instead of deriving it from `LlamaRuntimeCatalog.ReleaseTag`. Left as-is, this bump would have made every install permanently fail capability verification (the installed binary reports `build 10655`, which would never match the hardcoded check). Now derives the expected string from the catalog constant so future bumps don't hit the same trap.

## Testing

- `dotnet build` on `OpenClaw.SetupEngine` (which pulls in `OpenClaw.Shared`/`OpenClaw.Connection`): clean, 0 warnings/errors.
- `dotnet test tests/OpenClaw.Shared.Tests` (`LocalInferenceQualificationTests`): 21/21 passed.
- `dotnet test tests/OpenClaw.SetupEngine.Tests` (full suite): 998/998 passed.
- Manually verified all four new pinned artifacts against the actual `ggml-org/llama.cpp` b10655 release assets (downloaded fresh, hashed locally, cross-checked sizes against the GitHub release API).
- Manually ran the extracted b10655 `llama-server.exe` + this model end-to-end (outside the app) and confirmed a successful `/v1/chat/completions` response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
