### PR TITLE
fix(local-ai): model setup unavailable after install

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Pages/LocalAiPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/LocalAiPage.xaml
@@ -85,6 +85,16 @@
                     <Button x:Name="RetrySetupButton" x:Uid="LocalAiPage_RetrySetupButton"
                             Content="Retry setup or download" Click="OnRetrySetup" HorizontalAlignment="Left"
                             AutomationProperties.AutomationId="LocalAiRetrySetup"/>
+                    <StackPanel x:Name="ChangeModelPanel" Spacing="8" Visibility="Collapsed">
+                        <TextBlock x:Uid="LocalAiPage_ChangeModelDescription"
+                                  Text="Opens setup to choose another model. Replacing the existing Local Gateway still requires confirmation."
+                                  Style="{StaticResource CaptionTextBlockStyle}"
+                                  Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                  TextWrapping="Wrap"/>
+                        <Button x:Name="ChangeModelButton" x:Uid="LocalAiPage_ChangeModelButton"
+                               Content="Change model" Click="OnChangeModel" HorizontalAlignment="Left"
+                               AutomationProperties.AutomationId="LocalAiChangeModel"/>
+                    </StackPanel>
                 </StackPanel>
             </Border>
 

--- a/src/OpenClaw.Tray.WinUI/Pages/LocalAiPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/LocalAiPage.xaml.cs
@@ -93,6 +93,8 @@ public sealed partial class LocalAiPage : Page
         OpenLogsButton.IsEnabled = _viewModel.CanOpenLogs;
         RetrySetupButton.IsEnabled = _viewModel.CanRetrySetup;
         RetrySetupButton.Visibility = _viewModel.CanRetrySetup ? Visibility.Visible : Visibility.Collapsed;
+        ChangeModelButton.IsEnabled = _viewModel.CanChangeModel;
+        ChangeModelPanel.Visibility = _viewModel.HasInstalledModel ? Visibility.Visible : Visibility.Collapsed;
         RepairConnectionButton.IsEnabled = _viewModel.CanRepairConnection;
         OpenChatButton.IsEnabled = _viewModel.CanOpenChat;
     }
@@ -102,6 +104,7 @@ public sealed partial class LocalAiPage : Page
     private void OnRestart(object sender, RoutedEventArgs e) => RunAction(() => _viewModel?.RestartAsync() ?? Task.FromResult(false), nameof(OnRestart));
     private void OnOpenLogs(object sender, RoutedEventArgs e) => _viewModel?.OpenLogs();
     private void OnRetrySetup(object sender, RoutedEventArgs e) => _viewModel?.RetrySetup();
+    private void OnChangeModel(object sender, RoutedEventArgs e) => _viewModel?.ChangeModel();
     private void OnRepairConnection(object sender, RoutedEventArgs e) => _viewModel?.RepairConnection();
     private void OnOpenChat(object sender, RoutedEventArgs e) => _viewModel?.OpenChat();
     private static void RunAction(Func<Task<bool>> action, string source) =>

--- a/src/OpenClaw.Tray.WinUI/Presentation/LocalAiPageViewModel.cs
+++ b/src/OpenClaw.Tray.WinUI/Presentation/LocalAiPageViewModel.cs
@@ -119,6 +119,9 @@ internal sealed class LocalAiPageViewModel : INavigationAware, IDisposable, INot
     public bool CanOpenLogs => !IsBusy && HasManagedInstall;
     public bool CanRetrySetup => !IsBusy && ModelState is
         LocalAiModelPresentationState.NotInstalled or LocalAiModelPresentationState.Unknown;
+    public bool HasInstalledModel => ModelState is
+        LocalAiModelPresentationState.Verified or LocalAiModelPresentationState.Loaded;
+    public bool CanChangeModel => !IsBusy && HasInstalledModel;
     public bool CanRepairConnection => !IsBusy && GatewayState is not
         (LocalAiGatewayPresentationState.Connected or LocalAiGatewayPresentationState.Connecting);
     public bool CanOpenChat => !IsBusy &&
