### PR TITLE
fix(chat): restore default reasoning after off

### DIFF
--- a/src/OpenClaw.Chat/ChatModels.cs
+++ b/src/OpenClaw.Chat/ChatModels.cs
@@ -362,6 +362,12 @@ public interface IChatDataProvider : IAsyncDisposable
     /// </summary>
     Task ClearModelAsync(string threadId, CancellationToken cancellationToken = default) => Task.CompletedTask;
     Task SetThinkingLevelAsync(string threadId, string thinkingLevel, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Clears the session's explicit thinking-level override so the gateway can
+    /// restore its provider default. Distinct from <see cref="SetThinkingLevelAsync"/>
+    /// because the gateway models this as an explicit null.
+    /// </summary>
+    Task ClearThinkingLevelAsync(string threadId, CancellationToken cancellationToken = default) => Task.CompletedTask;
     Task SetPermissionModeAsync(string threadId, bool allowAll, CancellationToken cancellationToken = default);
     Task RespondToPermissionAsync(string threadId, string requestId, string action, CancellationToken cancellationToken = default);
     Task RespondToPermissionAsync(string threadId, string requestId, bool allow, CancellationToken cancellationToken = default) =>

--- a/src/OpenClaw.Tray.WinUI/Chat/ChatComposerController.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ChatComposerController.cs
@@ -318,6 +318,16 @@ internal sealed partial class ChatComposerController : IDisposable
         FireAndForget(_ => _port.SetThinkingLevelAsync(threadId, level, _lifetimeToken));
     }
 
+    public void ClearThinkingLevel()
+    {
+        if (_disposed)
+            return;
+        if (_vm.Inputs?.CurrentThread.Id is not { } threadId)
+            return;
+
+        FireAndForget(_ => _port.ClearThinkingLevelAsync(threadId, _lifetimeToken));
+    }
+
     /// <summary>Requests a command-catalog refresh. Assigns a monotonic operation ID
     /// and threads the shared lifetime token so the outstanding request is actually
     /// canceled on dispose. Refreshed results flow back only through the root's

--- a/src/OpenClaw.Tray.WinUI/Chat/ChatComposerRuntimePort.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ChatComposerRuntimePort.cs
@@ -89,6 +89,13 @@ internal sealed class ChatComposerRuntimePort(IChatDataProvider provider) : ICha
         catch (Exception ex) { System.Diagnostics.Trace.WriteLine($"[chat] operation failed: {ex}"); }
     }
 
+    public async Task ClearThinkingLevelAsync(string threadId, CancellationToken cancellationToken)
+    {
+        try { await provider.ClearThinkingLevelAsync(threadId, cancellationToken).ConfigureAwait(true); }
+        catch (OperationCanceledException) { }
+        catch (Exception ex) { System.Diagnostics.Trace.WriteLine($"[chat] operation failed: {ex}"); }
+    }
+
     public async Task EnsureCommandCatalogAsync(CancellationToken cancellationToken)
     {
         try { await provider.EnsureCommandCatalogAsync(cancellationToken).ConfigureAwait(true); }

--- a/src/OpenClaw.Tray.WinUI/Chat/ChatConversationState.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ChatConversationState.cs
@@ -392,22 +392,22 @@ internal sealed class ChatConversationState
         }
     }
 
-    internal ChatModelPatchLease BeginModelPatch(string threadId)
+    internal ChatSessionOptionPatchLease BeginSessionOptionPatch(string threadId)
     {
         lock (_gate)
-            return _presentation.BeginModelPatch(threadId);
+            return _presentation.BeginSessionOptionPatch(threadId);
     }
 
-    internal void CompleteModelPatch(ChatModelPatchLease lease, Exception? error)
+    internal void CompleteSessionOptionPatch(ChatSessionOptionPatchLease lease, Exception? error)
     {
         lock (_gate)
-            _presentation.CompleteModelPatch(lease, error);
+            _presentation.CompleteSessionOptionPatch(lease, error);
     }
 
-    internal Task? GetPendingModelPatch(string threadId)
+    internal Task? GetPendingSessionOptionPatch(string threadId)
     {
         lock (_gate)
-            return _presentation.GetPendingModelPatch(threadId);
+            return _presentation.GetPendingSessionOptionPatch(threadId);
     }
 
     internal bool TryBeginCommandCatalogFetch(out int epoch)

