### PR TITLE
fix(setup): retry CLI installer downloads

### DIFF
--- a/src/OpenClaw.SetupEngine.UI/Pages/CapabilitiesPage.xaml
+++ b/src/OpenClaw.SetupEngine.UI/Pages/CapabilitiesPage.xaml
@@ -273,7 +273,7 @@
                                           Header="Show the exact commands &amp; files">
                                     <TextBlock x:Name="ExactCommandsText" FontFamily="Cascadia Mono, Consolas" FontSize="12" TextWrapping="Wrap"
                                                Foreground="{ThemeResource TextFillColorSecondaryBrush}" Margin="0,4,0,4"
-                                               Text="wsl --install -d Ubuntu-24.04 --name OpenClawGateway --no-launch&#x0a;curl -fsSL --proto '=https' --tlsv1.2 &lt;install-url&gt; | bash&#x0a;openclaw config set gateway.bind loopback · port 18789&#x0a;openclaw gateway install --force   (systemd --user service)&#x0a;writes -&gt; %LOCALAPPDATA%\OpenClawTray\wsl\OpenClawGateway\&#x0a;writes -&gt; %APPDATA%\OpenClawTray\gateways.json + identity" />
+                                               Text="wsl --install -d Ubuntu-24.04 --name OpenClawGateway --no-launch&#x0a;curl --retry 5 --retry-all-errors --output &lt;temporary-installer&gt; &lt;install-url&gt;&#x0a;bash &lt;temporary-installer&gt;&#x0a;openclaw config set gateway.bind loopback · port 18789&#x0a;openclaw gateway install --force   (systemd --user service)&#x0a;writes -&gt; %LOCALAPPDATA%\OpenClawTray\wsl\OpenClawGateway\&#x0a;writes -&gt; %APPDATA%\OpenClawTray\gateways.json + identity" />
                                 </Expander>
                             </StackPanel>
                         </StackPanel>

--- a/src/OpenClaw.SetupEngine/InstallCliStep.cs
+++ b/src/OpenClaw.SetupEngine/InstallCliStep.cs
@@ -71,7 +71,12 @@ public sealed class InstallCliStep : SetupStep
                 return StepResult.Fail(ex.Message);
             }
 
-            var result = await ctx.Commands.RunInWslAsync(distro, installScript, TimeSpan.FromMinutes(5), ct: ct);
+            var result = await ctx.Commands.RunInWslAsync(
+                distro,
+                installScript,
+                TimeSpan.FromMinutes(5),
+                ct: ct,
+                inputViaStdin: true);
 
             if (result.ExitCode != 0)
                 return StepResult.Fail($"CLI install failed (exit {result.ExitCode}): {result.Stderr}");
@@ -171,7 +176,22 @@ public sealed class InstallCliStep : SetupStep
             runtimeArgument = $" --node-version '{escapedNodeVersion}'";
         }
 
-        return $"curl -fsSL --proto '=https' --tlsv1.2 '{escapedUrl}' | bash -s -- --version '{escapedVersion}'{runtimeArgument}";
+        return $"""
+            set -euo pipefail
+            installer="$(mktemp)"
+            trap 'rm -f "$installer"' EXIT
+            curl -fsSL \
+              --retry 5 \
+              --retry-all-errors \
+              --retry-delay 2 \
+              --retry-max-time 90 \
+              --connect-timeout 15 \
+              --proto '=https' \
+              --tlsv1.2 \
+              --output "$installer" \
+              '{escapedUrl}'
+            bash -s -- --version '{escapedVersion}'{runtimeArgument} < "$installer"
+            """;
     }
 
     internal static bool TryValidateCandidatePackagePath(

--- a/src/OpenClaw.SetupEngine/SetupReviewSummary.cs
+++ b/src/OpenClaw.SetupEngine/SetupReviewSummary.cs
@@ -59,7 +59,10 @@ public static class SetupReviewSummaryBuilder
             ? ""
             : $" --node-version {GatewayReleasePolicy.NodeVersion}";
         var installCommand =
-            $"curl -fsSL --proto '=https' --tlsv1.2 <install-url> | bash -s -- --version {release.Version}{runtimeArgument}";
+            $"set -euo pipefail; installer=\"$(mktemp)\"; trap 'rm -f \"$installer\"' EXIT; " +
+            $"curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --retry-max-time 90 --connect-timeout 15 " +
+            $"--proto '=https' --tlsv1.2 --output \"$installer\" <install-url>; " +
+            $"bash -s -- --version {release.Version}{runtimeArgument} < \"$installer\"";
         LocalModelInfo localAiModel =
             LocalModelCatalog.Find(config.LocalAi.SelectedModelId) ?? LocalModelCatalog.Default;
         string[] localAiCommands = config.LocalAi.Enabled

--- a/tests/OpenClaw.SetupEngine.Tests/SetupConfigTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupConfigTests.cs
@@ -425,6 +425,8 @@ public class SetupConfigTests : IDisposable
             Assert.Contains("Unverified custom installer", summary.InstallerDescription);
             Assert.Contains("CustomClaw", summary.ExactCommands);
             Assert.Contains("19999", summary.ExactCommands);
+            Assert.Contains("--retry-all-errors", summary.ExactCommands);
+            Assert.DoesNotContain("| bash", summary.ExactCommands);
             Assert.Equal("CustomClaw · LAN:19999", summary.CompletionGatewaySummary);
             Assert.StartsWith("llama-server · ", summary.LocalAiDescription, StringComparison.Ordinal);
             Assert.DoesNotContain("immutable revision", summary.LocalAiDescription, StringComparison.Ordinal);

--- a/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
@@ -1783,16 +1783,23 @@ public class SetupStepsTests : IDisposable
     }
 
     [Fact]