@@ -163,6 +166,7 @@ internal sealed class LocalAiPageViewModel : INavigationAware, IDisposable, INot
     public Task<bool> RestartAsync() => RunRuntimeActionAsync(CanRestart, _runtime.RestartAsync);
     public bool OpenLogs() => RunCommand(CanOpenLogs, _appCommands.OpenLocalAiLogs);
     public bool RetrySetup() => RunCommand(CanRetrySetup, _appCommands.ShowOnboarding);
+    public bool ChangeModel() => RunCommand(CanChangeModel, _appCommands.ShowOnboarding);
     public bool RepairConnection() => RunCommand(CanRepairConnection, _appCommands.Reconnect);
     public bool OpenChat() => RunCommand(CanOpenChat, _appCommands.ShowChat);
 

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -7079,6 +7079,8 @@ Make sure the gateway is running.</value>
   <data name="LocalAiPage_OpenLogsButton.Content" xml:space="preserve"><value>Open logs</value></data>
   <data name="LocalAiPage_ModelHeading.Text" xml:space="preserve"><value>Model</value></data>
   <data name="LocalAiPage_RetrySetupButton.Content" xml:space="preserve"><value>Retry setup or download</value></data>
+  <data name="LocalAiPage_ChangeModelDescription.Text" xml:space="preserve"><value>Opens setup to choose another model. Replacing the existing Local Gateway still requires confirmation.</value></data>
+  <data name="LocalAiPage_ChangeModelButton.Content" xml:space="preserve"><value>Change model</value></data>
   <data name="LocalAiPage_GatewayHeading.Text" xml:space="preserve"><value>Gateway connection</value></data>
   <data name="LocalAiPage_RepairConnectionButton.Content" xml:space="preserve"><value>Repair connection</value></data>
   <data name="LocalAiPage_OpenChatButton.Content" xml:space="preserve"><value>Open chat</value></data>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -7015,6 +7015,8 @@ Le binaire wxc-exec est introuvable. {1} S'il s'agit d'une build développeur, c
   <data name="LocalAiPage_OpenLogsButton.Content" xml:space="preserve"><value>Ouvrir les journaux</value></data>
   <data name="LocalAiPage_ModelHeading.Text" xml:space="preserve"><value>Modèle</value></data>
   <data name="LocalAiPage_RetrySetupButton.Content" xml:space="preserve"><value>Réessayer la configuration ou le téléchargement</value></data>
+  <data name="LocalAiPage_ChangeModelDescription.Text" xml:space="preserve"><value>Ouvre la configuration pour choisir un autre modèle. Le remplacement de la passerelle locale existante nécessite toujours une confirmation.</value></data>
+  <data name="LocalAiPage_ChangeModelButton.Content" xml:space="preserve"><value>Changer de modèle</value></data>
   <data name="LocalAiPage_GatewayHeading.Text" xml:space="preserve"><value>Connexion à la passerelle</value></data>
   <data name="LocalAiPage_RepairConnectionButton.Content" xml:space="preserve"><value>Réparer la connexion</value></data>
   <data name="LocalAiPage_OpenChatButton.Content" xml:space="preserve"><value>Ouvrir la discussion</value></data>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -7016,6 +7016,8 @@ Het binaire bestand wxc-exec is niet gevonden. {1} Als dit een ontwikkelaarsbuil
   <data name="LocalAiPage_OpenLogsButton.Content" xml:space="preserve"><value>Logboeken openen</value></data>
   <data name="LocalAiPage_ModelHeading.Text" xml:space="preserve"><value>AI-model</value></data>
   <data name="LocalAiPage_RetrySetupButton.Content" xml:space="preserve"><value>Installatie of download opnieuw proberen</value></data>