--- a/src/OpenClaw.Tray.WinUI/Chat/ChatPresentationState.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ChatPresentationState.cs
@@ -11,13 +11,13 @@ internal sealed record ChatUsageSnapshot(
     long ContextTokens);
 
 /// <summary>
-/// Owns session/model/catalog presentation inputs, serialized model patches,
+/// Owns session/model/catalog presentation inputs, serialized session-option patches,
 /// keyless diagnostics, and remembered chat selection. The root serializes
 /// every operation and supplies immutable timeline/queue snapshots.
 /// </summary>
 internal sealed class ChatPresentationState
 {
-    private readonly Dictionary<string, Task> _pendingModelPatches = new();
+    private readonly Dictionary<string, Task> _pendingSessionOptionPatches = new();
 
     private SessionInfo[] _sessions = [];
     private bool _sessionsListReceived;
@@ -150,17 +150,17 @@ internal sealed class ChatPresentationState
         _commandsFetchInFlight = false;
     }
 
-    internal ChatModelPatchLease BeginModelPatch(string threadId)
+    internal ChatSessionOptionPatchLease BeginSessionOptionPatch(string threadId)
     {
-        _pendingModelPatches.TryGetValue(threadId, out var previous);
+        _pendingSessionOptionPatches.TryGetValue(threadId, out var previous);
         var completion = new TaskCompletionSource(
             TaskCreationOptions.RunContinuationsAsynchronously);
-        _pendingModelPatches[threadId] = completion.Task;
+        _pendingSessionOptionPatches[threadId] = completion.Task;
         return new(threadId, previous, completion);
     }
 