-    public void InstallCli_BuildInstallCommand_AppendsExactReleaseAndRuntime()
+    public void InstallCli_BuildInstallCommand_DownloadsBeforeExecutingWithBoundedRetries()
     {
         var command = InstallCliStep.BuildInstallCommand(
             "https://openclaw.ai/install-cli.sh",
             "2026.5.22",
             GatewayReleasePolicy.NodeVersion);
 
-        Assert.Equal(
-            "curl -fsSL --proto '=https' --tlsv1.2 'https://openclaw.ai/install-cli.sh' | bash -s -- --version '2026.5.22' --node-version '22.22.3'",
-            command);
+        Assert.StartsWith("set -euo pipefail", command);
+        Assert.Contains("installer=\"$(mktemp)\"", command);
+        Assert.Contains("trap 'rm -f \"$installer\"' EXIT", command);
+        Assert.Contains("--retry 5", command);
+        Assert.Contains("--retry-all-errors", command);
+        Assert.Contains("--retry-max-time 90", command);
+        Assert.Contains("--output \"$installer\"", command);
+        Assert.Contains("'https://openclaw.ai/install-cli.sh'", command);
+        Assert.Contains("bash -s -- --version '2026.5.22' --node-version '22.22.3' < \"$installer\"", command);
+        Assert.DoesNotContain("| bash", command);
     }
 
     [Fact]
@@ -1800,7 +1807,28 @@ public class SetupStepsTests : IDisposable
     {
         var command = InstallCliStep.BuildInstallCommand("https://openclaw.ai/install-cli's.sh", "2026.5.22'a");
 
-        Assert.Equal("curl -fsSL --proto '=https' --tlsv1.2 'https://openclaw.ai/install-cli'\\''s.sh' | bash -s -- --version '2026.5.22'\\''a'", command);
+        Assert.Contains("'https://openclaw.ai/install-cli'\\''s.sh'", command);
+        Assert.Contains("--version '2026.5.22'\\''a'", command);
+    }
+
+    [Fact]
+    public async Task InstallCli_DownloadFailurePreservesCurlError()
+    {
+        var commands = new FakeCommandRunner(
+            _ => Ok(),
+            (_, command, _) => command.Contains("curl -fsSL", StringComparison.Ordinal)
+                ? new CommandResult(6, "", "curl: (6) Could not resolve host: openclaw.ai", TimeSpan.Zero, TimedOut: false)
+                : throw new InvalidOperationException($"Unexpected command: {command}"));
+        var config = new SetupConfig();
+        GatewayReleasePolicy.ResolveAndApply(config);
+        var ctx = CreateContext(config, commands);
+
+        var result = await new InstallCliStep().ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.Failed, result.Outcome);
+        Assert.Contains("exit 6", result.Message);
+        Assert.Contains("Could not resolve host: openclaw.ai", result.Message);
+        Assert.True(Assert.Single(commands.WslCalls).InputViaStdin);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Download the CLI installer completely to a temporary file before executing it.
- Retry transient fresh-WSL DNS and connection failures with a bounded curl policy.
- Send Bash through WSL stdin so shell variables survive `wsl.exe` argument translation.
- Preserve curl exit codes and stderr instead of reporting a misleading CLI-location error.
- Keep setup-review wording aligned with the actual flow.

Fixes #1256. Rebuilt as one topic commit on current `main` (`16cb6897`).

## Required proof pools

- `windows-wsl-gateway-e2e`: the product WSL installer transport and recovery path changed.
- `windows-winui-interactive`: setup-review copy changed.

## Validation

Current head: `d9618fd7bcb29578992691042a7f73f13d9634af`

- `.\build.ps1`: passed on Windows 11 ARM64; all projects and documentation validation succeeded.
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore`: 3,873 passed, 32 environment-gated skips.
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore`: 2,824 passed after one unrelated chat-queue timing flake passed on full rerun.
- `git diff --check origin/main...HEAD`: passed.

Rubber-duck review confirmed the current-main reconstruction preserves WSL-stdin transport, temporary-file execution, retry coverage, and error propagation. The maintainer review's transfer-deadline and retry-classification questions remain in the review thread for disposition.

## Real behavior proof

The current-head regression tests verify generated script transport through WSL stdin, retry configuration, curl exit-code/stderr preservation, and review-summary copy.

Supporting integrated-stack proof completed the full Local AI setup and download path on an RTX Spark ARM64 host. It did not inject an actual DNS failure, so it does not replace retry-path proof.

Not verified / blocked: a live current-head managed-WSL DNS-failure and recovery run still requires `windows-wsl-gateway-e2e`.

## Security and compatibility

- Installer content is written to a temporary file before execution and removed by the shell cleanup trap.
- HTTPS protocol/TLS restrictions remain in place.
- No new permissions or credential handling are introduced.