+  <data name="LocalAiPage_ChangeModelDescription.Text" xml:space="preserve"><value>Opent de installatie om een ander model te kiezen. Voor het vervangen van de bestaande lokale gateway blijft bevestiging vereist.</value></data>
+  <data name="LocalAiPage_ChangeModelButton.Content" xml:space="preserve"><value>Model wijzigen</value></data>
   <data name="LocalAiPage_GatewayHeading.Text" xml:space="preserve"><value>Gatewayverbinding</value></data>
   <data name="LocalAiPage_RepairConnectionButton.Content" xml:space="preserve"><value>Verbinding herstellen</value></data>
   <data name="LocalAiPage_OpenChatButton.Content" xml:space="preserve"><value>Chat openen</value></data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -7015,6 +7015,8 @@
   <data name="LocalAiPage_OpenLogsButton.Content" xml:space="preserve"><value>打开日志</value></data>
   <data name="LocalAiPage_ModelHeading.Text" xml:space="preserve"><value>模型</value></data>
   <data name="LocalAiPage_RetrySetupButton.Content" xml:space="preserve"><value>重试设置或下载</value></data>
+  <data name="LocalAiPage_ChangeModelDescription.Text" xml:space="preserve"><value>打开设置以选择其他模型。替换现有本地网关仍需确认。</value></data>
+  <data name="LocalAiPage_ChangeModelButton.Content" xml:space="preserve"><value>更换模型</value></data>
   <data name="LocalAiPage_GatewayHeading.Text" xml:space="preserve"><value>网关连接</value></data>
   <data name="LocalAiPage_RepairConnectionButton.Content" xml:space="preserve"><value>修复连接</value></data>
   <data name="LocalAiPage_OpenChatButton.Content" xml:space="preserve"><value>打开聊天</value></data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -7015,6 +7015,8 @@
   <data name="LocalAiPage_OpenLogsButton.Content" xml:space="preserve"><value>開啟記錄</value></data>
   <data name="LocalAiPage_ModelHeading.Text" xml:space="preserve"><value>模型</value></data>
   <data name="LocalAiPage_RetrySetupButton.Content" xml:space="preserve"><value>重試設定或下載</value></data>
+  <data name="LocalAiPage_ChangeModelDescription.Text" xml:space="preserve"><value>開啟設定以選擇其他模型。取代現有本機閘道仍需確認。</value></data>
+  <data name="LocalAiPage_ChangeModelButton.Content" xml:space="preserve"><value>變更模型</value></data>
   <data name="LocalAiPage_GatewayHeading.Text" xml:space="preserve"><value>閘道連線</value></data>
   <data name="LocalAiPage_RepairConnectionButton.Content" xml:space="preserve"><value>修復連線</value></data>
   <data name="LocalAiPage_OpenChatButton.Content" xml:space="preserve"><value>開啟聊天</value></data>