-    internal void CompleteModelPatch(
-        ChatModelPatchLease lease,
+    internal void CompleteSessionOptionPatch(
+        ChatSessionOptionPatchLease lease,
         Exception? error)
     {
         if (error is null)
@@ -168,15 +168,15 @@ internal sealed class ChatPresentationState
         else
             lease.Completion.TrySetException(error);
 
-        if (_pendingModelPatches.TryGetValue(lease.ThreadId, out var current) &&
+        if (_pendingSessionOptionPatches.TryGetValue(lease.ThreadId, out var current) &&
             ReferenceEquals(current, lease.Completion.Task))
         {
-            _pendingModelPatches.Remove(lease.ThreadId);
+            _pendingSessionOptionPatches.Remove(lease.ThreadId);
         }
     }
 
-    internal Task? GetPendingModelPatch(string threadId) =>
-        _pendingModelPatches.TryGetValue(threadId, out var pending)
+    internal Task? GetPendingSessionOptionPatch(string threadId) =>
+        _pendingSessionOptionPatches.TryGetValue(threadId, out var pending)
             ? pending
             : null;
 

--- a/src/OpenClaw.Tray.WinUI/Chat/ChatRuntimeTransitions.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ChatRuntimeTransitions.cs
@@ -136,7 +136,7 @@ internal sealed record ChatSendPreparation(
     bool IsCurrent,
     ChatDataSnapshot? Snapshot);
 
-internal sealed record ChatModelPatchLease(
+internal sealed record ChatSessionOptionPatchLease(
     string ThreadId,
     Task? Previous,
     TaskCompletionSource Completion);

--- a/src/OpenClaw.Tray.WinUI/Chat/IChatComposerRuntimePort.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/IChatComposerRuntimePort.cs
@@ -37,5 +37,7 @@ internal interface IChatComposerRuntimePort
 
     Task SetThinkingLevelAsync(string threadId, string thinkingLevel, CancellationToken cancellationToken);
 
+    Task ClearThinkingLevelAsync(string threadId, CancellationToken cancellationToken);
+
     Task EnsureCommandCatalogAsync(CancellationToken cancellationToken);
 }

--- a/src/OpenClaw.Tray.WinUI/Chat/IChatGatewayBridge.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/IChatGatewayBridge.cs
@@ -79,6 +79,11 @@ public interface IChatGatewayBridge : IDisposable
     /// </summary>
     Task ClearSessionModelAsync(string sessionKey);
     Task PatchSessionThinkingLevelAsync(string sessionKey, string thinkingLevel);
+    /// <summary>
+    /// Clears the session's thinking-level override with an explicit JSON null,
+    /// restoring the gateway/provider default.
+    /// </summary>
+    Task ClearSessionThinkingLevelAsync(string sessionKey);
     Task<ChatHistoryInfo> RequestChatHistoryAsync(string? sessionKey);
     Task<AssistantMediaResolutionResult> ResolveAssistantMediaAsync(
         string sessionKey,
@@ -218,6 +223,9 @@ public sealed class GatewayClientChatBridge : IChatGatewayBridge
 
     public Task PatchSessionThinkingLevelAsync(string sessionKey, string thinkingLevel) =>
         _client.PatchSessionAsync(sessionKey, new SessionPatch { ThinkingLevel = thinkingLevel });
+
+    public Task ClearSessionThinkingLevelAsync(string sessionKey) =>
+        _client.PatchSessionAsync(sessionKey, new SessionPatch { ThinkingLevel = SessionPatch.Clear });
 
     public Task<CommandCatalog> ListCommandsAsync(CommandCatalogQuery? query = null) =>
         _client.ListCommandsAsync(query);

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
@@ -403,7 +403,7 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
 
         try
         {
-            await AwaitPendingModelPatchAsync(threadId, cancellationToken);
+            await AwaitPendingSessionOptionPatchAsync(threadId, cancellationToken);
             var preparation = _state.PrepareSendAttempt(
                 dispatch,
                 ProjectionContext());
@@ -761,7 +761,7 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         // string; a blank value here is a no-op rather than a clear. Use
         // ClearModelAsync to revert a session to the gateway default.
         if (string.IsNullOrWhiteSpace(model)) return;
-        await TrackModelPatchAsync(threadId, () => _bridge.PatchSessionModelAsync(threadId, model));
+        await TrackSessionOptionPatchAsync(threadId, () => _bridge.PatchSessionModelAsync(threadId, model));
     }
 
     public async Task ClearModelAsync(string threadId, CancellationToken cancellationToken = default)
@@ -769,12 +769,12 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         cancellationToken.ThrowIfCancellationRequested();
         // Tri-state clear: removes the session's model override (explicit null)
         // so it tracks the gateway/agent default again.
-        await TrackModelPatchAsync(threadId, () => _bridge.ClearSessionModelAsync(threadId));
+        await TrackSessionOptionPatchAsync(threadId, () => _bridge.ClearSessionModelAsync(threadId));
     }
 
-    private async Task TrackModelPatchAsync(string threadId, Func<Task> patchOperation)
+    private async Task TrackSessionOptionPatchAsync(string threadId, Func<Task> patchOperation)
     {
-        var lease = _state.BeginModelPatch(threadId);
+        var lease = _state.BeginSessionOptionPatch(threadId);
         Exception? failure = null;
         try
         {
@@ -783,7 +783,7 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
                 try { await lease.Previous; }
                 catch (Exception ex)
                 {
-                    Logger.Debug($"ChatDataProvider: continuing model patch after previous patch failed: {ex.Message}");
+                    Logger.Debug($"ChatDataProvider: continuing session option patch after previous patch failed: {ex.Message}");
                 }
             }
             await patchOperation();
@@ -795,20 +795,20 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         }
         finally
         {
-            _state.CompleteModelPatch(lease, failure);
+            _state.CompleteSessionOptionPatch(lease, failure);
         }
     }
 
-    private async Task AwaitPendingModelPatchAsync(string threadId, CancellationToken cancellationToken)
+    private async Task AwaitPendingSessionOptionPatchAsync(string threadId, CancellationToken cancellationToken)
     {
-        var pending = _state.GetPendingModelPatch(threadId);
+        var pending = _state.GetPendingSessionOptionPatch(threadId);
         if (pending is not null)
         {
             try { await pending.WaitAsync(cancellationToken); }
             catch (OperationCanceledException) { throw; }
             catch (Exception ex)
             {
-                Logger.Debug($"ChatDataProvider: continuing send after model patch failed: {ex.Message}");
+                Logger.Debug($"ChatDataProvider: continuing send after session option patch failed: {ex.Message}");
             }
         }
     }
@@ -816,7 +816,17 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
     public async Task SetThinkingLevelAsync(string threadId, string thinkingLevel, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        await _bridge.PatchSessionThinkingLevelAsync(threadId, thinkingLevel);
+        await TrackSessionOptionPatchAsync(
+            threadId,
+            () => _bridge.PatchSessionThinkingLevelAsync(threadId, thinkingLevel));
+    }
+
+    public async Task ClearThinkingLevelAsync(string threadId, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        await TrackSessionOptionPatchAsync(
+            threadId,
+            () => _bridge.ClearSessionThinkingLevelAsync(threadId));
     }
 
     public async Task EnsureCommandCatalogAsync(CancellationToken cancellationToken = default)

--- a/src/OpenClaw.Tray.WinUI/Chat/ReactorChatComposer.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ReactorChatComposer.cs
@@ -139,7 +139,8 @@ internal sealed class ReactorChatComposer : Component<ReactorChatComposerViewPro
                 .Select(model => new ChatModelChoice(model, model))
                 .ToArray();
         var selectableModels = modelChoices.Where(model => model.IsSelectable).ToArray();
-        var modelNames = new[] { Localized("Chat_Composer_Reasoning_Default", "Default") }
+        var defaultReasoningLabel = Localized("Chat_Composer_Reasoning_Default", "Default");
+        var modelNames = new[] { defaultReasoningLabel }
             .Concat(selectableModels.Select(ChatModelLabels.BuildMenuLabel))
             .ToArray();
         var modelIndex = string.IsNullOrWhiteSpace(inputs.CurrentThread.Model)
@@ -147,9 +148,12 @@ internal sealed class ReactorChatComposer : Component<ReactorChatComposerViewPro
             : Math.Max(0, Array.FindIndex(
                 selectableModels,
                 model => model.MatchesModel(inputs.CurrentThread.Model, inputs.CurrentThread.ModelProvider)) + 1);
-        var thinkingIndex = Math.Max(0, Array.IndexOf(
-            ThinkingLevels,
-            inputs.CurrentThread.ThinkingLevel ?? "medium"));
+        var thinkingIndex = string.IsNullOrWhiteSpace(inputs.CurrentThread.ThinkingLevel)
+            ? 0
+            : Math.Max(0, Array.IndexOf(ThinkingLevels, inputs.CurrentThread.ThinkingLevel) + 1);
+        var thinkingNames = new[] { defaultReasoningLabel }
+            .Concat(ThinkingLevels)
+            .ToArray();
         var actionLabel = inputs.TurnActive
             ? Localized("Chat_Composer_Tooltip_Stop", "Stop")
             : Localized("Chat_Composer_Tooltip_Send", "Send");
@@ -575,7 +579,7 @@ internal sealed class ReactorChatComposer : Component<ReactorChatComposerViewPro
                 .ToArray());
 
         var modelPickerLabel = modelIndex == 0
