### PR TITLE
fix(chat): prevent stale attachment metadata writes

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Chat/ChatMetadataStore.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ChatMetadataStore.cs
@@ -118,15 +118,21 @@ internal sealed class ChatMetadataStore : IDisposable
     private readonly object _attachmentSaveGate = new();
     private readonly string _toolCacheFilePath;
     private readonly string _attachmentCacheFilePath;
+    private readonly Action<long>? _attachmentSnapshotCaptured;
     private Dictionary<string, List<CachedToolMeta>> _toolCache;
     private Dictionary<string, List<CachedAttachmentMeta>> _attachmentCache;
     private readonly Dictionary<string, long> _evictedResetGenerations = new(StringComparer.Ordinal);
     private Timer? _toolSaveTimer;
     private long _toolSaveVersion;
+    private long _attachmentSaveVersion;
     private bool _toolCacheDirty;
+    private bool _attachmentCacheDirty;
     private bool _disposed;
 
-    internal ChatMetadataStore(string toolCacheFilePath, string? attachmentCacheFilePath = null)
+    internal ChatMetadataStore(
+        string toolCacheFilePath,
+        string? attachmentCacheFilePath = null,
+        Action<long>? attachmentSnapshotCaptured = null)
     {
         _toolCacheFilePath = !string.IsNullOrWhiteSpace(toolCacheFilePath)
             ? toolCacheFilePath
@@ -134,6 +140,7 @@ internal sealed class ChatMetadataStore : IDisposable
         _attachmentCacheFilePath = !string.IsNullOrWhiteSpace(attachmentCacheFilePath)
             ? attachmentCacheFilePath
             : DefaultAttachmentMetaCacheFilePath(_toolCacheFilePath);
+        _attachmentSnapshotCaptured = attachmentSnapshotCaptured;
         _toolCache = LoadToolMetaCache(_toolCacheFilePath);
         _attachmentCache = LoadAttachmentMetaCache(_attachmentCacheFilePath);
     }
@@ -308,6 +315,7 @@ internal sealed class ChatMetadataStore : IDisposable
         if (items.Count == 0)
             return;
 
+        long saveVersion;
         lock (_gate)
         {
             if (_disposed || IsStaleResetGenerationLocked(threadId, resetGeneration))
@@ -332,9 +340,11 @@ internal sealed class ChatMetadataStore : IDisposable
             });
             if (list.Count > MaxAttachmentEntriesPerSession)
                 list.RemoveRange(0, list.Count - MaxAttachmentEntriesPerSession);
+            _attachmentCacheDirty = true;
+            saveVersion = ++_attachmentSaveVersion;
         }
 
-        SaveAttachmentCache();
+        SaveAttachmentCache(saveVersion);
     }
 
     internal Queue<CachedToolMeta>? GetToolMetadata(
@@ -429,6 +439,7 @@ internal sealed class ChatMetadataStore : IDisposable
     {
         var saveTool = false;
         var saveAttachments = false;
+        long attachmentSaveVersion = 0;
         lock (_gate)
         {
             if (_evictedResetGenerations.TryGetValue(threadId, out var current) &&
@@ -463,12 +474,17 @@ internal sealed class ChatMetadataStore : IDisposable
                 _toolCacheDirty = true;
                 _toolSaveVersion++;
             }
+            if (saveAttachments)
+            {
+                _attachmentCacheDirty = true;
+                attachmentSaveVersion = ++_attachmentSaveVersion;
+            }
         }
 
         if (saveTool)
             SaveToolCache();
         if (saveAttachments)
-            SaveAttachmentCache();
+            SaveAttachmentCache(attachmentSaveVersion);
     }
 
     private bool RemoveOlderToolEntries(
@@ -524,16 +540,18 @@ internal sealed class ChatMetadataStore : IDisposable
     internal void Flush()
     {
         Timer? timer;
+        long attachmentSaveVersion;
         lock (_gate)
         {
             timer = _toolSaveTimer;
             _toolSaveTimer = null;
             _toolSaveVersion++;
+            attachmentSaveVersion = _attachmentSaveVersion;
         }
 
         timer?.Dispose();
         SaveToolCache();
-        SaveAttachmentCache();
+        SaveAttachmentCache(attachmentSaveVersion);
     }
 
     public void Dispose()
@@ -605,24 +623,42 @@ internal sealed class ChatMetadataStore : IDisposable
         }
     }
 