--- a/tests/OpenClaw.Tray.Tests/Presentation/LocalAiPageViewModelTests.cs
+++ b/tests/OpenClaw.Tray.Tests/Presentation/LocalAiPageViewModelTests.cs
@@ -1,0 +1,181 @@
+using OpenClaw.Connection.LocalAi;
+using OpenClawTray.Presentation;
+
+namespace OpenClaw.Tray.Tests.Presentation;
+
+public sealed class LocalAiPageViewModelTests
+{
+    [Theory]
+    [InlineData(LocalAiModelAvailabilityState.Verified)]
+    [InlineData(LocalAiModelAvailabilityState.Loaded)]
+    public void InstalledModel_OffersChangeModelThroughExistingSetupRoute(
+        LocalAiModelAvailabilityState modelState)
+    {
+        using var harness = new LocalAiHarness(modelState);
+
+        Assert.True(harness.ViewModel.CanChangeModel);
+        Assert.True(harness.ViewModel.HasInstalledModel);
+        Assert.False(harness.ViewModel.CanRetrySetup);
+
+        Assert.True(harness.ViewModel.ChangeModel());
+
+        Assert.Equal(0, harness.Commands.ShowGatewayWizardCount);
+        Assert.Equal(1, harness.Commands.ShowOnboardingCount);
+    }
+
+    [Theory]
+    [InlineData(LocalAiModelAvailabilityState.Unknown)]
+    [InlineData(LocalAiModelAvailabilityState.NotInstalled)]
+    public void MissingModel_KeepsRetrySetupAndDoesNotOfferChangeModel(
+        LocalAiModelAvailabilityState modelState)
+    {
+        using var harness = new LocalAiHarness(modelState);
+
+        Assert.False(harness.ViewModel.CanChangeModel);
+        Assert.False(harness.ViewModel.HasInstalledModel);
+        Assert.True(harness.ViewModel.CanRetrySetup);
+
+        Assert.False(harness.ViewModel.ChangeModel());
+        Assert.True(harness.ViewModel.RetrySetup());
+
+        Assert.Equal(0, harness.Commands.ShowGatewayWizardCount);
+        Assert.Equal(1, harness.Commands.ShowOnboardingCount);
+    }
+
+    [Fact]
+    public async Task InstalledModel_RemainsVisibleButCannotOpenSetupDuringRuntimeAction()
+    {
+        using var harness = new LocalAiHarness(
+            LocalAiModelAvailabilityState.Verified,
+            LocalAiRuntimeState.Stopped);
+        harness.Runtime.BlockStart();
+
+        Task<bool> startTask = harness.ViewModel.StartAsync();
+
+        Assert.True(harness.ViewModel.HasInstalledModel);
+        Assert.False(harness.ViewModel.CanChangeModel);
+        Assert.False(harness.ViewModel.ChangeModel());
+        Assert.Equal(0, harness.Commands.ShowOnboardingCount);
+
+        harness.Runtime.CompleteStart();
+        Assert.True(await startTask);
+    }
+
+    [Fact]
+    public void LocalAiPage_ChangeModelActionIsLocalizedAccessibleAndWired()
+    {
+        string root = TestRepositoryPaths.GetRepositoryRoot();
+        string pageDirectory = Path.Combine(root, "src", "OpenClaw.Tray.WinUI", "Pages");
+        string xaml = File.ReadAllText(Path.Combine(pageDirectory, "LocalAiPage.xaml"));
+        string codeBehind = File.ReadAllText(Path.Combine(pageDirectory, "LocalAiPage.xaml.cs"));
+
+        Assert.Contains("x:Uid=\"LocalAiPage_ChangeModelButton\"", xaml);
+        Assert.Contains("x:Uid=\"LocalAiPage_ChangeModelDescription\"", xaml);
+        Assert.Contains("AutomationProperties.AutomationId=\"LocalAiChangeModel\"", xaml);
+        Assert.Contains("Click=\"OnChangeModel\"", xaml);
+        Assert.Contains("_viewModel?.ChangeModel()", codeBehind);
+    }
+
+    private sealed class LocalAiHarness : IDisposable
+    {
+        private readonly FakeLocalAiRuntime _runtime;
+        private readonly PermissionsPageRuntimeSource _gatewaySource;
+        private readonly RecordingUiDispatcher _dispatcher;
+
+        public LocalAiHarness(
+            LocalAiModelAvailabilityState modelState,
+            LocalAiRuntimeState runtimeState = LocalAiRuntimeState.Healthy)
+        {
+            _runtime = new FakeLocalAiRuntime(CreateSnapshot(modelState, runtimeState));
+            var gatewayHost = new FakePermissionsPageRuntimeHost();
+            _gatewaySource = new PermissionsPageRuntimeSource(gatewayHost);
+            Commands = new FakeAppCommands();
+            _dispatcher = new RecordingUiDispatcher();
+            ViewModel = new LocalAiPageViewModel(_runtime, _gatewaySource, Commands, _dispatcher);
+        }
+
+        public FakeAppCommands Commands { get; }
+        public FakeLocalAiRuntime Runtime => _runtime;
+        public LocalAiPageViewModel ViewModel { get; }
+
+        public void Dispose()
+        {
+            ViewModel.Dispose();
+            Commands.Dispose();
+            _gatewaySource.Dispose();
+            _dispatcher.Dispose();
+            _runtime.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        }
+
+        private static LocalAiRuntimeSnapshot CreateSnapshot(
+            LocalAiModelAvailabilityState modelState,
+            LocalAiRuntimeState runtimeState)
+        {
+            DateTimeOffset now = DateTimeOffset.UtcNow;
+            LocalAiModelEvidence evidence = modelState switch
+            {
+                LocalAiModelAvailabilityState.Verified => new(
+                    modelState,
+                    now,
+                    new string('a', 64),
+                    1024),
+                LocalAiModelAvailabilityState.Loaded => new(
+                    modelState,
+                    now,
+                    new string('a', 64),
+                    1024,
+                    "test-model"),
+                LocalAiModelAvailabilityState.NotInstalled => LocalAiModelEvidence.NotInstalled(now),
+                _ => LocalAiModelEvidence.Unknown(now),
+            };
+
+            return new LocalAiRuntimeSnapshot(
+                modelState is LocalAiModelAvailabilityState.Verified or LocalAiModelAvailabilityState.Loaded
+                    ? runtimeState
+                    : LocalAiRuntimeState.NotInstalled,
+                modelState is LocalAiModelAvailabilityState.Verified or LocalAiModelAvailabilityState.Loaded
+                    ? LocalAiOwnership.CompanionManaged
+                    : LocalAiOwnership.None,
+                new Uri("http://127.0.0.1:11983"),
+                "test",
+                "test-model",
+                evidence,
+                null,
+                null,
+                null,
+                now);
+        }
+    }
+
+    internal sealed class FakeLocalAiRuntime(LocalAiRuntimeSnapshot snapshot) : ILocalAiRuntime
+    {
+        private TaskCompletionSource<LocalAiRuntimeSnapshot>? _startCompletion;
+
+        public LocalAiRuntimeSnapshot Snapshot { get; } = snapshot;
+
+        public event EventHandler<LocalAiRuntimeSnapshotChangedEventArgs>? StateChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public void BlockStart() =>
+            _startCompletion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void CompleteStart() => _startCompletion?.TrySetResult(Snapshot);
+
+        public Task<LocalAiRuntimeSnapshot> EnsureStartedAsync(CancellationToken cancellationToken = default) =>
+            _startCompletion?.Task ?? Task.FromResult(Snapshot);
+
+        public Task<LocalAiRuntimeSnapshot> StopAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(Snapshot);
+
+        public Task<LocalAiRuntimeSnapshot> RestartAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(Snapshot);
+
+        public Task<LocalAiRuntimeSnapshot> RefreshAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(Snapshot);
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/Presentation/PresentationTestDoubles.cs
+++ b/tests/OpenClaw.Tray.Tests/Presentation/PresentationTestDoubles.cs
@@ -74,8 +74,8 @@ internal sealed class FakeAppCommands : IAppCommands, IDisposable
     public void ShowVoiceOverlay() { }
     public void ShowChat() { }
     public void CheckForUpdates() { }
-    public void ShowOnboarding() { }
-    public void ShowGatewayWizard() { }
+    public void ShowOnboarding() => ShowOnboardingCount++;
+    public void ShowGatewayWizard() => ShowGatewayWizardCount++;
     public void ShowConnectionStatus() { }
     public void NotifySettingsSaved()
     {
@@ -95,6 +95,8 @@ internal sealed class FakeAppCommands : IAppCommands, IDisposable
     public SettingsWriteOrigin? LastAutoStartOrigin { get; private set; }
     public bool? AutoStartApplied { get; private set; }
     public int AutoStartApplyCount { get; private set; }
+    public int ShowOnboardingCount { get; private set; }
+    public int ShowGatewayWizardCount { get; private set; }
 
     /// <summary>Result returned by <see cref="ApplyAutoStart"/> so tests can simulate OS-write failure.</summary>
     public bool AutoStartResult { get; set; } = true;


### PR DESCRIPTION
Closes #1243

## What Problem This Solves

Fixes an issue where users with an installed Local AI model could stop or restart it, but could not reopen model setup from the Local AI page.

## Why This Change Was Made

Adds one localized **Change model** action for verified or loaded models. It reuses the existing full onboarding route, so setup remains the single configuration implementation and existing Local Gateway replacement confirmation stays in force. The action remains visible for installed models and is disabled while a Local AI runtime operation is active.

## User Impact

Users can reopen Local AI model setup directly from the model card without searching through Settings. The page explains that replacing an existing Local Gateway still requires confirmation.

## Evidence

Focused presentation tests cover verified, loaded, missing, unknown, and runtime-busy states. Current-head live UI diagnostics are recorded under **Real Behavior Proof**.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs or instructions
- [x] Tests or validation
- [ ] Security hardening
- [ ] Chore or infrastructure

## Scope

- [x] Tray or WinUI UX
- [ ] Windows node capability
- [ ] Local MCP or `winnode`
- [ ] Gateway, connection, or pairing
- [x] Setup or onboarding
- [ ] Permissions, privacy, or security
- [x] Tests, CI, or docs

## Validation

- `./build.ps1`: passed, all 5 projects built
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore`: passed, 3,819 passed, 32 skipped
- `dotnet test ./tests/OpenClaw.SetupEngine.Tests/OpenClaw.SetupEngine.Tests.csproj --no-restore`: passed, 1,010 passed
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore --filter "FullyQualifiedName~LocalAiPageViewModelTests|FullyQualifiedName~LocalizationValidationTests"`: passed, 21 passed
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore --blame-hang --blame-hang-timeout 5m`: blocked after 2,281 tests passed. The test host repeatedly hangs in the pre-existing `BrowserProxyEndpointScopingTests.Diagnostics_NoOverride_TunnelWithoutBrowserProxyForward_DoesNotProbeTunnelLocalPlusTwo` native listener inspection. The same test hangs when run alone. Crabbox was unavailable on this controller, so a remote full Tray run could not replace the blocked local run.
- `python .agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output`: clean after accepting and fixing its runtime-busy concurrency finding

## Real Behavior Proof

- Environment tested: Windows 11, isolated OpenClaw Dev identity with synthetic one-byte installed-model receipt and isolated roaming/local data
- PR head or commit tested: `7769ea95`
- Exact steps or command run: built with `./build.ps1 -DevBuild`, launched with `./run-app-local.ps1 -NoBuild -Dev -DataDir <isolated> -AllowNonMain`, opened `openclaw-dev://hub/local-ai`, closed the startup setup window, then invoked **Change model**
- Evidence after fix: live WinUI accessibility diagnostics showed `Downloaded and verified`, model `proof-model`, the safety copy `Replacing the existing Local Gateway still requires confirmation`, and enabled button `Change model` with automation ID `LocalAiChangeModel`
- Observed result: invoking `LocalAiChangeModel` created a new `OpenClaw Setup (Dev)` window at `Security notice`, `Step 1 of 6`, with an enabled `Continue` button. This proves the Local AI action uses the supported full setup route rather than a second configuration path.
- Screenshot or artifact links verified? N/A. The background compositor returned a black capture, so copied live UI accessibility diagnostics are used instead.
- Not verified or blocked: full Tray suite blocked by the unrelated native listener-inspection hang described above

## Security Impact

- New permissions or capabilities? No
- Secrets or tokens handling changed? No
- New or changed network calls? No
- Command or tool execution surface changed? No
- Data access scope changed? No
- If any answer is `Yes`, explain the risk and mitigation: N/A

## Compatibility and Migration

- Backward compatible? Yes
- Config or environment changes? No
- Migration needed? No
- If yes, list the exact upgrade steps: N/A

## Review Conversations

- [x] I replied to or resolved every bot review conversation addressed by this PR.
- [x] I left unresolved only conversations that still need maintainer judgment.

Rubber-duck review identified the initial wrong-route implementation and it was corrected to reuse `ShowOnboarding`. Autoreview identified the runtime-busy concurrency edge and it was corrected while preserving installed-state visibility. Final autoreview reported no accepted or actionable findings.