-            ? Localized("Chat_Composer_Reasoning_Default", "Default")
+            ? defaultReasoningLabel
             : selectableModels[modelIndex - 1].DisplayName;
         var modelPicker = MenuFlyout(
             PickerButton(
@@ -600,17 +604,23 @@ internal sealed class ReactorChatComposer : Component<ReactorChatComposerViewPro
 
         var reasoningPicker = MenuFlyout(
             PickerButton(
-                ThinkingLevels[thinkingIndex],
-                $"{Localized("Chat_Composer_Accessibility_Reasoning", "Reasoning")}: {ThinkingLevels[thinkingIndex]}",
+                thinkingNames[thinkingIndex],
+                $"{Localized("Chat_Composer_Accessibility_Reasoning", "Reasoning")}: {thinkingNames[thinkingIndex]}",
                 "ChatComposerReasoningPicker",
                 !inputs.MessageOptionsDisabled,
                 props.IsCompact ? 54 : 96),
-            ThinkingLevels
+            thinkingNames
                 .Select((level, index) => RadioMenuItem(
                     level,
                     "chat-thinking-level",
                     index == thinkingIndex,
-                    () => controller.SetThinkingLevel(level)))
+                    () =>
+                    {
+                        if (index == 0)
+                            controller.ClearThinkingLevel();
+                        else
+                            controller.SetThinkingLevel(ThinkingLevels[index - 1]);
+                    }))
                 .ToArray());
 
         var attachButton = IconButton(

--- a/tests/OpenClaw.Shared.Tests/GatewayProtocolModelsTests.cs
+++ b/tests/OpenClaw.Shared.Tests/GatewayProtocolModelsTests.cs
@@ -441,6 +441,7 @@ public class GatewayProtocolModelsTests
         var patch = new SessionPatch
         {
             Model = SessionPatch.Clear,
+            ThinkingLevel = SessionPatch.Clear,
             ExecNode = SessionPatch.Clear,
             FastMode = SessionPatch.Clear,
             ResponseUsage = SessionPatch.Clear,
@@ -451,14 +452,13 @@ public class GatewayProtocolModelsTests
         var payload = patch.ToPayload("agent:main");
 
         // Cleared fields are present with an explicit null value (not omitted).
-        foreach (var name in new[] { "model", "execNode", "fastMode", "responseUsage", "sendPolicy", "groupActivation" })
+        foreach (var name in new[] { "model", "thinkingLevel", "execNode", "fastMode", "responseUsage", "sendPolicy", "groupActivation" })
         {
             Assert.True(payload.ContainsKey(name), $"expected '{name}' to be present");
             Assert.Null(payload[name]);
         }
 
         // Untouched fields stay omitted.
-        Assert.False(payload.ContainsKey("thinkingLevel"));
         Assert.False(payload.ContainsKey("execHost"));
     }
 
@@ -467,6 +467,9 @@ public class GatewayProtocolModelsTests
     {
         var json = JsonSerializer.Serialize(new SessionPatch { Model = SessionPatch.Clear }.ToPayload("k"));
         Assert.Contains("\"model\":null", json);
+
+        var thinkingJson = JsonSerializer.Serialize(new SessionPatch { ThinkingLevel = SessionPatch.Clear }.ToPayload("k"));
+        Assert.Contains("\"thinkingLevel\":null", thinkingJson);
 
         var fastJson = JsonSerializer.Serialize(new SessionPatch { FastMode = SessionPatch.Clear }.ToPayload("k"));
         Assert.Contains("\"fastMode\":null", fastJson);

--- a/tests/OpenClaw.Tray.Tests/ChatComposerControllerTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ChatComposerControllerTests.cs
@@ -20,13 +20,14 @@ namespace OpenClaw.Tray.Tests;
 /// </summary>
 public sealed class ChatComposerControllerTests
 {
-    private static ChatThread MakeThread(string id = "session-1") =>
+    private static ChatThread MakeThread(string id = "session-1", string? thinkingLevel = null) =>
         new()
         {
             Id = id,
             Title = "Test Session",
             Status = ChatThreadStatus.Running,
             Activity = ChatActivity.Idle,
+            ThinkingLevel = thinkingLevel,
         };
 
     private static ChatComposerInputs MakeInputs(long revision = 1, ChatThread? thread = null, string connectionState = "connected") =>
@@ -563,7 +564,26 @@ public sealed class ChatComposerControllerTests
         controller.SetThinkingLevel("high");
 
         Assert.Equal(1, port.SetThinkingLevelCallCount);
+        Assert.Equal(0, port.ClearThinkingLevelCallCount);
         Assert.Equal(("session-1", "high"), port.LastSetThinkingLevelCall);
+    }
+
+    [Fact]
+    public void ClearThinkingLevel_FromOff_DelegatesExplicitClearNotConcreteLevel()
+    {
+        var vm = new ChatComposerViewModel(new RecordingUiDispatcher(), initialSpeakerMuted: false);
+        vm.ApplyInputs(MakeInputs(thread: MakeThread(thinkingLevel: "off")));
+        var port = new FakeChatComposerRuntimePort();
+        var controller = new ChatComposerController(
+            vm,
+            port,
+            new ChatComposerHostActions(null, null, null, null, null));
+
+        controller.ClearThinkingLevel();
+
+        Assert.Equal(1, port.ClearThinkingLevelCallCount);
+        Assert.Equal("session-1", port.LastClearThinkingLevelThreadId);
+        Assert.Equal(0, port.SetThinkingLevelCallCount);
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/FakeChatComposerRuntimePort.cs
+++ b/tests/OpenClaw.Tray.Tests/FakeChatComposerRuntimePort.cs
@@ -55,6 +55,9 @@ internal sealed class FakeChatComposerRuntimePort : IChatComposerRuntimePort
     public (string ThreadId, string Level)? LastSetThinkingLevelCall { get; private set; }
     public CancellationToken? LastSetThinkingLevelToken { get; private set; }
 
+    public int ClearThinkingLevelCallCount { get; private set; }
+    public string? LastClearThinkingLevelThreadId { get; private set; }
+
     public int EnsureCommandCatalogCallCount { get; private set; }
     public CancellationToken? LastEnsureCommandCatalogToken { get; private set; }
 
@@ -122,6 +125,13 @@ internal sealed class FakeChatComposerRuntimePort : IChatComposerRuntimePort
         SetThinkingLevelCallCount++;
         LastSetThinkingLevelCall = (threadId, thinkingLevel);
         LastSetThinkingLevelToken = cancellationToken;
+        return Task.CompletedTask;
+    }
+
+    public Task ClearThinkingLevelAsync(string threadId, CancellationToken cancellationToken)
+    {
+        ClearThinkingLevelCallCount++;
+        LastClearThinkingLevelThreadId = threadId;
         return Task.CompletedTask;
     }
 

--- a/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
@@ -78,6 +78,8 @@ public class OpenClawChatDataProviderTests
         public Func<string, string?, string?, Task>? SendBehavior { get; set; }
         public Func<string, string, Task>? PatchSessionModelBehavior { get; set; }
         public Func<string, Task>? ClearSessionModelBehavior { get; set; }
+        public Func<string, string, Task>? PatchSessionThinkingLevelBehavior { get; set; }
+        public Func<string, Task>? ClearSessionThinkingLevelBehavior { get; set; }
         public Func<string?, Task<ChatHistoryInfo>>? HistoryBehavior { get; set; }
         public Func<string, Task>? AbortBehavior { get; set; }
         public SessionInfo[] Sessions { get; set; } = Array.Empty<SessionInfo>();
@@ -194,7 +196,18 @@ public class OpenClawChatDataProviderTests
             return ClearSessionModelBehavior?.Invoke(sessionKey) ?? Task.CompletedTask;
         }
         public List<string> ClearedModelKeys { get; } = new();
-        public Task PatchSessionThinkingLevelAsync(string sessionKey, string thinkingLevel) => Task.CompletedTask;
+        public Task PatchSessionThinkingLevelAsync(string sessionKey, string thinkingLevel)
+        {
+            PatchedThinkingLevels.Add((sessionKey, thinkingLevel));
+            return PatchSessionThinkingLevelBehavior?.Invoke(sessionKey, thinkingLevel) ?? Task.CompletedTask;
+        }
+        public List<(string SessionKey, string ThinkingLevel)> PatchedThinkingLevels { get; } = new();
+        public Task ClearSessionThinkingLevelAsync(string sessionKey)
+        {
+            ClearedThinkingLevelKeys.Add(sessionKey);
+            return ClearSessionThinkingLevelBehavior?.Invoke(sessionKey) ?? Task.CompletedTask;
+        }
+        public List<string> ClearedThinkingLevelKeys { get; } = new();
 
         public Task<ChatHistoryInfo> RequestChatHistoryAsync(string? sessionKey)
         {
@@ -9672,6 +9685,56 @@ public class OpenClawChatDataProviderTests
 
         Assert.Equal(new[] { "main" }, bridge.ClearedModelKeys);
         Assert.Empty(bridge.PatchedModels);
+    }
+
+    [Fact]
+    public async Task SetThinkingLevelAsync_ForwardsConcreteLevelToBridge()
+    {
+        var (bridge, provider, _, _) = CreateProvider(new[] { MainSession() });
+        await provider.LoadAsync();
+
+        await provider.SetThinkingLevelAsync("main", "high");
+
+        Assert.Equal([("main", "high")], bridge.PatchedThinkingLevels);
+        Assert.Empty(bridge.ClearedThinkingLevelKeys);
+    }
+
+    [Fact]
+    public async Task ClearThinkingLevelAsync_ClearsOverrideViaBridge()
+    {
+        var (bridge, provider, _, _) = CreateProvider(new[] { MainSession() });
+        await provider.LoadAsync();
+
+        await provider.ClearThinkingLevelAsync("main");
+
+        Assert.Equal(["main"], bridge.ClearedThinkingLevelKeys);
+        Assert.Empty(bridge.PatchedThinkingLevels);
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_WaitsForInFlightThinkingLevelClearBeforeGatewaySend()
+    {
+        var patchStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releasePatch = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var (bridge, provider, _, _) = CreateProvider(new[] { MainSession() });
+        bridge.ClearSessionThinkingLevelBehavior = _ =>
+        {
+            patchStarted.TrySetResult();
+            return releasePatch.Task;
+        };
+        await provider.LoadAsync();
+
+        var clearTask = provider.ClearThinkingLevelAsync("main");
+        await patchStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        var sendTask = provider.SendMessageAsync("main", "Use default reasoning");
+        await Task.Delay(50);
+
+        Assert.Empty(bridge.SentMessages);
+        releasePatch.SetResult();
+        await Task.WhenAll(clearTask, sendTask);
+
+        Assert.Equal(["main"], bridge.ClearedThinkingLevelKeys);
+        Assert.Equal(["Use default reasoning"], bridge.SentMessages);
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/ToolMetaCacheTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ToolMetaCacheTests.cs
@@ -571,6 +571,7 @@ public class ToolMetaCacheTests
         public Task PatchSessionModelAsync(string sessionKey, string model) => Task.CompletedTask;
         public Task ClearSessionModelAsync(string sessionKey) => Task.CompletedTask;
         public Task PatchSessionThinkingLevelAsync(string sessionKey, string thinkingLevel) => Task.CompletedTask;
+        public Task ClearSessionThinkingLevelAsync(string sessionKey) => Task.CompletedTask;
         public Task<ChatHistoryInfo> RequestChatHistoryAsync(string? sessionKey) => Task.FromResult(History);
         public Task SendChatAbortAsync(string runId, string? sessionKey = null) => Task.CompletedTask;
         public Task ResolveExecApprovalAsync(string approvalId, string decision) => Task.CompletedTask;


### PR DESCRIPTION
Fixes #980

Adds a clearly labeled **Default** reasoning entry to the native chat composer. Selecting it clears the session `thinkingLevel` through the existing `SessionPatch.Clear` explicit-null contract instead of substituting a concrete level.

The clear operation is typed through the composer, controller, runtime port, provider, and gateway bridge boundaries. Model and thinking-level session option patches are serialized per session, and the next send waits for the pending patch so the first prompt after restoring Default cannot race the clear.

Concrete reasoning levels still pass through unchanged. Gateway errors and Copilot model metadata behavior are unchanged.

## Validation

- `./build.ps1`: passed
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore`: passed, 3,819 passed, 32 skipped
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore --filter "FullyQualifiedName!~BrowserProxyEndpointScopingTests"`: passed, 2,733 passed
- `dotnet test ./tests/OpenClaw.SetupEngine.Tests/OpenClaw.SetupEngine.Tests.csproj --no-restore`: passed, 1,010 passed
- `python .agents/skills/autoreview/scripts/autoreview --mode local`: clean, no accepted or actionable findings
- Final rubber-duck review: no issues

The unfiltered Tray run passed 2,276 tests, then the test host hung while `BrowserProxyEndpointScopingTests.Diagnostics_NoOverride_TunnelWithoutBrowserProxyForward_DoesNotProbeTunnelLocalPlusTwo` was active. Running that unrelated class alone also hung on this host in `PortDiagnosticsService.GetActiveTcpListeners`. The remaining 2,733 Tray tests passed in an isolated data directory.

## Real behavior proof

- `ClearThinkingLevel_FromOff_DelegatesExplicitClearNotConcreteLevel` proves an `off` session routes Default to the dedicated clear operation and does not send a concrete level.
- `SessionPatch_ToPayload_ClearSerializesToJsonNull` proves the wire payload contains `"thinkingLevel":null`.
- `SendMessageAsync_WaitsForInFlightThinkingLevelClearBeforeGatewaySend` proves the next message waits until the Default clear completes.
- Concrete-level tests prove `high` still reaches the Gateway bridge unchanged.

**UI proof: Not verified / blocked.** The current branch app launched successfully with `./run-app-local.ps1 -NoBuild -AllowNonMain`, and the chat deep link opened the current-head native chat surface. The composer could not render because the existing Gateway connection failed with `SSH tunnel failed: TCP listener ownership could not be verified.` No Gateway settings or model metadata were changed to work around that truthful runtime error.