-    private void SaveAttachmentCache()
+    private void SaveAttachmentCache(long expectedVersion)
     {
         try
         {
             Dictionary<string, List<CachedAttachmentMeta>> snapshot;
             lock (_gate)
             {
+                if (expectedVersion != _attachmentSaveVersion ||
+                    !_attachmentCacheDirty)
+                {
+                    return;
+                }
+
                 snapshot = _attachmentCache.ToDictionary(
                     pair => pair.Key,
                     pair => pair.Value.Select(Clone).ToList(),
                     StringComparer.Ordinal);
             }
 
+            _attachmentSnapshotCaptured?.Invoke(expectedVersion);
             EvictOldestSessions(snapshot);
             var json = JsonSerializer.Serialize(snapshot, CacheJsonOptions);
             lock (_attachmentSaveGate)
             {
+                lock (_gate)
+                {
+                    if (expectedVersion != _attachmentSaveVersion)
+                        return;
+                }
+
                 AtomicWrite(_attachmentCacheFilePath, json, "attachment metadata");
+                lock (_gate)
+                {
+                    if (expectedVersion == _attachmentSaveVersion)
+                        _attachmentCacheDirty = false;
+                }
             }
         }
         catch (Exception ex)

--- a/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
@@ -11668,50 +11668,64 @@ public class OpenClawChatDataProviderTests
     [Fact]
     public async Task AttachmentMetadata_ConcurrentSavesPreserveEveryCompletedSend()
     {
-        const int sendCount = 16;
         using var tempDir = new TempDirectory();
+        var toolPath = Path.Combine(tempDir.DirectoryPath, "tool-metadata.json");
         var attachmentPath = Path.Combine(tempDir.DirectoryPath, "attachment-metadata.json");
-        var sessions = Enumerable.Range(0, sendCount)
-            .Select(index => new SessionInfo
+        var firstSnapshotCaptured = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        using var releaseFirstSnapshot = new ManualResetEventSlim();
+        using var store = new ChatMetadataStore(
+            toolPath,
+            attachmentPath,
+            version =>
             {
-                Key = $"thread-{index}",
-                DisplayName = $"Thread {index}",
-                Status = "active",
-                IsMain = index == 0,
-            })
-            .ToArray();
-        var (bridge, provider, _, _) = CreateProvider(
-            sessions,
-            attachmentMetaCachePath: attachmentPath);
-        await provider.LoadAsync();
+                if (version != 1)
+                    return;
 
-        var allStarted = new CountdownEvent(sendCount);
-        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        bridge.SendBehavior = async (_, _, _) =>
+                firstSnapshotCaptured.SetResult();
+                releaseFirstSnapshot.Wait();
+            });
+
+        static ChatAttachment Attachment(string fileName) => new()
         {
-            allStarted.Signal();
-            await release.Task;
+            Type = "image",
+            MimeType = "image/png",
+            FileName = fileName,
+            Content = Convert.ToBase64String([1]),
+            SizeBytes = 1,
         };
 
-        var sends = sessions.Select((session, index) =>
-            provider.SendMessageAsync(session.Key, $"caption-{index}", default,
-            [
-                new ChatAttachment
-                {
-                    Type = "image",
-                    MimeType = "image/png",
-                    FileName = $"file-{index}.png",
-                    Content = Convert.ToBase64String([(byte)index]),
-                    SizeBytes = 1,
-                },
-            ])).ToArray();
-        Assert.True(allStarted.Wait(TimeSpan.FromSeconds(5)));
-        release.SetResult();
-        await Task.WhenAll(sends);
+        var firstSave = Task.Run(() =>
+            store.CacheAttachments(
+                "thread-1",
+                "session-1",
+                0,
+                "first",
+                [Attachment("first.png")],
+                1_000));
+        try
+        {
+            await firstSnapshotCaptured.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            store.CacheAttachments(
+                "thread-2",
+                "session-2",
+                0,
+                "second",
+                [Attachment("second.png")],
+                2_000);
+        }
+        finally
+        {
+            releaseFirstSnapshot.Set();
+        }
 
-        var persisted = await File.ReadAllTextAsync(attachmentPath);
-        for (var index = 0; index < sendCount; index++)
-            Assert.Contains($"file-{index}.png", persisted, StringComparison.Ordinal);
+        await firstSave;
+
+        var cache = JsonSerializer.Deserialize<
+            Dictionary<string, List<ChatMetadataStore.CachedAttachmentMeta>>>(
+                await File.ReadAllTextAsync(attachmentPath));
+        Assert.Equal("first.png", Assert.Single(cache!["session-1"]).Attachments[0].FileName);
+        Assert.Equal("second.png", Assert.Single(cache["session-2"]).Attachments[0].FileName);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Version attachment-cache mutations and reject stale snapshots before serialized disk writes.
- Preserve the existing lock boundary so the general metadata state lock is not held during serialization or disk IO.
- Make `AttachmentMetadata_ConcurrentSavesPreserveEveryCompletedSend` deterministic by pausing the older snapshot until the newer save completes, then verifying both completed sends remain on disk.

## Validation

- `./build.ps1`: passed.
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore`: 3,819 passed, 32 skipped.
- `dotnet test ./tests/OpenClaw.SetupEngine.Tests/OpenClaw.SetupEngine.Tests.csproj --no-restore`: 1,022 passed.
- Focused `AttachmentMetadata_ConcurrentSavesPreserveEveryCompletedSend`: 25/25 passed before the final rebase and 10/10 passed on the current head.
- Full `OpenClaw.Tray.Tests` was attempted twice. The runner hung without a test failure summary and the second diagnostic run was externally stopped. Hosted CI remains the full-suite proof.
- Rubber-duck review: no blocking issues.
- `python .agents\skills\autoreview\scripts\autoreview --mode local --engine codex --model gpt-5.6-sol --thinking high --stream-engine-output`: clean, no accepted or actionable findings, overall confidence 0.94.

## Real behavior proof

The deterministic regression test captures attachment save version 1, blocks it after snapshot capture, completes version 2 with both sends, and then releases version 1. The stale version 1 writer is rejected and the persisted JSON retains both `first.png` and `second.png`.

## PR #1205 dependency

PR #1205 must merge this fix from `main` after this PR lands, then rerun its GitHub CI. This PR does not merge #1205 or itself.