### PR TITLE
fix(local-ai): clarify unavailable Local AI setup states (clean replacement for #1204)

### DIFF
--- a/src/OpenClaw.SetupEngine.UI/Pages/CapabilitiesPage.xaml
+++ b/src/OpenClaw.SetupEngine.UI/Pages/CapabilitiesPage.xaml
@@ -123,6 +123,7 @@
                                          Visibility="Collapsed">
                                     <InfoBar.ActionButton>
                                         <HyperlinkButton x:Name="LocalAiUnavailableDetailsButton"
+                                                         x:Uid="Onboarding_LocalAi_UnavailableDetailsButton"
                                                          AutomationProperties.AutomationId="LocalAiUnavailableDetailsButton"
                                                          Content="See why"
                                                          Click="LocalAiUnavailableDetails_Click" />

--- a/src/OpenClaw.SetupEngine.UI/Pages/CapabilitiesPage.xaml
+++ b/src/OpenClaw.SetupEngine.UI/Pages/CapabilitiesPage.xaml
@@ -114,6 +114,36 @@
                                         <TextBlock Grid.Column="2" Text="Several GB" Style="{StaticResource CaptionTextBlockStyle}" Foreground="{ThemeResource TextFillColorTertiaryBrush}" FontFamily="Cascadia Mono, Consolas" VerticalAlignment="Center" />
                                     </Grid>
                                 </Border>
+                                <InfoBar x:Name="LocalAiUnavailablePanel"
+                                         AutomationProperties.AutomationId="LocalAiUnavailablePanel"
+                                         AutomationProperties.LiveSetting="Polite"
+                                         IsOpen="True" IsClosable="False" Severity="Informational"
+                                         Title="Local AI is not available"
+                                         Message="This PC does not meet one or more Local AI requirements."
+                                         Visibility="Collapsed">
+                                    <InfoBar.ActionButton>
+                                        <HyperlinkButton x:Name="LocalAiUnavailableDetailsButton"
+                                                         AutomationProperties.AutomationId="LocalAiUnavailableDetailsButton"
+                                                         Content="See why"
+                                                         Click="LocalAiUnavailableDetails_Click" />
+                                    </InfoBar.ActionButton>
+                                </InfoBar>
+                                <StackPanel x:Name="LocalAiAvailabilityRecoveryPanel"
+                                            Orientation="Horizontal"
+                                            Spacing="8"
+                                            VerticalAlignment="Center"
+                                            Visibility="Collapsed">
+                                    <ProgressRing x:Name="LocalAiAvailabilityProgressRing"
+                                                  Width="16"
+                                                  Height="16"
+                                                  IsActive="False"
+                                                  AutomationProperties.AccessibilityView="Raw" />
+                                    <HyperlinkButton x:Name="LocalAiRecheckAvailabilityButton"
+                                                     x:Uid="Onboarding_LocalAi_RecheckAvailabilityButton"
+                                                     AutomationProperties.AutomationId="LocalAiRecheckAvailabilityButton"
+                                                     Content="Recheck"
+                                                     Click="LocalAiRecheckAvailability_Click" />
+                                </StackPanel>
                                 <Border x:Name="LocalAiInstallReviewCard"
                                         AutomationProperties.AutomationId="LocalAiInstallReviewCard"
                                         Visibility="Collapsed"
@@ -121,78 +151,67 @@
                                         BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                                         BorderThickness="1" CornerRadius="4" Padding="14,12">
                                     <StackPanel Spacing="10">
-                                        <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="14">
-                                            <FontIcon Grid.Column="0" Glyph="&#xE950;" FontSize="18" VerticalAlignment="Center" />
-                                            <StackPanel Grid.Column="1" Spacing="2">
-                                                <TextBlock Text="Local AI on this PC" Style="{StaticResource BodyStrongTextBlockStyle}" />
-                                                <TextBlock Text="OpenClaw installs a verified native llama-server and downloads a pinned GGUF model from Hugging Face."
-                                                           TextWrapping="Wrap" Style="{StaticResource CaptionTextBlockStyle}"
-                                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                                            </StackPanel>
-                                            <ToggleSwitch x:Name="LocalAiToggle" Grid.Column="2"
-                                                          AutomationProperties.AutomationId="LocalAiSetupToggle"
-                                                          AutomationProperties.Name="Set up Local AI on this PC"
-                                                          OnContent="" OffContent="" MinWidth="0"
-                                                          Toggled="LocalAiToggle_Toggled" VerticalAlignment="Center" />
-                                        </Grid>
-                                        <InfoBar x:Name="LocalAiUnavailablePanel"
-                                                 AutomationProperties.AutomationId="LocalAiUnavailablePanel"
-                                                 IsOpen="True" IsClosable="False" Severity="Warning"
-                                                 Title="Local AI cannot run on this PC"
-                                                 Visibility="Collapsed">
-                                            <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,-12,0,12">
-                                                <TextBlock Text="One or more Local AI requirements are unavailable."
-                                                           TextWrapping="Wrap" VerticalAlignment="Center" />
-                                                <HyperlinkButton x:Name="LocalAiUnavailableDetailsButton"
-                                                                 AutomationProperties.AutomationId="LocalAiUnavailableDetailsButton"
-                                                                 Content="See why" Padding="0"
-                                                                 HorizontalAlignment="Left"
-                                                                 Click="LocalAiUnavailableDetails_Click" />
-                                            </StackPanel>
-                                        </InfoBar>
-                                        <StackPanel x:Name="LocalAiDetailsPanel" Spacing="6" Margin="32,0,0,0" Visibility="Collapsed">
-                                            <TextBlock x:Name="LocalAiHardwareStatusText"
-                                                       AutomationProperties.AutomationId="LocalAiHardwareStatus"
-                                                       AutomationProperties.LiveSetting="Polite"
-                                                       Style="{StaticResource CaptionTextBlockStyle}"
-                                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
-                                            <TextBlock Text="Model" Style="{StaticResource CaptionTextBlockStyle}"
-                                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                                            <ComboBox x:Name="LocalAiModelSelector"
-                                                      AutomationProperties.AutomationId="LocalAiModelSelector"
-                                                      AutomationProperties.Name="Local AI model"
-                                                      HorizontalAlignment="Stretch"
-                                                      SelectionChanged="LocalAiModelSelector_SelectionChanged" />
-                                            <TextBlock x:Name="LocalAiEngineDetailText"
-                                                       Style="{StaticResource CaptionTextBlockStyle}"
-                                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
-                                            <TextBlock x:Name="LocalAiModelDetailText"
-                                                       Style="{StaticResource CaptionTextBlockStyle}"
-                                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
-                                            <TextBlock x:Name="LocalAiSettingsDetailText"
-                                                       Style="{StaticResource CaptionTextBlockStyle}"
-                                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
-                                            <InfoBar x:Name="LocalAiNetworkingConsentPanel"
-                                                     AutomationProperties.AutomationId="LocalAiNetworkingConsentPanel"
-                                                     AutomationProperties.LiveSetting="Assertive"
-                                                     IsOpen="True" IsClosable="False" Severity="Warning"
-                                                     Title="WSL networking change required" Visibility="Collapsed">
-                                                <StackPanel Spacing="6" Margin="0,0,0,12">
-                                                    <TextBlock Text="Local AI needs mirrored WSL networking. Setup will update your global .wslconfig and stop all running WSL distributions once. No distributions are deleted. Save any work in WSL first."
-                                                               Style="{StaticResource CaptionTextBlockStyle}" TextWrapping="Wrap" />
-                                                    <CheckBox x:Name="LocalAiNetworkingConsentCheckBox"
-                                                              AutomationProperties.AutomationId="LocalAiNetworkingConsentCheckBox"
-                                                              AutomationProperties.Name="Allow the global WSL networking change and one-time WSL shutdown"
-                                                              Content="I understand and allow this global WSL change and one-time shutdown."
-                                                              Checked="LocalAiNetworkingConsent_Changed"
-                                                              Unchecked="LocalAiNetworkingConsent_Changed" />
+                                        <StackPanel x:Name="LocalAiOptionContent"
+                                                    AutomationProperties.Name="Local AI setup options"
+                                                    Spacing="10">
+                                            <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="14">
+                                                <FontIcon Grid.Column="0" Glyph="&#xE950;" FontSize="18" VerticalAlignment="Center" />
+                                                <StackPanel Grid.Column="1" Spacing="2">
+                                                    <TextBlock Text="Local AI on this PC" Style="{StaticResource BodyStrongTextBlockStyle}" />
+                                                    <TextBlock Text="OpenClaw installs a verified native llama-server and downloads a pinned GGUF model from Hugging Face."
+                                                               TextWrapping="Wrap" Style="{StaticResource CaptionTextBlockStyle}"
+                                                               Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                                                 </StackPanel>
-                                            </InfoBar>
-                                            <InfoBar x:Name="LocalAiNetworkingInspectionError"
-                                                     AutomationProperties.AutomationId="LocalAiNetworkingInspectionError"
-                                                     AutomationProperties.LiveSetting="Assertive"
-                                                     IsOpen="True" IsClosable="False" Severity="Error"
-                                                     Title="Could not check WSL networking" Visibility="Collapsed" />
+                                                <ToggleSwitch x:Name="LocalAiToggle" Grid.Column="2"
+                                                              AutomationProperties.AutomationId="LocalAiSetupToggle"
+                                                              AutomationProperties.Name="Set up Local AI on this PC"
+                                                              OnContent="" OffContent="" MinWidth="0"
+                                                              Toggled="LocalAiToggle_Toggled" VerticalAlignment="Center" />
+                                            </Grid>
+                                            <StackPanel x:Name="LocalAiDetailsPanel" Spacing="6" Margin="32,0,0,0" Visibility="Collapsed">
+                                                <TextBlock x:Name="LocalAiHardwareStatusText"
+                                                           AutomationProperties.AutomationId="LocalAiHardwareStatus"
+                                                           AutomationProperties.LiveSetting="Polite"
+                                                           Style="{StaticResource CaptionTextBlockStyle}"
+                                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
+                                                <TextBlock Text="Model" Style="{StaticResource CaptionTextBlockStyle}"
+                                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                                                <ComboBox x:Name="LocalAiModelSelector"
+                                                          AutomationProperties.AutomationId="LocalAiModelSelector"
+                                                          AutomationProperties.Name="Local AI model"
+                                                          HorizontalAlignment="Stretch"
+                                                          SelectionChanged="LocalAiModelSelector_SelectionChanged" />
+                                                <TextBlock x:Name="LocalAiEngineDetailText"
+                                                           Style="{StaticResource CaptionTextBlockStyle}"
+                                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
+                                                <TextBlock x:Name="LocalAiModelDetailText"
+                                                           Style="{StaticResource CaptionTextBlockStyle}"
+                                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
+                                                <TextBlock x:Name="LocalAiSettingsDetailText"
+                                                           Style="{StaticResource CaptionTextBlockStyle}"
+                                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
+                                                <InfoBar x:Name="LocalAiNetworkingConsentPanel"
+                                                         AutomationProperties.AutomationId="LocalAiNetworkingConsentPanel"
+                                                         AutomationProperties.LiveSetting="Assertive"
+                                                         IsOpen="True" IsClosable="False" Severity="Warning"
+                                                         Title="WSL networking change required" Visibility="Collapsed">
+                                                    <StackPanel Spacing="6" Margin="0,0,0,12">
+                                                        <TextBlock Text="Local AI needs mirrored WSL networking. Setup will update your global .wslconfig and stop all running WSL distributions once. No distributions are deleted. Save any work in WSL first."
+                                                                   Style="{StaticResource CaptionTextBlockStyle}" TextWrapping="Wrap" />
+                                                        <CheckBox x:Name="LocalAiNetworkingConsentCheckBox"
+                                                                  AutomationProperties.AutomationId="LocalAiNetworkingConsentCheckBox"
+                                                                  AutomationProperties.Name="Allow the global WSL networking change and one-time WSL shutdown"
+                                                                  Content="I understand and allow this global WSL change and one-time shutdown."
+                                                                  Checked="LocalAiNetworkingConsent_Changed"
+                                                                  Unchecked="LocalAiNetworkingConsent_Changed" />
+                                                    </StackPanel>
+                                                </InfoBar>
+                                                <InfoBar x:Name="LocalAiNetworkingInspectionError"
+                                                         AutomationProperties.AutomationId="LocalAiNetworkingInspectionError"
+                                                         AutomationProperties.LiveSetting="Assertive"
+                                                         IsOpen="True" IsClosable="False" Severity="Error"
+                                                         Title="Could not check WSL networking" Visibility="Collapsed" />
+                                            </StackPanel>
                                         </StackPanel>
                                     </StackPanel>
                                 </Border>

--- a/src/OpenClaw.SetupEngine.UI/Pages/CapabilitiesPage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/CapabilitiesPage.xaml.cs
@@ -285,9 +285,10 @@ public sealed partial class CapabilitiesPage : Page
         LocalInferenceEligibilityResult? eligibility = null;
         try
         {
-            _localAiHardware = await hardwareTask;
+            HostHardwareInfo hardware = await hardwareTask;
             if (!CanApplyLocalAiAvailability(checking.Generation, setupWindow))
                 return;
+            _localAiHardware = hardware;
             eligibility = LocalInferenceEligibility.Evaluate(
                 _localAiHardware,
                 _config!.LocalAi.SelectedModelId);
@@ -316,11 +317,12 @@ public sealed partial class CapabilitiesPage : Page
         string? wslNetworkingReason = null;
         try
         {
-            _localAiNetworkingStatus = forceNetworkingConsent
+            WslGlobalConfigStatus networkingStatus = forceNetworkingConsent
                 ? new(false, false)
                 : CreateWslGlobalConfigManager().Inspect();
             if (!CanApplyLocalAiAvailability(checking.Generation, setupWindow))
                 return;
+            _localAiNetworkingStatus = networkingStatus;
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidDataException)
         {
@@ -388,7 +390,7 @@ public sealed partial class CapabilitiesPage : Page
         ApplyLocalAiAvailabilityChrome(snapshot);
         _localAiSelectionEligible = false;
         _suppressLocalAiToggle = true;
-        LocalAiToggle.IsOn = false;
+        LocalAiToggle.IsOn = _config!.LocalAi.Enabled;
         _suppressLocalAiToggle = false;
         LocalAiToggle.Visibility = Visibility.Visible;
         LocalAiDetailsPanel.Visibility = Visibility.Collapsed;
@@ -396,8 +398,6 @@ public sealed partial class CapabilitiesPage : Page
         SetLocalAiOptionAvailability(
             isAvailable: false,
             "OpenClaw is checking Local AI requirements.");
-        _config!.LocalAi.Enabled = false;
-        _config.SkipWizard = _skipWizardWithoutLocalAi;
         ApplySetupReviewSummary(_config);
         UpdatePrimaryButtonState();
     }

--- a/src/OpenClaw.SetupEngine.UI/Pages/CapabilitiesPage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/CapabilitiesPage.xaml.cs
@@ -1,5 +1,6 @@
 using Microsoft.UI;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
@@ -32,7 +33,9 @@ public sealed partial class CapabilitiesPage : Page
     private long? _localAiSelectedGpuCapacityBytes;
     private WslGlobalConfigStatus? _localAiNetworkingStatus;
     private string _localAiUnavailableReason = string.Empty;
+    private readonly LocalAiSetupAvailabilityCoordinator _localAiAvailability = new();
     private bool _treatBundledAllOnAsPlaceholder;
+    private bool _forceLocalAiNetworkingConsent;
     private int _step = 1;
 
     // Capability profiles preset only runtime-gated settings. Device info/status
@@ -101,11 +104,12 @@ public sealed partial class CapabilitiesPage : Page
         UpdateTailscaleOptions();
         var previewPage = SetupPreview.RequestedPage;
         var localAiReviewPreview = previewPage is "capabilities-review" or "capabilities-review-consent";
+        _forceLocalAiNetworkingConsent = previewPage == "capabilities-review-consent";
         if (localAiReviewPreview)
             _config.LocalAi.Enabled = true;
         AsyncEventHandlerGuard.Run(
             () => InitializeLocalAiReviewAsync(
-                forceNetworkingConsent: previewPage == "capabilities-review-consent"),
+                forceNetworkingConsent: _forceLocalAiNetworkingConsent),
             NullLogger.Instance,
             nameof(InitializeLocalAiReviewAsync));
         ApplySetupReviewSummary(_config);
@@ -116,6 +120,7 @@ public sealed partial class CapabilitiesPage : Page
 
     protected override void OnNavigatedFrom(NavigationEventArgs e)
     {
+        _localAiAvailability.CancelCurrent();
         if (_setupWindow is not null)
         {
             _setupWindow.Activated -= SetupWindow_Activated;
@@ -263,11 +268,17 @@ public sealed partial class CapabilitiesPage : Page
         ExactCommandsText.Text = summary.ExactCommands;
     }
 
-    private async Task InitializeLocalAiReviewAsync(bool forceNetworkingConsent)
+    private async Task InitializeLocalAiReviewAsync(
+        bool forceNetworkingConsent,
+        bool refreshHardwareProbe = false,
+        LocalAiSetupAvailabilitySnapshot? startedAvailability = null)
     {
+        LocalAiSetupAvailabilitySnapshot checking =
+            startedAvailability ?? _localAiAvailability.StartProbe();
+        ShowLocalAiAvailabilityChecking(checking);
         SetupWindow? setupWindow = _setupWindow;
         Task<HostHardwareInfo> hardwareTask = setupWindow is not null
-            ? setupWindow.GetLocalAiHardwareAsync()
+            ? setupWindow.GetLocalAiHardwareAsync(forceRefresh: refreshHardwareProbe)
             : Task.Run(() => new NvmlHostHardwareProbe().Probe());
 
         string? hardwareReason = null;
@@ -275,6 +286,8 @@ public sealed partial class CapabilitiesPage : Page
         try
         {
             _localAiHardware = await hardwareTask;
+            if (!CanApplyLocalAiAvailability(checking.Generation, setupWindow))
+                return;
             eligibility = LocalInferenceEligibility.Evaluate(
                 _localAiHardware,
                 _config!.LocalAi.SelectedModelId);
@@ -287,11 +300,17 @@ public sealed partial class CapabilitiesPage : Page
             if (!eligibility.CanInstall || eligibility.Plan is null || eligibility.SelectedGpu is null)
                 hardwareReason = DescribeLocalAiUnavailable(eligibility);
         }
-        catch
+        catch (Exception ex)
         {
-            hardwareReason =
-                "OpenClaw could not read the NVIDIA GPU, driver, CUDA, or memory information. " +
-                "Check the NVIDIA driver installation and try setup again.";
+            Debug.WriteLine($"Local AI hardware probe failed: {ex}");
+            if (_localAiAvailability.TryApplyProbeFailure(
+                    checking.Generation,
+                    LocalAiProbeFailureReason,
+                    out var unavailableSnapshot))
+            {
+                ShowLocalAiProbeUnknown(unavailableSnapshot);
+            }
+            return;
         }
 
         string? wslNetworkingReason = null;
@@ -300,6 +319,8 @@ public sealed partial class CapabilitiesPage : Page
             _localAiNetworkingStatus = forceNetworkingConsent
                 ? new(false, false)
                 : CreateWslGlobalConfigManager().Inspect();
+            if (!CanApplyLocalAiAvailability(checking.Generation, setupWindow))
+                return;
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidDataException)
         {
@@ -309,7 +330,7 @@ public sealed partial class CapabilitiesPage : Page
                 "Check that the file is valid and readable, then try setup again.";
         }
 
-        if (_setupWindow is null && setupWindow is not null)
+        if (!CanApplyLocalAiAvailability(checking.Generation, setupWindow))
             return;
 
         string? unavailableReason = LocalAiAvailabilityReasons.Build(
@@ -317,14 +338,23 @@ public sealed partial class CapabilitiesPage : Page
             wslNetworkingReason);
         if (unavailableReason is not null)
         {
-            ShowLocalAiUnavailable(unavailableReason);
+            if (_localAiAvailability.TryApplyUnsupported(
+                    checking.Generation,
+                    unavailableReason,
+                    out var unavailableSnapshot))
+            {
+                ShowLocalAiUnavailable(unavailableSnapshot);
+            }
             return;
         }
 
+        if (!_localAiAvailability.TryApplyAvailable(checking.Generation, out var availableSnapshot))
+            return;
         Debug.Assert(eligibility is not null);
+        ApplyLocalAiAvailabilityChrome(availableSnapshot);
         LocalAiInstallReviewCard.Visibility = Visibility.Visible;
-        LocalAiUnavailablePanel.Visibility = Visibility.Collapsed;
         LocalAiToggle.Visibility = Visibility.Visible;
+        SetLocalAiOptionAvailability(isAvailable: true);
         _localAiSelectionEligible = eligibility.Status == LocalInferenceEligibilityStatus.Eligible;
         _config!.LocalAi.SelectedModelId ??= eligibility.Plan!.Model.Id;
         PopulateLocalAiModels();
@@ -334,6 +364,14 @@ public sealed partial class CapabilitiesPage : Page
         UpdateLocalAiOptions(forceNetworkingConsent);
         ApplySetupReviewSummary(_config);
     }
+
+    private const string LocalAiProbeFailureReason =
+        "OpenClaw could not read the NVIDIA GPU, driver, CUDA, or memory information. " +
+        "Confirm the NVIDIA driver is available, then recheck Local AI requirements.";
+
+    private bool CanApplyLocalAiAvailability(int generation, SetupWindow? setupWindow) =>
+        _localAiAvailability.IsCurrent(generation) &&
+        (_setupWindow is not null || setupWindow is null);
 
     private static WslGlobalConfigManager CreateWslGlobalConfigManager()
     {
@@ -345,47 +383,127 @@ public sealed partial class CapabilitiesPage : Page
             Path.Combine(localDataDir, "LocalAI", "network-backup"));
     }
 
-    private void ShowLocalAiUnavailable(string reason)
+    private void ShowLocalAiAvailabilityChecking(LocalAiSetupAvailabilitySnapshot snapshot)
+    {
+        ApplyLocalAiAvailabilityChrome(snapshot);
+        _localAiSelectionEligible = false;
+        _suppressLocalAiToggle = true;
+        LocalAiToggle.IsOn = false;
+        _suppressLocalAiToggle = false;
+        LocalAiToggle.Visibility = Visibility.Visible;
+        LocalAiDetailsPanel.Visibility = Visibility.Collapsed;
+        LocalAiInstallReviewCard.Visibility = Visibility.Visible;
+        SetLocalAiOptionAvailability(
+            isAvailable: false,
+            "OpenClaw is checking Local AI requirements.");
+        _config!.LocalAi.Enabled = false;
+        _config.SkipWizard = _skipWizardWithoutLocalAi;
+        ApplySetupReviewSummary(_config);
+        UpdatePrimaryButtonState();
+    }
+
+    private void ShowLocalAiProbeUnknown(LocalAiSetupAvailabilitySnapshot snapshot)
+    {
+        ApplyLocalAiAvailabilityChrome(snapshot);
+        _localAiSelectionEligible = false;
+        _suppressLocalAiToggle = true;
+        LocalAiToggle.IsOn = false;
+        _suppressLocalAiToggle = false;
+        LocalAiToggle.Visibility = Visibility.Visible;
+        LocalAiDetailsPanel.Visibility = Visibility.Collapsed;
+        LocalAiInstallReviewCard.Visibility = Visibility.Visible;
+        SetLocalAiOptionAvailability(
+            isAvailable: false,
+            "OpenClaw could not verify Local AI requirements. Recheck availability to try again.");
+        _config!.LocalAi.Enabled = false;
+        _config.SkipWizard = _skipWizardWithoutLocalAi;
+        ApplySetupReviewSummary(_config);
+        UpdatePrimaryButtonState();
+    }
+
+    private void ShowLocalAiUnavailable(LocalAiSetupAvailabilitySnapshot snapshot)
     {
         _localAiSelectionEligible = false;
         _suppressLocalAiToggle = true;
         LocalAiToggle.IsOn = false;
         _suppressLocalAiToggle = false;
-        LocalAiToggle.Visibility = Visibility.Collapsed;
+        LocalAiToggle.Visibility = Visibility.Visible;
         LocalAiDetailsPanel.Visibility = Visibility.Collapsed;
-        _localAiUnavailableReason = reason;
-        LocalAiUnavailablePanel.Visibility = Visibility.Visible;
+        ApplyLocalAiAvailabilityChrome(snapshot);
         LocalAiInstallReviewCard.Visibility = Visibility.Visible;
+        SetLocalAiOptionAvailability(isAvailable: false);
         _config!.LocalAi.Enabled = false;
         _config.SkipWizard = _skipWizardWithoutLocalAi;
         ApplySetupReviewSummary(_config);
     }
 
     private static string DescribeLocalAiUnavailable(LocalInferenceEligibilityResult eligibility) =>
-        eligibility.SelectionFailureCode switch
+        LocalInferenceEligibilityDiagnostics.DescribeUnavailable(eligibility);
+
+    private void ApplyLocalAiAvailabilityChrome(LocalAiSetupAvailabilitySnapshot snapshot)
+    {
+        _localAiUnavailableReason = snapshot.Reason ?? string.Empty;
+        LocalAiUnavailablePanel.Visibility =
+            snapshot.IsAvailable ? Visibility.Collapsed : Visibility.Visible;
+        LocalAiUnavailablePanel.Title = snapshot.Status switch
         {
-            LocalInferenceSelectionFailureCode.RuntimeUnavailable =>
-                "This Local AI release does not include a native llama-server runtime for the detected Windows architecture.",
-            LocalInferenceSelectionFailureCode.NoNvidiaGpu =>
-                "No NVIDIA GPU was reported by the NVIDIA driver. Install or repair the NVIDIA driver, then try setup again.",
-            LocalInferenceSelectionFailureCode.UnknownModel =>
-                "The selected model is not available in this Local AI release.",
-            _ => eligibility.FailureCode switch
-            {
-                LocalInferenceEligibilityFailureCode.HardwareFactsIncomplete =>
-                    "OpenClaw could not read a stable NVIDIA GPU identifier, memory, driver, or CUDA capability.",
-                LocalInferenceEligibilityFailureCode.InsufficientGpuMemory =>
-                    $"{eligibility.Plan?.Model.DisplayName ?? "The selected model"} requires " +
-                    $"{FormatSize(eligibility.RequiredTotalMemoryBytes)} of GPU memory for model weights, KV cache, and runtime workspace. " +
-                    $"OpenClaw detected {FormatOptionalSize(eligibility.DetectedTotalMemoryBytes)}.",
-                LocalInferenceEligibilityFailureCode.DriverTooOld =>
-                    $"NVIDIA driver {eligibility.SelectedGpu?.DriverVersion ?? "unknown"} was detected. " +
-                    $"Local AI requires version {LocalInferenceEligibility.MinimumNvidiaDriverVersion} or newer.",
-                LocalInferenceEligibilityFailureCode.CudaCapabilityTooLow =>
-                    "The NVIDIA driver does not provide CUDA 13 support. A separate CUDA Toolkit is not required.",
-                _ => "OpenClaw could not verify the Local AI requirements on this system.",
-            },
+            LocalAiSetupAvailabilityStatus.Checking => "Checking Local AI requirements",
+            LocalAiSetupAvailabilityStatus.Unknown => "Local AI availability could not be verified",
+            _ => "Local AI is not available",
         };
+        LocalAiUnavailablePanel.Message = snapshot.Status switch
+        {
+            LocalAiSetupAvailabilityStatus.Checking =>
+                "OpenClaw is checking the NVIDIA GPU, driver, CUDA, memory, and WSL requirements.",
+            LocalAiSetupAvailabilityStatus.Unknown =>
+                "OpenClaw could not verify Local AI requirements right now. Recheck after confirming the NVIDIA driver is available.",
+            _ => "This PC does not meet one or more Local AI requirements.",
+        };
+        LocalAiUnavailableDetailsButton.Visibility =
+            string.IsNullOrWhiteSpace(_localAiUnavailableReason) ? Visibility.Collapsed : Visibility.Visible;
+        LocalAiAvailabilityRecoveryPanel.Visibility =
+            snapshot.IsChecking || snapshot.IsUnknown ? Visibility.Visible : Visibility.Collapsed;
+        LocalAiAvailabilityProgressRing.IsActive = snapshot.IsChecking;
+        LocalAiAvailabilityProgressRing.Visibility =
+            snapshot.IsChecking ? Visibility.Visible : Visibility.Collapsed;
+        LocalAiRecheckAvailabilityButton.Visibility =
+            snapshot.IsUnknown ? Visibility.Visible : Visibility.Collapsed;
+        LocalAiRecheckAvailabilityButton.IsEnabled = snapshot.CanRecheck;
+    }
+
+    private void SetLocalAiOptionAvailability(bool isAvailable, string? helpText = null)
+    {
+        LocalAiOptionContent.IsHitTestVisible = isAvailable;
+        LocalAiOptionContent.Opacity = isAvailable ? 1 : 0.55;
+        LocalAiToggle.IsEnabled = isAvailable;
+        LocalAiModelSelector.IsEnabled = isAvailable;
+        LocalAiNetworkingConsentCheckBox.IsEnabled = isAvailable;
+        AutomationProperties.SetHelpText(
+            LocalAiOptionContent,
+            isAvailable
+                ? string.Empty
+                : helpText ?? "Unavailable because this PC does not meet the Local AI requirements.");
+    }
+
+    private void LocalAiRecheckAvailability_Click(object sender, RoutedEventArgs e) =>
+        AsyncEventHandlerGuard.Run(
+            RecheckLocalAiAvailabilityAsync,
+            NullLogger.Instance,
+            nameof(LocalAiRecheckAvailability_Click));
+
+    private Task RecheckLocalAiAvailabilityAsync()
+    {
+        if (!_localAiAvailability.TryStartRecheck(out var snapshot))
+        {
+            ApplyLocalAiAvailabilityChrome(snapshot);
+            return Task.CompletedTask;
+        }
+
+        return InitializeLocalAiReviewAsync(
+            forceNetworkingConsent: _forceLocalAiNetworkingConsent,
+            refreshHardwareProbe: true,
+            startedAvailability: snapshot);
+    }
 
     private void LocalAiUnavailableDetails_Click(object sender, RoutedEventArgs e) =>
         AsyncEventHandlerGuard.Run(

--- a/src/OpenClaw.SetupEngine.UI/Pages/CapabilitiesPage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/CapabilitiesPage.xaml.cs
@@ -421,7 +421,7 @@ public sealed partial class CapabilitiesPage : Page
         ApplyLocalAiAvailabilityChrome(snapshot);
         _localAiSelectionEligible = false;
         _suppressLocalAiToggle = true;
-        LocalAiToggle.IsOn = false;
+        LocalAiToggle.IsOn = _config!.LocalAi.Enabled;
         _suppressLocalAiToggle = false;
         LocalAiToggle.Visibility = Visibility.Visible;
         LocalAiDetailsPanel.Visibility = Visibility.Collapsed;
@@ -429,8 +429,6 @@ public sealed partial class CapabilitiesPage : Page
         SetLocalAiOptionAvailability(
             isAvailable: false,
             SetupLocalization.GetString("Onboarding_LocalAi_ProbeUnknownHelpText"));
-        _config!.LocalAi.Enabled = false;
-        _config.SkipWizard = _skipWizardWithoutLocalAi;
         ApplySetupReviewSummary(_config);
         UpdatePrimaryButtonState();
     }

--- a/src/OpenClaw.SetupEngine.UI/Pages/CapabilitiesPage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/CapabilitiesPage.xaml.cs
@@ -292,6 +292,21 @@ public sealed partial class CapabilitiesPage : Page
             eligibility = LocalInferenceEligibility.Evaluate(
                 _localAiHardware,
                 _config!.LocalAi.SelectedModelId);
+            if (eligibility.FailureCode == LocalInferenceEligibilityFailureCode.HardwareFactsIncomplete)
+            {
+                // Incomplete facts (a partial/transient NVML read) are inconclusive, not a
+                // definitive "this device cannot run Local AI". Report it the same way as a
+                // thrown probe failure so recheck stays available instead of the option being
+                // permanently disabled.
+                if (_localAiAvailability.TryApplyProbeFailure(
+                        checking.Generation,
+                        LocalAiProbeFailureReason,
+                        out var incompleteSnapshot))
+                {
+                    ShowLocalAiProbeUnknown(incompleteSnapshot);
+                }
+                return;
+            }
             _localAiSelectedGpuCapacityBytes = eligibility.DetectedTotalMemoryBytes;
             _localAiRecommendedModelId = LocalModelCatalog.Models
                 .OrderByDescending(model => model.Weights.SizeBytes)

--- a/src/OpenClaw.SetupEngine.UI/Pages/CapabilitiesPage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/CapabilitiesPage.xaml.cs
@@ -382,9 +382,8 @@ public sealed partial class CapabilitiesPage : Page
         ApplySetupReviewSummary(_config);
     }
 
-    private const string LocalAiProbeFailureReason =
-        "OpenClaw could not read the NVIDIA GPU, driver, CUDA, or memory information. " +
-        "Confirm the NVIDIA driver is available, then recheck Local AI requirements.";
+    private static string LocalAiProbeFailureReason =>
+        SetupLocalization.GetString("Onboarding_LocalAi_ProbeFailureReason");
 
     private bool CanApplyLocalAiAvailability(int generation, SetupWindow? setupWindow) =>
         _localAiAvailability.IsCurrent(generation) &&
@@ -412,7 +411,7 @@ public sealed partial class CapabilitiesPage : Page
         LocalAiInstallReviewCard.Visibility = Visibility.Visible;
         SetLocalAiOptionAvailability(
             isAvailable: false,
-            "OpenClaw is checking Local AI requirements.");
+            SetupLocalization.GetString("Onboarding_LocalAi_CheckingHelpText"));
         ApplySetupReviewSummary(_config);
         UpdatePrimaryButtonState();
     }
@@ -429,7 +428,7 @@ public sealed partial class CapabilitiesPage : Page
         LocalAiInstallReviewCard.Visibility = Visibility.Visible;
         SetLocalAiOptionAvailability(
             isAvailable: false,
-            "OpenClaw could not verify Local AI requirements. Recheck availability to try again.");
+            SetupLocalization.GetString("Onboarding_LocalAi_ProbeUnknownHelpText"));
         _config!.LocalAi.Enabled = false;
         _config.SkipWizard = _skipWizardWithoutLocalAi;
         ApplySetupReviewSummary(_config);
@@ -453,8 +452,40 @@ public sealed partial class CapabilitiesPage : Page
         UpdatePrimaryButtonState();
     }
 
-    private static string DescribeLocalAiUnavailable(LocalInferenceEligibilityResult eligibility) =>
-        LocalInferenceEligibilityDiagnostics.DescribeUnavailable(eligibility);
+    private static string DescribeLocalAiUnavailable(LocalInferenceEligibilityResult eligibility)
+    {
+        LocalInferenceUnavailableReason reason = LocalInferenceEligibilityDiagnostics.GetUnavailableReason(eligibility);
+        return reason.Kind switch
+        {
+            LocalInferenceUnavailableReasonKind.RuntimeUnavailable =>
+                SetupLocalization.GetString("LocalAi_Reason_RuntimeUnavailable"),
+            LocalInferenceUnavailableReasonKind.NoNvidiaGpu =>
+                SetupLocalization.GetString("LocalAi_Reason_NoNvidiaGpu"),
+            LocalInferenceUnavailableReasonKind.UnknownModel =>
+                SetupLocalization.GetString("LocalAi_Reason_UnknownModel"),
+            LocalInferenceUnavailableReasonKind.HardwareFactsIncomplete =>
+                SetupLocalization.GetString("LocalAi_Reason_HardwareFactsIncomplete"),
+            LocalInferenceUnavailableReasonKind.InsufficientGpuMemory =>
+                SetupLocalization.Format(
+                    "LocalAi_Reason_InsufficientGpuMemory",
+                    reason.ModelDisplayName ?? SetupLocalization.GetString("LocalAi_Reason_UnknownModelName"),
+                    FormatGigabytes(reason.RequiredGigabytes),
+                    reason.DetectedGigabytes is { } detected
+                        ? FormatGigabytes(detected)
+                        : SetupLocalization.GetString("LocalAi_Reason_UnknownMemoryAmount")),
+            LocalInferenceUnavailableReasonKind.DriverTooOld =>
+                SetupLocalization.Format(
+                    "LocalAi_Reason_DriverTooOld",
+                    reason.DetectedDriverVersion ?? SetupLocalization.GetString("LocalAi_Reason_UnknownDriverVersion"),
+                    reason.MinimumDriverVersion),
+            LocalInferenceUnavailableReasonKind.CudaCapabilityTooLow =>
+                SetupLocalization.GetString("LocalAi_Reason_CudaCapabilityTooLow"),
+            _ => SetupLocalization.GetString("LocalAi_Reason_Generic"),
+        };
+    }
+
+    private static string FormatGigabytes(double gigabytes) =>
+        SetupLocalization.Format("LocalAi_Reason_GigabytesFormat", gigabytes);
 
     private void ApplyLocalAiAvailabilityChrome(LocalAiSetupAvailabilitySnapshot snapshot)
     {
@@ -463,17 +494,19 @@ public sealed partial class CapabilitiesPage : Page
             snapshot.IsAvailable ? Visibility.Collapsed : Visibility.Visible;
         LocalAiUnavailablePanel.Title = snapshot.Status switch
         {
-            LocalAiSetupAvailabilityStatus.Checking => "Checking Local AI requirements",
-            LocalAiSetupAvailabilityStatus.Unknown => "Local AI availability could not be verified",
-            _ => "Local AI is not available",
+            LocalAiSetupAvailabilityStatus.Checking =>
+                SetupLocalization.GetString("Onboarding_LocalAi_CheckingTitle"),
+            LocalAiSetupAvailabilityStatus.Unknown =>
+                SetupLocalization.GetString("Onboarding_LocalAi_ProbeUnknownTitle"),
+            _ => SetupLocalization.GetString("Onboarding_LocalAi_UnavailableTitle"),
         };
         LocalAiUnavailablePanel.Message = snapshot.Status switch
         {
             LocalAiSetupAvailabilityStatus.Checking =>
-                "OpenClaw is checking the NVIDIA GPU, driver, CUDA, memory, and WSL requirements.",
+                SetupLocalization.GetString("Onboarding_LocalAi_CheckingMessage"),
             LocalAiSetupAvailabilityStatus.Unknown =>
-                "OpenClaw could not verify Local AI requirements right now. Recheck after confirming the NVIDIA driver is available.",
-            _ => "This PC does not meet one or more Local AI requirements.",
+                SetupLocalization.GetString("Onboarding_LocalAi_ProbeUnknownMessage"),
+            _ => SetupLocalization.GetString("Onboarding_LocalAi_UnavailableMessage"),
         };
         LocalAiUnavailableDetailsButton.Visibility =
             string.IsNullOrWhiteSpace(_localAiUnavailableReason) ? Visibility.Collapsed : Visibility.Visible;
@@ -498,7 +531,7 @@ public sealed partial class CapabilitiesPage : Page
             LocalAiOptionContent,
             isAvailable
                 ? string.Empty
-                : helpText ?? "Unavailable because this PC does not meet the Local AI requirements.");
+                : helpText ?? SetupLocalization.GetString("Onboarding_LocalAi_UnavailableHelpText"));
     }
 
     private void LocalAiRecheckAvailability_Click(object sender, RoutedEventArgs e) =>
@@ -536,13 +569,13 @@ public sealed partial class CapabilitiesPage : Page
         var dialog = new ContentDialog
         {
             XamlRoot = xamlRoot,
-            Title = "Why Local AI is unavailable",
+            Title = SetupLocalization.GetString("Onboarding_LocalAi_UnavailableDetailsDialogTitle"),
             Content = new TextBlock
             {
                 Text = _localAiUnavailableReason,
                 TextWrapping = TextWrapping.Wrap,
             },
-            CloseButtonText = "Close",
+            CloseButtonText = SetupLocalization.GetString("Onboarding_LocalAi_UnavailableDetailsDialogClose"),
         };
         await dialog.ShowAsync();
     }

--- a/src/OpenClaw.SetupEngine.UI/Pages/CapabilitiesPage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/CapabilitiesPage.xaml.cs
@@ -435,6 +435,7 @@ public sealed partial class CapabilitiesPage : Page
         _config!.LocalAi.Enabled = false;
         _config.SkipWizard = _skipWizardWithoutLocalAi;
         ApplySetupReviewSummary(_config);
+        UpdatePrimaryButtonState();
     }
 
     private static string DescribeLocalAiUnavailable(LocalInferenceEligibilityResult eligibility) =>

--- a/src/OpenClaw.SetupEngine.UI/Pages/CapabilitiesPage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/CapabilitiesPage.xaml.cs
@@ -289,10 +289,13 @@ public sealed partial class CapabilitiesPage : Page
             if (!CanApplyLocalAiAvailability(checking.Generation, setupWindow))
                 return;
             _localAiHardware = hardware;
-            eligibility = LocalInferenceEligibility.Evaluate(
-                _localAiHardware,
-                _config!.LocalAi.SelectedModelId);
-            if (eligibility.FailureCode == LocalInferenceEligibilityFailureCode.HardwareFactsIncomplete)
+
+            // Gate on device-level eligibility (the best catalog model this hardware can run),
+            // not the currently configured model. A stale/removed SelectedModelId must not make
+            // an otherwise-capable device look unavailable and hide the badge/option; it only
+            // means the configured model needs to fall back to a valid one below.
+            LocalInferenceEligibilityResult deviceEligibility = LocalInferenceEligibility.Evaluate(_localAiHardware);
+            if (deviceEligibility.FailureCode == LocalInferenceEligibilityFailureCode.HardwareFactsIncomplete)
             {
                 // Incomplete facts (a partial/transient NVML read) are inconclusive, not a
                 // definitive "this device cannot run Local AI". Report it the same way as a
@@ -307,18 +310,44 @@ public sealed partial class CapabilitiesPage : Page
                 }
                 return;
             }
-            _localAiSelectedGpuCapacityBytes = eligibility.DetectedTotalMemoryBytes;
+            _localAiSelectedGpuCapacityBytes = deviceEligibility.DetectedTotalMemoryBytes;
             _localAiRecommendedModelId = LocalModelCatalog.Models
                 .OrderByDescending(model => model.Weights.SizeBytes)
                 .FirstOrDefault(model =>
                     _localAiSelectedGpuCapacityBytes is { } capacityBytes &&
                     LocalInferenceEligibility.GetRequiredMemoryBytes(model) <= capacityBytes)?.Id;
-            if (!eligibility.CanInstall || eligibility.Plan is null || eligibility.SelectedGpu is null)
-                hardwareReason = DescribeLocalAiUnavailable(eligibility);
+
+            if (!deviceEligibility.CanInstall || deviceEligibility.Plan is null || deviceEligibility.SelectedGpu is null)
+            {
+                hardwareReason = DescribeLocalAiUnavailable(deviceEligibility);
+            }
+            else
+            {
+                // The device can run Local AI. Reconcile the configured model selection: a
+                // model that no longer exists in the catalog, or exists but this specific
+                // hardware cannot run at all (e.g. the config was moved to a machine with a
+                // smaller GPU), falls back to the recommended (or the device-eligible default)
+                // model instead of leaving setup stuck on a known-incompatible selection. A
+                // merely busy GPU (EligibleButBusy) is not reconciled away: the same model would
+                // still work once the GPU frees up, and CanInstall already covers that case.
+                if (_config!.LocalAi.SelectedModelId is { } selectedModelId &&
+                    !LocalInferenceEligibility.Evaluate(_localAiHardware, selectedModelId).CanInstall)
+                {
+                    _config.LocalAi.SelectedModelId = null;
+                }
+                _config.LocalAi.SelectedModelId ??= _localAiRecommendedModelId ?? deviceEligibility.Plan.Model.Id;
+
+                eligibility = LocalInferenceEligibility.Evaluate(
+                    _localAiHardware,
+                    _config.LocalAi.SelectedModelId);
+            }
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"Local AI hardware probe failed: {ex}");
+            // Trace.TraceWarning is not compiled out in Release (unlike Debug.WriteLine) and its
+            // default listener forwards to OutputDebugString, so this stays visible via
+            // DebugView/ETW instead of silently disappearing in a packaged build.
+            Trace.TraceWarning($"Local AI hardware probe failed: {ex}");
             if (_localAiAvailability.TryApplyProbeFailure(
                     checking.Generation,
                     LocalAiProbeFailureReason,
@@ -341,10 +370,8 @@ public sealed partial class CapabilitiesPage : Page
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidDataException)
         {
-            Debug.WriteLine($"WSL networking inspection failed: {ex}");
-            wslNetworkingReason =
-                "OpenClaw cannot safely read the global .wslconfig file. " +
-                "Check that the file is valid and readable, then try setup again.";
+            Trace.TraceWarning($"WSL networking inspection failed: {ex}");
+            wslNetworkingReason = SetupLocalization.GetString("Onboarding_LocalAi_WslConfigReadFailureReason");
         }
 
         if (!CanApplyLocalAiAvailability(checking.Generation, setupWindow))
@@ -412,6 +439,7 @@ public sealed partial class CapabilitiesPage : Page
         SetLocalAiOptionAvailability(
             isAvailable: false,
             SetupLocalization.GetString("Onboarding_LocalAi_CheckingHelpText"));
+        RestoreLocalAiToggleAsPendingStateEscapeHatch();
         ApplySetupReviewSummary(_config);
         UpdatePrimaryButtonState();
     }
@@ -429,8 +457,27 @@ public sealed partial class CapabilitiesPage : Page
         SetLocalAiOptionAvailability(
             isAvailable: false,
             SetupLocalization.GetString("Onboarding_LocalAi_ProbeUnknownHelpText"));
+        RestoreLocalAiToggleAsPendingStateEscapeHatch();
         ApplySetupReviewSummary(_config);
         UpdatePrimaryButtonState();
+    }
+
+    /// <summary>
+    /// SetLocalAiOptionAvailability(isAvailable: false) sets LocalAiOptionContent.IsHitTestVisible
+    /// to false, which suppresses pointer input for its entire subtree regardless of any
+    /// descendant's own IsEnabled value; setting LocalAiToggle.IsEnabled back to true alone would
+    /// not make it clickable. Availability being merely pending (Checking/ProbeUnknown), not yet a
+    /// definitive result, must not remove the user's only way out, so this restores hit-testing on
+    /// the shared container and re-enables just the toggle: turning Local AI off unblocks Continue
+    /// via the existing LocalAiToggle.IsOn != true branch, instead of ever letting Continue itself
+    /// bypass an as-yet-undetermined WSL networking-consent requirement. The other Local AI
+    /// controls (model selector, consent checkbox) stay genuinely non-interactive because their
+    /// own IsEnabled is still false, independent of the container's hit-testability.
+    /// </summary>
+    private void RestoreLocalAiToggleAsPendingStateEscapeHatch()
+    {
+        LocalAiOptionContent.IsHitTestVisible = true;
+        LocalAiToggle.IsEnabled = true;
     }
 
     private void ShowLocalAiUnavailable(LocalAiSetupAvailabilitySnapshot snapshot)
@@ -720,6 +767,12 @@ public sealed partial class CapabilitiesPage : Page
 
     private void UpdatePrimaryButtonState()
     {
+        // Local AI availability being merely pending (Checking/ProbeUnknown) must never let
+        // Continue bypass eligibility or an as-yet-undetermined WSL networking-consent
+        // requirement. ShowLocalAiAvailabilityChecking/ShowLocalAiProbeUnknown keep
+        // LocalAiToggle itself interactive during those states specifically so the user always
+        // has a way out: turning Local AI off satisfies the LocalAiToggle.IsOn != true branch
+        // below immediately, without needing Continue to advance on incomplete information.
         PrimaryButton.IsEnabled =
             _step != 3 ||
             LocalAiToggle.IsOn != true ||

--- a/src/OpenClaw.SetupEngine.UI/Pages/LocalAiSetupAvailabilityCoordinator.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/LocalAiSetupAvailabilityCoordinator.cs
@@ -1,0 +1,87 @@
+namespace OpenClaw.SetupEngine.UI.Pages;
+
+internal enum LocalAiSetupAvailabilityStatus
+{
+    Checking,
+    Unknown,
+    Available,
+    Unsupported,
+}
+
+internal readonly record struct LocalAiSetupAvailabilitySnapshot(
+    int Generation,
+    LocalAiSetupAvailabilityStatus Status,
+    string? Reason)
+{
+    public bool IsChecking => Status == LocalAiSetupAvailabilityStatus.Checking;
+    public bool IsUnknown => Status == LocalAiSetupAvailabilityStatus.Unknown;
+    public bool IsAvailable => Status == LocalAiSetupAvailabilityStatus.Available;
+    public bool IsUnsupported => Status == LocalAiSetupAvailabilityStatus.Unsupported;
+    public bool CanRecheck => Status == LocalAiSetupAvailabilityStatus.Unknown;
+}
+
+internal sealed class LocalAiSetupAvailabilityCoordinator
+{
+    private int _generation;
+    private LocalAiSetupAvailabilitySnapshot _current;
+
+    public LocalAiSetupAvailabilitySnapshot Current => _current;
+
+    public LocalAiSetupAvailabilitySnapshot StartProbe()
+    {
+        int generation = unchecked(++_generation);
+        _current = new(generation, LocalAiSetupAvailabilityStatus.Checking, Reason: null);
+        return _current;
+    }
+
+    public bool TryStartRecheck(out LocalAiSetupAvailabilitySnapshot snapshot)
+    {
+        if (!_current.CanRecheck)
+        {
+            snapshot = _current;
+            return false;
+        }
+
+        snapshot = StartProbe();
+        return true;
+    }
+
+    public bool TryApplyAvailable(int generation, out LocalAiSetupAvailabilitySnapshot snapshot) =>
+        TryApply(generation, LocalAiSetupAvailabilityStatus.Available, reason: null, out snapshot);
+
+    public bool TryApplyUnsupported(
+        int generation,
+        string reason,
+        out LocalAiSetupAvailabilitySnapshot snapshot) =>
+        TryApply(generation, LocalAiSetupAvailabilityStatus.Unsupported, reason, out snapshot);
+
+    public bool TryApplyProbeFailure(
+        int generation,
+        string reason,
+        out LocalAiSetupAvailabilitySnapshot snapshot) =>
+        TryApply(generation, LocalAiSetupAvailabilityStatus.Unknown, reason, out snapshot);
+
+    public void CancelCurrent()
+    {
+        unchecked { _generation++; }
+    }
+
+    public bool IsCurrent(int generation) => generation == _generation;
+
+    private bool TryApply(
+        int generation,
+        LocalAiSetupAvailabilityStatus status,
+        string? reason,
+        out LocalAiSetupAvailabilitySnapshot snapshot)
+    {
+        if (!IsCurrent(generation))
+        {
+            snapshot = _current;
+            return false;
+        }
+
+        _current = new(generation, status, reason);
+        snapshot = _current;
+        return true;
+    }
+}

--- a/src/OpenClaw.SetupEngine.UI/Pages/ProgressPage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/ProgressPage.xaml.cs
@@ -101,15 +101,17 @@ public sealed partial class ProgressPage : Page
 
     private void RenderProgressPreview()
     {
-        bool localAiPreview = SetupPreview.RequestedPage == "progress-local-ai";
+        bool localAiPreview =
+            _config?.LocalAi.Enabled == true ||
+            SetupPreview.RequestedPage == "progress-local-ai";
         TitleText.Text = localAiPreview ? "Setting up OpenClaw and Local AI" : "Setting up OpenClaw";
         SubtitleText.Text = localAiPreview
             ? "Downloading the selected Hugging Face model: about 18 minutes left"
             : "Creating OpenClawGateway WSL instance: about 4 minutes left";
         var ids = StepGroups.Select(g => g.GroupId).ToArray();
-        int previewRunningIndex = localAiPreview
-            ? Array.IndexOf(ids, "local-ai-model")
-            : 3;
+        int previewRunningIndex = Array.IndexOf(
+            ids,
+            localAiPreview ? "local-ai-model" : "wsl-create");
         for (int i = 0; i < ids.Length; i++)
         {
             var status = i < previewRunningIndex
@@ -131,17 +133,20 @@ public sealed partial class ProgressPage : Page
 
     private void BuildStepRows()
     {
-        foreach (var (groupId, displayName, _) in StepGroups)
+        foreach (var (groupId, displayName, stepIds) in StepGroups)
         {
             var row = new StepRow(
                 displayName,
                 showDetailProgress: groupId is "local-ai-engine" or "local-ai-model");
             _rows[groupId] = row;
             StepsPanel.Children.Add(row.Element);
-            if (_config?.LocalAi.Enabled != true && groupId.StartsWith("local-ai", StringComparison.Ordinal))
+            if (_config?.LocalAi.Enabled != true && IsLocalAiOnlyGroup(stepIds))
                 row.Element.Visibility = Visibility.Collapsed;
         }
     }
+
+    private static bool IsLocalAiOnlyGroup(string[] stepIds) =>
+        stepIds.All(stepId => stepId.Contains("local-ai", StringComparison.Ordinal));
 
     private void StartPipeline() =>
         AsyncEventHandlerGuard.Run(

--- a/src/OpenClaw.SetupEngine.UI/Pages/WelcomePage.xaml
+++ b/src/OpenClaw.SetupEngine.UI/Pages/WelcomePage.xaml
@@ -65,30 +65,27 @@
                                                Style="{StaticResource CaptionTextBlockStyle}"
                                                Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" />
                                 </Border>
+                                <Border x:Name="LocalAiAvailabilityBadge"
+                                        AutomationProperties.AutomationId="WelcomeLocalAiAvailable"
+                                        AutomationProperties.AccessibilityView="Raw"
+                                        CornerRadius="4" Padding="7,1" VerticalAlignment="Center"
+                                        BorderBrush="{ThemeResource SystemFillColorSuccessBrush}"
+                                        BorderThickness="1" Visibility="Collapsed">
+                                    <StackPanel Orientation="Horizontal" Spacing="4">
+                                        <FontIcon Glyph="&#xE950;" FontSize="11"
+                                                  IsTextScaleFactorEnabled="False"
+                                                  Foreground="{ThemeResource SystemFillColorSuccessBrush}"
+                                                  AutomationProperties.AccessibilityView="Raw" />
+                                        <TextBlock Text="Local AI available"
+                                                   Style="{StaticResource CaptionTextBlockStyle}"
+                                                   Foreground="{ThemeResource SystemFillColorSuccessBrush}" />
+                                    </StackPanel>
+                                </Border>
                             </StackPanel>
                             <TextBlock TextWrapping="Wrap"
                                        Style="{StaticResource CaptionTextBlockStyle}"
                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                        Text="A private, self-hosted OpenClaw gateway in an isolated Ubuntu WSL instance. We'll show exactly what gets installed before anything runs." />
-                            <StackPanel x:Name="LocalAiAvailabilityPanel"
-                                        AutomationProperties.AutomationId="WelcomeLocalAiAvailable"
-                                        AutomationProperties.LiveSetting="Polite"
-                                        Spacing="2" Margin="0,5,0,0" Visibility="Collapsed">
-                                <StackPanel Orientation="Horizontal" Spacing="6">
-                                    <FontIcon Glyph="&#xE73E;" FontSize="12"
-                                              IsTextScaleFactorEnabled="False"
-                                              Foreground="{ThemeResource SystemFillColorSuccessBrush}" />
-                                    <TextBlock Text="Local AI available"
-                                               Style="{StaticResource CaptionTextBlockStyle}"
-                                               FontWeight="SemiBold"
-                                               Foreground="{ThemeResource SystemFillColorSuccessBrush}" />
-                                </StackPanel>
-                                <TextBlock x:Name="LocalAiAvailabilityText"
-                                           AutomationProperties.AutomationId="WelcomeLocalAiHardware"
-                                           TextWrapping="Wrap"
-                                           Style="{StaticResource CaptionTextBlockStyle}"
-                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                            </StackPanel>
                         </StackPanel>
                     </Grid>
                 </ListViewItem>

--- a/src/OpenClaw.SetupEngine.UI/Pages/WelcomePage.xaml
+++ b/src/OpenClaw.SetupEngine.UI/Pages/WelcomePage.xaml
@@ -39,6 +39,7 @@
                 <ListViewItem x:Name="InstallChoice"
                               AutomationProperties.AutomationId="WelcomeInstallLocalGatewayChoice"
                               AutomationProperties.Name="Install a local gateway (WSL), recommended"
+                              AutomationProperties.LiveSetting="Polite"
                               HorizontalContentAlignment="Stretch"
                               VerticalContentAlignment="Center"
                               Padding="16,12">

--- a/src/OpenClaw.SetupEngine.UI/Pages/WelcomePage.xaml
+++ b/src/OpenClaw.SetupEngine.UI/Pages/WelcomePage.xaml
@@ -76,7 +76,8 @@
                                                   IsTextScaleFactorEnabled="False"
                                                   Foreground="{ThemeResource SystemFillColorSuccessBrush}"
                                                   AutomationProperties.AccessibilityView="Raw" />
-                                        <TextBlock Text="Local AI available"
+                                        <TextBlock x:Uid="Onboarding_Welcome_LocalAiAvailableBadge"
+                                                   Text="Local AI available"
                                                    Style="{StaticResource CaptionTextBlockStyle}"
                                                    Foreground="{ThemeResource SystemFillColorSuccessBrush}" />
                                     </StackPanel>

--- a/src/OpenClaw.SetupEngine.UI/Pages/WelcomePage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/WelcomePage.xaml.cs
@@ -1,5 +1,6 @@
 using Microsoft.UI.Composition;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Hosting;
 using Microsoft.UI.Xaml.Navigation;
@@ -67,12 +68,13 @@ public sealed partial class WelcomePage : Page
         LocalInferenceEligibilityResult eligibility = LocalInferenceEligibility.Evaluate(
             hardware,
             config.LocalAi.SelectedModelId);
-        if (!eligibility.CanInstall || eligibility.SelectedGpu is not { } gpu)
+        if (!eligibility.CanInstall || eligibility.SelectedGpu is null)
             return;
 
-        LocalAiAvailabilityText.Text =
-            $"{gpu.Name} detected. Install a local gateway to use local AI inference on this PC.";
-        LocalAiAvailabilityPanel.Visibility = Visibility.Visible;
+        LocalAiAvailabilityBadge.Visibility = Visibility.Visible;
+        AutomationProperties.SetName(
+            InstallChoice,
+            "Install a local gateway (WSL), recommended, Local AI available");
     }
 
     private void StartMascotBreatheAnimation()

--- a/src/OpenClaw.SetupEngine.UI/Pages/WelcomePage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/WelcomePage.xaml.cs
@@ -74,7 +74,8 @@ public sealed partial class WelcomePage : Page
         LocalAiAvailabilityBadge.Visibility = Visibility.Visible;
         AutomationProperties.SetName(
             InstallChoice,
-            "Install a local gateway (WSL), recommended, Local AI available");
+            $"{AutomationProperties.GetName(InstallChoice)}, " +
+            $"{SetupLocalization.GetString("Onboarding_Welcome_LocalAiAvailableBadge.Text")}");
     }
 
     private void StartMascotBreatheAnimation()

--- a/src/OpenClaw.SetupEngine.UI/Pages/WelcomePage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/WelcomePage.xaml.cs
@@ -1,6 +1,7 @@
 using Microsoft.UI.Composition;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Hosting;
 using Microsoft.UI.Xaml.Navigation;
@@ -17,6 +18,7 @@ public sealed partial class WelcomePage : Page
     private SetupConfig? _config;
     private bool _installSelected = true; // default selection
     private bool _suppressSelectionWrite;
+    private string? _installChoiceBaseAutomationName;
 
     public WelcomePage()
     {
@@ -65,17 +67,26 @@ public sealed partial class WelcomePage : Page
         if (!IsLoaded || !ReferenceEquals(SetupWindow.Active, setupWindow))
             return;
 
-        LocalInferenceEligibilityResult eligibility = LocalInferenceEligibility.Evaluate(
-            hardware,
-            config.LocalAi.SelectedModelId);
+        LocalInferenceEligibilityResult eligibility = LocalInferenceEligibility.Evaluate(hardware);
         if (!eligibility.CanInstall || eligibility.SelectedGpu is null)
             return;
 
         LocalAiAvailabilityBadge.Visibility = Visibility.Visible;
+        // Capture the control's base accessible name once, so repeated detections (e.g. the
+        // page is re-loaded after navigating back) rebuild the announcement from the same
+        // starting point instead of appending the badge suffix again on every call.
+        _installChoiceBaseAutomationName ??= AutomationProperties.GetName(InstallChoice);
         AutomationProperties.SetName(
             InstallChoice,
-            $"{AutomationProperties.GetName(InstallChoice)}, " +
+            $"{_installChoiceBaseAutomationName}, " +
             $"{SetupLocalization.GetString("Onboarding_Welcome_LocalAiAvailableBadge.Text")}");
+        // FromElement returns null until a screen reader (or other AT client) has already
+        // queried this element for a peer. This probe can complete before that happens, so the
+        // live-region announcement would otherwise be silently skipped; force peer creation so
+        // the event always has somewhere to go.
+        AutomationPeer automationPeer = FrameworkElementAutomationPeer.FromElement(InstallChoice)
+            ?? FrameworkElementAutomationPeer.CreatePeerForElement(InstallChoice);
+        automationPeer.RaiseAutomationEvent(AutomationEvents.LiveRegionChanged);
     }
 
     private void StartMascotBreatheAnimation()

--- a/src/OpenClaw.SetupEngine.UI/SetupLocalization.cs
+++ b/src/OpenClaw.SetupEngine.UI/SetupLocalization.cs
@@ -54,7 +54,11 @@ internal static class SetupLocalization
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"SetupLocalization: resource lookup failed for '{resourceKey}': {ex.Message}");
+            // Trace.TraceWarning (unlike Debug.WriteLine) is not compiled out in Release: the
+            // TRACE constant is defined in both build configurations by default, and the
+            // default trace listener forwards to OutputDebugString, so this remains visible via
+            // DebugView/ETW in a packaged Release build instead of silently disappearing.
+            Trace.TraceWarning($"SetupLocalization: resource lookup failed for '{resourceKey}': {ex.Message}");
             return null;
         }
     }
@@ -72,7 +76,7 @@ internal static class SetupLocalization
         }
         catch (FormatException)
         {
-            Debug.WriteLine($"SetupLocalization: format failed for '{resourceKey}': template='{template}'");
+            Trace.TraceWarning($"SetupLocalization: format failed for '{resourceKey}': template='{template}'");
             return template;
         }
     }

--- a/src/OpenClaw.SetupEngine.UI/SetupLocalization.cs
+++ b/src/OpenClaw.SetupEngine.UI/SetupLocalization.cs
@@ -21,18 +21,41 @@ internal static class SetupLocalization
 
     public static string GetString(string resourceKey)
     {
+        string? value = TryGetValueAsString(resourceKey);
+        if (!string.IsNullOrEmpty(value))
+            return value;
+
+        // XAML property resources (the ones an x:Uid="Key" binding resolves for a "Key.Property"
+        // entry, e.g. "Onboarding_Welcome_LocalAiAvailableBadge.Text") are stored under a
+        // "Key/Property" path, not a literal dot. Retry that shape so code-behind can share the
+        // same resw entry an x:Uid binding already uses, instead of duplicating the string under
+        // a second key.
+        int propertySeparator = resourceKey.LastIndexOf('.');
+        if (propertySeparator > 0 && propertySeparator < resourceKey.Length - 1)
+        {
+            string propertyResourcePath =
+                $"{resourceKey[..propertySeparator]}/{resourceKey[(propertySeparator + 1)..]}";
+            value = TryGetValueAsString(propertyResourcePath);
+            if (!string.IsNullOrEmpty(value))
+                return value;
+        }
+
+        return resourceKey;
+    }
+
+    private static string? TryGetValueAsString(string resourceKey)
+    {
         try
         {
             ResourceCandidate? candidate = Manager.MainResourceMap.GetValue(
                 $"Resources/{resourceKey}",
                 Manager.CreateResourceContext());
-            string? value = candidate?.ValueAsString;
-            return string.IsNullOrEmpty(value) ? resourceKey : value;
+            return candidate?.ValueAsString;
         }
         catch (Exception ex)
         {
             Debug.WriteLine($"SetupLocalization: resource lookup failed for '{resourceKey}': {ex.Message}");
-            return resourceKey;
+            return null;
         }
     }
 

--- a/src/OpenClaw.SetupEngine.UI/SetupLocalization.cs
+++ b/src/OpenClaw.SetupEngine.UI/SetupLocalization.cs
@@ -1,0 +1,56 @@
+using System.Diagnostics;
+using Microsoft.Windows.ApplicationModel.Resources;
+
+namespace OpenClaw.SetupEngine.UI;
+
+/// <summary>
+/// Resource-string lookup for <see cref="OpenClaw.SetupEngine.UI"/> code-behind. This project has
+/// no <c>.resw</c> files of its own and cannot reference the Tray app project (which references
+/// this project, so the reverse would be circular). There is no standalone Setup UI executable in
+/// Release builds: this project is always hosted inside the Tray app process, so string keys
+/// resolve against the same merged app resource map that the Tray app's own localization helper
+/// reads, using keys defined in the Tray app's <c>Strings\*\Resources.resw</c> files (the existing
+/// <c>x:Uid="Onboarding_LocalAi_RecheckAvailabilityButton"</c> binding already relies on the same
+/// mechanism for XAML-declared strings).
+/// </summary>
+internal static class SetupLocalization
+{
+    private static ResourceManager? s_resourceManager;
+
+    private static ResourceManager Manager => s_resourceManager ??= new ResourceManager();
+
+    public static string GetString(string resourceKey)
+    {
+        try
+        {
+            ResourceCandidate? candidate = Manager.MainResourceMap.GetValue(
+                $"Resources/{resourceKey}",
+                Manager.CreateResourceContext());
+            string? value = candidate?.ValueAsString;
+            return string.IsNullOrEmpty(value) ? resourceKey : value;
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"SetupLocalization: resource lookup failed for '{resourceKey}': {ex.Message}");
+            return resourceKey;
+        }
+    }
+
+    /// <summary>
+    /// Localized <see cref="string.Format(string, object?[])"/>. Catches <see cref="FormatException"/>
+    /// caused by a malformed translation so a translator typo can't crash the UI thread.
+    /// </summary>
+    public static string Format(string resourceKey, params object?[] args)
+    {
+        string template = GetString(resourceKey);
+        try
+        {
+            return string.Format(template, args);
+        }
+        catch (FormatException)
+        {
+            Debug.WriteLine($"SetupLocalization: format failed for '{resourceKey}': template='{template}'");
+            return template;
+        }
+    }
+}

--- a/src/OpenClaw.SetupEngine.UI/SetupWindow.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/SetupWindow.xaml.cs
@@ -198,12 +198,19 @@ public sealed partial class SetupWindow : Window
     public bool IsWelcomeInstallSelected => _isWelcomeInstallSelected;
     public void SetWelcomeInstallSelected(bool installSelected) => _isWelcomeInstallSelected = installSelected;
 
-    internal Task<HostHardwareInfo> GetLocalAiHardwareAsync()
+    internal Task<HostHardwareInfo> GetLocalAiHardwareAsync(bool forceRefresh = false)
     {
         lock (_localAiHardwareProbeLock)
         {
-            return _localAiHardwareProbeTask ??=
-                Task.Run(() => new NvmlHostHardwareProbe().Probe());
+            if (forceRefresh ||
+                _localAiHardwareProbeTask is null ||
+                _localAiHardwareProbeTask.IsFaulted ||
+                _localAiHardwareProbeTask.IsCanceled)
+            {
+                _localAiHardwareProbeTask = Task.Run(() => new NvmlHostHardwareProbe().Probe());
+            }
+
+            return _localAiHardwareProbeTask;
         }
     }
 

--- a/src/OpenClaw.Shared/Inference/Catalog/LocalInferenceEligibilityDiagnostics.cs
+++ b/src/OpenClaw.Shared/Inference/Catalog/LocalInferenceEligibilityDiagnostics.cs
@@ -1,0 +1,40 @@
+namespace OpenClaw.Shared.Inference.Catalog;
+
+public static class LocalInferenceEligibilityDiagnostics
+{
+    public static string DescribeUnavailable(LocalInferenceEligibilityResult eligibility)
+    {
+        ArgumentNullException.ThrowIfNull(eligibility);
+
+        return eligibility.SelectionFailureCode switch
+        {
+            LocalInferenceSelectionFailureCode.RuntimeUnavailable =>
+                "This Local AI release does not include a native llama-server runtime for the detected Windows architecture.",
+            LocalInferenceSelectionFailureCode.NoNvidiaGpu =>
+                "No NVIDIA GPU was reported by the NVIDIA driver. Install or repair the NVIDIA driver, then try setup again.",
+            LocalInferenceSelectionFailureCode.UnknownModel =>
+                "The selected model is not available in this Local AI release.",
+            _ => eligibility.FailureCode switch
+            {
+                LocalInferenceEligibilityFailureCode.HardwareFactsIncomplete =>
+                    "OpenClaw could not read a stable NVIDIA GPU identifier, memory, driver, or CUDA capability.",
+                LocalInferenceEligibilityFailureCode.InsufficientGpuMemory =>
+                    $"{eligibility.Plan?.Model.DisplayName ?? "The selected model"} requires " +
+                    $"{FormatSize(eligibility.RequiredTotalMemoryBytes)} of GPU memory for model weights, KV cache, and runtime workspace. " +
+                    $"OpenClaw detected {FormatOptionalSize(eligibility.DetectedTotalMemoryBytes)}.",
+                LocalInferenceEligibilityFailureCode.DriverTooOld =>
+                    $"NVIDIA driver {eligibility.SelectedGpu?.DriverVersion ?? "unknown"} was detected. " +
+                    $"Local AI requires version {LocalInferenceEligibility.MinimumNvidiaDriverVersion} or newer.",
+                LocalInferenceEligibilityFailureCode.CudaCapabilityTooLow =>
+                    "The NVIDIA driver does not provide CUDA 13 support. A separate CUDA Toolkit is not required.",
+                _ => "OpenClaw could not verify the Local AI requirements on this system.",
+            },
+        };
+    }
+
+    private static string FormatSize(long bytes) =>
+        $"{bytes / 1_000_000_000d:0.#} GB";
+
+    private static string FormatOptionalSize(long? bytes) =>
+        bytes is { } value ? FormatSize(value) : "an unknown amount";
+}

--- a/src/OpenClaw.Shared/Inference/Catalog/LocalInferenceEligibilityDiagnostics.cs
+++ b/src/OpenClaw.Shared/Inference/Catalog/LocalInferenceEligibilityDiagnostics.cs
@@ -1,40 +1,69 @@
 namespace OpenClaw.Shared.Inference.Catalog;
 
+/// <summary>Discriminant for why Local AI is unavailable. Carries no language-specific text;
+/// UI layers turn this into localized copy using their own resource strings.</summary>
+public enum LocalInferenceUnavailableReasonKind
+{
+    RuntimeUnavailable,
+    NoNvidiaGpu,
+    UnknownModel,
+    HardwareFactsIncomplete,
+    InsufficientGpuMemory,
+    DriverTooOld,
+    CudaCapabilityTooLow,
+    Unknown,
+}
+
+/// <summary>
+/// Locale-neutral facts describing why Local AI is unavailable. This type intentionally carries
+/// no English (or any other language) text: <see cref="OpenClaw.Shared"/> stays locale-neutral,
+/// and each UI layer (setup, Hub) formats <see cref="Kind"/> plus these facts into localized
+/// copy using its own resource strings.
+/// </summary>
+public sealed record LocalInferenceUnavailableReason(
+    LocalInferenceUnavailableReasonKind Kind,
+    string? ModelDisplayName,
+    double RequiredGigabytes,
+    double? DetectedGigabytes,
+    string? DetectedDriverVersion,
+    string MinimumDriverVersion);
+
 public static class LocalInferenceEligibilityDiagnostics
 {
-    public static string DescribeUnavailable(LocalInferenceEligibilityResult eligibility)
+    public static LocalInferenceUnavailableReason GetUnavailableReason(LocalInferenceEligibilityResult eligibility)
     {
         ArgumentNullException.ThrowIfNull(eligibility);
 
-        return eligibility.SelectionFailureCode switch
+        LocalInferenceUnavailableReasonKind kind = eligibility.SelectionFailureCode switch
         {
             LocalInferenceSelectionFailureCode.RuntimeUnavailable =>
-                "This Local AI release does not include a native llama-server runtime for the detected Windows architecture.",
+                LocalInferenceUnavailableReasonKind.RuntimeUnavailable,
             LocalInferenceSelectionFailureCode.NoNvidiaGpu =>
-                "No NVIDIA GPU was reported by the NVIDIA driver. Install or repair the NVIDIA driver, then try setup again.",
+                LocalInferenceUnavailableReasonKind.NoNvidiaGpu,
             LocalInferenceSelectionFailureCode.UnknownModel =>
-                "The selected model is not available in this Local AI release.",
+                LocalInferenceUnavailableReasonKind.UnknownModel,
             _ => eligibility.FailureCode switch
             {
                 LocalInferenceEligibilityFailureCode.HardwareFactsIncomplete =>
-                    "OpenClaw could not read a stable NVIDIA GPU identifier, memory, driver, or CUDA capability.",
+                    LocalInferenceUnavailableReasonKind.HardwareFactsIncomplete,
                 LocalInferenceEligibilityFailureCode.InsufficientGpuMemory =>
-                    $"{eligibility.Plan?.Model.DisplayName ?? "The selected model"} requires " +
-                    $"{FormatSize(eligibility.RequiredTotalMemoryBytes)} of GPU memory for model weights, KV cache, and runtime workspace. " +
-                    $"OpenClaw detected {FormatOptionalSize(eligibility.DetectedTotalMemoryBytes)}.",
+                    LocalInferenceUnavailableReasonKind.InsufficientGpuMemory,
                 LocalInferenceEligibilityFailureCode.DriverTooOld =>
-                    $"NVIDIA driver {eligibility.SelectedGpu?.DriverVersion ?? "unknown"} was detected. " +
-                    $"Local AI requires version {LocalInferenceEligibility.MinimumNvidiaDriverVersion} or newer.",
+                    LocalInferenceUnavailableReasonKind.DriverTooOld,
                 LocalInferenceEligibilityFailureCode.CudaCapabilityTooLow =>
-                    "The NVIDIA driver does not provide CUDA 13 support. A separate CUDA Toolkit is not required.",
-                _ => "OpenClaw could not verify the Local AI requirements on this system.",
+                    LocalInferenceUnavailableReasonKind.CudaCapabilityTooLow,
+                _ => LocalInferenceUnavailableReasonKind.Unknown,
             },
         };
+
+        return new LocalInferenceUnavailableReason(
+            kind,
+            eligibility.Plan?.Model.DisplayName,
+            ToGigabytes(eligibility.RequiredTotalMemoryBytes),
+            eligibility.DetectedTotalMemoryBytes is { } detected ? ToGigabytes(detected) : null,
+            eligibility.SelectedGpu?.DriverVersion,
+            LocalInferenceEligibility.MinimumNvidiaDriverVersion.ToString());
     }
 
-    private static string FormatSize(long bytes) =>
-        $"{bytes / 1_000_000_000d:0.#} GB";
-
-    private static string FormatOptionalSize(long? bytes) =>
-        bytes is { } value ? FormatSize(value) : "an unknown amount";
+    private static double ToGigabytes(long bytes) => bytes / 1_000_000_000d;
 }

--- a/src/OpenClaw.Tray.WinUI/Pages/LocalAiPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/LocalAiPage.xaml
@@ -3,7 +3,8 @@
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
-        <StackPanel Padding="24" Spacing="12" HorizontalAlignment="Stretch" MaxWidth="900">
+        <Grid HorizontalAlignment="Stretch">
+            <StackPanel Padding="24" Spacing="12" HorizontalAlignment="Stretch" MaxWidth="900">
             <TextBlock x:Uid="LocalAiPage_Title" Text="Local AI"
                        Style="{StaticResource TitleTextBlockStyle}"
                        AutomationProperties.AutomationId="LocalAiPageMarker"/>
@@ -12,9 +13,47 @@
                        Style="{StaticResource CaptionTextBlockStyle}"
                        Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap"/>
 
-            <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" BorderThickness="1"
-                    CornerRadius="8" Padding="16" AutomationProperties.AutomationId="LocalAiEngineCard">
+            <InfoBar x:Name="LocalAiUnavailableInfoBar"
+                     x:Uid="LocalAiPage_UnavailableInfoBar"
+                     Title="Local AI is not available"
+                     Severity="Informational"
+                     IsOpen="True" IsClosable="False"
+                     Visibility="Collapsed"
+                     AutomationProperties.AutomationId="LocalAiUnavailableInfoBar"
+                     AutomationProperties.LiveSetting="Polite">
+                <InfoBar.ActionButton>
+                    <HyperlinkButton x:Name="LocalAiUnavailableDetailsButton"
+                                     x:Uid="LocalAiPage_UnavailableDetailsButton"
+                                     Content="See why"
+                                     AutomationProperties.AutomationId="LocalAiUnavailableDetailsButton"
+                                     Click="LocalAiUnavailableDetails_Click"/>
+                </InfoBar.ActionButton>
+            </InfoBar>
+            <HyperlinkButton x:Name="LocalAiRecheckAvailabilityButton"
+                             x:Uid="LocalAiPage_RecheckAvailabilityButton"
+                             Content="Recheck"
+                             HorizontalAlignment="Left"
+                             AutomationProperties.AutomationId="LocalAiRecheckAvailabilityButton"
+                             Click="LocalAiRecheckAvailability_Click"
+                             Visibility="Collapsed"/>
+            <TeachingTip x:Name="LocalAiUnavailableDetailsTip"
+                         x:Uid="LocalAiPage_UnavailableDetailsTip"
+                         Title="Why Local AI is unavailable"
+                         Target="{x:Bind LocalAiUnavailableDetailsButton}"
+                         PreferredPlacement="Bottom"
+                         IsLightDismissEnabled="True">
+                <TextBlock x:Name="LocalAiUnavailableReasonText"
+                           TextWrapping="Wrap"
+                           MaxWidth="420"/>
+            </TeachingTip>
+
+            <ContentControl x:Name="LocalAiEngineOption"
+                            IsTabStop="False"
+                            HorizontalContentAlignment="Stretch"
+                            AutomationProperties.AutomationId="LocalAiEngineCard">
+                <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" BorderThickness="1"
+                        CornerRadius="8" Padding="16">
                 <StackPanel Spacing="10">
                     <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="12">
                         <Ellipse x:Name="EngineStatusDot" Width="12" Height="12" VerticalAlignment="Center"
@@ -62,11 +101,16 @@
                                 Click="OnOpenLogs" AutomationProperties.AutomationId="LocalAiOpenLogs"/>
                     </StackPanel>
                 </StackPanel>
-            </Border>
+                </Border>
+            </ContentControl>
 
-            <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" BorderThickness="1"
-                    CornerRadius="8" Padding="16" AutomationProperties.AutomationId="LocalAiModelCard">
+            <ContentControl x:Name="LocalAiModelOption"
+                            IsTabStop="False"
+                            HorizontalContentAlignment="Stretch"
+                            AutomationProperties.AutomationId="LocalAiModelCard">
+                <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" BorderThickness="1"
+                        CornerRadius="8" Padding="16">
                 <StackPanel Spacing="10">
                     <TextBlock x:Uid="LocalAiPage_ModelHeading" Text="Model"
                                Style="{StaticResource BodyStrongTextBlockStyle}"/>
@@ -96,11 +140,16 @@
                                AutomationProperties.AutomationId="LocalAiChangeModel"/>
                     </StackPanel>
                 </StackPanel>
-            </Border>
+                </Border>
+            </ContentControl>
 
-            <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" BorderThickness="1"
-                    CornerRadius="8" Padding="16" AutomationProperties.AutomationId="LocalAiGatewayCard">
+            <ContentControl x:Name="LocalAiGatewayOption"
+                            IsTabStop="False"
+                            HorizontalContentAlignment="Stretch"
+                            AutomationProperties.AutomationId="LocalAiGatewayCard">
+                <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" BorderThickness="1"
+                        CornerRadius="8" Padding="16">
                 <StackPanel Spacing="10">
                     <TextBlock x:Uid="LocalAiPage_GatewayHeading" Text="Gateway connection"
                                Style="{StaticResource BodyStrongTextBlockStyle}"/>
@@ -123,7 +172,9 @@
                                 AutomationProperties.AutomationId="LocalAiOpenChat"/>
                     </StackPanel>
                 </StackPanel>
-            </Border>
-        </StackPanel>
+                </Border>
+            </ContentControl>
+            </StackPanel>
+        </Grid>
     </ScrollViewer>
 </Page>

--- a/src/OpenClaw.Tray.WinUI/Pages/LocalAiPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/LocalAiPage.xaml
@@ -29,13 +29,20 @@
                                      Click="LocalAiUnavailableDetails_Click"/>
                 </InfoBar.ActionButton>
             </InfoBar>
-            <HyperlinkButton x:Name="LocalAiRecheckAvailabilityButton"
-                             x:Uid="LocalAiPage_RecheckAvailabilityButton"
-                             Content="Recheck"
-                             HorizontalAlignment="Left"
-                             AutomationProperties.AutomationId="LocalAiRecheckAvailabilityButton"
-                             Click="LocalAiRecheckAvailability_Click"
-                             Visibility="Collapsed"/>
+            <StackPanel Orientation="Horizontal" Spacing="8">
+                <ProgressRing x:Name="LocalAiAvailabilityProgressRing"
+                              Width="16"
+                              Height="16"
+                              IsActive="False"
+                              AutomationProperties.AccessibilityView="Raw"/>
+                <HyperlinkButton x:Name="LocalAiRecheckAvailabilityButton"
+                                 x:Uid="LocalAiPage_RecheckAvailabilityButton"
+                                 Content="Recheck"
+                                 HorizontalAlignment="Left"
+                                 AutomationProperties.AutomationId="LocalAiRecheckAvailabilityButton"
+                                 Click="LocalAiRecheckAvailability_Click"
+                                 Visibility="Collapsed"/>
+            </StackPanel>
             <TeachingTip x:Name="LocalAiUnavailableDetailsTip"
                          x:Uid="LocalAiPage_UnavailableDetailsTip"
                          Title="Why Local AI is unavailable"

--- a/src/OpenClaw.Tray.WinUI/Pages/LocalAiPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/LocalAiPage.xaml.cs
@@ -87,6 +87,18 @@ public sealed partial class LocalAiPage : Page
         ActionErrorText.Visibility = string.IsNullOrWhiteSpace(ActionErrorText.Text) ? Visibility.Collapsed : Visibility.Visible;
         EngineBusyIndicator.IsActive = _viewModel.IsBusy;
         EngineBusyIndicator.Visibility = _viewModel.IsBusy ? Visibility.Visible : Visibility.Collapsed;
+        LocalAiUnavailableInfoBar.Visibility =
+            _viewModel.ShowAvailabilityInfoBar
+                ? Visibility.Visible
+                : Visibility.Collapsed;
+        LocalAiUnavailableInfoBar.Message = LocalizationHelper.GetString(
+            _viewModel.HasAvailabilityProbeError
+                ? "LocalAiPage_UnavailableProbeMessage"
+                : "LocalAiPage_UnavailableRequirementsMessage");
+        LocalAiRecheckAvailabilityButton.Visibility = _viewModel.HasAvailabilityProbeError
+            ? Visibility.Visible
+            : Visibility.Collapsed;
+        LocalAiRecheckAvailabilityButton.IsEnabled = _viewModel.CanRecheckAvailability;
         StartButton.IsEnabled = _viewModel.CanStart;
         StopButton.IsEnabled = _viewModel.CanStop;
         RestartButton.IsEnabled = _viewModel.CanRestart;
@@ -107,6 +119,13 @@ public sealed partial class LocalAiPage : Page
     private void OnChangeModel(object sender, RoutedEventArgs e) => _viewModel?.ChangeModel();
     private void OnRepairConnection(object sender, RoutedEventArgs e) => _viewModel?.RepairConnection();
     private void OnOpenChat(object sender, RoutedEventArgs e) => _viewModel?.OpenChat();
+    private void LocalAiRecheckAvailability_Click(object sender, RoutedEventArgs e) => _viewModel?.RecheckAvailability();
+    private void LocalAiUnavailableDetails_Click(object sender, RoutedEventArgs e)
+    {
+        LocalAiUnavailableReasonText.Text = _viewModel?.LocalAiUnavailableReason ?? string.Empty;
+        LocalAiUnavailableDetailsTip.IsOpen = !LocalAiUnavailableDetailsTip.IsOpen;
+    }
+
     private static void RunAction(Func<Task<bool>> action, string source) =>
         AsyncEventHandlerGuard.Run(action, new AppLogger(), source);
     private static Brush ResolveBrush(string key) => (Brush)Application.Current.Resources[key];

--- a/src/OpenClaw.Tray.WinUI/Pages/LocalAiPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/LocalAiPage.xaml.cs
@@ -2,6 +2,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using OpenClaw.Shared;
+using OpenClaw.Shared.Inference.Catalog;
 using OpenClawTray.Helpers;
 using OpenClawTray.Presentation;
 using System.Globalization;
@@ -122,9 +123,48 @@ public sealed partial class LocalAiPage : Page
     private void LocalAiRecheckAvailability_Click(object sender, RoutedEventArgs e) => _viewModel?.RecheckAvailability();
     private void LocalAiUnavailableDetails_Click(object sender, RoutedEventArgs e)
     {
-        LocalAiUnavailableReasonText.Text = _viewModel?.LocalAiUnavailableReason ?? string.Empty;
+        LocalAiUnavailableReasonText.Text = _viewModel?.LocalAiUnavailableReason is { } reason
+            ? DescribeUnavailable(reason)
+            : string.Empty;
         LocalAiUnavailableDetailsTip.IsOpen = !LocalAiUnavailableDetailsTip.IsOpen;
     }
+
+    /// <summary>
+    /// Turns the locale-neutral <see cref="LocalInferenceUnavailableReason"/> the ViewModel
+    /// exposes into localized text. This lives in the View (not the ViewModel) because
+    /// <see cref="LocalizationHelper"/> depends on the packaged app's resource map, which the
+    /// ViewModel's unit tests (source-linked without a WinUI host) cannot resolve.
+    /// </summary>
+    private static string DescribeUnavailable(LocalInferenceUnavailableReason reason) => reason.Kind switch
+    {
+        LocalInferenceUnavailableReasonKind.RuntimeUnavailable =>
+            LocalizationHelper.GetString("LocalAi_Reason_RuntimeUnavailable"),
+        LocalInferenceUnavailableReasonKind.NoNvidiaGpu =>
+            LocalizationHelper.GetString("LocalAi_Reason_NoNvidiaGpu"),
+        LocalInferenceUnavailableReasonKind.UnknownModel =>
+            LocalizationHelper.GetString("LocalAi_Reason_UnknownModel"),
+        LocalInferenceUnavailableReasonKind.HardwareFactsIncomplete =>
+            LocalizationHelper.GetString("LocalAi_Reason_HardwareFactsIncomplete"),
+        LocalInferenceUnavailableReasonKind.InsufficientGpuMemory =>
+            LocalizationHelper.Format(
+                "LocalAi_Reason_InsufficientGpuMemory",
+                reason.ModelDisplayName ?? LocalizationHelper.GetString("LocalAi_Reason_UnknownModelName"),
+                FormatGigabytes(reason.RequiredGigabytes),
+                reason.DetectedGigabytes is { } detected
+                    ? FormatGigabytes(detected)
+                    : LocalizationHelper.GetString("LocalAi_Reason_UnknownMemoryAmount")),
+        LocalInferenceUnavailableReasonKind.DriverTooOld =>
+            LocalizationHelper.Format(
+                "LocalAi_Reason_DriverTooOld",
+                reason.DetectedDriverVersion ?? LocalizationHelper.GetString("LocalAi_Reason_UnknownDriverVersion"),
+                reason.MinimumDriverVersion),
+        LocalInferenceUnavailableReasonKind.CudaCapabilityTooLow =>
+            LocalizationHelper.GetString("LocalAi_Reason_CudaCapabilityTooLow"),
+        _ => LocalizationHelper.GetString("LocalAi_Reason_Generic"),
+    };
+
+    private static string FormatGigabytes(double gigabytes) =>
+        LocalizationHelper.Format("LocalAi_Reason_GigabytesFormat", gigabytes);
 
     private static void RunAction(Func<Task<bool>> action, string source) =>
         AsyncEventHandlerGuard.Run(action, new AppLogger(), source);

--- a/src/OpenClaw.Tray.WinUI/Pages/LocalAiPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/LocalAiPage.xaml.cs
@@ -92,10 +92,30 @@ public sealed partial class LocalAiPage : Page
             _viewModel.ShowAvailabilityInfoBar
                 ? Visibility.Visible
                 : Visibility.Collapsed;
-        LocalAiUnavailableInfoBar.Message = LocalizationHelper.GetString(
-            _viewModel.HasAvailabilityProbeError
-                ? "LocalAiPage_UnavailableProbeMessage"
-                : "LocalAiPage_UnavailableRequirementsMessage");
+        LocalAiAvailabilityProgressRing.IsActive = _viewModel.IsCheckingAvailability;
+        LocalAiAvailabilityProgressRing.Visibility = _viewModel.IsCheckingAvailability
+            ? Visibility.Visible
+            : Visibility.Collapsed;
+        if (_viewModel.IsCheckingAvailability)
+        {
+            LocalAiUnavailableInfoBar.Title = LocalizationHelper.GetString("LocalAiPage_CheckingTitle");
+            LocalAiUnavailableInfoBar.Severity = InfoBarSeverity.Informational;
+            LocalAiUnavailableInfoBar.Message = LocalizationHelper.GetString("LocalAiPage_CheckingMessage");
+        }
+        else
+        {
+            LocalAiUnavailableInfoBar.Title = LocalizationHelper.GetString(
+                _viewModel.HasAvailabilityProbeError
+                    ? "LocalAiPage_UnavailableProbeTitle"
+                    : "LocalAiPage_UnavailableInfoBar.Title");
+            LocalAiUnavailableInfoBar.Severity = _viewModel.HasAvailabilityProbeError
+                ? InfoBarSeverity.Warning
+                : InfoBarSeverity.Informational;
+            LocalAiUnavailableInfoBar.Message = LocalizationHelper.GetString(
+                _viewModel.HasAvailabilityProbeError
+                    ? "LocalAiPage_UnavailableProbeMessage"
+                    : "LocalAiPage_UnavailableRequirementsMessage");
+        }
         LocalAiRecheckAvailabilityButton.Visibility = _viewModel.HasAvailabilityProbeError
             ? Visibility.Visible
             : Visibility.Collapsed;

--- a/src/OpenClaw.Tray.WinUI/Presentation/AppServiceRegistration.cs
+++ b/src/OpenClaw.Tray.WinUI/Presentation/AppServiceRegistration.cs
@@ -1,4 +1,5 @@
 using OpenClaw.Shared.ExecApprovals;
+using OpenClaw.Shared.Inference;
 using Microsoft.Extensions.DependencyInjection;
 using OpenClawTray.Chat;
 using OpenClawTray.Services;
@@ -42,6 +43,7 @@ internal static class AppServiceRegistration
         // its Saved-event subscription during shutdown.
         services.AddSingleton<ISettingsStore, SettingsStore>();
         services.AddSingleton<IPermissionsPageRuntimeSource, PermissionsPageRuntimeSource>();
+        services.AddSingleton<IHostHardwareProbe, NvmlHostHardwareProbe>();
 
         // Container-owned navigation lifetime manager (disposed with the root provider).
         services.AddSingleton<NavigationScopeManager>();

--- a/src/OpenClaw.Tray.WinUI/Presentation/LocalAiPageViewModel.cs
+++ b/src/OpenClaw.Tray.WinUI/Presentation/LocalAiPageViewModel.cs
@@ -1,8 +1,10 @@
 using OpenClaw.Connection;
 using OpenClaw.Connection.LocalAi;
+using OpenClaw.Shared.Inference;
 using OpenClaw.Shared.Inference.Catalog;
 using OpenClawTray.Services;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace OpenClawTray.Presentation;
@@ -18,24 +20,32 @@ internal sealed class LocalAiPageViewModel : INavigationAware, IDisposable, INot
     private readonly IPermissionsPageRuntimeSource _gatewaySource;
     private readonly IAppCommands _appCommands;
     private readonly IUiDispatcher _dispatcher;
+    private readonly IHostHardwareProbe _hardwareProbe;
     private LocalAiRuntimeSnapshot _runtimeSnapshot;
     private GatewayConnectionSnapshot _gatewaySnapshot;
     private CancellationTokenSource? _refreshCancellation;
+    private CancellationTokenSource? _availabilityCancellation;
     private bool _subscribed;
     private bool _disposed;
     private bool _isBusy;
     private string? _actionError;
+    private bool _isAvailabilityKnown;
+    private bool _isLocalAiAvailable;
+    private bool _hasAvailabilityProbeError;
+    private string? _localAiUnavailableReason;
 
     public LocalAiPageViewModel(
         ILocalAiRuntime runtime,
         IPermissionsPageRuntimeSource gatewaySource,
         IAppCommands appCommands,
-        IUiDispatcher dispatcher)
+        IUiDispatcher dispatcher,
+        IHostHardwareProbe hardwareProbe)
     {
         _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
         _gatewaySource = gatewaySource ?? throw new ArgumentNullException(nameof(gatewaySource));
         _appCommands = appCommands ?? throw new ArgumentNullException(nameof(appCommands));
         _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+        _hardwareProbe = hardwareProbe ?? throw new ArgumentNullException(nameof(hardwareProbe));
         _runtimeSnapshot = runtime.Snapshot;
         _gatewaySnapshot = gatewaySource.Current.ConnectionSnapshot;
     }
@@ -110,6 +120,13 @@ internal sealed class LocalAiPageViewModel : INavigationAware, IDisposable, INot
     public string? GatewayDetail => _gatewaySnapshot.GatewayName ?? _gatewaySnapshot.GatewayUrl;
     public string? ActionError => _actionError;
     public bool IsBusy => _isBusy;
+    public bool IsAvailabilityKnown => _isAvailabilityKnown;
+    public bool IsLocalAiAvailable => _isAvailabilityKnown && _isLocalAiAvailable;
+    public bool HasAvailabilityProbeError => _hasAvailabilityProbeError;
+    public bool ShowAvailabilityInfoBar => (_isAvailabilityKnown && !_isLocalAiAvailable) || _hasAvailabilityProbeError;
+    public bool IsSetupAvailable => !_isAvailabilityKnown || _isLocalAiAvailable;
+    public bool CanRecheckAvailability => _hasAvailabilityProbeError && _availabilityCancellation is null && !IsBusy;
+    public string? LocalAiUnavailableReason => _localAiUnavailableReason;
     public bool CanStart => !IsBusy && HasManagedInstall &&
         _runtimeSnapshot.State is LocalAiRuntimeState.Stopped or LocalAiRuntimeState.Failed;
     public bool CanStop => !IsBusy && _runtimeSnapshot.Ownership == LocalAiOwnership.CompanionManaged &&
@@ -117,7 +134,7 @@ internal sealed class LocalAiPageViewModel : INavigationAware, IDisposable, INot
     public bool CanRestart => !IsBusy && _runtimeSnapshot.Ownership == LocalAiOwnership.CompanionManaged &&
         _runtimeSnapshot.State == LocalAiRuntimeState.Healthy;
     public bool CanOpenLogs => !IsBusy && HasManagedInstall;
-    public bool CanRetrySetup => !IsBusy && ModelState is
+    public bool CanRetrySetup => IsSetupAvailable && !IsBusy && ModelState is
         LocalAiModelPresentationState.NotInstalled or LocalAiModelPresentationState.Unknown;
     public bool HasInstalledModel => ModelState is
         LocalAiModelPresentationState.Verified or LocalAiModelPresentationState.Loaded;
@@ -147,11 +164,13 @@ internal sealed class LocalAiPageViewModel : INavigationAware, IDisposable, INot
         ApplyRuntimeSnapshot(_runtime.Snapshot);
         ApplyGatewaySnapshot(_gatewaySource.Current.ConnectionSnapshot);
         StartRuntimeRefresh();
+        StartAvailabilityRefresh();
     }
 
     public void Deactivate()
     {
         CancelRuntimeRefresh();
+        CancelAvailabilityRefresh();
         if (_subscribed)
         {
             _runtime.StateChanged -= OnRuntimeStateChanged;
@@ -169,6 +188,14 @@ internal sealed class LocalAiPageViewModel : INavigationAware, IDisposable, INot
     public bool ChangeModel() => RunCommand(CanChangeModel, _appCommands.ShowOnboarding);
     public bool RepairConnection() => RunCommand(CanRepairConnection, _appCommands.Reconnect);
     public bool OpenChat() => RunCommand(CanOpenChat, _appCommands.ShowChat);
+    public bool RecheckAvailability()
+    {
+        ThrowIfDisposed();
+        if (!IsActive || _availabilityCancellation is not null)
+            return false;
+        StartAvailabilityRefresh();
+        return true;
+    }
 
     private static bool RunCommand(bool allowed, Action command)
     {
@@ -192,6 +219,91 @@ internal sealed class LocalAiPageViewModel : INavigationAware, IDisposable, INot
         _refreshCancellation = null;
         cancellation?.Cancel();
     }
+
+    private void StartAvailabilityRefresh()
+    {
+        CancelAvailabilityRefresh();
+        _isAvailabilityKnown = false;
+        _isLocalAiAvailable = false;
+        _hasAvailabilityProbeError = false;
+        _localAiUnavailableReason = null;
+        OnPropertyChanged(null);
+        var cancellation = new CancellationTokenSource();
+        _availabilityCancellation = cancellation;
+        _ = RefreshAvailabilityAsync(cancellation);
+    }
+
+    private void CancelAvailabilityRefresh()
+    {
+        CancellationTokenSource? cancellation = _availabilityCancellation;
+        _availabilityCancellation = null;
+        cancellation?.Cancel();
+    }
+
+    private async Task RefreshAvailabilityAsync(CancellationTokenSource cancellation)
+    {
+        try
+        {
+            HostHardwareInfo hardware = await Task.Run(
+                _hardwareProbe.Probe,
+                cancellation.Token).ConfigureAwait(false);
+            LocalInferenceEligibilityResult eligibility = LocalInferenceEligibility.Evaluate(
+                hardware,
+                _runtimeSnapshot.ModelId);
+            bool isAvailable = eligibility.CanInstall;
+            string? unavailableReason = isAvailable
+                ? null
+                : LocalInferenceEligibilityDiagnostics.DescribeUnavailable(eligibility);
+            if (!IsCurrentAvailabilityProbe(cancellation))
+                return;
+            ApplyOnUiThread(() =>
+            {
+                if (!IsCurrentAvailabilityProbe(cancellation))
+                    return;
+                _isAvailabilityKnown = true;
+                _isLocalAiAvailable = isAvailable;
+                _hasAvailabilityProbeError = false;
+                _localAiUnavailableReason = unavailableReason;
+                OnPropertyChanged(null);
+            });
+        }
+        catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Local AI availability probe failed: {ex}");
+            const string unavailableReason =
+                "OpenClaw could not read the NVIDIA GPU, driver, CUDA, or memory information. " +
+                "Check the NVIDIA driver installation and try setup again.";
+            if (!IsCurrentAvailabilityProbe(cancellation))
+                return;
+            ApplyOnUiThread(() =>
+            {
+                if (!IsCurrentAvailabilityProbe(cancellation))
+                    return;
+                _isAvailabilityKnown = false;
+                _isLocalAiAvailable = false;
+                _hasAvailabilityProbeError = true;
+                _localAiUnavailableReason = unavailableReason;
+                OnPropertyChanged(null);
+            });
+        }
+        finally
+        {
+            bool completedCurrentProbe = ReferenceEquals(_availabilityCancellation, cancellation);
+            if (completedCurrentProbe)
+                _availabilityCancellation = null;
+            if (completedCurrentProbe)
+            {
+                ApplyOnUiThread(() => OnPropertyChanged(nameof(CanRecheckAvailability)));
+            }
+            cancellation.Dispose();
+        }
+    }
+
+    private bool IsCurrentAvailabilityProbe(CancellationTokenSource cancellation) =>
+        ReferenceEquals(_availabilityCancellation, cancellation);
 
     private async Task RefreshRuntimeSnapshotAsync(CancellationTokenSource cancellation)
     {

--- a/src/OpenClaw.Tray.WinUI/Presentation/LocalAiPageViewModel.cs
+++ b/src/OpenClaw.Tray.WinUI/Presentation/LocalAiPageViewModel.cs
@@ -242,6 +242,11 @@ internal sealed class LocalAiPageViewModel : INavigationAware, IDisposable, INot
 
     private async Task RefreshAvailabilityAsync(CancellationTokenSource cancellation)
     {
+        // The probe result is applied and the cancellation is released together, inside the
+        // single dispatched callback below. Clearing _availabilityCancellation here (before the
+        // dispatched callback runs) would make a queued-but-not-yet-run callback's own
+        // IsCurrentAvailabilityProbe guard fail against itself, silently dropping a real
+        // asynchronous DispatcherQueue completion.
         try
         {
             HostHardwareInfo hardware = await Task.Run(
@@ -254,21 +259,18 @@ internal sealed class LocalAiPageViewModel : INavigationAware, IDisposable, INot
             string? unavailableReason = isAvailable
                 ? null
                 : LocalInferenceEligibilityDiagnostics.DescribeUnavailable(eligibility);
-            if (!IsCurrentAvailabilityProbe(cancellation))
-                return;
-            ApplyOnUiThread(() =>
-            {
-                if (!IsCurrentAvailabilityProbe(cancellation))
-                    return;
-                _isAvailabilityKnown = true;
-                _isLocalAiAvailable = isAvailable;
-                _hasAvailabilityProbeError = false;
-                _localAiUnavailableReason = unavailableReason;
-                OnPropertyChanged(null);
-            });
+            ApplyOnUiThread(() => ApplyAvailabilityResult(
+                cancellation,
+                isAvailabilityKnown: true,
+                isLocalAiAvailable: isAvailable,
+                hasAvailabilityProbeError: false,
+                unavailableReason));
         }
         catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
         {
+            // A newer probe already replaced (or cleared) _availabilityCancellation, so this
+            // probe is stale by definition. Just release the token; do not touch shared state.
+            cancellation.Dispose();
         }
         catch (Exception ex)
         {
@@ -276,30 +278,36 @@ internal sealed class LocalAiPageViewModel : INavigationAware, IDisposable, INot
             const string unavailableReason =
                 "OpenClaw could not read the NVIDIA GPU, driver, CUDA, or memory information. " +
                 "Check the NVIDIA driver installation and try setup again.";
-            if (!IsCurrentAvailabilityProbe(cancellation))
-                return;
-            ApplyOnUiThread(() =>
-            {
-                if (!IsCurrentAvailabilityProbe(cancellation))
-                    return;
-                _isAvailabilityKnown = false;
-                _isLocalAiAvailable = false;
-                _hasAvailabilityProbeError = true;
-                _localAiUnavailableReason = unavailableReason;
-                OnPropertyChanged(null);
-            });
+            ApplyOnUiThread(() => ApplyAvailabilityResult(
+                cancellation,
+                isAvailabilityKnown: false,
+                isLocalAiAvailable: false,
+                hasAvailabilityProbeError: true,
+                unavailableReason));
         }
-        finally
-        {
-            bool completedCurrentProbe = ReferenceEquals(_availabilityCancellation, cancellation);
-            if (completedCurrentProbe)
-                _availabilityCancellation = null;
-            if (completedCurrentProbe)
-            {
-                ApplyOnUiThread(() => OnPropertyChanged(nameof(CanRecheckAvailability)));
-            }
-            cancellation.Dispose();
-        }
+    }
+
+    /// <summary>
+    /// Applies a completed availability probe's result and releases its cancellation together,
+    /// on the UI thread, so the currency check and the state clear cannot race a real
+    /// asynchronous DispatcherQueue callback.
+    /// </summary>
+    private void ApplyAvailabilityResult(
+        CancellationTokenSource cancellation,
+        bool isAvailabilityKnown,
+        bool isLocalAiAvailable,
+        bool hasAvailabilityProbeError,
+        string? unavailableReason)
+    {
+        if (!IsCurrentAvailabilityProbe(cancellation))
+            return;
+        _availabilityCancellation = null;
+        _isAvailabilityKnown = isAvailabilityKnown;
+        _isLocalAiAvailable = isLocalAiAvailable;
+        _hasAvailabilityProbeError = hasAvailabilityProbeError;
+        _localAiUnavailableReason = unavailableReason;
+        OnPropertyChanged(null);
+        cancellation.Dispose();
     }
 
     private bool IsCurrentAvailabilityProbe(CancellationTokenSource cancellation) =>

--- a/src/OpenClaw.Tray.WinUI/Presentation/LocalAiPageViewModel.cs
+++ b/src/OpenClaw.Tray.WinUI/Presentation/LocalAiPageViewModel.cs
@@ -4,7 +4,6 @@ using OpenClaw.Shared.Inference;
 using OpenClaw.Shared.Inference.Catalog;
 using OpenClawTray.Services;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace OpenClawTray.Presentation;
@@ -123,7 +122,10 @@ internal sealed class LocalAiPageViewModel : INavigationAware, IDisposable, INot
     public bool IsAvailabilityKnown => _isAvailabilityKnown;
     public bool IsLocalAiAvailable => _isAvailabilityKnown && _isLocalAiAvailable;
     public bool HasAvailabilityProbeError => _hasAvailabilityProbeError;
-    public bool ShowAvailabilityInfoBar => (_isAvailabilityKnown && !_isLocalAiAvailable) || _hasAvailabilityProbeError;
+    /// <summary>An availability probe (initial check or recheck) is currently in flight.</summary>
+    public bool IsCheckingAvailability => _availabilityCancellation is not null;
+    public bool ShowAvailabilityInfoBar =>
+        (_isAvailabilityKnown && !_isLocalAiAvailable) || _hasAvailabilityProbeError || IsCheckingAvailability;
     public bool IsSetupAvailable => !_isAvailabilityKnown || _isLocalAiAvailable;
     public bool CanRecheckAvailability => _hasAvailabilityProbeError && _availabilityCancellation is null && !IsBusy;
     public LocalInferenceUnavailableReason? LocalAiUnavailableReason => _localAiUnavailableReason;
@@ -191,7 +193,7 @@ internal sealed class LocalAiPageViewModel : INavigationAware, IDisposable, INot
     public bool RecheckAvailability()
     {
         ThrowIfDisposed();
-        if (!IsActive || _availabilityCancellation is not null)
+        if (!IsActive || !CanRecheckAvailability)
             return false;
         StartAvailabilityRefresh();
         return true;
@@ -215,8 +217,10 @@ internal sealed class LocalAiPageViewModel : INavigationAware, IDisposable, INot
 
     private void CancelRuntimeRefresh()
     {
-        CancellationTokenSource? cancellation = _refreshCancellation;
-        _refreshCancellation = null;
+        // Same atomic grab-and-clear as CancelAvailabilityRefresh(): RefreshRuntimeSnapshotAsync's
+        // finally block clears/disposes this token from a worker thread after ConfigureAwait(false),
+        // so a plain read-then-write here could race it the same way.
+        CancellationTokenSource? cancellation = Interlocked.Exchange(ref _refreshCancellation, null);
         cancellation?.Cancel();
     }
 
@@ -227,16 +231,28 @@ internal sealed class LocalAiPageViewModel : INavigationAware, IDisposable, INot
         _isLocalAiAvailable = false;
         _hasAvailabilityProbeError = false;
         _localAiUnavailableReason = null;
-        OnPropertyChanged(null);
         var cancellation = new CancellationTokenSource();
+        // Assign the new probe slot before notifying, so IsCheckingAvailability (which reads
+        // _availabilityCancellation) already reports true in this notification. Notifying first
+        // would report the pre-refresh "not checking" state, so a UI bound to PropertyChanged
+        // (like the Hub page) would not reliably show checking/recheck progress until the probe
+        // had already completed.
         _availabilityCancellation = cancellation;
+        OnPropertyChanged(null);
         _ = RefreshAvailabilityAsync(cancellation);
     }
 
     private void CancelAvailabilityRefresh()
     {
-        CancellationTokenSource? cancellation = _availabilityCancellation;
-        _availabilityCancellation = null;
+        // Interlocked.Exchange atomically grabs and clears the field together, so this can
+        // never race the worker-thread rejected-enqueue path in
+        // ApplyAvailabilityResultOnUiThread: whichever side's atomic operation the CPU
+        // actually applies first "wins" the token, and the other side observes the field
+        // already null and does nothing further with it. A plain read-then-null-then-Cancel()
+        // sequence would let this method capture the token into a local variable, lose the
+        // field-ownership race to the worker thread's CompareExchange, and then still call
+        // Cancel() on the copy the worker already disposed, throwing ObjectDisposedException.
+        CancellationTokenSource? cancellation = Interlocked.Exchange(ref _availabilityCancellation, null);
         cancellation?.Cancel();
     }
 
@@ -276,24 +292,24 @@ internal sealed class LocalAiPageViewModel : INavigationAware, IDisposable, INot
                 // inconclusive, not a definitive "this device cannot run Local AI". Report it the
                 // same way as a thrown probe failure below so recheck stays available instead of
                 // permanently disabling Local AI on this device.
-                ApplyOnUiThread(() => ApplyAvailabilityResult(
+                ApplyAvailabilityResultOnUiThread(
                     cancellation,
                     isAvailabilityKnown: false,
                     isLocalAiAvailable: false,
                     hasAvailabilityProbeError: true,
-                    ProbeFailureReason));
+                    ProbeFailureReason);
                 return;
             }
             bool isAvailable = eligibility.CanInstall;
             LocalInferenceUnavailableReason? unavailableReason = isAvailable
                 ? null
                 : LocalInferenceEligibilityDiagnostics.GetUnavailableReason(eligibility);
-            ApplyOnUiThread(() => ApplyAvailabilityResult(
+            ApplyAvailabilityResultOnUiThread(
                 cancellation,
                 isAvailabilityKnown: true,
                 isLocalAiAvailable: isAvailable,
                 hasAvailabilityProbeError: false,
-                unavailableReason));
+                unavailableReason);
         }
         catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
         {
@@ -303,20 +319,99 @@ internal sealed class LocalAiPageViewModel : INavigationAware, IDisposable, INot
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"Local AI availability probe failed: {ex}");
-            ApplyOnUiThread(() => ApplyAvailabilityResult(
+            Logger.Warn($"Local AI availability probe failed: {ex}");
+            ApplyAvailabilityResultOnUiThread(
                 cancellation,
                 isAvailabilityKnown: false,
                 isLocalAiAvailable: false,
                 hasAvailabilityProbeError: true,
-                ProbeFailureReason));
+                ProbeFailureReason);
         }
     }
 
     /// <summary>
+    /// Dispatches a completed availability probe's result to the UI thread, guaranteeing
+    /// <paramref name="cancellation"/> is disposed exactly once no matter which path runs: applied
+    /// inline, applied from a genuinely deferred dispatcher callback, or never applied at all
+    /// because the ViewModel is already disposed/inactive or the dispatcher refused the enqueue.
+    /// A plain <see cref="ApplyOnUiThread"/> call would silently leak the token on those last two
+    /// paths, since its own no-op guard runs before (or instead of) the wrapped action.
+    /// </summary>
+    private void ApplyAvailabilityResultOnUiThread(
+        CancellationTokenSource cancellation,
+        bool isAvailabilityKnown,
+        bool isLocalAiAvailable,
+        bool hasAvailabilityProbeError,
+        LocalInferenceUnavailableReason? unavailableReason)
+    {
+        if (_disposed || !IsActive)
+        {
+            // This check and the dispose below run on the probing worker thread (this whole
+            // method is reached from RefreshAvailabilityAsync after ConfigureAwait(false)), so
+            // it must not assume Deactivate()/Dispose() having flipped these plain, unsynchronized
+            // flags means CancelAvailabilityRefresh() has already fully claimed and released this
+            // exact token; that assumption depends on cross-thread visibility ordering these plain
+            // fields don't guarantee. Route through the same atomic release path as the
+            // rejected-enqueue branch below instead of disposing unconditionally.
+            ReleaseAbandonedAvailabilityProbe(cancellation);
+            return;
+        }
+
+        if (_dispatcher.HasThreadAccess)
+        {
+            ApplyAvailabilityResult(
+                cancellation, isAvailabilityKnown, isLocalAiAvailable, hasAvailabilityProbeError, unavailableReason);
+            return;
+        }
+
+        bool enqueued = _dispatcher.TryEnqueue(() =>
+        {
+            // This callback runs on the UI thread (that is what TryEnqueue guarantees when it
+            // returns true), the same thread CancelAvailabilityRefresh() runs on, so the two are
+            // already serialized here; no atomic coordination is needed for this plain check.
+            if (_disposed || !IsActive)
+            {
+                cancellation.Dispose();
+                return;
+            }
+            ApplyAvailabilityResult(
+                cancellation, isAvailabilityKnown, isLocalAiAvailable, hasAvailabilityProbeError, unavailableReason);
+        });
+        if (!enqueued)
+        {
+            // The dispatcher refused the enqueue (e.g. it is shutting down). This runs on the
+            // probing worker thread, not the UI thread, so it must not call OnPropertyChanged
+            // (WinUI's page code-behind touches controls from that notification and would throw
+            // on the wrong thread) either.
+            ReleaseAbandonedAvailabilityProbe(cancellation);
+        }
+    }
+
+    /// <summary>
+    /// Releases an availability-probe token from a worker thread when it will never reach
+    /// <see cref="ApplyAvailabilityResult"/> (the ViewModel is disposed/inactive, or the
+    /// dispatcher refused the enqueue). Interlocked.CompareExchange atomically claims the token:
+    /// only the side that actually swaps it out for null may dispose it, so this can never
+    /// dispose a token CancelAvailabilityRefresh() is concurrently (or has already) called
+    /// Cancel() on. CancelAvailabilityRefresh() uses the matching Interlocked.Exchange to
+    /// grab-and-clear the field atomically, so exactly one of the two atomic operations "wins"
+    /// any given token; the loser observes the field already null and leaves its local copy of
+    /// the token untouched. A rare undisposed CancellationTokenSource when the loser is this
+    /// method is an acceptable trade-off for never risking ObjectDisposedException, since this
+    /// class never registers a timeout that would give the token an unmanaged resource to leak.
+    /// </summary>
+    private void ReleaseAbandonedAvailabilityProbe(CancellationTokenSource cancellation)
+    {
+        if (Interlocked.CompareExchange(ref _availabilityCancellation, null, cancellation) == cancellation)
+            cancellation.Dispose();
+    }
+
+    /// <summary>
     /// Applies a completed availability probe's result and releases its cancellation together,
-    /// on the UI thread, so the currency check and the state clear cannot race a real
-    /// asynchronous DispatcherQueue callback.
+    /// so the currency check and the state clear cannot race a real asynchronous DispatcherQueue
+    /// callback. Always disposes <paramref name="cancellation"/>: a stale probe (superseded by a
+    /// newer one) is no longer referenced by <see cref="_availabilityCancellation"/> by
+    /// definition, so nothing else can still cancel or dispose this exact instance.
     /// </summary>
     private void ApplyAvailabilityResult(
         CancellationTokenSource cancellation,
@@ -326,7 +421,10 @@ internal sealed class LocalAiPageViewModel : INavigationAware, IDisposable, INot
         LocalInferenceUnavailableReason? unavailableReason)
     {
         if (!IsCurrentAvailabilityProbe(cancellation))
+        {
+            cancellation.Dispose();
             return;
+        }
         _availabilityCancellation = null;
         _isAvailabilityKnown = isAvailabilityKnown;
         _isLocalAiAvailable = isLocalAiAvailable;
@@ -357,9 +455,16 @@ internal sealed class LocalAiPageViewModel : INavigationAware, IDisposable, INot
         }
         finally
         {
-            if (ReferenceEquals(_refreshCancellation, cancellation))
-                _refreshCancellation = null;
-            cancellation.Dispose();
+            // Interlocked.CompareExchange pairs with CancelRuntimeRefresh()'s
+            // Interlocked.Exchange: only the side that atomically wins clearing the field may
+            // dispose this token, so a concurrent CancelRuntimeRefresh() on the UI thread can
+            // never call Cancel() on an instance this worker thread already disposed. If
+            // CancelRuntimeRefresh() already claimed the field first, this side leaves the
+            // token undisposed rather than risk disposing it out from under an in-flight
+            // Cancel() call; CancellationTokenSource has no unmanaged resource to leak unless a
+            // timeout was registered, which this class never does.
+            if (Interlocked.CompareExchange(ref _refreshCancellation, null, cancellation) == cancellation)
+                cancellation.Dispose();
         }
     }
 

--- a/src/OpenClaw.Tray.WinUI/Presentation/LocalAiPageViewModel.cs
+++ b/src/OpenClaw.Tray.WinUI/Presentation/LocalAiPageViewModel.cs
@@ -138,7 +138,7 @@ internal sealed class LocalAiPageViewModel : INavigationAware, IDisposable, INot
         LocalAiModelPresentationState.NotInstalled or LocalAiModelPresentationState.Unknown;
     public bool HasInstalledModel => ModelState is
         LocalAiModelPresentationState.Verified or LocalAiModelPresentationState.Loaded;
-    public bool CanChangeModel => !IsBusy && HasInstalledModel;
+    public bool CanChangeModel => IsSetupAvailable && !IsBusy && HasInstalledModel;
     public bool CanRepairConnection => !IsBusy && GatewayState is not
         (LocalAiGatewayPresentationState.Connected or LocalAiGatewayPresentationState.Connecting);
     public bool CanOpenChat => !IsBusy &&

--- a/src/OpenClaw.Tray.WinUI/Presentation/LocalAiPageViewModel.cs
+++ b/src/OpenClaw.Tray.WinUI/Presentation/LocalAiPageViewModel.cs
@@ -240,6 +240,10 @@ internal sealed class LocalAiPageViewModel : INavigationAware, IDisposable, INot
         cancellation?.Cancel();
     }
 
+    private const string LocalAiAvailabilityProbeFailureReason =
+        "OpenClaw could not read the NVIDIA GPU, driver, CUDA, or memory information. " +
+        "Check the NVIDIA driver installation and try setup again.";
+
     private async Task RefreshAvailabilityAsync(CancellationTokenSource cancellation)
     {
         // The probe result is applied and the cancellation is released together, inside the
@@ -257,6 +261,20 @@ internal sealed class LocalAiPageViewModel : INavigationAware, IDisposable, INot
             // deprecated, or oversized model) must not report the device itself as unavailable
             // and block retry-setup from switching to a compatible catalog model.
             LocalInferenceEligibilityResult eligibility = LocalInferenceEligibility.Evaluate(hardware);
+            if (eligibility.FailureCode == LocalInferenceEligibilityFailureCode.HardwareFactsIncomplete)
+            {
+                // Incomplete facts (a driver/NVML read that came back partial or transient) are
+                // inconclusive, not a definitive "this device cannot run Local AI". Report it the
+                // same way as a thrown probe failure below so recheck stays available instead of
+                // permanently disabling Local AI on this device.
+                ApplyOnUiThread(() => ApplyAvailabilityResult(
+                    cancellation,
+                    isAvailabilityKnown: false,
+                    isLocalAiAvailable: false,
+                    hasAvailabilityProbeError: true,
+                    LocalAiAvailabilityProbeFailureReason));
+                return;
+            }
             bool isAvailable = eligibility.CanInstall;
             string? unavailableReason = isAvailable
                 ? null
@@ -277,15 +295,12 @@ internal sealed class LocalAiPageViewModel : INavigationAware, IDisposable, INot
         catch (Exception ex)
         {
             Debug.WriteLine($"Local AI availability probe failed: {ex}");
-            const string unavailableReason =
-                "OpenClaw could not read the NVIDIA GPU, driver, CUDA, or memory information. " +
-                "Check the NVIDIA driver installation and try setup again.";
             ApplyOnUiThread(() => ApplyAvailabilityResult(
                 cancellation,
                 isAvailabilityKnown: false,
                 isLocalAiAvailable: false,
                 hasAvailabilityProbeError: true,
-                unavailableReason));
+                LocalAiAvailabilityProbeFailureReason));
         }
     }
 

--- a/src/OpenClaw.Tray.WinUI/Presentation/LocalAiPageViewModel.cs
+++ b/src/OpenClaw.Tray.WinUI/Presentation/LocalAiPageViewModel.cs
@@ -32,7 +32,7 @@ internal sealed class LocalAiPageViewModel : INavigationAware, IDisposable, INot
     private bool _isAvailabilityKnown;
     private bool _isLocalAiAvailable;
     private bool _hasAvailabilityProbeError;
-    private string? _localAiUnavailableReason;
+    private LocalInferenceUnavailableReason? _localAiUnavailableReason;
 
     public LocalAiPageViewModel(
         ILocalAiRuntime runtime,
@@ -126,7 +126,7 @@ internal sealed class LocalAiPageViewModel : INavigationAware, IDisposable, INot
     public bool ShowAvailabilityInfoBar => (_isAvailabilityKnown && !_isLocalAiAvailable) || _hasAvailabilityProbeError;
     public bool IsSetupAvailable => !_isAvailabilityKnown || _isLocalAiAvailable;
     public bool CanRecheckAvailability => _hasAvailabilityProbeError && _availabilityCancellation is null && !IsBusy;
-    public string? LocalAiUnavailableReason => _localAiUnavailableReason;
+    public LocalInferenceUnavailableReason? LocalAiUnavailableReason => _localAiUnavailableReason;
     public bool CanStart => !IsBusy && HasManagedInstall &&
         _runtimeSnapshot.State is LocalAiRuntimeState.Stopped or LocalAiRuntimeState.Failed;
     public bool CanStop => !IsBusy && _runtimeSnapshot.Ownership == LocalAiOwnership.CompanionManaged &&
@@ -240,9 +240,18 @@ internal sealed class LocalAiPageViewModel : INavigationAware, IDisposable, INot
         cancellation?.Cancel();
     }
 
-    private const string LocalAiAvailabilityProbeFailureReason =
-        "OpenClaw could not read the NVIDIA GPU, driver, CUDA, or memory information. " +
-        "Check the NVIDIA driver installation and try setup again.";
+    /// <summary>
+    /// Locale-neutral placeholder used when the probe itself failed to produce facts (thrown
+    /// exception, or a successful read that came back incomplete). The View resolves this kind
+    /// into localized text; no language-specific text lives on the ViewModel.
+    /// </summary>
+    private static readonly LocalInferenceUnavailableReason ProbeFailureReason = new(
+        LocalInferenceUnavailableReasonKind.HardwareFactsIncomplete,
+        ModelDisplayName: null,
+        RequiredGigabytes: 0,
+        DetectedGigabytes: null,
+        DetectedDriverVersion: null,
+        MinimumDriverVersion: string.Empty);
 
     private async Task RefreshAvailabilityAsync(CancellationTokenSource cancellation)
     {
@@ -272,13 +281,13 @@ internal sealed class LocalAiPageViewModel : INavigationAware, IDisposable, INot
                     isAvailabilityKnown: false,
                     isLocalAiAvailable: false,
                     hasAvailabilityProbeError: true,
-                    LocalAiAvailabilityProbeFailureReason));
+                    ProbeFailureReason));
                 return;
             }
             bool isAvailable = eligibility.CanInstall;
-            string? unavailableReason = isAvailable
+            LocalInferenceUnavailableReason? unavailableReason = isAvailable
                 ? null
-                : LocalInferenceEligibilityDiagnostics.DescribeUnavailable(eligibility);
+                : LocalInferenceEligibilityDiagnostics.GetUnavailableReason(eligibility);
             ApplyOnUiThread(() => ApplyAvailabilityResult(
                 cancellation,
                 isAvailabilityKnown: true,
@@ -300,7 +309,7 @@ internal sealed class LocalAiPageViewModel : INavigationAware, IDisposable, INot
                 isAvailabilityKnown: false,
                 isLocalAiAvailable: false,
                 hasAvailabilityProbeError: true,
-                LocalAiAvailabilityProbeFailureReason));
+                ProbeFailureReason));
         }
     }
 
@@ -314,7 +323,7 @@ internal sealed class LocalAiPageViewModel : INavigationAware, IDisposable, INot
         bool isAvailabilityKnown,
         bool isLocalAiAvailable,
         bool hasAvailabilityProbeError,
-        string? unavailableReason)
+        LocalInferenceUnavailableReason? unavailableReason)
     {
         if (!IsCurrentAvailabilityProbe(cancellation))
             return;

--- a/src/OpenClaw.Tray.WinUI/Presentation/LocalAiPageViewModel.cs
+++ b/src/OpenClaw.Tray.WinUI/Presentation/LocalAiPageViewModel.cs
@@ -252,9 +252,11 @@ internal sealed class LocalAiPageViewModel : INavigationAware, IDisposable, INot
             HostHardwareInfo hardware = await Task.Run(
                 _hardwareProbe.Probe,
                 cancellation.Token).ConfigureAwait(false);
-            LocalInferenceEligibilityResult eligibility = LocalInferenceEligibility.Evaluate(
-                hardware,
-                _runtimeSnapshot.ModelId);
+            // Evaluate device-level eligibility (the best catalog model this hardware can run),
+            // not the currently selected/installed model. A selection-specific failure (unknown,
+            // deprecated, or oversized model) must not report the device itself as unavailable
+            // and block retry-setup from switching to a compatible catalog model.
+            LocalInferenceEligibilityResult eligibility = LocalInferenceEligibility.Evaluate(hardware);
             bool isAvailable = eligibility.CanInstall;
             string? unavailableReason = isAvailable
                 ? null

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -7139,4 +7139,8 @@ Make sure the gateway is running.</value>
   <data name="LocalAi_Reason_UnknownMemoryAmount" xml:space="preserve"><value>an unknown amount</value></data>
   <data name="LocalAi_Reason_GigabytesFormat" xml:space="preserve"><value>{0:0.#} GB</value></data>
   <data name="Onboarding_Welcome_LocalAiAvailableBadge.Text" xml:space="preserve"><value>Local AI available</value></data>
+  <data name="Onboarding_LocalAi_WslConfigReadFailureReason" xml:space="preserve"><value>OpenClaw cannot safely read the global .wslconfig file. Check that the file is valid and readable, then try setup again.</value></data>
+  <data name="LocalAiPage_UnavailableProbeTitle" xml:space="preserve"><value>Local AI availability could not be verified</value></data>
+  <data name="LocalAiPage_CheckingTitle" xml:space="preserve"><value>Checking Local AI availability</value></data>
+  <data name="LocalAiPage_CheckingMessage" xml:space="preserve"><value>OpenClaw is verifying whether this device can run Local AI. This only takes a moment.</value></data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -7113,4 +7113,29 @@ Make sure the gateway is running.</value>
   <data name="LocalAiPage_ModelRecipeFormat" xml:space="preserve"><value>{0} context · {1} KV · Loads on first request</value></data>
   <data name="Command_GoToLocalAi_Title" xml:space="preserve"><value>Go to Local AI</value></data>
   <data name="Command_GoToLocalAi_Subtitle" xml:space="preserve"><value>View llama-server, model, and gateway status</value></data>
+  <data name="Onboarding_LocalAi_UnavailableDetailsButton.Content" xml:space="preserve"><value>See why</value></data>
+  <data name="Onboarding_LocalAi_CheckingTitle" xml:space="preserve"><value>Checking Local AI requirements</value></data>
+  <data name="Onboarding_LocalAi_CheckingMessage" xml:space="preserve"><value>OpenClaw is checking the NVIDIA GPU, driver, CUDA, memory, and WSL requirements.</value></data>
+  <data name="Onboarding_LocalAi_CheckingHelpText" xml:space="preserve"><value>OpenClaw is checking Local AI requirements.</value></data>
+  <data name="Onboarding_LocalAi_ProbeUnknownTitle" xml:space="preserve"><value>Local AI availability could not be verified</value></data>
+  <data name="Onboarding_LocalAi_ProbeUnknownMessage" xml:space="preserve"><value>OpenClaw could not verify Local AI requirements right now. Recheck after confirming the NVIDIA driver is available.</value></data>
+  <data name="Onboarding_LocalAi_ProbeUnknownHelpText" xml:space="preserve"><value>OpenClaw could not verify Local AI requirements. Recheck availability to try again.</value></data>
+  <data name="Onboarding_LocalAi_UnavailableTitle" xml:space="preserve"><value>Local AI is not available</value></data>
+  <data name="Onboarding_LocalAi_UnavailableMessage" xml:space="preserve"><value>This PC does not meet one or more Local AI requirements.</value></data>
+  <data name="Onboarding_LocalAi_UnavailableHelpText" xml:space="preserve"><value>Unavailable because this PC does not meet the Local AI requirements.</value></data>
+  <data name="Onboarding_LocalAi_ProbeFailureReason" xml:space="preserve"><value>OpenClaw could not read the NVIDIA GPU, driver, CUDA, or memory information. Confirm the NVIDIA driver is available, then recheck Local AI requirements.</value></data>
+  <data name="Onboarding_LocalAi_UnavailableDetailsDialogTitle" xml:space="preserve"><value>Why Local AI is unavailable</value></data>
+  <data name="Onboarding_LocalAi_UnavailableDetailsDialogClose" xml:space="preserve"><value>Close</value></data>
+  <data name="LocalAi_Reason_RuntimeUnavailable" xml:space="preserve"><value>This Local AI release does not include a native llama-server runtime for the detected Windows architecture.</value></data>
+  <data name="LocalAi_Reason_NoNvidiaGpu" xml:space="preserve"><value>No NVIDIA GPU was reported by the NVIDIA driver. Install or repair the NVIDIA driver, then try setup again.</value></data>
+  <data name="LocalAi_Reason_UnknownModel" xml:space="preserve"><value>The selected model is not available in this Local AI release.</value></data>
+  <data name="LocalAi_Reason_HardwareFactsIncomplete" xml:space="preserve"><value>OpenClaw could not read a stable NVIDIA GPU identifier, memory, driver, or CUDA capability.</value></data>
+  <data name="LocalAi_Reason_InsufficientGpuMemory" xml:space="preserve"><value>{0} requires {1} of GPU memory for model weights, KV cache, and runtime workspace. OpenClaw detected {2}.</value></data>
+  <data name="LocalAi_Reason_DriverTooOld" xml:space="preserve"><value>NVIDIA driver {0} was detected. Local AI requires version {1} or newer.</value></data>
+  <data name="LocalAi_Reason_CudaCapabilityTooLow" xml:space="preserve"><value>The NVIDIA driver does not provide CUDA 13 support. A separate CUDA Toolkit is not required.</value></data>
+  <data name="LocalAi_Reason_Generic" xml:space="preserve"><value>OpenClaw could not verify the Local AI requirements on this system.</value></data>
+  <data name="LocalAi_Reason_UnknownModelName" xml:space="preserve"><value>The selected model</value></data>
+  <data name="LocalAi_Reason_UnknownDriverVersion" xml:space="preserve"><value>unknown</value></data>
+  <data name="LocalAi_Reason_UnknownMemoryAmount" xml:space="preserve"><value>an unknown amount</value></data>
+  <data name="LocalAi_Reason_GigabytesFormat" xml:space="preserve"><value>{0:0.#} GB</value></data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -7138,4 +7138,5 @@ Make sure the gateway is running.</value>
   <data name="LocalAi_Reason_UnknownDriverVersion" xml:space="preserve"><value>unknown</value></data>
   <data name="LocalAi_Reason_UnknownMemoryAmount" xml:space="preserve"><value>an unknown amount</value></data>
   <data name="LocalAi_Reason_GigabytesFormat" xml:space="preserve"><value>{0:0.#} GB</value></data>
+  <data name="Onboarding_Welcome_LocalAiAvailableBadge.Text" xml:space="preserve"><value>Local AI available</value></data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -1080,8 +1080,11 @@ Use one of these options:
   <data name="Onboarding_Connection_Later" xml:space="preserve">
     <value>Configure Later</value>
   </data>
+  <data name="Onboarding_LocalAi_RecheckAvailabilityButton.Content" xml:space="preserve">
+    <value>Recheck</value>
+  </data>
   <data name="Onboarding_Ready_Title" xml:space="preserve">
-    <value>All Set!</value>
+    <value>All set!</value>
   </data>
   <data name="Onboarding_Ready_Subtitle" xml:space="preserve">
     <value>OpenClaw is ready to go. Here are some things to try:</value>
@@ -7069,6 +7072,12 @@ Make sure the gateway is running.</value>
   <data name="HubWindow_NavigationViewItem_LocalAi.Content" xml:space="preserve"><value>Local AI</value></data>
   <data name="LocalAiPage_Title.Text" xml:space="preserve"><value>Local AI</value></data>
   <data name="LocalAiPage_Intro.Text" xml:space="preserve"><value>Run the verified native llama-server privately on this computer. Models load only when requested.</value></data>
+  <data name="LocalAiPage_UnavailableInfoBar.Title" xml:space="preserve"><value>Local AI is not available</value></data>
+  <data name="LocalAiPage_UnavailableDetailsButton.Content" xml:space="preserve"><value>See why</value></data>
+  <data name="LocalAiPage_UnavailableDetailsTip.Title" xml:space="preserve"><value>Why Local AI is unavailable</value></data>
+  <data name="LocalAiPage_RecheckAvailabilityButton.Content" xml:space="preserve"><value>Recheck</value></data>
+  <data name="LocalAiPage_UnavailableRequirementsMessage" xml:space="preserve"><value>This device does not meet one or more Local AI requirements.</value></data>
+  <data name="LocalAiPage_UnavailableProbeMessage" xml:space="preserve"><value>OpenClaw could not verify Local AI requirements right now. Recheck after confirming the NVIDIA driver is available.</value></data>
   <data name="LocalAiPage_EngineHeading.Text" xml:space="preserve"><value>llama-server</value></data>
   <data name="LocalAiPage_VersionLabel.Text" xml:space="preserve"><value>Version</value></data>
   <data name="LocalAiPage_EndpointLabel.Text" xml:space="preserve"><value>Endpoint</value></data>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -1057,6 +1057,9 @@ Utilisez l'une de ces options :
   <data name="Onboarding_Connection_Later" xml:space="preserve">
     <value>Configurer plus tard</value>
   </data>
+  <data name="Onboarding_LocalAi_RecheckAvailabilityButton.Content" xml:space="preserve">
+    <value>Revérifier</value>
+  </data>
   <data name="Onboarding_Ready_Title" xml:space="preserve">
     <value>Tout est prêt !</value>
   </data>
@@ -7005,6 +7008,12 @@ Le binaire wxc-exec est introuvable. {1} S'il s'agit d'une build développeur, c
   <data name="HubWindow_NavigationViewItem_LocalAi.Content" xml:space="preserve"><value>IA locale</value></data>
   <data name="LocalAiPage_Title.Text" xml:space="preserve"><value>IA locale</value></data>
   <data name="LocalAiPage_Intro.Text" xml:space="preserve"><value>Exécutez le llama-server natif vérifié en privé sur cet ordinateur. Les modèles ne sont chargés qu'à la demande.</value></data>
+  <data name="LocalAiPage_UnavailableInfoBar.Title" xml:space="preserve"><value>L'IA locale n'est pas disponible</value></data>
+  <data name="LocalAiPage_UnavailableDetailsButton.Content" xml:space="preserve"><value>Voir pourquoi</value></data>
+  <data name="LocalAiPage_UnavailableDetailsTip.Title" xml:space="preserve"><value>Pourquoi l'IA locale n'est pas disponible</value></data>
+  <data name="LocalAiPage_RecheckAvailabilityButton.Content" xml:space="preserve"><value>Revérifier</value></data>
+  <data name="LocalAiPage_UnavailableRequirementsMessage" xml:space="preserve"><value>Cet appareil ne répond pas à une ou plusieurs exigences de l'IA locale.</value></data>
+  <data name="LocalAiPage_UnavailableProbeMessage" xml:space="preserve"><value>OpenClaw n'a pas pu vérifier les exigences de l'IA locale pour le moment. Vérifiez la disponibilité du pilote NVIDIA puis réessayez.</value></data>
   <data name="LocalAiPage_EngineHeading.Text" xml:space="preserve"><value>llama-server</value></data>
   <data name="LocalAiPage_VersionLabel.Text" xml:space="preserve"><value>Version du moteur</value></data>
   <data name="LocalAiPage_EndpointLabel.Text" xml:space="preserve"><value>Point de terminaison</value></data>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -7075,4 +7075,8 @@ Le binaire wxc-exec est introuvable. {1} S'il s'agit d'une build développeur, c
   <data name="LocalAi_Reason_UnknownMemoryAmount" xml:space="preserve"><value>une quantité inconnue</value></data>
   <data name="LocalAi_Reason_GigabytesFormat" xml:space="preserve"><value>{0:0.#} GB</value></data>
   <data name="Onboarding_Welcome_LocalAiAvailableBadge.Text" xml:space="preserve"><value>IA locale disponible</value></data>
+  <data name="Onboarding_LocalAi_WslConfigReadFailureReason" xml:space="preserve"><value>OpenClaw ne peut pas lire le fichier .wslconfig global en toute sécurité. Vérifiez que le fichier est valide et lisible, puis réessayez la configuration.</value></data>
+  <data name="LocalAiPage_UnavailableProbeTitle" xml:space="preserve"><value>La disponibilité de l'IA locale n'a pas pu être vérifiée</value></data>
+  <data name="LocalAiPage_CheckingTitle" xml:space="preserve"><value>Vérification de la disponibilité de l'IA locale</value></data>
+  <data name="LocalAiPage_CheckingMessage" xml:space="preserve"><value>OpenClaw vérifie si cet appareil peut exécuter l'IA locale. Cela ne prend qu'un instant.</value></data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -7049,4 +7049,29 @@ Le binaire wxc-exec est introuvable. {1} S'il s'agit d'une build développeur, c
   <data name="LocalAiPage_ModelRecipeFormat" xml:space="preserve"><value>Contexte {0} · KV {1} · Chargement à la première demande</value></data>
   <data name="Command_GoToLocalAi_Title" xml:space="preserve"><value>Accéder à l'IA locale</value></data>
   <data name="Command_GoToLocalAi_Subtitle" xml:space="preserve"><value>Afficher l'état de llama-server, du modèle et de la passerelle</value></data>
+  <data name="Onboarding_LocalAi_UnavailableDetailsButton.Content" xml:space="preserve"><value>Voir pourquoi</value></data>
+  <data name="Onboarding_LocalAi_CheckingTitle" xml:space="preserve"><value>Vérification des exigences de l'IA locale</value></data>
+  <data name="Onboarding_LocalAi_CheckingMessage" xml:space="preserve"><value>OpenClaw vérifie le GPU NVIDIA, le pilote, CUDA, la mémoire et les exigences WSL.</value></data>
+  <data name="Onboarding_LocalAi_CheckingHelpText" xml:space="preserve"><value>OpenClaw vérifie les exigences de l'IA locale.</value></data>
+  <data name="Onboarding_LocalAi_ProbeUnknownTitle" xml:space="preserve"><value>La disponibilité de l'IA locale n'a pas pu être vérifiée</value></data>
+  <data name="Onboarding_LocalAi_ProbeUnknownMessage" xml:space="preserve"><value>OpenClaw n'a pas pu vérifier les exigences de l'IA locale pour le moment. Vérifiez la disponibilité du pilote NVIDIA puis réessayez.</value></data>
+  <data name="Onboarding_LocalAi_ProbeUnknownHelpText" xml:space="preserve"><value>OpenClaw n'a pas pu vérifier les exigences de l'IA locale. Revérifiez la disponibilité pour réessayer.</value></data>
+  <data name="Onboarding_LocalAi_UnavailableTitle" xml:space="preserve"><value>L'IA locale n'est pas disponible</value></data>
+  <data name="Onboarding_LocalAi_UnavailableMessage" xml:space="preserve"><value>Cet ordinateur ne répond pas à une ou plusieurs exigences de l'IA locale.</value></data>
+  <data name="Onboarding_LocalAi_UnavailableHelpText" xml:space="preserve"><value>Non disponible car cet ordinateur ne répond pas aux exigences de l'IA locale.</value></data>
+  <data name="Onboarding_LocalAi_ProbeFailureReason" xml:space="preserve"><value>OpenClaw n'a pas pu lire les informations du GPU NVIDIA, du pilote, de CUDA ou de la mémoire. Vérifiez la disponibilité du pilote NVIDIA, puis revérifiez les exigences de l'IA locale.</value></data>
+  <data name="Onboarding_LocalAi_UnavailableDetailsDialogTitle" xml:space="preserve"><value>Pourquoi l'IA locale n'est pas disponible</value></data>
+  <data name="Onboarding_LocalAi_UnavailableDetailsDialogClose" xml:space="preserve"><value>Fermer</value></data>
+  <data name="LocalAi_Reason_RuntimeUnavailable" xml:space="preserve"><value>Cette version de l'IA locale n'inclut pas de runtime llama-server natif pour l'architecture Windows détectée.</value></data>
+  <data name="LocalAi_Reason_NoNvidiaGpu" xml:space="preserve"><value>Aucun GPU NVIDIA n'a été signalé par le pilote NVIDIA. Installez ou réparez le pilote NVIDIA, puis réessayez la configuration.</value></data>
+  <data name="LocalAi_Reason_UnknownModel" xml:space="preserve"><value>Le modèle sélectionné n'est pas disponible dans cette version de l'IA locale.</value></data>
+  <data name="LocalAi_Reason_HardwareFactsIncomplete" xml:space="preserve"><value>OpenClaw n'a pas pu lire un identifiant GPU NVIDIA stable, la mémoire, le pilote ou la capacité CUDA.</value></data>
+  <data name="LocalAi_Reason_InsufficientGpuMemory" xml:space="preserve"><value>{0} nécessite {1} de mémoire GPU pour les poids du modèle, le cache KV et l'espace de travail d'exécution. OpenClaw a détecté {2}.</value></data>
+  <data name="LocalAi_Reason_DriverTooOld" xml:space="preserve"><value>Le pilote NVIDIA {0} a été détecté. L'IA locale nécessite la version {1} ou ultérieure.</value></data>
+  <data name="LocalAi_Reason_CudaCapabilityTooLow" xml:space="preserve"><value>Le pilote NVIDIA ne prend pas en charge CUDA 13. Un CUDA Toolkit séparé n'est pas requis.</value></data>
+  <data name="LocalAi_Reason_Generic" xml:space="preserve"><value>OpenClaw n'a pas pu vérifier les exigences de l'IA locale sur ce système.</value></data>
+  <data name="LocalAi_Reason_UnknownModelName" xml:space="preserve"><value>Le modèle sélectionné</value></data>
+  <data name="LocalAi_Reason_UnknownDriverVersion" xml:space="preserve"><value>inconnu</value></data>
+  <data name="LocalAi_Reason_UnknownMemoryAmount" xml:space="preserve"><value>une quantité inconnue</value></data>
+  <data name="LocalAi_Reason_GigabytesFormat" xml:space="preserve"><value>{0:0.#} GB</value></data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -7074,4 +7074,5 @@ Le binaire wxc-exec est introuvable. {1} S'il s'agit d'une build développeur, c
   <data name="LocalAi_Reason_UnknownDriverVersion" xml:space="preserve"><value>inconnu</value></data>
   <data name="LocalAi_Reason_UnknownMemoryAmount" xml:space="preserve"><value>une quantité inconnue</value></data>
   <data name="LocalAi_Reason_GigabytesFormat" xml:space="preserve"><value>{0:0.#} GB</value></data>
+  <data name="Onboarding_Welcome_LocalAiAvailableBadge.Text" xml:space="preserve"><value>IA locale disponible</value></data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -7075,4 +7075,5 @@ Het binaire bestand wxc-exec is niet gevonden. {1} Als dit een ontwikkelaarsbuil
   <data name="LocalAi_Reason_UnknownDriverVersion" xml:space="preserve"><value>onbekend</value></data>
   <data name="LocalAi_Reason_UnknownMemoryAmount" xml:space="preserve"><value>een onbekende hoeveelheid</value></data>
   <data name="LocalAi_Reason_GigabytesFormat" xml:space="preserve"><value>{0:0.#} GB</value></data>
+  <data name="Onboarding_Welcome_LocalAiAvailableBadge.Text" xml:space="preserve"><value>Lokale AI beschikbaar</value></data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -7076,4 +7076,8 @@ Het binaire bestand wxc-exec is niet gevonden. {1} Als dit een ontwikkelaarsbuil
   <data name="LocalAi_Reason_UnknownMemoryAmount" xml:space="preserve"><value>een onbekende hoeveelheid</value></data>
   <data name="LocalAi_Reason_GigabytesFormat" xml:space="preserve"><value>{0:0.#} GB</value></data>
   <data name="Onboarding_Welcome_LocalAiAvailableBadge.Text" xml:space="preserve"><value>Lokale AI beschikbaar</value></data>
+  <data name="Onboarding_LocalAi_WslConfigReadFailureReason" xml:space="preserve"><value>OpenClaw kan het globale .wslconfig-bestand niet veilig lezen. Controleer of het bestand geldig en leesbaar is en probeer de installatie opnieuw.</value></data>
+  <data name="LocalAiPage_UnavailableProbeTitle" xml:space="preserve"><value>Beschikbaarheid van lokale AI kon niet worden geverifieerd</value></data>
+  <data name="LocalAiPage_CheckingTitle" xml:space="preserve"><value>Beschikbaarheid van lokale AI controleren</value></data>
+  <data name="LocalAiPage_CheckingMessage" xml:space="preserve"><value>OpenClaw controleert of dit apparaat lokale AI kan uitvoeren. Dit duurt slechts een moment.</value></data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -1058,6 +1058,9 @@ Gebruik een van deze opties:
   <data name="Onboarding_Connection_Later" xml:space="preserve">
     <value>Later configureren</value>
   </data>
+  <data name="Onboarding_LocalAi_RecheckAvailabilityButton.Content" xml:space="preserve">
+    <value>Opnieuw controleren</value>
+  </data>
   <data name="Onboarding_Ready_Title" xml:space="preserve">
     <value>Alles klaar!</value>
   </data>
@@ -7006,6 +7009,12 @@ Het binaire bestand wxc-exec is niet gevonden. {1} Als dit een ontwikkelaarsbuil
   <data name="HubWindow_NavigationViewItem_LocalAi.Content" xml:space="preserve"><value>Lokale AI</value></data>
   <data name="LocalAiPage_Title.Text" xml:space="preserve"><value>Lokale AI</value></data>
   <data name="LocalAiPage_Intro.Text" xml:space="preserve"><value>Voer de geverifieerde native llama-server privé uit op deze computer. Modellen worden alleen op aanvraag geladen.</value></data>
+  <data name="LocalAiPage_UnavailableInfoBar.Title" xml:space="preserve"><value>Lokale AI is niet beschikbaar</value></data>
+  <data name="LocalAiPage_UnavailableDetailsButton.Content" xml:space="preserve"><value>Bekijk waarom</value></data>
+  <data name="LocalAiPage_UnavailableDetailsTip.Title" xml:space="preserve"><value>Waarom lokale AI niet beschikbaar is</value></data>
+  <data name="LocalAiPage_RecheckAvailabilityButton.Content" xml:space="preserve"><value>Opnieuw controleren</value></data>
+  <data name="LocalAiPage_UnavailableRequirementsMessage" xml:space="preserve"><value>Dit apparaat voldoet niet aan een of meer vereisten voor lokale AI.</value></data>
+  <data name="LocalAiPage_UnavailableProbeMessage" xml:space="preserve"><value>OpenClaw kon de vereisten voor lokale AI nu niet verifiëren. Controleer of het NVIDIA-stuurprogramma beschikbaar is en probeer het opnieuw.</value></data>
   <data name="LocalAiPage_EngineHeading.Text" xml:space="preserve"><value>llama-server</value></data>
   <data name="LocalAiPage_VersionLabel.Text" xml:space="preserve"><value>Versie</value></data>
   <data name="LocalAiPage_EndpointLabel.Text" xml:space="preserve"><value>Eindpunt</value></data>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -7050,4 +7050,29 @@ Het binaire bestand wxc-exec is niet gevonden. {1} Als dit een ontwikkelaarsbuil
   <data name="LocalAiPage_ModelRecipeFormat" xml:space="preserve"><value>{0} context · {1} KV · Laden bij eerste aanvraag</value></data>
   <data name="Command_GoToLocalAi_Title" xml:space="preserve"><value>Naar Lokale AI</value></data>
   <data name="Command_GoToLocalAi_Subtitle" xml:space="preserve"><value>Status van llama-server, model en gateway bekijken</value></data>
+  <data name="Onboarding_LocalAi_UnavailableDetailsButton.Content" xml:space="preserve"><value>Bekijk waarom</value></data>
+  <data name="Onboarding_LocalAi_CheckingTitle" xml:space="preserve"><value>Vereisten voor lokale AI worden gecontroleerd</value></data>
+  <data name="Onboarding_LocalAi_CheckingMessage" xml:space="preserve"><value>OpenClaw controleert de NVIDIA-GPU, stuurprogramma, CUDA, geheugen en WSL-vereisten.</value></data>
+  <data name="Onboarding_LocalAi_CheckingHelpText" xml:space="preserve"><value>OpenClaw controleert de vereisten voor lokale AI.</value></data>
+  <data name="Onboarding_LocalAi_ProbeUnknownTitle" xml:space="preserve"><value>Beschikbaarheid van lokale AI kon niet worden geverifieerd</value></data>
+  <data name="Onboarding_LocalAi_ProbeUnknownMessage" xml:space="preserve"><value>OpenClaw kon de vereisten voor lokale AI nu niet verifiëren. Controleer of het NVIDIA-stuurprogramma beschikbaar is en probeer het opnieuw.</value></data>
+  <data name="Onboarding_LocalAi_ProbeUnknownHelpText" xml:space="preserve"><value>OpenClaw kon de vereisten voor lokale AI niet verifiëren. Controleer de beschikbaarheid opnieuw om het nogmaals te proberen.</value></data>
+  <data name="Onboarding_LocalAi_UnavailableTitle" xml:space="preserve"><value>Lokale AI is niet beschikbaar</value></data>
+  <data name="Onboarding_LocalAi_UnavailableMessage" xml:space="preserve"><value>Deze pc voldoet niet aan een of meer vereisten voor lokale AI.</value></data>
+  <data name="Onboarding_LocalAi_UnavailableHelpText" xml:space="preserve"><value>Niet beschikbaar omdat deze pc niet voldoet aan de vereisten voor lokale AI.</value></data>
+  <data name="Onboarding_LocalAi_ProbeFailureReason" xml:space="preserve"><value>OpenClaw kon de informatie over de NVIDIA-GPU, het stuurprogramma, CUDA of het geheugen niet lezen. Controleer of het NVIDIA-stuurprogramma beschikbaar is en controleer de vereisten voor lokale AI opnieuw.</value></data>
+  <data name="Onboarding_LocalAi_UnavailableDetailsDialogTitle" xml:space="preserve"><value>Waarom lokale AI niet beschikbaar is</value></data>
+  <data name="Onboarding_LocalAi_UnavailableDetailsDialogClose" xml:space="preserve"><value>Sluiten</value></data>
+  <data name="LocalAi_Reason_RuntimeUnavailable" xml:space="preserve"><value>Deze release van lokale AI bevat geen native llama-server-runtime voor de gedetecteerde Windows-architectuur.</value></data>
+  <data name="LocalAi_Reason_NoNvidiaGpu" xml:space="preserve"><value>Er is geen NVIDIA-GPU gerapporteerd door het NVIDIA-stuurprogramma. Installeer of herstel het NVIDIA-stuurprogramma en probeer de installatie opnieuw.</value></data>
+  <data name="LocalAi_Reason_UnknownModel" xml:space="preserve"><value>Het geselecteerde model is niet beschikbaar in deze release van lokale AI.</value></data>
+  <data name="LocalAi_Reason_HardwareFactsIncomplete" xml:space="preserve"><value>OpenClaw kon geen stabiele NVIDIA-GPU-id, geheugen, stuurprogramma of CUDA-mogelijkheid lezen.</value></data>
+  <data name="LocalAi_Reason_InsufficientGpuMemory" xml:space="preserve"><value>{0} vereist {1} GPU-geheugen voor modelgewichten, KV-cache en runtime-werkruimte. OpenClaw detecteerde {2}.</value></data>
+  <data name="LocalAi_Reason_DriverTooOld" xml:space="preserve"><value>NVIDIA-stuurprogramma {0} is gedetecteerd. Lokale AI vereist versie {1} of nieuwer.</value></data>
+  <data name="LocalAi_Reason_CudaCapabilityTooLow" xml:space="preserve"><value>Het NVIDIA-stuurprogramma biedt geen ondersteuning voor CUDA 13. Een aparte CUDA Toolkit is niet vereist.</value></data>
+  <data name="LocalAi_Reason_Generic" xml:space="preserve"><value>OpenClaw kon de vereisten voor lokale AI op dit systeem niet verifiëren.</value></data>
+  <data name="LocalAi_Reason_UnknownModelName" xml:space="preserve"><value>Het geselecteerde model</value></data>
+  <data name="LocalAi_Reason_UnknownDriverVersion" xml:space="preserve"><value>onbekend</value></data>
+  <data name="LocalAi_Reason_UnknownMemoryAmount" xml:space="preserve"><value>een onbekende hoeveelheid</value></data>
+  <data name="LocalAi_Reason_GigabytesFormat" xml:space="preserve"><value>{0:0.#} GB</value></data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -7049,4 +7049,29 @@
   <data name="LocalAiPage_ModelRecipeFormat" xml:space="preserve"><value>{0} 上下文 · {1} KV · 首次请求时加载</value></data>
   <data name="Command_GoToLocalAi_Title" xml:space="preserve"><value>转到本地 AI</value></data>
   <data name="Command_GoToLocalAi_Subtitle" xml:space="preserve"><value>查看 llama-server、模型和网关状态</value></data>
+  <data name="Onboarding_LocalAi_UnavailableDetailsButton.Content" xml:space="preserve"><value>查看原因</value></data>
+  <data name="Onboarding_LocalAi_CheckingTitle" xml:space="preserve"><value>正在检查本地 AI 要求</value></data>
+  <data name="Onboarding_LocalAi_CheckingMessage" xml:space="preserve"><value>OpenClaw 正在检查 NVIDIA GPU、驱动、CUDA、内存和 WSL 要求。</value></data>
+  <data name="Onboarding_LocalAi_CheckingHelpText" xml:space="preserve"><value>OpenClaw 正在检查本地 AI 要求。</value></data>
+  <data name="Onboarding_LocalAi_ProbeUnknownTitle" xml:space="preserve"><value>无法验证本地 AI 可用性</value></data>
+  <data name="Onboarding_LocalAi_ProbeUnknownMessage" xml:space="preserve"><value>OpenClaw 目前无法验证本地 AI 要求。请确认 NVIDIA 驱动可用后重试。</value></data>
+  <data name="Onboarding_LocalAi_ProbeUnknownHelpText" xml:space="preserve"><value>OpenClaw 无法验证本地 AI 要求。请重新检查可用性以重试。</value></data>
+  <data name="Onboarding_LocalAi_UnavailableTitle" xml:space="preserve"><value>本地 AI 不可用</value></data>
+  <data name="Onboarding_LocalAi_UnavailableMessage" xml:space="preserve"><value>此电脑不满足一项或多项本地 AI 要求。</value></data>
+  <data name="Onboarding_LocalAi_UnavailableHelpText" xml:space="preserve"><value>不可用,因为此电脑不满足本地 AI 要求。</value></data>
+  <data name="Onboarding_LocalAi_ProbeFailureReason" xml:space="preserve"><value>OpenClaw 无法读取 NVIDIA GPU、驱动、CUDA 或内存信息。请确认 NVIDIA 驱动可用,然后重新检查本地 AI 要求。</value></data>
+  <data name="Onboarding_LocalAi_UnavailableDetailsDialogTitle" xml:space="preserve"><value>本地 AI 不可用的原因</value></data>
+  <data name="Onboarding_LocalAi_UnavailableDetailsDialogClose" xml:space="preserve"><value>关闭</value></data>
+  <data name="LocalAi_Reason_RuntimeUnavailable" xml:space="preserve"><value>此本地 AI 版本不包含适用于检测到的 Windows 体系结构的原生 llama-server 运行时。</value></data>
+  <data name="LocalAi_Reason_NoNvidiaGpu" xml:space="preserve"><value>NVIDIA 驱动未报告任何 NVIDIA GPU。请安装或修复 NVIDIA 驱动,然后重试安装。</value></data>
+  <data name="LocalAi_Reason_UnknownModel" xml:space="preserve"><value>所选模型在此本地 AI 版本中不可用。</value></data>
+  <data name="LocalAi_Reason_HardwareFactsIncomplete" xml:space="preserve"><value>OpenClaw 无法读取稳定的 NVIDIA GPU 标识符、内存、驱动或 CUDA 能力。</value></data>
+  <data name="LocalAi_Reason_InsufficientGpuMemory" xml:space="preserve"><value>{0}需要 {1} 的 GPU 内存用于模型权重、KV 缓存和运行时工作区。OpenClaw 检测到 {2}。</value></data>
+  <data name="LocalAi_Reason_DriverTooOld" xml:space="preserve"><value>检测到 NVIDIA 驱动 {0}。本地 AI 需要 {1} 或更高版本。</value></data>
+  <data name="LocalAi_Reason_CudaCapabilityTooLow" xml:space="preserve"><value>NVIDIA 驱动不支持 CUDA 13。无需单独的 CUDA Toolkit。</value></data>
+  <data name="LocalAi_Reason_Generic" xml:space="preserve"><value>OpenClaw 无法验证此系统上的本地 AI 要求。</value></data>
+  <data name="LocalAi_Reason_UnknownModelName" xml:space="preserve"><value>所选模型</value></data>
+  <data name="LocalAi_Reason_UnknownDriverVersion" xml:space="preserve"><value>未知</value></data>
+  <data name="LocalAi_Reason_UnknownMemoryAmount" xml:space="preserve"><value>未知数量</value></data>
+  <data name="LocalAi_Reason_GigabytesFormat" xml:space="preserve"><value>{0:0.#} GB</value></data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -1057,6 +1057,9 @@
   <data name="Onboarding_Connection_Later" xml:space="preserve">
     <value>稍后配置</value>
   </data>
+  <data name="Onboarding_LocalAi_RecheckAvailabilityButton.Content" xml:space="preserve">
+    <value>重新检查</value>
+  </data>
   <data name="Onboarding_Ready_Title" xml:space="preserve">
     <value>一切就绪！</value>
   </data>
@@ -7005,6 +7008,12 @@
   <data name="HubWindow_NavigationViewItem_LocalAi.Content" xml:space="preserve"><value>本地 AI</value></data>
   <data name="LocalAiPage_Title.Text" xml:space="preserve"><value>本地 AI</value></data>
   <data name="LocalAiPage_Intro.Text" xml:space="preserve"><value>在此计算机上私密运行经过验证的原生 llama-server。模型仅在收到请求时加载。</value></data>
+  <data name="LocalAiPage_UnavailableInfoBar.Title" xml:space="preserve"><value>本地 AI 不可用</value></data>
+  <data name="LocalAiPage_UnavailableDetailsButton.Content" xml:space="preserve"><value>查看原因</value></data>
+  <data name="LocalAiPage_UnavailableDetailsTip.Title" xml:space="preserve"><value>本地 AI 不可用的原因</value></data>
+  <data name="LocalAiPage_RecheckAvailabilityButton.Content" xml:space="preserve"><value>重新检查</value></data>
+  <data name="LocalAiPage_UnavailableRequirementsMessage" xml:space="preserve"><value>此设备不满足一项或多项本地 AI 要求。</value></data>
+  <data name="LocalAiPage_UnavailableProbeMessage" xml:space="preserve"><value>OpenClaw 目前无法验证本地 AI 要求。请确认 NVIDIA 驱动可用后重试。</value></data>
   <data name="LocalAiPage_EngineHeading.Text" xml:space="preserve"><value>llama-server</value></data>
   <data name="LocalAiPage_VersionLabel.Text" xml:space="preserve"><value>版本</value></data>
   <data name="LocalAiPage_EndpointLabel.Text" xml:space="preserve"><value>终结点</value></data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -7075,4 +7075,8 @@
   <data name="LocalAi_Reason_UnknownMemoryAmount" xml:space="preserve"><value>未知数量</value></data>
   <data name="LocalAi_Reason_GigabytesFormat" xml:space="preserve"><value>{0:0.#} GB</value></data>
   <data name="Onboarding_Welcome_LocalAiAvailableBadge.Text" xml:space="preserve"><value>本地 AI 可用</value></data>
+  <data name="Onboarding_LocalAi_WslConfigReadFailureReason" xml:space="preserve"><value>OpenClaw 无法安全读取全局 .wslconfig 文件。请检查该文件是否有效且可读,然后重试安装。</value></data>
+  <data name="LocalAiPage_UnavailableProbeTitle" xml:space="preserve"><value>无法验证本地 AI 可用性</value></data>
+  <data name="LocalAiPage_CheckingTitle" xml:space="preserve"><value>正在检查本地 AI 可用性</value></data>
+  <data name="LocalAiPage_CheckingMessage" xml:space="preserve"><value>OpenClaw 正在检查此设备是否可以运行本地 AI。这只需要片刻。</value></data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -7074,4 +7074,5 @@
   <data name="LocalAi_Reason_UnknownDriverVersion" xml:space="preserve"><value>未知</value></data>
   <data name="LocalAi_Reason_UnknownMemoryAmount" xml:space="preserve"><value>未知数量</value></data>
   <data name="LocalAi_Reason_GigabytesFormat" xml:space="preserve"><value>{0:0.#} GB</value></data>
+  <data name="Onboarding_Welcome_LocalAiAvailableBadge.Text" xml:space="preserve"><value>本地 AI 可用</value></data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -7074,4 +7074,5 @@
   <data name="LocalAi_Reason_UnknownDriverVersion" xml:space="preserve"><value>未知</value></data>
   <data name="LocalAi_Reason_UnknownMemoryAmount" xml:space="preserve"><value>未知數量</value></data>
   <data name="LocalAi_Reason_GigabytesFormat" xml:space="preserve"><value>{0:0.#} GB</value></data>
+  <data name="Onboarding_Welcome_LocalAiAvailableBadge.Text" xml:space="preserve"><value>本機 AI 可用</value></data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -7049,4 +7049,29 @@
   <data name="LocalAiPage_ModelRecipeFormat" xml:space="preserve"><value>{0} 內容範圍 · {1} KV · 第一次要求時載入</value></data>
   <data name="Command_GoToLocalAi_Title" xml:space="preserve"><value>前往本機 AI</value></data>
   <data name="Command_GoToLocalAi_Subtitle" xml:space="preserve"><value>檢視 llama-server、模型和閘道狀態</value></data>
+  <data name="Onboarding_LocalAi_UnavailableDetailsButton.Content" xml:space="preserve"><value>查看原因</value></data>
+  <data name="Onboarding_LocalAi_CheckingTitle" xml:space="preserve"><value>正在檢查本機 AI 要求</value></data>
+  <data name="Onboarding_LocalAi_CheckingMessage" xml:space="preserve"><value>OpenClaw 正在檢查 NVIDIA GPU、驅動程式、CUDA、記憶體和 WSL 要求。</value></data>
+  <data name="Onboarding_LocalAi_CheckingHelpText" xml:space="preserve"><value>OpenClaw 正在檢查本機 AI 要求。</value></data>
+  <data name="Onboarding_LocalAi_ProbeUnknownTitle" xml:space="preserve"><value>無法驗證本機 AI 可用性</value></data>
+  <data name="Onboarding_LocalAi_ProbeUnknownMessage" xml:space="preserve"><value>OpenClaw 目前無法驗證本機 AI 要求。請確認 NVIDIA 驅動程式可用後再試一次。</value></data>
+  <data name="Onboarding_LocalAi_ProbeUnknownHelpText" xml:space="preserve"><value>OpenClaw 無法驗證本機 AI 要求。請重新檢查可用性以再試一次。</value></data>
+  <data name="Onboarding_LocalAi_UnavailableTitle" xml:space="preserve"><value>本機 AI 無法使用</value></data>
+  <data name="Onboarding_LocalAi_UnavailableMessage" xml:space="preserve"><value>此電腦不符合一或多項本機 AI 要求。</value></data>
+  <data name="Onboarding_LocalAi_UnavailableHelpText" xml:space="preserve"><value>無法使用,因為此電腦不符合本機 AI 要求。</value></data>
+  <data name="Onboarding_LocalAi_ProbeFailureReason" xml:space="preserve"><value>OpenClaw 無法讀取 NVIDIA GPU、驅動程式、CUDA 或記憶體資訊。請確認 NVIDIA 驅動程式可用,然後重新檢查本機 AI 要求。</value></data>
+  <data name="Onboarding_LocalAi_UnavailableDetailsDialogTitle" xml:space="preserve"><value>本機 AI 無法使用的原因</value></data>
+  <data name="Onboarding_LocalAi_UnavailableDetailsDialogClose" xml:space="preserve"><value>關閉</value></data>
+  <data name="LocalAi_Reason_RuntimeUnavailable" xml:space="preserve"><value>此本機 AI 版本不包含適用於偵測到的 Windows 架構的原生 llama-server 執行階段。</value></data>
+  <data name="LocalAi_Reason_NoNvidiaGpu" xml:space="preserve"><value>NVIDIA 驅動程式未回報任何 NVIDIA GPU。請安裝或修復 NVIDIA 驅動程式,然後再試一次設定。</value></data>
+  <data name="LocalAi_Reason_UnknownModel" xml:space="preserve"><value>所選模型在此本機 AI 版本中無法使用。</value></data>
+  <data name="LocalAi_Reason_HardwareFactsIncomplete" xml:space="preserve"><value>OpenClaw 無法讀取穩定的 NVIDIA GPU 識別碼、記憶體、驅動程式或 CUDA 能力。</value></data>
+  <data name="LocalAi_Reason_InsufficientGpuMemory" xml:space="preserve"><value>{0} 需要 {1} 的 GPU 記憶體,用於模型權重、KV 快取和執行階段工作區。OpenClaw 偵測到 {2}。</value></data>
+  <data name="LocalAi_Reason_DriverTooOld" xml:space="preserve"><value>偵測到 NVIDIA 驅動程式 {0}。本機 AI 需要 {1} 或更新版本。</value></data>
+  <data name="LocalAi_Reason_CudaCapabilityTooLow" xml:space="preserve"><value>NVIDIA 驅動程式不支援 CUDA 13。不需要另外安裝 CUDA Toolkit。</value></data>
+  <data name="LocalAi_Reason_Generic" xml:space="preserve"><value>OpenClaw 無法驗證此系統上的本機 AI 要求。</value></data>
+  <data name="LocalAi_Reason_UnknownModelName" xml:space="preserve"><value>所選模型</value></data>
+  <data name="LocalAi_Reason_UnknownDriverVersion" xml:space="preserve"><value>未知</value></data>
+  <data name="LocalAi_Reason_UnknownMemoryAmount" xml:space="preserve"><value>未知數量</value></data>
+  <data name="LocalAi_Reason_GigabytesFormat" xml:space="preserve"><value>{0:0.#} GB</value></data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -7075,4 +7075,8 @@
   <data name="LocalAi_Reason_UnknownMemoryAmount" xml:space="preserve"><value>未知數量</value></data>
   <data name="LocalAi_Reason_GigabytesFormat" xml:space="preserve"><value>{0:0.#} GB</value></data>
   <data name="Onboarding_Welcome_LocalAiAvailableBadge.Text" xml:space="preserve"><value>本機 AI 可用</value></data>
+  <data name="Onboarding_LocalAi_WslConfigReadFailureReason" xml:space="preserve"><value>OpenClaw 無法安全讀取全域 .wslconfig 檔案。請確認檔案有效且可讀取,然後再試一次設定。</value></data>
+  <data name="LocalAiPage_UnavailableProbeTitle" xml:space="preserve"><value>無法驗證本機 AI 可用性</value></data>
+  <data name="LocalAiPage_CheckingTitle" xml:space="preserve"><value>正在檢查本機 AI 可用性</value></data>
+  <data name="LocalAiPage_CheckingMessage" xml:space="preserve"><value>OpenClaw 正在檢查此裝置是否可以執行本機 AI。這只需要片刻。</value></data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -1057,6 +1057,9 @@
   <data name="Onboarding_Connection_Later" xml:space="preserve">
     <value>稍後設定</value>
   </data>
+  <data name="Onboarding_LocalAi_RecheckAvailabilityButton.Content" xml:space="preserve">
+    <value>重新檢查</value>
+  </data>
   <data name="Onboarding_Ready_Title" xml:space="preserve">
     <value>一切就緒！</value>
   </data>
@@ -7005,6 +7008,12 @@
   <data name="HubWindow_NavigationViewItem_LocalAi.Content" xml:space="preserve"><value>本機 AI</value></data>
   <data name="LocalAiPage_Title.Text" xml:space="preserve"><value>本機 AI</value></data>
   <data name="LocalAiPage_Intro.Text" xml:space="preserve"><value>在這部電腦上私密執行經過驗證的原生 llama-server。模型只會在收到要求時載入。</value></data>
+  <data name="LocalAiPage_UnavailableInfoBar.Title" xml:space="preserve"><value>本機 AI 無法使用</value></data>
+  <data name="LocalAiPage_UnavailableDetailsButton.Content" xml:space="preserve"><value>查看原因</value></data>
+  <data name="LocalAiPage_UnavailableDetailsTip.Title" xml:space="preserve"><value>本機 AI 無法使用的原因</value></data>
+  <data name="LocalAiPage_RecheckAvailabilityButton.Content" xml:space="preserve"><value>重新檢查</value></data>
+  <data name="LocalAiPage_UnavailableRequirementsMessage" xml:space="preserve"><value>此裝置不符合一或多項本機 AI 要求。</value></data>
+  <data name="LocalAiPage_UnavailableProbeMessage" xml:space="preserve"><value>OpenClaw 目前無法驗證本機 AI 要求。請確認 NVIDIA 驅動程式可用後再試一次。</value></data>
   <data name="LocalAiPage_EngineHeading.Text" xml:space="preserve"><value>llama-server</value></data>
   <data name="LocalAiPage_VersionLabel.Text" xml:space="preserve"><value>版本</value></data>
   <data name="LocalAiPage_EndpointLabel.Text" xml:space="preserve"><value>端點</value></data>

--- a/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
@@ -1182,6 +1182,7 @@ public sealed class AppRefactorContractTests
     }
 
     [Fact]
+    [Fact]
     public void SetupWelcome_BlocksOnWslReadinessBeforeLocalAiDecisionUi()
     {
         var root = TestRepositoryPaths.GetRepositoryRoot();
@@ -1215,6 +1216,21 @@ public sealed class AppRefactorContractTests
             "GetLocalAiHardwareAsync()");
         Assert.DoesNotContain("GetWslViabilityAsync", capabilities);
         Assert.DoesNotContain("WslViabilityKind", capabilities);
+    }
+
+    [Fact]
+    public void SetupProgress_HidesEveryLocalAiOnlyGroupAndKeepsNonLocalPreviewActive()
+    {
+        var root = TestRepositoryPaths.GetRepositoryRoot();
+        var code = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.SetupEngine.UI", "Pages", "ProgressPage.xaml.cs"));
+        var buildRows = ExtractMethod(code, "BuildStepRows");
+        var preview = ExtractMethod(code, "RenderProgressPreview");
+
+        Assert.Contains("IsLocalAiOnlyGroup(stepIds)", buildRows);
+        Assert.Contains("stepIds.All(stepId => stepId.Contains(\"local-ai\"", code);
+        Assert.Contains("localAiPreview ? \"local-ai-model\" : \"wsl-create\"", preview);
+        Assert.DoesNotContain("groupId.StartsWith(\"local-ai\"", buildRows);
+        Assert.DoesNotContain(": 3;", preview);
     }
 
     [Fact]
@@ -1410,12 +1426,14 @@ public sealed class AppRefactorContractTests
         Assert.Contains("LocalAiInstallReviewCard.Visibility = Visibility.Visible", ExtractMethod(source, "ShowLocalAiUnavailable"));
         Assert.Contains("LocalAiAvailabilityReasons.Build", source);
         Assert.DoesNotContain("WslViability", source);
-        Assert.Contains("One or more Local AI requirements are unavailable.", xaml);
-        Assert.Matches(
-            new Regex(
-                "<InfoBar\\s+x:Name=\"LocalAiUnavailablePanel\"[^>]*>\\s*" +
-                "<StackPanel\\s+Orientation=\"Horizontal\"\\s+Spacing=\"8\"\\s+Margin=\"0,-12,0,12\">"),
-            xaml);
+        Assert.Contains("This PC does not meet one or more Local AI requirements.", xaml);
+        Assert.Contains("Title=\"Local AI is not available\"", xaml);
+        Assert.Contains("SetLocalAiOptionAvailability(isAvailable: false)", ExtractMethod(source, "ShowLocalAiUnavailable"));
+        Assert.Contains("Message=\"This PC does not meet one or more Local AI requirements.\"", xaml);
+        Assert.Contains("<InfoBar.ActionButton>", xaml);
+        Assert.True(
+            xaml.IndexOf("x:Name=\"LocalAiUnavailablePanel\"", StringComparison.Ordinal) <
+            xaml.IndexOf("x:Name=\"LocalAiInstallReviewCard\"", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -1423,11 +1441,12 @@ public sealed class AppRefactorContractTests
     {
         var root = TestRepositoryPaths.GetRepositoryRoot();
         var source = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.SetupEngine.UI", "Pages", "CapabilitiesPage.xaml.cs"));
+        var diagnostics = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.Shared", "Inference", "Catalog", "LocalInferenceEligibilityDiagnostics.cs"));
 
         Assert.Contains("LocalInferenceEligibility.GetRequiredMemoryBytes(model) <= capacityBytes", source);
-        Assert.Contains("eligibility.RequiredTotalMemoryBytes", source);
-        Assert.Contains("eligibility.DetectedTotalMemoryBytes", source);
-        Assert.Contains("model weights, KV cache, and runtime workspace", source);
+        Assert.Contains("eligibility.RequiredTotalMemoryBytes", diagnostics);
+        Assert.Contains("eligibility.DetectedTotalMemoryBytes", diagnostics);
+        Assert.Contains("model weights, KV cache, and runtime workspace", diagnostics);
         Assert.DoesNotContain("2 GiB runtime margin", source);
         Assert.DoesNotContain("HardwareProfile", source);
         Assert.DoesNotContain("RTX PRO 6000", source);

--- a/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
@@ -1182,7 +1182,6 @@ public sealed class AppRefactorContractTests
     }
 
     [Fact]
-    [Fact]
     public void SetupWelcome_BlocksOnWslReadinessBeforeLocalAiDecisionUi()
     {
         var root = TestRepositoryPaths.GetRepositoryRoot();
@@ -1422,7 +1421,7 @@ public sealed class AppRefactorContractTests
         var source = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.SetupEngine.UI", "Pages", "CapabilitiesPage.xaml.cs"));
         var xaml = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.SetupEngine.UI", "Pages", "CapabilitiesPage.xaml"));
         Assert.Contains("LocalAiUnavailableDetailsButton", xaml);
-        Assert.Contains("Why Local AI is unavailable", source);
+        Assert.Contains("SetupLocalization.GetString(\"Onboarding_LocalAi_UnavailableDetailsDialogTitle\")", source);
         Assert.Contains("LocalAiInstallReviewCard.Visibility = Visibility.Visible", ExtractMethod(source, "ShowLocalAiUnavailable"));
         Assert.Contains("LocalAiAvailabilityReasons.Build", source);
         Assert.DoesNotContain("WslViability", source);
@@ -1442,11 +1441,12 @@ public sealed class AppRefactorContractTests
         var root = TestRepositoryPaths.GetRepositoryRoot();
         var source = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.SetupEngine.UI", "Pages", "CapabilitiesPage.xaml.cs"));
         var diagnostics = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.Shared", "Inference", "Catalog", "LocalInferenceEligibilityDiagnostics.cs"));
+        var resources = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.Tray.WinUI", "Strings", "en-us", "Resources.resw"));
 
         Assert.Contains("LocalInferenceEligibility.GetRequiredMemoryBytes(model) <= capacityBytes", source);
         Assert.Contains("eligibility.RequiredTotalMemoryBytes", diagnostics);
         Assert.Contains("eligibility.DetectedTotalMemoryBytes", diagnostics);
-        Assert.Contains("model weights, KV cache, and runtime workspace", diagnostics);
+        Assert.Contains("model weights, KV cache, and runtime workspace", resources);
         Assert.DoesNotContain("2 GiB runtime margin", source);
         Assert.DoesNotContain("HardwareProfile", source);
         Assert.DoesNotContain("RTX PRO 6000", source);

--- a/tests/OpenClaw.Tray.Tests/LocalAiSetupAvailabilityCoordinatorTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalAiSetupAvailabilityCoordinatorTests.cs
@@ -1,0 +1,112 @@
+using OpenClaw.SetupEngine.UI.Pages;
+
+namespace OpenClaw.Tray.Tests;
+
+public sealed class LocalAiSetupAvailabilityCoordinatorTests
+{
+    [Fact]
+    public void ProbeFailure_BecomesUnknownAndRetryable()
+    {
+        var coordinator = new LocalAiSetupAvailabilityCoordinator();
+        var checking = coordinator.StartProbe();
+
+        Assert.True(coordinator.TryApplyProbeFailure(
+            checking.Generation,
+            "Probe failed.",
+            out var unknown));
+
+        Assert.Equal(LocalAiSetupAvailabilityStatus.Unknown, unknown.Status);
+        Assert.True(unknown.CanRecheck);
+        Assert.Equal("Probe failed.", unknown.Reason);
+    }
+
+    [Fact]
+    public void RetryAfterUnknown_CanRecoverToAvailable()
+    {
+        var coordinator = new LocalAiSetupAvailabilityCoordinator();
+        var first = coordinator.StartProbe();
+        Assert.True(coordinator.TryApplyProbeFailure(first.Generation, "Probe failed.", out var unknown));
+
+        Assert.True(coordinator.TryStartRecheck(out var retry));
+        Assert.True(retry.IsChecking);
+        Assert.NotEqual(unknown.Generation, retry.Generation);
+        Assert.True(coordinator.TryApplyAvailable(retry.Generation, out var available));
+
+        Assert.True(available.IsAvailable);
+        Assert.False(available.CanRecheck);
+        Assert.Null(available.Reason);
+    }
+
+    [Fact]
+    public void InFlightRetry_DoesNotStartSecondProbe()
+    {
+        var coordinator = new LocalAiSetupAvailabilityCoordinator();
+        var checking = coordinator.StartProbe();
+
+        Assert.False(coordinator.TryStartRecheck(out var current));
+
+        Assert.Equal(checking.Generation, current.Generation);
+        Assert.True(current.IsChecking);
+    }
+
+    [Fact]
+    public void StaleCompletion_CannotOverwriteCurrentProbe()
+    {
+        var coordinator = new LocalAiSetupAvailabilityCoordinator();
+        var stale = coordinator.StartProbe();
+        var current = coordinator.StartProbe();
+
+        Assert.False(coordinator.TryApplyUnsupported(stale.Generation, "Unsupported.", out _));
+        Assert.True(coordinator.TryApplyAvailable(current.Generation, out var available));
+
+        Assert.True(available.IsAvailable);
+        Assert.True(coordinator.Current.IsAvailable);
+    }
+
+    [Fact]
+    public void CancelledProbe_CannotOverwriteNextProbe()
+    {
+        var coordinator = new LocalAiSetupAvailabilityCoordinator();
+        var cancelled = coordinator.StartProbe();
+        coordinator.CancelCurrent();
+        var current = coordinator.StartProbe();
+
+        Assert.False(coordinator.TryApplyProbeFailure(cancelled.Generation, "Cancelled.", out _));
+        Assert.True(coordinator.TryApplyAvailable(current.Generation, out var available));
+
+        Assert.True(available.IsAvailable);
+    }
+
+    [Fact]
+    public void ConfirmedUnsupported_RemainsDefinitiveAndNotRetryable()
+    {
+        var coordinator = new LocalAiSetupAvailabilityCoordinator();
+        var checking = coordinator.StartProbe();
+
+        Assert.True(coordinator.TryApplyUnsupported(
+            checking.Generation,
+            "No qualified NVIDIA GPU was detected.",
+            out var unsupported));
+
+        Assert.True(unsupported.IsUnsupported);
+        Assert.False(unsupported.CanRecheck);
+        Assert.Equal("No qualified NVIDIA GPU was detected.", unsupported.Reason);
+    }
+
+    [Fact]
+    public void RecheckAfterConfirmedUnsupported_DoesNotStartProbe()
+    {
+        var coordinator = new LocalAiSetupAvailabilityCoordinator();
+        var checking = coordinator.StartProbe();
+        Assert.True(coordinator.TryApplyUnsupported(
+            checking.Generation,
+            "No qualified NVIDIA GPU was detected.",
+            out var unsupported));
+
+        Assert.False(coordinator.TryStartRecheck(out var current));
+
+        Assert.Equal(unsupported.Generation, current.Generation);
+        Assert.True(current.IsUnsupported);
+        Assert.False(coordinator.Current.IsChecking);
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/LocalAiSetupUxContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalAiSetupUxContractTests.cs
@@ -1,0 +1,222 @@
+using OpenClaw.TestSupport;
+
+namespace OpenClaw.Tray.Tests;
+
+public sealed class LocalAiSetupUxContractTests
+{
+    [Fact]
+    public void WelcomePage_ShowsLocalAiAsIconBadgeBesideRecommended()
+    {
+        string root = TestRepositoryPaths.GetRepositoryRoot();
+        string xaml = File.ReadAllText(Path.Combine(
+            root,
+            "src",
+            "OpenClaw.SetupEngine.UI",
+            "Pages",
+            "WelcomePage.xaml"));
+        string source = File.ReadAllText(Path.Combine(
+            root,
+            "src",
+            "OpenClaw.SetupEngine.UI",
+            "Pages",
+            "WelcomePage.xaml.cs"));
+        string badge = ExtractElement(xaml, "LocalAiAvailabilityBadge", "</Border>");
+
+        Assert.Contains("WelcomeLocalAiAvailable", badge);
+        Assert.Contains("Glyph=\"&#xE950;\"", badge);
+        Assert.Contains("Local AI available", badge);
+        Assert.Contains("AutomationProperties.AccessibilityView=\"Raw\"", badge);
+        AssertInOrder(xaml, "Text=\"Recommended\"", "x:Name=\"LocalAiAvailabilityBadge\"");
+        Assert.DoesNotContain("LocalAiAvailabilityPanel", xaml);
+        Assert.DoesNotContain("LocalAiAvailabilityText", xaml);
+        Assert.DoesNotContain("detected. Install a local gateway", source);
+        Assert.Contains("AutomationProperties.SetName(", source);
+    }
+
+    [Fact]
+    public void CapabilitiesReview_SeparatesReasonActionFromDisabledOptions()
+    {
+        string root = TestRepositoryPaths.GetRepositoryRoot();
+        string xaml = File.ReadAllText(Path.Combine(
+            root,
+            "src",
+            "OpenClaw.SetupEngine.UI",
+            "Pages",
+            "CapabilitiesPage.xaml"));
+        string source = File.ReadAllText(Path.Combine(
+            root,
+            "src",
+            "OpenClaw.SetupEngine.UI",
+            "Pages",
+            "CapabilitiesPage.xaml.cs"));
+        string infoBar = ExtractElement(xaml, "LocalAiUnavailablePanel", "</InfoBar>");
+
+        Assert.Contains("Title=\"Local AI is not available\"", xaml);
+        Assert.Contains("Severity=\"Informational\"", xaml);
+        Assert.Contains("AutomationProperties.LiveSetting=\"Polite\"", xaml);
+        Assert.Contains("Message=\"This PC does not meet one or more Local AI requirements.\"", infoBar);
+        Assert.Contains("<InfoBar.ActionButton>", infoBar);
+        Assert.DoesNotContain("<StackPanel", infoBar);
+        Assert.DoesNotContain("Padding=\"0\"", infoBar);
+        Assert.Contains("x:Name=\"LocalAiAvailabilityRecoveryPanel\"", xaml);
+        Assert.Contains("x:Name=\"LocalAiAvailabilityProgressRing\"", xaml);
+        Assert.Contains("x:Name=\"LocalAiRecheckAvailabilityButton\"", xaml);
+        Assert.Contains("x:Uid=\"Onboarding_LocalAi_RecheckAvailabilityButton\"", xaml);
+        Assert.Contains("AutomationProperties.AutomationId=\"LocalAiRecheckAvailabilityButton\"", xaml);
+        AssertInOrder(
+            xaml,
+            "x:Name=\"LocalAiUnavailablePanel\"",
+            "x:Name=\"LocalAiUnavailableDetailsButton\"",
+            "x:Name=\"LocalAiAvailabilityRecoveryPanel\"",
+            "x:Name=\"LocalAiRecheckAvailabilityButton\"",
+            "x:Name=\"LocalAiInstallReviewCard\"",
+            "x:Name=\"LocalAiOptionContent\"");
+        Assert.Contains("LocalAiSetupAvailabilityCoordinator", source);
+        Assert.Contains("TryApplyProbeFailure", source);
+        Assert.Contains("ShowLocalAiProbeUnknown", source);
+        Assert.Contains("LocalAiRecheckAvailability_Click", source);
+        Assert.Contains("GetLocalAiHardwareAsync(forceRefresh: refreshHardwareProbe)", source);
+        Assert.Contains("CanApplyLocalAiAvailability(checking.Generation, setupWindow)", source);
+        Assert.Contains("LocalAiOptionContent.IsHitTestVisible = isAvailable", source);
+        Assert.Contains("LocalAiOptionContent.Opacity = isAvailable ? 1 : 0.55", source);
+        Assert.Contains("LocalAiToggle.IsEnabled = isAvailable", source);
+        Assert.Contains("LocalAiModelSelector.IsEnabled = isAvailable", source);
+        Assert.Contains("LocalAiNetworkingConsentCheckBox.IsEnabled = isAvailable", source);
+        Assert.Contains("SetLocalAiOptionAvailability(isAvailable: false)", source);
+        Assert.Contains("SetLocalAiOptionAvailability(isAvailable: true)", source);
+    }
+
+    [Fact]
+    public void CapabilitiesReview_RecheckAffordance_HasLocalizedResourceKeys()
+    {
+        string root = TestRepositoryPaths.GetRepositoryRoot();
+        string xaml = File.ReadAllText(Path.Combine(
+            root,
+            "src",
+            "OpenClaw.SetupEngine.UI",
+            "Pages",
+            "CapabilitiesPage.xaml"));
+
+        Assert.Contains("x:Uid=\"Onboarding_LocalAi_RecheckAvailabilityButton\"", xaml);
+
+        foreach (string locale in new[] { "en-us", "fr-fr", "nl-nl", "zh-cn", "zh-tw" })
+        {
+            string resources = File.ReadAllText(Path.Combine(
+                root,
+                "src",
+                "OpenClaw.Tray.WinUI",
+                "Strings",
+                locale,
+                "Resources.resw"));
+            Assert.Contains("Onboarding_LocalAi_RecheckAvailabilityButton.Content", resources);
+        }
+    }
+
+    [Fact]
+    public void SetupWindow_LocalAiHardwareProbeCache_CanRefreshAfterFault()
+    {
+        string root = TestRepositoryPaths.GetRepositoryRoot();
+        string source = File.ReadAllText(Path.Combine(
+            root,
+            "src",
+            "OpenClaw.SetupEngine.UI",
+            "SetupWindow.xaml.cs"));
+        string method = ExtractMethod(source, "GetLocalAiHardwareAsync");
+
+        Assert.Contains("bool forceRefresh = false", method);
+        Assert.Contains("forceRefresh ||", method);
+        Assert.Contains("_localAiHardwareProbeTask.IsFaulted", method);
+        Assert.Contains("_localAiHardwareProbeTask.IsCanceled", method);
+        Assert.Contains("_localAiHardwareProbeTask = Task.Run", method);
+    }
+
+    [Fact]
+    public void LocalAiPage_InfoBarPrecedesAndDoesNotDisableReasonAction()
+    {
+        string root = TestRepositoryPaths.GetRepositoryRoot();
+        string xaml = File.ReadAllText(Path.Combine(
+            root,
+            "src",
+            "OpenClaw.Tray.WinUI",
+            "Pages",
+            "LocalAiPage.xaml"));
+        string source = File.ReadAllText(Path.Combine(
+            root,
+            "src",
+            "OpenClaw.Tray.WinUI",
+            "Pages",
+            "LocalAiPage.xaml.cs"));
+        string infoBar = ExtractElement(xaml, "LocalAiUnavailableInfoBar", "</InfoBar>");
+
+        AssertInOrder(
+            xaml,
+            "<ScrollViewer VerticalScrollBarVisibility=\"Auto\">",
+            "<Grid HorizontalAlignment=\"Stretch\">",
+            "<StackPanel Padding=\"24\" Spacing=\"12\" HorizontalAlignment=\"Stretch\" MaxWidth=\"900\">",
+            "x:Uid=\"LocalAiPage_Intro\"",
+            "x:Name=\"LocalAiUnavailableInfoBar\"",
+            "x:Name=\"LocalAiEngineOption\"");
+        Assert.Contains("Title=\"Local AI is not available\"", xaml);
+        Assert.Contains("AutomationProperties.LiveSetting=\"Polite\"", xaml);
+        Assert.Contains("<InfoBar.ActionButton>", infoBar);
+        Assert.Contains("x:Name=\"LocalAiUnavailableDetailsButton\"", infoBar);
+        Assert.Contains("AutomationProperties.AutomationId=\"LocalAiUnavailableDetailsButton\"", infoBar);
+        Assert.Contains("x:Name=\"LocalAiRecheckAvailabilityButton\"", xaml);
+        Assert.Contains("AutomationProperties.AutomationId=\"LocalAiRecheckAvailabilityButton\"", xaml);
+        Assert.DoesNotContain("Padding=\"0\"", infoBar);
+        Assert.DoesNotContain("HorizontalAlignment=\"Left\"", infoBar);
+        Assert.Contains("x:Name=\"LocalAiUnavailableDetailsTip\"", xaml);
+        Assert.Contains("Target=\"{x:Bind LocalAiUnavailableDetailsButton}\"", xaml);
+        Assert.Contains("x:Name=\"LocalAiEngineOption\"", xaml);
+        Assert.Contains("x:Name=\"LocalAiModelOption\"", xaml);
+        Assert.Contains("x:Name=\"LocalAiGatewayOption\"", xaml);
+        Assert.DoesNotContain("SetOptionAvailability(", source);
+        Assert.DoesNotContain("option.IsEnabled = isAvailable", source);
+        Assert.Contains("ShowAvailabilityInfoBar", source);
+        Assert.Contains("CanRecheckAvailability", source);
+        Assert.Contains("LocalAiRecheckAvailability_Click", source);
+        Assert.Contains("LocalAiUnavailableDetailsTip.IsOpen = !LocalAiUnavailableDetailsTip.IsOpen", source);
+    }
+
+    private static string ExtractElement(string source, string elementName, string closingTag)
+    {
+        int start = source.IndexOf($"x:Name=\"{elementName}\"", StringComparison.Ordinal);
+        Assert.True(start >= 0, $"Could not find {elementName}.");
+        int end = source.IndexOf(closingTag, start, StringComparison.Ordinal);
+        Assert.True(end >= 0, $"Could not find the end of {elementName}.");
+        return source[start..(end + closingTag.Length)];
+    }
+
+    private static void AssertInOrder(string source, params string[] values)
+    {
+        int previous = -1;
+        foreach (string value in values)
+        {
+            int current = source.IndexOf(value, previous + 1, StringComparison.Ordinal);
+            Assert.True(current > previous, $"Expected '{value}' after the previous value.");
+            previous = current;
+        }
+    }
+
+    private static string ExtractMethod(string source, string methodName)
+    {
+        int nameStart = source.IndexOf(methodName, StringComparison.Ordinal);
+        Assert.True(nameStart >= 0, $"Could not find method {methodName}.");
+        int brace = source.IndexOf('{', nameStart);
+        Assert.True(brace >= 0, $"Could not find body for method {methodName}.");
+        int depth = 0;
+        for (int index = brace; index < source.Length; index++)
+        {
+            if (source[index] == '{')
+                depth++;
+            else if (source[index] == '}')
+            {
+                depth--;
+                if (depth == 0)
+                    return source[nameStart..(index + 1)];
+            }
+        }
+
+        throw new InvalidOperationException($"Could not find end of method {methodName}.");
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/LocalAiSetupUxContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalAiSetupUxContractTests.cs
@@ -61,6 +61,23 @@ public sealed class LocalAiSetupUxContractTests
         }
     }
 
+    /// <summary>
+    /// The Welcome-page badge/accessible name must reflect whether this hardware can run
+    /// Local AI at all, not whether the currently configured model is still valid. A stale or
+    /// removed SelectedModelId must not hide the badge for an otherwise-capable device.
+    /// </summary>
+    [Fact]
+    public void WelcomePage_LocalAiBadge_GatesOnDeviceEligibilityNotSelectedModel()
+    {
+        string root = TestRepositoryPaths.GetRepositoryRoot();
+        string source = File.ReadAllText(Path.Combine(
+            root, "src", "OpenClaw.SetupEngine.UI", "Pages", "WelcomePage.xaml.cs"));
+        string method = ExtractMethod(source, "DetectLocalAiAvailabilityAsync");
+
+        Assert.Contains("LocalInferenceEligibility.Evaluate(hardware);", method);
+        Assert.DoesNotContain("config.LocalAi.SelectedModelId", method);
+    }
+
     [Fact]
     public void CapabilitiesReview_SeparatesReasonActionFromDisabledOptions()
     {
@@ -117,8 +134,8 @@ public sealed class LocalAiSetupUxContractTests
             "_localAiNetworkingStatus = networkingStatus;");
         AssertInOrder(
             source,
-            "eligibility = LocalInferenceEligibility.Evaluate(",
-            "if (eligibility.FailureCode == LocalInferenceEligibilityFailureCode.HardwareFactsIncomplete)",
+            "deviceEligibility = LocalInferenceEligibility.Evaluate(",
+            "if (deviceEligibility.FailureCode == LocalInferenceEligibilityFailureCode.HardwareFactsIncomplete)",
             "TryApplyProbeFailure(",
             "ShowLocalAiProbeUnknown(incompleteSnapshot);");
         Assert.Contains("LocalAiOptionContent.IsHitTestVisible = isAvailable", source);
@@ -140,6 +157,39 @@ public sealed class LocalAiSetupUxContractTests
         Assert.Contains("LocalAiToggle.IsOn = _config!.LocalAi.Enabled;", probeUnknownMethod);
         Assert.DoesNotContain("_config!.LocalAi.Enabled = false;", probeUnknownMethod);
         Assert.DoesNotContain("_config.SkipWizard = _skipWizardWithoutLocalAi;", probeUnknownMethod);
+    }
+
+    /// <summary>
+    /// The "is Local AI unavailable" gate and the recommended/selected model must be decided
+    /// from device-level eligibility (the best catalog model this hardware can run), not from
+    /// the currently configured SelectedModelId. A stale/removed model, or one that exists but
+    /// this hardware cannot run at all, must be reconciled to a valid one instead of making an
+    /// otherwise-capable device look unavailable or leaving setup on a known-incompatible model.
+    /// A merely busy GPU (EligibleButBusy) is not reconciled away: CanInstall covers that case
+    /// and the same model would still work once the GPU frees up.
+    /// </summary>
+    [Fact]
+    public void CapabilitiesReview_GatesOnDeviceEligibilityAndReconcilesStaleSelectedModel()
+    {
+        string root = TestRepositoryPaths.GetRepositoryRoot();
+        string source = File.ReadAllText(Path.Combine(
+            root, "src", "OpenClaw.SetupEngine.UI", "Pages", "CapabilitiesPage.xaml.cs"));
+        // "InitializeLocalAiReviewAsync" also appears at its earlier call site
+        // (AsyncEventHandlerGuard.Run(() => InitializeLocalAiReviewAsync(...))), so search for
+        // the method's declaration specifically; otherwise ExtractMethod would grab the body of
+        // whatever method follows the call site instead of the real one.
+        string method = ExtractMethod(source, "private async Task InitializeLocalAiReviewAsync");
+
+        AssertInOrder(
+            method,
+            "LocalInferenceEligibilityResult deviceEligibility = LocalInferenceEligibility.Evaluate(_localAiHardware);",
+            "if (!deviceEligibility.CanInstall || deviceEligibility.Plan is null || deviceEligibility.SelectedGpu is null)",
+            "hardwareReason = DescribeLocalAiUnavailable(deviceEligibility);",
+            "!LocalInferenceEligibility.Evaluate(_localAiHardware, selectedModelId).CanInstall",
+            "_config.LocalAi.SelectedModelId = null;",
+            "_config.LocalAi.SelectedModelId ??= _localAiRecommendedModelId ?? deviceEligibility.Plan.Model.Id;",
+            "eligibility = LocalInferenceEligibility.Evaluate(",
+            "_config.LocalAi.SelectedModelId);");
     }
 
     [Fact]
@@ -199,6 +249,7 @@ public sealed class LocalAiSetupUxContractTests
             "SetupLocalization.GetString(\"Onboarding_LocalAi_ProbeFailureReason\")",
             "SetupLocalization.GetString(\"Onboarding_LocalAi_UnavailableDetailsDialogTitle\")",
             "SetupLocalization.GetString(\"Onboarding_LocalAi_UnavailableDetailsDialogClose\")",
+            "SetupLocalization.GetString(\"Onboarding_LocalAi_WslConfigReadFailureReason\")",
         ];
         foreach (string call in setupResourceCalls)
             Assert.Contains(call, source);
@@ -210,6 +261,7 @@ public sealed class LocalAiSetupUxContractTests
         Assert.DoesNotContain(
             "\"Unavailable because this PC does not meet the Local AI requirements.\"", source);
         Assert.DoesNotContain("\"Why Local AI is unavailable\"", source);
+        Assert.DoesNotContain("OpenClaw cannot safely read the global .wslconfig file.", source);
 
         string[] resourceKeys =
         [
@@ -365,6 +417,132 @@ public sealed class LocalAiSetupUxContractTests
         Assert.Contains("CanRecheckAvailability", source);
         Assert.Contains("LocalAiRecheckAvailability_Click", source);
         Assert.Contains("LocalAiUnavailableDetailsTip.IsOpen = !LocalAiUnavailableDetailsTip.IsOpen", source);
+    }
+
+    /// <summary>
+    /// The Hub InfoBar must distinguish a definitive "device is unavailable" result from a
+    /// merely-unverified probe-error/checking state with a different localized title and
+    /// severity, and must show explicit checking/recheck progress (a progress ring plus a
+    /// "checking" title/message) instead of silently hiding all availability chrome while a
+    /// probe is in flight.
+    /// </summary>
+    [Fact]
+    public void LocalAiPage_DistinguishesDefinitiveUnavailableFromCheckingAndProbeUnknown()
+    {
+        string root = TestRepositoryPaths.GetRepositoryRoot();
+        string xaml = File.ReadAllText(Path.Combine(
+            root, "src", "OpenClaw.Tray.WinUI", "Pages", "LocalAiPage.xaml"));
+        string source = File.ReadAllText(Path.Combine(
+            root, "src", "OpenClaw.Tray.WinUI", "Pages", "LocalAiPage.xaml.cs"));
+
+        Assert.Contains("x:Name=\"LocalAiAvailabilityProgressRing\"", xaml);
+
+        string refreshMethod = ExtractMethod(source, "private void RefreshFromViewModel");
+        Assert.Contains("_viewModel.IsCheckingAvailability", refreshMethod);
+        Assert.Contains("LocalizationHelper.GetString(\"LocalAiPage_CheckingTitle\")", refreshMethod);
+        Assert.Contains("LocalizationHelper.GetString(\"LocalAiPage_CheckingMessage\")", refreshMethod);
+        Assert.Contains("\"LocalAiPage_UnavailableProbeTitle\"", refreshMethod);
+        Assert.Contains("\"LocalAiPage_UnavailableInfoBar.Title\"", refreshMethod);
+        Assert.Contains("InfoBarSeverity.Warning", refreshMethod);
+        Assert.Contains("InfoBarSeverity.Informational", refreshMethod);
+        Assert.Contains("LocalAiAvailabilityProgressRing.IsActive = _viewModel.IsCheckingAvailability", refreshMethod);
+
+        string[] resourceKeys =
+        [
+            "LocalAiPage_CheckingTitle",
+            "LocalAiPage_CheckingMessage",
+            "LocalAiPage_UnavailableProbeTitle",
+        ];
+        foreach (string locale in new[] { "en-us", "fr-fr", "nl-nl", "zh-cn", "zh-tw" })
+        {
+            string resources = File.ReadAllText(Path.Combine(
+                root, "src", "OpenClaw.Tray.WinUI", "Strings", locale, "Resources.resw"));
+            foreach (string key in resourceKeys)
+                Assert.Contains($"\"{key}\"", resources);
+        }
+    }
+
+    /// <summary>
+    /// The Hub's recheck command must enforce its own <c>CanRecheckAvailability</c> gate (not
+    /// just an availability-cancellation-in-flight check), so a caller cannot re-trigger a
+    /// probe outside the states the UI itself allows it in.
+    /// </summary>
+    [Fact]
+    public void LocalAiPageViewModel_RecheckAvailability_EnforcesCanRecheckAvailabilityGate()
+    {
+        string root = TestRepositoryPaths.GetRepositoryRoot();
+        string source = File.ReadAllText(Path.Combine(
+            root, "src", "OpenClaw.Tray.WinUI", "Presentation", "LocalAiPageViewModel.cs"));
+        string method = ExtractMethod(source, "public bool RecheckAvailability");
+
+        Assert.Contains("!IsActive || !CanRecheckAvailability", method);
+    }
+
+    /// <summary>
+    /// Setup step 3 must never dead-end: while Local AI availability is still pending
+    /// (Checking/ProbeUnknown), the toggle must stay interactive even though every other
+    /// Local AI control is disabled, so turning Local AI off is always an escape hatch. Continue
+    /// itself must never bypass eligibility or an as-yet-undetermined WSL networking-consent
+    /// requirement merely because availability hasn't resolved yet — that would let a fast user
+    /// leave step 3 before the consent checkbox is even known to be required.
+    /// </summary>
+    [Fact]
+    public void CapabilitiesReview_PendingAvailabilityIsEscapedByToggleNotByBypassingContinue()
+    {
+        string root = TestRepositoryPaths.GetRepositoryRoot();
+        string source = File.ReadAllText(Path.Combine(
+            root, "src", "OpenClaw.SetupEngine.UI", "Pages", "CapabilitiesPage.xaml.cs"));
+
+        // SetLocalAiOptionAvailability(isAvailable: false) sets LocalAiOptionContent's
+        // IsHitTestVisible to false, which blocks pointer input for its whole subtree regardless
+        // of a descendant's own IsEnabled; the escape hatch must restore hit-testing on that
+        // shared container, not just flip the toggle's own IsEnabled back on.
+        string restoreMethod = ExtractMethod(source, "private void RestoreLocalAiToggleAsPendingStateEscapeHatch");
+        AssertInOrder(
+            restoreMethod,
+            "LocalAiOptionContent.IsHitTestVisible = true;",
+            "LocalAiToggle.IsEnabled = true;");
+
+        string checkingMethod = ExtractMethod(source, "private void ShowLocalAiAvailabilityChecking");
+        AssertInOrder(
+            checkingMethod,
+            "SetLocalAiOptionAvailability(",
+            "RestoreLocalAiToggleAsPendingStateEscapeHatch();");
+
+        string probeUnknownMethod = ExtractMethod(source, "private void ShowLocalAiProbeUnknown");
+        AssertInOrder(
+            probeUnknownMethod,
+            "SetLocalAiOptionAvailability(",
+            "RestoreLocalAiToggleAsPendingStateEscapeHatch();");
+
+        // Continue's gate must not special-case pending availability: it only ever short-circuits
+        // on the toggle being off, or requires a fully resolved, eligible, consented state.
+        string primaryButtonMethod = ExtractMethod(source, "private void UpdatePrimaryButtonState");
+        Assert.DoesNotContain("_localAiAvailability", primaryButtonMethod);
+        Assert.Contains("LocalAiToggle.IsOn != true ||", primaryButtonMethod);
+        Assert.Contains(
+            "(_localAiSelectionEligible &&\r\n             (!_localAiNetworkingConsentRequired || LocalAiNetworkingConsentCheckBox.IsChecked == true));",
+            primaryButtonMethod);
+    }
+
+    /// <summary>
+    /// The Welcome page's accessible-name badge suffix must be idempotent: repeated detections
+    /// (e.g. the page reloads after navigating back) must rebuild the announcement from a
+    /// captured base name instead of appending the suffix again on every call.
+    /// </summary>
+    [Fact]
+    public void WelcomePage_LocalAiBadgeAccessibleName_IsIdempotentAcrossRepeatedDetections()
+    {
+        string root = TestRepositoryPaths.GetRepositoryRoot();
+        string source = File.ReadAllText(Path.Combine(
+            root, "src", "OpenClaw.SetupEngine.UI", "Pages", "WelcomePage.xaml.cs"));
+        string xaml = File.ReadAllText(Path.Combine(
+            root, "src", "OpenClaw.SetupEngine.UI", "Pages", "WelcomePage.xaml"));
+
+        Assert.Contains("_installChoiceBaseAutomationName ??= AutomationProperties.GetName(InstallChoice);", source);
+        Assert.Contains("FrameworkElementAutomationPeer.FromElement(InstallChoice)", source);
+        Assert.Contains("AutomationEvents.LiveRegionChanged", source);
+        Assert.Contains("AutomationProperties.LiveSetting=\"Polite\"", xaml);
     }
 
     private static string ExtractElement(string source, string elementName, string closingTag)

--- a/tests/OpenClaw.Tray.Tests/LocalAiSetupUxContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalAiSetupUxContractTests.cs
@@ -133,6 +133,13 @@ public sealed class LocalAiSetupUxContractTests
         Assert.Contains("LocalAiToggle.IsOn = _config!.LocalAi.Enabled;", checkingMethod);
         Assert.DoesNotContain("_config!.LocalAi.Enabled = false;", checkingMethod);
         Assert.DoesNotContain("_config.SkipWizard = _skipWizardWithoutLocalAi;", checkingMethod);
+
+        // A probe failure is retryable, not definitive: a successful recheck must restore the
+        // user's prior Local AI selection instead of a transient failure having cleared it.
+        string probeUnknownMethod = ExtractMethod(source, "private void ShowLocalAiProbeUnknown");
+        Assert.Contains("LocalAiToggle.IsOn = _config!.LocalAi.Enabled;", probeUnknownMethod);
+        Assert.DoesNotContain("_config!.LocalAi.Enabled = false;", probeUnknownMethod);
+        Assert.DoesNotContain("_config.SkipWizard = _skipWizardWithoutLocalAi;", probeUnknownMethod);
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/LocalAiSetupUxContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalAiSetupUxContractTests.cs
@@ -33,6 +33,34 @@ public sealed class LocalAiSetupUxContractTests
         Assert.Contains("AutomationProperties.SetName(", source);
     }
 
+    /// <summary>
+    /// The Welcome-page badge text and the accessible name it appends when Local AI is
+    /// available must route through SetupLocalization (not hardcoded English), sharing one
+    /// resw entry between the x:Uid-bound visual text and the code-behind accessible name.
+    /// </summary>
+    [Fact]
+    public void WelcomePage_LocalAiAvailableBadgeAndAccessibleName_AreLocalizedInEverySupportedLocale()
+    {
+        string root = TestRepositoryPaths.GetRepositoryRoot();
+        string xaml = File.ReadAllText(Path.Combine(
+            root, "src", "OpenClaw.SetupEngine.UI", "Pages", "WelcomePage.xaml"));
+        string source = File.ReadAllText(Path.Combine(
+            root, "src", "OpenClaw.SetupEngine.UI", "Pages", "WelcomePage.xaml.cs"));
+        string badge = ExtractElement(xaml, "LocalAiAvailabilityBadge", "</Border>");
+
+        Assert.Contains("x:Uid=\"Onboarding_Welcome_LocalAiAvailableBadge\"", badge);
+        Assert.Contains(
+            "SetupLocalization.GetString(\"Onboarding_Welcome_LocalAiAvailableBadge.Text\")", source);
+        Assert.Contains("AutomationProperties.GetName(InstallChoice)", source);
+
+        foreach (string locale in new[] { "en-us", "fr-fr", "nl-nl", "zh-cn", "zh-tw" })
+        {
+            string resources = File.ReadAllText(Path.Combine(
+                root, "src", "OpenClaw.Tray.WinUI", "Strings", locale, "Resources.resw"));
+            Assert.Contains("\"Onboarding_Welcome_LocalAiAvailableBadge.Text\"", resources);
+        }
+    }
+
     [Fact]
     public void CapabilitiesReview_SeparatesReasonActionFromDisabledOptions()
     {

--- a/tests/OpenClaw.Tray.Tests/LocalAiSetupUxContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalAiSetupUxContractTests.cs
@@ -87,6 +87,12 @@ public sealed class LocalAiSetupUxContractTests
             "WslGlobalConfigStatus networkingStatus = forceNetworkingConsent",
             "if (!CanApplyLocalAiAvailability(checking.Generation, setupWindow))",
             "_localAiNetworkingStatus = networkingStatus;");
+        AssertInOrder(
+            source,
+            "eligibility = LocalInferenceEligibility.Evaluate(",
+            "if (eligibility.FailureCode == LocalInferenceEligibilityFailureCode.HardwareFactsIncomplete)",
+            "TryApplyProbeFailure(",
+            "ShowLocalAiProbeUnknown(incompleteSnapshot);");
         Assert.Contains("LocalAiOptionContent.IsHitTestVisible = isAvailable", source);
         Assert.Contains("LocalAiOptionContent.Opacity = isAvailable ? 1 : 0.55", source);
         Assert.Contains("LocalAiToggle.IsEnabled = isAvailable", source);

--- a/tests/OpenClaw.Tray.Tests/LocalAiSetupUxContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalAiSetupUxContractTests.cs
@@ -133,6 +133,139 @@ public sealed class LocalAiSetupUxContractTests
         }
     }
 
+    /// <summary>
+    /// The setup page's unavailable/checking/probe-error InfoBar title, message, and action, its
+    /// accessibility help text, its probe-failure reason, and its "why unavailable" dialog must
+    /// route through SetupLocalization (not hardcoded English) and have matching resw keys in
+    /// every supported locale.
+    /// </summary>
+    [Fact]
+    public void CapabilitiesReview_UnavailableAndProbeErrorCopy_IsLocalizedInEverySupportedLocale()
+    {
+        string root = TestRepositoryPaths.GetRepositoryRoot();
+        string xaml = File.ReadAllText(Path.Combine(
+            root, "src", "OpenClaw.SetupEngine.UI", "Pages", "CapabilitiesPage.xaml"));
+        string source = File.ReadAllText(Path.Combine(
+            root, "src", "OpenClaw.SetupEngine.UI", "Pages", "CapabilitiesPage.xaml.cs"));
+
+        Assert.Contains("x:Uid=\"Onboarding_LocalAi_UnavailableDetailsButton\"", xaml);
+
+        string[] setupResourceCalls =
+        [
+            "SetupLocalization.GetString(\"Onboarding_LocalAi_CheckingTitle\")",
+            "SetupLocalization.GetString(\"Onboarding_LocalAi_CheckingMessage\")",
+            "SetupLocalization.GetString(\"Onboarding_LocalAi_CheckingHelpText\")",
+            "SetupLocalization.GetString(\"Onboarding_LocalAi_ProbeUnknownTitle\")",
+            "SetupLocalization.GetString(\"Onboarding_LocalAi_ProbeUnknownMessage\")",
+            "SetupLocalization.GetString(\"Onboarding_LocalAi_ProbeUnknownHelpText\")",
+            "SetupLocalization.GetString(\"Onboarding_LocalAi_UnavailableTitle\")",
+            "SetupLocalization.GetString(\"Onboarding_LocalAi_UnavailableMessage\")",
+            "SetupLocalization.GetString(\"Onboarding_LocalAi_UnavailableHelpText\")",
+            "SetupLocalization.GetString(\"Onboarding_LocalAi_ProbeFailureReason\")",
+            "SetupLocalization.GetString(\"Onboarding_LocalAi_UnavailableDetailsDialogTitle\")",
+            "SetupLocalization.GetString(\"Onboarding_LocalAi_UnavailableDetailsDialogClose\")",
+        ];
+        foreach (string call in setupResourceCalls)
+            Assert.Contains(call, source);
+
+        // The setup page never hardcodes the English copy it used to.
+        Assert.DoesNotContain("\"OpenClaw is checking Local AI requirements.\"", source);
+        Assert.DoesNotContain(
+            "\"OpenClaw could not verify Local AI requirements. Recheck availability to try again.\"", source);
+        Assert.DoesNotContain(
+            "\"Unavailable because this PC does not meet the Local AI requirements.\"", source);
+        Assert.DoesNotContain("\"Why Local AI is unavailable\"", source);
+
+        string[] resourceKeys =
+        [
+            "Onboarding_LocalAi_UnavailableDetailsButton.Content",
+            "Onboarding_LocalAi_CheckingTitle",
+            "Onboarding_LocalAi_CheckingMessage",
+            "Onboarding_LocalAi_CheckingHelpText",
+            "Onboarding_LocalAi_ProbeUnknownTitle",
+            "Onboarding_LocalAi_ProbeUnknownMessage",
+            "Onboarding_LocalAi_ProbeUnknownHelpText",
+            "Onboarding_LocalAi_UnavailableTitle",
+            "Onboarding_LocalAi_UnavailableMessage",
+            "Onboarding_LocalAi_UnavailableHelpText",
+            "Onboarding_LocalAi_ProbeFailureReason",
+            "Onboarding_LocalAi_UnavailableDetailsDialogTitle",
+            "Onboarding_LocalAi_UnavailableDetailsDialogClose",
+        ];
+        foreach (string locale in new[] { "en-us", "fr-fr", "nl-nl", "zh-cn", "zh-tw" })
+        {
+            string resources = File.ReadAllText(Path.Combine(
+                root, "src", "OpenClaw.Tray.WinUI", "Strings", locale, "Resources.resw"));
+            foreach (string key in resourceKeys)
+                Assert.Contains($"\"{key}\"", resources);
+        }
+    }
+
+    /// <summary>
+    /// The detailed diagnostic reason (why hardware is unavailable — insufficient GPU memory,
+    /// old driver, missing GPU, incomplete facts, etc.) is shared fact-only from
+    /// LocalInferenceEligibilityDiagnostics; both the setup page and the Hub page localize it
+    /// through their own resource-string helpers, with matching keys in every supported locale.
+    /// </summary>
+    [Fact]
+    public void LocalAiUnavailableReason_IsLocaleNeutralInSharedAndLocalizedInBothUiOwners()
+    {
+        string root = TestRepositoryPaths.GetRepositoryRoot();
+        string diagnostics = File.ReadAllText(Path.Combine(
+            root, "src", "OpenClaw.Shared", "Inference", "Catalog", "LocalInferenceEligibilityDiagnostics.cs"));
+        string setupSource = File.ReadAllText(Path.Combine(
+            root, "src", "OpenClaw.SetupEngine.UI", "Pages", "CapabilitiesPage.xaml.cs"));
+        string viewModelSource = File.ReadAllText(Path.Combine(
+            root, "src", "OpenClaw.Tray.WinUI", "Presentation", "LocalAiPageViewModel.cs"));
+        string hubPageSource = File.ReadAllText(Path.Combine(
+            root, "src", "OpenClaw.Tray.WinUI", "Pages", "LocalAiPage.xaml.cs"));
+
+        // Shared stays locale-neutral: facts and a kind enum, no English sentences.
+        Assert.Contains("LocalInferenceUnavailableReasonKind", diagnostics);
+        Assert.Contains("GetUnavailableReason", diagnostics);
+        Assert.DoesNotContain("model weights, KV cache, and runtime workspace", diagnostics);
+        Assert.DoesNotContain("No NVIDIA GPU was reported", diagnostics);
+
+        // The Hub ViewModel is source-linked into this test project without a WinUI resource
+        // host and must stay free of LocalizationHelper/resource-key literals; it only exposes
+        // the locale-neutral reason for the View to format.
+        Assert.DoesNotContain("LocalizationHelper", viewModelSource);
+        Assert.Contains("LocalInferenceUnavailableReason? LocalAiUnavailableReason", viewModelSource);
+
+        // The View (LocalAiPage.xaml.cs) and the setup page each format the reason locally,
+        // through the shared LocalAi_Reason_* keys.
+        string[] reasonKeys =
+        [
+            "LocalAi_Reason_RuntimeUnavailable",
+            "LocalAi_Reason_NoNvidiaGpu",
+            "LocalAi_Reason_UnknownModel",
+            "LocalAi_Reason_HardwareFactsIncomplete",
+            "LocalAi_Reason_InsufficientGpuMemory",
+            "LocalAi_Reason_DriverTooOld",
+            "LocalAi_Reason_CudaCapabilityTooLow",
+            "LocalAi_Reason_Generic",
+            "LocalAi_Reason_UnknownModelName",
+            "LocalAi_Reason_UnknownDriverVersion",
+            "LocalAi_Reason_UnknownMemoryAmount",
+            "LocalAi_Reason_GigabytesFormat",
+        ];
+        foreach (string key in reasonKeys)
+        {
+            Assert.Contains($"\"{key}\"", hubPageSource);
+            Assert.Contains($"\"{key}\"", setupSource);
+        }
+
+        // A thrown probe failure and a successful-but-incomplete read both resolve to
+        // HardwareFactsIncomplete: one shared message, no separate "probe failure" key.
+        foreach (string locale in new[] { "en-us", "fr-fr", "nl-nl", "zh-cn", "zh-tw" })
+        {
+            string resources = File.ReadAllText(Path.Combine(
+                root, "src", "OpenClaw.Tray.WinUI", "Strings", locale, "Resources.resw"));
+            foreach (string key in reasonKeys)
+                Assert.Contains($"\"{key}\"", resources);
+        }
+    }
+
     [Fact]
     public void SetupWindow_LocalAiHardwareProbeCache_CanRefreshAfterFault()
     {

--- a/tests/OpenClaw.Tray.Tests/LocalAiSetupUxContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalAiSetupUxContractTests.cs
@@ -77,6 +77,16 @@ public sealed class LocalAiSetupUxContractTests
         Assert.Contains("LocalAiRecheckAvailability_Click", source);
         Assert.Contains("GetLocalAiHardwareAsync(forceRefresh: refreshHardwareProbe)", source);
         Assert.Contains("CanApplyLocalAiAvailability(checking.Generation, setupWindow)", source);
+        AssertInOrder(
+            source,
+            "HostHardwareInfo hardware = await hardwareTask;",
+            "if (!CanApplyLocalAiAvailability(checking.Generation, setupWindow))",
+            "_localAiHardware = hardware;");
+        AssertInOrder(
+            source,
+            "WslGlobalConfigStatus networkingStatus = forceNetworkingConsent",
+            "if (!CanApplyLocalAiAvailability(checking.Generation, setupWindow))",
+            "_localAiNetworkingStatus = networkingStatus;");
         Assert.Contains("LocalAiOptionContent.IsHitTestVisible = isAvailable", source);
         Assert.Contains("LocalAiOptionContent.Opacity = isAvailable ? 1 : 0.55", source);
         Assert.Contains("LocalAiToggle.IsEnabled = isAvailable", source);
@@ -84,6 +94,11 @@ public sealed class LocalAiSetupUxContractTests
         Assert.Contains("LocalAiNetworkingConsentCheckBox.IsEnabled = isAvailable", source);
         Assert.Contains("SetLocalAiOptionAvailability(isAvailable: false)", source);
         Assert.Contains("SetLocalAiOptionAvailability(isAvailable: true)", source);
+
+        string checkingMethod = ExtractMethod(source, "private void ShowLocalAiAvailabilityChecking");
+        Assert.Contains("LocalAiToggle.IsOn = _config!.LocalAi.Enabled;", checkingMethod);
+        Assert.DoesNotContain("_config!.LocalAi.Enabled = false;", checkingMethod);
+        Assert.DoesNotContain("_config.SkipWizard = _skipWizardWithoutLocalAi;", checkingMethod);
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/LocalizationHelperSourceTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalizationHelperSourceTests.cs
@@ -15,6 +15,22 @@ public sealed class LocalizationHelperSourceTests
         Assert.Contains("\"{resourceKey[..propertySeparator]}/{resourceKey[(propertySeparator + 1)..]}\"", source);
     }
 
+    /// <summary>
+    /// SetupEngine.UI's own resource helper (it cannot reference LocalizationHelper directly,
+    /// see SetupLocalization.cs) must resolve the same "Key.Property" -> "Key/Property" XAML
+    /// property resource shape, so code-behind can share one resw entry with an x:Uid binding
+    /// instead of duplicating the string under a second key.
+    /// </summary>
+    [Fact]
+    public void SetupLocalization_ResolvesXamlPropertyResourceKeys()
+    {
+        var source = ReadSource("src", "OpenClaw.SetupEngine.UI", "SetupLocalization.cs");
+
+        Assert.Contains("LastIndexOf('.')", source);
+        Assert.Contains(
+            "$\"{resourceKey[..propertySeparator]}/{resourceKey[(propertySeparator + 1)..]}\"", source);
+    }
+
     private static string ReadSource(params string[] parts)
         => File.ReadAllText(Path.Combine(new[] { TestRepositoryPaths.GetRepositoryRoot() }.Concat(parts).ToArray()));
 }

--- a/tests/OpenClaw.Tray.Tests/LocalizationValidationTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalizationValidationTests.cs
@@ -333,6 +333,10 @@ public class LocalizationValidationTests
         "WorkspacePage_RootFolder",
         "WorkspacePage_SearchResultsPath",
         "WorkspacePage_BrowserTruncated",
+        // "GB" is an internationally recognized SI byte-size abbreviation kept identical
+        // across every supported locale (matches how NodesPage_Label_* technical loanwords
+        // above are handled); only the surrounding sentence is translated per locale.
+        "LocalAi_Reason_GigabytesFormat",
     };
 
     private static readonly HashSet<string> EnUsOnlyFallbackResourceKeys = new(StringComparer.Ordinal);

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -182,6 +182,7 @@
     <!-- Pulled in for console-log tail tests. Pure logic, no WinUI deps. -->
     <Compile Include="..\..\src\OpenClaw.SetupEngine.UI\WizardConsoleTail.cs" Link="WizardConsoleTail.cs" />
     <Compile Include="..\..\src\OpenClaw.SetupEngine.UI\WizardPayloadHelpers.cs" Link="WizardPayloadHelpers.cs" />
+    <Compile Include="..\..\src\OpenClaw.SetupEngine.UI\Pages\LocalAiSetupAvailabilityCoordinator.cs" Link="Pages\LocalAiSetupAvailabilityCoordinator.cs" />
   </ItemGroup>
 
   <!-- Phase 2 presentation seam: WinUI-free DI + navigation core, hand-linked so it

--- a/tests/OpenClaw.Tray.Tests/Presentation/AppServiceRegistrationTests.cs
+++ b/tests/OpenClaw.Tray.Tests/Presentation/AppServiceRegistrationTests.cs
@@ -2,6 +2,7 @@ using System.IO;
 using Microsoft.Extensions.DependencyInjection;
 using OpenClaw.Shared;
 using OpenClaw.Shared.ExecApprovals;
+using OpenClaw.Shared.Inference;
 using OpenClawTray.Chat;
 using OpenClawTray.Presentation;
 using OpenClawTray.Services;
@@ -68,6 +69,10 @@ public sealed class AppServiceRegistrationTests
             Assert.Same(settings, provider.GetRequiredService<SettingsManager>());
             Assert.Same(execApprovalsStore, provider.GetRequiredService<IExecApprovalsPresentationStore>());
             Assert.Same(runtimeHost, provider.GetRequiredService<IPermissionsPageRuntimeHost>());
+            Assert.IsType<NvmlHostHardwareProbe>(provider.GetRequiredService<IHostHardwareProbe>());
+            Assert.Same(
+                provider.GetRequiredService<IHostHardwareProbe>(),
+                provider.GetRequiredService<IHostHardwareProbe>());
             Assert.Same(provider.GetRequiredService<ISettingsStore>(), provider.GetRequiredService<ISettingsStore>());
             Assert.Same(provider.GetRequiredService<IPermissionsPageRuntimeSource>(), provider.GetRequiredService<IPermissionsPageRuntimeSource>());
         }

--- a/tests/OpenClaw.Tray.Tests/Presentation/LocalAiPageViewModelTests.cs
+++ b/tests/OpenClaw.Tray.Tests/Presentation/LocalAiPageViewModelTests.cs
@@ -32,6 +32,7 @@ public sealed class LocalAiPageViewModelTests
 
         Assert.False(viewModel.IsAvailabilityKnown);
         Assert.True(viewModel.IsSetupAvailable);
+        Assert.True(viewModel.CanChangeModel);
 
         await ActivateAndWaitForAvailabilityAsync(viewModel);
 
@@ -44,12 +45,14 @@ public sealed class LocalAiPageViewModelTests
         Assert.True(viewModel.CanRestart);
         Assert.True(viewModel.CanOpenLogs);
         Assert.False(viewModel.CanRetrySetup);
+        Assert.False(viewModel.CanChangeModel);
         Assert.True(viewModel.CanRepairConnection);
         Assert.False(viewModel.CanOpenChat);
         Assert.True(await viewModel.StopAsync());
         Assert.True(await viewModel.RestartAsync());
         Assert.True(viewModel.OpenLogs());
         Assert.False(viewModel.RetrySetup());
+        Assert.False(viewModel.ChangeModel());
         Assert.True(viewModel.RepairConnection());
         Assert.False(viewModel.OpenChat());
         Assert.Equal(1, commands.OpenLocalAiLogsCount);

--- a/tests/OpenClaw.Tray.Tests/Presentation/LocalAiPageViewModelTests.cs
+++ b/tests/OpenClaw.Tray.Tests/Presentation/LocalAiPageViewModelTests.cs
@@ -235,6 +235,96 @@ public sealed class LocalAiPageViewModelTests
         Assert.True(viewModel.IsSetupAvailable);
         Assert.False(viewModel.CanRecheckAvailability);
         Assert.Null(viewModel.LocalAiUnavailableReason);
+
+        // Availability is now a known success (no probe error), so a further recheck request is
+        // not meaningful and must be refused rather than silently re-running the probe.
+        Assert.False(viewModel.RecheckAvailability());
+    }
+
+    /// <summary>
+    /// While an availability probe (initial check or a recheck) is in flight, the Hub must show
+    /// explicit checking progress rather than silently hiding all availability chrome; the
+    /// coordinating InfoBar visibility must stay up until a result (success or failure) applies.
+    /// </summary>
+    [Fact]
+    public async Task IsCheckingAvailability_IsTrueWhileProbeInFlightAndClearsAfterResult()
+    {
+        var runtime = new FakeLocalAiRuntime(LocalAiRuntimeSnapshot.Initial(
+            new Uri("http://127.0.0.1:18080"),
+            DateTimeOffset.UtcNow));
+        using var gatewaySource = new PermissionsPageRuntimeSource(new FakePermissionsPageRuntimeHost());
+        var probeGate = new TaskCompletionSource();
+        using var viewModel = new LocalAiPageViewModel(
+            runtime,
+            gatewaySource,
+            new FakeAppCommands(),
+            new RecordingUiDispatcher(),
+            new GatedHardwareProbe(probeGate.Task, CreateQualifiedHardware));
+
+        Assert.False(viewModel.IsCheckingAvailability);
+
+        viewModel.Activate(null);
+
+        await WaitForConditionAsync(() => viewModel.IsCheckingAvailability, TimeSpan.FromSeconds(5));
+        Assert.True(viewModel.IsCheckingAvailability);
+        Assert.True(viewModel.ShowAvailabilityInfoBar);
+        Assert.False(viewModel.HasAvailabilityProbeError);
+        Assert.False(viewModel.CanRecheckAvailability);
+
+        probeGate.TrySetResult();
+        await WaitForAsync(viewModel, () => viewModel.IsAvailabilityKnown);
+
+        Assert.False(viewModel.IsCheckingAvailability);
+        Assert.True(viewModel.IsLocalAiAvailable);
+        Assert.False(viewModel.ShowAvailabilityInfoBar);
+    }
+
+    /// <summary>
+    /// StartAvailabilityRefresh() must assign the new probe slot before raising its
+    /// PropertyChanged notification, so a UI bound to that event (like the Hub page) reliably
+    /// observes IsCheckingAvailability already true the moment a recheck starts, instead of only
+    /// after the probe has already completed (which could hide the checking/recheck progress UI
+    /// entirely for a fast probe).
+    /// </summary>
+    [Fact]
+    public async Task RecheckAvailability_SynchronouslyNotifiesIsCheckingAvailability()
+    {
+        var runtime = new FakeLocalAiRuntime(LocalAiRuntimeSnapshot.Initial(
+            new Uri("http://127.0.0.1:18080"),
+            DateTimeOffset.UtcNow));
+        using var gatewaySource = new PermissionsPageRuntimeSource(new FakePermissionsPageRuntimeHost());
+        using var viewModel = new LocalAiPageViewModel(
+            runtime,
+            gatewaySource,
+            new FakeAppCommands(),
+            new RecordingUiDispatcher(),
+            new SequencedHardwareProbe(
+                () => throw new InvalidOperationException("probe failed"),
+                CreateQualifiedHardware));
+
+        await ActivateAndWaitForAvailabilityResultAsync(viewModel);
+        Assert.True(viewModel.HasAvailabilityProbeError);
+
+        bool observedCheckingInNotification = false;
+        viewModel.PropertyChanged += (_, _) =>
+        {
+            if (viewModel.IsCheckingAvailability)
+                observedCheckingInNotification = true;
+        };
+
+        Assert.True(viewModel.RecheckAvailability());
+
+        // StartAvailabilityRefresh() runs synchronously up to its own notification (the probe
+        // itself is fire-and-forget), so this must already be true by the time RecheckAvailability
+        // returns -- not just eventually true once the probe happens to finish.
+        Assert.True(observedCheckingInNotification);
+
+        // A generous polling wait (rather than the shared WaitForAsync's fixed 5s event-driven
+        // wait) tolerates thread-pool warm-up jitter from adjacent tests that briefly block a
+        // worker thread (e.g. GatedHardwareProbe/BlockingFirstHardwareProbe); the assertion above
+        // already proves the notification-ordering fix, so this is only draining the recheck's
+        // background probe before the ViewModel is disposed.
+        await WaitForConditionAsync(() => viewModel.IsAvailabilityKnown, TimeSpan.FromSeconds(15));
     }
 
     [Fact]
@@ -411,6 +501,43 @@ public sealed class LocalAiPageViewModelTests
         Assert.True(viewModel.HasAvailabilityProbeError);
         Assert.True(viewModel.CanRecheckAvailability);
         Assert.Equal(LocalInferenceUnavailableReasonKind.HardwareFactsIncomplete, viewModel.LocalAiUnavailableReason?.Kind);
+    }
+
+    /// <summary>
+    /// If the dispatcher refuses the enqueue entirely (e.g. it is shutting down),
+    /// <c>ApplyAvailabilityResultOnUiThread</c> must relinquish the current-probe slot before
+    /// disposing the token, not just dispose it. Otherwise the ViewModel is stuck reporting
+    /// <see cref="LocalAiPageViewModel.IsCheckingAvailability"/> forever, and a later
+    /// deactivate/dispose tries to cancel the already-disposed token and throws
+    /// <see cref="ObjectDisposedException"/>.
+    /// </summary>
+    [Fact]
+    public async Task RejectedEnqueue_ReleasesProbeSlotAndDoesNotThrowOnLaterDeactivate()
+    {
+        var runtime = new FakeLocalAiRuntime(LocalAiRuntimeSnapshot.Initial(
+            new Uri("http://127.0.0.1:18080"),
+            DateTimeOffset.UtcNow));
+        using var gatewaySource = new PermissionsPageRuntimeSource(new FakePermissionsPageRuntimeHost());
+        var dispatcher = new RecordingUiDispatcher { HasThreadAccess = false, RejectEnqueue = true };
+        using var viewModel = new LocalAiPageViewModel(
+            runtime,
+            gatewaySource,
+            new FakeAppCommands(),
+            dispatcher,
+            new FixedHardwareProbe(CreateQualifiedHardware()));
+
+        viewModel.Activate(null);
+
+        await WaitForConditionAsync(() => !viewModel.IsCheckingAvailability, TimeSpan.FromSeconds(5));
+
+        // The probe result was never applied (the dispatcher refused it), but the probe slot
+        // must be released so nothing is stuck "checking" forever.
+        Assert.False(viewModel.IsCheckingAvailability);
+        Assert.False(viewModel.IsAvailabilityKnown);
+
+        // Deactivating must not try to Cancel() an already-disposed token.
+        var exception = Record.Exception(() => viewModel.Deactivate());
+        Assert.Null(exception);
     }
 
     [Theory]
@@ -605,6 +732,17 @@ public sealed class LocalAiPageViewModelTests
         }
 
         public void ReleaseFirstProbe() => _releaseFirstProbe.TrySetResult();
+    }
+
+    /// <summary>Blocks inside <see cref="Probe"/> until <paramref name="release"/> completes, so a
+    /// test can observe the ViewModel's "checking" state before letting the probe resolve.</summary>
+    private sealed class GatedHardwareProbe(Task release, Func<HostHardwareInfo> result) : IHostHardwareProbe
+    {
+        public HostHardwareInfo Probe()
+        {
+            release.GetAwaiter().GetResult();
+            return result();
+        }
     }
 
     /// <summary>Harness for the "installed model" (change-model / retry-setup) scenarios, which

--- a/tests/OpenClaw.Tray.Tests/Presentation/LocalAiPageViewModelTests.cs
+++ b/tests/OpenClaw.Tray.Tests/Presentation/LocalAiPageViewModelTests.cs
@@ -1,10 +1,415 @@
+using OpenClaw.Connection;
 using OpenClaw.Connection.LocalAi;
+using OpenClaw.Shared.Inference;
+using OpenClaw.Shared.Inference.Catalog;
 using OpenClawTray.Presentation;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
 
 namespace OpenClaw.Tray.Tests.Presentation;
 
 public sealed class LocalAiPageViewModelTests
 {
+    [Fact]
+    public async Task UnsupportedHardware_KeepsExistingRuntimeManagementAvailable()
+    {
+        var runtime = new FakeLocalAiRuntime(CreateInstalledSnapshot());
+        var runtimeHost = new FakePermissionsPageRuntimeHost
+        {
+            ConnectionSnapshot = GatewayConnectionSnapshot.Idle with
+            {
+                OperatorState = RoleConnectionState.Idle,
+            },
+        };
+        using var gatewaySource = new PermissionsPageRuntimeSource(runtimeHost);
+        var commands = new FakeAppCommands();
+        using var viewModel = new LocalAiPageViewModel(
+            runtime,
+            gatewaySource,
+            commands,
+            new RecordingUiDispatcher(),
+            new FixedHardwareProbe(HostHardwareInfo.Unknown));
+
+        Assert.False(viewModel.IsAvailabilityKnown);
+        Assert.True(viewModel.IsSetupAvailable);
+
+        await ActivateAndWaitForAvailabilityAsync(viewModel);
+
+        Assert.True(viewModel.IsAvailabilityKnown);
+        Assert.False(viewModel.IsLocalAiAvailable);
+        Assert.False(viewModel.IsSetupAvailable);
+        Assert.Contains("NVIDIA GPU", viewModel.LocalAiUnavailableReason);
+        Assert.False(viewModel.CanStart);
+        Assert.True(viewModel.CanStop);
+        Assert.True(viewModel.CanRestart);
+        Assert.True(viewModel.CanOpenLogs);
+        Assert.False(viewModel.CanRetrySetup);
+        Assert.True(viewModel.CanRepairConnection);
+        Assert.False(viewModel.CanOpenChat);
+        Assert.True(await viewModel.StopAsync());
+        Assert.True(await viewModel.RestartAsync());
+        Assert.True(viewModel.OpenLogs());
+        Assert.False(viewModel.RetrySetup());
+        Assert.True(viewModel.RepairConnection());
+        Assert.False(viewModel.OpenChat());
+        Assert.Equal(1, commands.OpenLocalAiLogsCount);
+        Assert.Equal(0, commands.ShowOnboardingCount);
+        Assert.Equal(1, commands.ReconnectCount);
+        Assert.Equal(0, commands.ShowChatCount);
+        Assert.Equal(1, runtime.StopCount);
+        Assert.Equal(1, runtime.RestartCount);
+    }
+
+    [Fact]
+    public async Task UnsupportedHardware_KeepsChatAvailableForHealthyConnectedRuntime()
+    {
+        var runtime = new FakeLocalAiRuntime(CreateInstalledSnapshot());
+        var runtimeHost = new FakePermissionsPageRuntimeHost
+        {
+            ConnectionSnapshot = GatewayConnectionSnapshot.Idle with
+            {
+                OperatorState = RoleConnectionState.Connected,
+            },
+        };
+        using var gatewaySource = new PermissionsPageRuntimeSource(runtimeHost);
+        var commands = new FakeAppCommands();
+        using var viewModel = new LocalAiPageViewModel(
+            runtime,
+            gatewaySource,
+            commands,
+            new RecordingUiDispatcher(),
+            new FixedHardwareProbe(HostHardwareInfo.Unknown));
+
+        await ActivateAndWaitForAvailabilityAsync(viewModel);
+
+        Assert.False(viewModel.IsLocalAiAvailable);
+        Assert.True(viewModel.CanOpenChat);
+        Assert.True(viewModel.OpenChat());
+        Assert.Equal(1, commands.ShowChatCount);
+    }
+
+    [Fact]
+    public async Task UnsupportedHardware_KeepsInstalledStoppedRuntimeStartAvailable()
+    {
+        var runtime = new FakeLocalAiRuntime(CreateInstalledSnapshot(LocalAiRuntimeState.Stopped));
+        using var gatewaySource = new PermissionsPageRuntimeSource(new FakePermissionsPageRuntimeHost());
+        using var viewModel = new LocalAiPageViewModel(
+            runtime,
+            gatewaySource,
+            new FakeAppCommands(),
+            new RecordingUiDispatcher(),
+            new FixedHardwareProbe(HostHardwareInfo.Unknown));
+
+        await ActivateAndWaitForAvailabilityAsync(viewModel);
+
+        Assert.False(viewModel.IsSetupAvailable);
+        Assert.True(viewModel.CanStart);
+        Assert.True(await viewModel.StartAsync());
+        Assert.Equal(1, runtime.StartCount);
+    }
+
+    [Fact]
+    public async Task UnsupportedHardware_BlocksFreshSetupRetry()
+    {
+        var runtime = new FakeLocalAiRuntime(LocalAiRuntimeSnapshot.Initial(
+            new Uri("http://127.0.0.1:18080"),
+            DateTimeOffset.UtcNow));
+        using var gatewaySource = new PermissionsPageRuntimeSource(new FakePermissionsPageRuntimeHost());
+        using var viewModel = new LocalAiPageViewModel(
+            runtime,
+            gatewaySource,
+            new FakeAppCommands(),
+            new RecordingUiDispatcher(),
+            new FixedHardwareProbe(HostHardwareInfo.Unknown));
+
+        await ActivateAndWaitForAvailabilityAsync(viewModel);
+
+        Assert.False(viewModel.IsSetupAvailable);
+        Assert.False(viewModel.CanStart);
+        Assert.False(viewModel.CanRetrySetup);
+    }
+
+    /// <summary>
+    /// A stale/unknown selected model ID (for example, a model removed from the catalog since
+    /// it was configured) must not report qualified hardware as unavailable and block the user
+    /// from retrying setup with a different, compatible catalog model.
+    /// </summary>
+    [Fact]
+    public async Task UnknownSelectedModel_StillReportsQualifiedHardwareAsAvailable()
+    {
+        var runtime = new FakeLocalAiRuntime(LocalAiRuntimeSnapshot.Initial(
+            new Uri("http://127.0.0.1:18080"),
+            DateTimeOffset.UtcNow) with
+        {
+            ModelId = "no-longer-in-catalog",
+        });
+        using var gatewaySource = new PermissionsPageRuntimeSource(new FakePermissionsPageRuntimeHost());
+        using var viewModel = new LocalAiPageViewModel(
+            runtime,
+            gatewaySource,
+            new FakeAppCommands(),
+            new RecordingUiDispatcher(),
+            new FixedHardwareProbe(CreateQualifiedHardware()));
+
+        await ActivateAndWaitForAvailabilityAsync(viewModel);
+
+        Assert.True(viewModel.IsLocalAiAvailable);
+        Assert.True(viewModel.IsSetupAvailable);
+        Assert.True(viewModel.CanRetrySetup);
+        Assert.Null(viewModel.LocalAiUnavailableReason);
+    }
+
+    /// <summary>
+    /// Incomplete hardware facts (a partial/transient NVML read, e.g. a GPU present without a
+    /// stable ID or driver version) are inconclusive, not a definitive "unsupported device", so
+    /// the page must classify this the same as a thrown probe failure: an error state that keeps
+    /// recheck available, instead of a permanent IsLocalAiAvailable=false.
+    /// </summary>
+    [Fact]
+    public async Task IncompleteHardwareFacts_IsTreatedAsRetryableProbeErrorNotDefinitiveUnavailable()
+    {
+        var runtime = new FakeLocalAiRuntime(LocalAiRuntimeSnapshot.Initial(
+            new Uri("http://127.0.0.1:18080"),
+            DateTimeOffset.UtcNow));
+        using var gatewaySource = new PermissionsPageRuntimeSource(new FakePermissionsPageRuntimeHost());
+        HostHardwareInfo qualified = CreateQualifiedHardware();
+        HostHardwareInfo incomplete = qualified with
+        {
+            Gpus = [qualified.Gpus[0] with { DriverVersion = null }],
+        };
+        using var viewModel = new LocalAiPageViewModel(
+            runtime,
+            gatewaySource,
+            new FakeAppCommands(),
+            new RecordingUiDispatcher(),
+            new FixedHardwareProbe(incomplete));
+
+        await ActivateAndWaitForAvailabilityResultAsync(viewModel);
+
+        Assert.False(viewModel.IsAvailabilityKnown);
+        Assert.False(viewModel.IsLocalAiAvailable);
+        Assert.True(viewModel.HasAvailabilityProbeError);
+        Assert.True(viewModel.CanRecheckAvailability);
+        Assert.Contains("could not read", viewModel.LocalAiUnavailableReason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ProbeFailure_UsesUnknownStateUntilRecheckSucceeds()
+    {
+        var runtime = new FakeLocalAiRuntime(LocalAiRuntimeSnapshot.Initial(
+            new Uri("http://127.0.0.1:18080"),
+            DateTimeOffset.UtcNow));
+        using var gatewaySource = new PermissionsPageRuntimeSource(new FakePermissionsPageRuntimeHost());
+        using var viewModel = new LocalAiPageViewModel(
+            runtime,
+            gatewaySource,
+            new FakeAppCommands(),
+            new RecordingUiDispatcher(),
+            new SequencedHardwareProbe(
+                () => throw new InvalidOperationException("probe failed"),
+                CreateQualifiedHardware));
+
+        Assert.False(viewModel.RecheckAvailability());
+
+        await ActivateAndWaitForAvailabilityResultAsync(viewModel);
+
+        Assert.False(viewModel.IsAvailabilityKnown);
+        Assert.False(viewModel.IsLocalAiAvailable);
+        Assert.True(viewModel.HasAvailabilityProbeError);
+        Assert.True(viewModel.ShowAvailabilityInfoBar);
+        Assert.True(viewModel.IsSetupAvailable);
+        Assert.True(viewModel.CanRetrySetup);
+        Assert.True(viewModel.CanRecheckAvailability);
+        Assert.Contains("could not read", viewModel.LocalAiUnavailableReason, StringComparison.OrdinalIgnoreCase);
+
+        Assert.True(viewModel.RecheckAvailability());
+        await WaitForAsync(viewModel, () => viewModel.IsAvailabilityKnown);
+
+        Assert.True(viewModel.IsAvailabilityKnown);
+        Assert.True(viewModel.IsLocalAiAvailable);
+        Assert.False(viewModel.HasAvailabilityProbeError);
+        Assert.False(viewModel.ShowAvailabilityInfoBar);
+        Assert.True(viewModel.IsSetupAvailable);
+        Assert.False(viewModel.CanRecheckAvailability);
+        Assert.Null(viewModel.LocalAiUnavailableReason);
+    }
+
+    [Fact]
+    public async Task ProbeFailure_PublishesChangeWhenRecheckBecomesAvailable()
+    {
+        var runtime = new FakeLocalAiRuntime(LocalAiRuntimeSnapshot.Initial(
+            new Uri("http://127.0.0.1:18080"),
+            DateTimeOffset.UtcNow));
+        using var gatewaySource = new PermissionsPageRuntimeSource(new FakePermissionsPageRuntimeHost());
+        using var viewModel = new LocalAiPageViewModel(
+            runtime,
+            gatewaySource,
+            new FakeAppCommands(),
+            new RecordingUiDispatcher(),
+            new SequencedHardwareProbe(
+                () => throw new InvalidOperationException("probe failed")));
+
+        var observed = new List<(bool HasError, bool CanRecheck)>();
+        var recheckAvailable = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        viewModel.PropertyChanged += (_, _) =>
+        {
+            var snapshot = (viewModel.HasAvailabilityProbeError, viewModel.CanRecheckAvailability);
+            observed.Add(snapshot);
+            if (snapshot is (true, true))
+                recheckAvailable.TrySetResult();
+        };
+
+        viewModel.Activate(null);
+        await recheckAvailable.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Contains(observed, state => state is (true, true));
+
+        // The failed-probe result and the cancellation clear that unlocks recheck are applied
+        // together in one property-changed notification, so an error-but-not-yet-rechecked
+        // transient state must never be observed.
+        Assert.DoesNotContain(observed, state => state is (true, false));
+    }
+
+    [Fact]
+    public async Task QualifiedHardware_EnablesApplicableOptionsAndRoutesActions()
+    {
+        var runtime = new FakeLocalAiRuntime(CreateInstalledSnapshot());
+        var runtimeHost = new FakePermissionsPageRuntimeHost
+        {
+            ConnectionSnapshot = GatewayConnectionSnapshot.Idle with
+            {
+                OperatorState = RoleConnectionState.Connected,
+            },
+        };
+        using var gatewaySource = new PermissionsPageRuntimeSource(runtimeHost);
+        var commands = new FakeAppCommands();
+        using var viewModel = new LocalAiPageViewModel(
+            runtime,
+            gatewaySource,
+            commands,
+            new RecordingUiDispatcher(),
+            new FixedHardwareProbe(CreateQualifiedHardware()));
+
+        await ActivateAndWaitForAvailabilityAsync(viewModel);
+
+        Assert.True(viewModel.IsLocalAiAvailable);
+        Assert.True(viewModel.IsSetupAvailable);
+        Assert.Null(viewModel.LocalAiUnavailableReason);
+        Assert.True(viewModel.CanStop);
+        Assert.True(viewModel.CanRestart);
+        Assert.True(viewModel.CanOpenLogs);
+        Assert.True(viewModel.CanOpenChat);
+        Assert.True(viewModel.OpenLogs());
+        Assert.True(viewModel.OpenChat());
+        Assert.Equal(1, commands.OpenLocalAiLogsCount);
+        Assert.Equal(1, commands.ShowChatCount);
+    }
+
+    [Fact]
+    public async Task StaleAvailabilityProbe_DoesNotOverwriteNewerResult()
+    {
+        var runtime = new FakeLocalAiRuntime(LocalAiRuntimeSnapshot.Initial(
+            new Uri("http://127.0.0.1:18080"),
+            DateTimeOffset.UtcNow));
+        using var gatewaySource = new PermissionsPageRuntimeSource(new FakePermissionsPageRuntimeHost());
+        var probe = new BlockingFirstHardwareProbe(CreateQualifiedHardware);
+        using var viewModel = new LocalAiPageViewModel(
+            runtime,
+            gatewaySource,
+            new FakeAppCommands(),
+            new RecordingUiDispatcher(),
+            probe);
+
+        viewModel.Activate(null);
+        await probe.FirstProbeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        viewModel.Deactivate();
+        viewModel.Activate(null);
+        await WaitForAsync(viewModel, () => viewModel.IsAvailabilityKnown && viewModel.IsLocalAiAvailable);
+
+        probe.ReleaseFirstProbe();
+        await Task.Delay(100);
+
+        Assert.True(viewModel.IsAvailabilityKnown);
+        Assert.True(viewModel.IsLocalAiAvailable);
+        Assert.False(viewModel.HasAvailabilityProbeError);
+        Assert.Null(viewModel.LocalAiUnavailableReason);
+    }
+
+    /// <summary>
+    /// Guards against a probe-completion race: if the dispatcher defers the queued UI callback
+    /// (a real WinUI <c>DispatcherQueue.TryEnqueue</c> callback does not run inline), the
+    /// eventual callback must still see itself as the current probe and apply the successful
+    /// result, instead of a premature field clear making it drop the result.
+    /// </summary>
+    [Fact]
+    public async Task DelayedDispatch_AppliesSuccessfulProbeResultWhenQueuedCallbackRunsLater()
+    {
+        var runtime = new FakeLocalAiRuntime(CreateInstalledSnapshot());
+        using var gatewaySource = new PermissionsPageRuntimeSource(new FakePermissionsPageRuntimeHost());
+        var dispatcher = new RecordingUiDispatcher { HasThreadAccess = false, RunEnqueuedImmediately = false };
+        using var viewModel = new LocalAiPageViewModel(
+            runtime,
+            gatewaySource,
+            new FakeAppCommands(),
+            dispatcher,
+            new FixedHardwareProbe(CreateQualifiedHardware()));
+
+        viewModel.Activate(null);
+
+        // Activation starts both the runtime snapshot refresh and the availability probe; both
+        // complete on a background thread and each queues one UI callback that the dispatcher
+        // holds back instead of running inline.
+        await WaitForConditionAsync(() => dispatcher.EnqueuedCount >= 2, TimeSpan.FromSeconds(5));
+
+        Assert.False(viewModel.IsAvailabilityKnown);
+        Assert.False(viewModel.HasAvailabilityProbeError);
+        Assert.False(viewModel.CanRecheckAvailability);
+
+        dispatcher.FlushPending();
+
+        Assert.True(viewModel.IsAvailabilityKnown);
+        Assert.True(viewModel.IsLocalAiAvailable);
+        Assert.False(viewModel.HasAvailabilityProbeError);
+        Assert.Null(viewModel.LocalAiUnavailableReason);
+        Assert.False(viewModel.CanRecheckAvailability);
+    }
+
+    /// <summary>
+    /// Same race as <see cref="DelayedDispatch_AppliesSuccessfulProbeResultWhenQueuedCallbackRunsLater"/>,
+    /// but for a failed probe: the deferred callback must still mark the probe error and leave
+    /// recheck available once it finally runs.
+    /// </summary>
+    [Fact]
+    public async Task DelayedDispatch_AppliesFailedProbeResultWhenQueuedCallbackRunsLater()
+    {
+        var runtime = new FakeLocalAiRuntime(LocalAiRuntimeSnapshot.Initial(
+            new Uri("http://127.0.0.1:18080"),
+            DateTimeOffset.UtcNow));
+        using var gatewaySource = new PermissionsPageRuntimeSource(new FakePermissionsPageRuntimeHost());
+        var dispatcher = new RecordingUiDispatcher { HasThreadAccess = false, RunEnqueuedImmediately = false };
+        using var viewModel = new LocalAiPageViewModel(
+            runtime,
+            gatewaySource,
+            new FakeAppCommands(),
+            dispatcher,
+            new SequencedHardwareProbe(() => throw new InvalidOperationException("probe failed")));
+
+        viewModel.Activate(null);
+
+        await WaitForConditionAsync(() => dispatcher.EnqueuedCount >= 2, TimeSpan.FromSeconds(5));
+
+        Assert.False(viewModel.IsAvailabilityKnown);
+        Assert.False(viewModel.HasAvailabilityProbeError);
+
+        dispatcher.FlushPending();
+
+        Assert.False(viewModel.IsAvailabilityKnown);
+        Assert.False(viewModel.IsLocalAiAvailable);
+        Assert.True(viewModel.HasAvailabilityProbeError);
+        Assert.True(viewModel.CanRecheckAvailability);
+        Assert.Contains("could not read", viewModel.LocalAiUnavailableReason, StringComparison.OrdinalIgnoreCase);
+    }
+
     [Theory]
     [InlineData(LocalAiModelAvailabilityState.Verified)]
     [InlineData(LocalAiModelAvailabilityState.Loaded)]
@@ -76,6 +481,131 @@ public sealed class LocalAiPageViewModelTests
         Assert.Contains("_viewModel?.ChangeModel()", codeBehind);
     }
 
+    private static async Task ActivateAndWaitForAvailabilityAsync(LocalAiPageViewModel viewModel)
+    {
+        await ActivateAndWaitForAvailabilityResultAsync(viewModel);
+        await WaitForAsync(viewModel, () => viewModel.IsAvailabilityKnown);
+    }
+
+    private static async Task ActivateAndWaitForAvailabilityResultAsync(LocalAiPageViewModel viewModel)
+    {
+        viewModel.Activate(null);
+        await WaitForAsync(viewModel, () => viewModel.IsAvailabilityKnown || viewModel.HasAvailabilityProbeError);
+    }
+
+    private static async Task WaitForAsync(LocalAiPageViewModel viewModel, Func<bool> condition)
+    {
+        if (condition())
+            return;
+
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        PropertyChangedEventHandler? handler = null;
+        handler = (_, _) =>
+        {
+            if (!condition())
+                return;
+            viewModel.PropertyChanged -= handler;
+            completion.TrySetResult();
+        };
+        viewModel.PropertyChanged += handler;
+        await completion.Task.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    private static async Task WaitForConditionAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        DateTime deadline = DateTime.UtcNow + timeout;
+        while (!condition())
+        {
+            if (DateTime.UtcNow > deadline)
+                throw new TimeoutException("Condition was not met within the timeout.");
+            await Task.Delay(10);
+        }
+    }
+
+    private static HostHardwareInfo CreateQualifiedHardware() =>
+        new(
+            Architecture.X64,
+            TotalPhysicalMemoryBytes: 256_000_000_000,
+            AvailablePhysicalMemoryBytes: 128_000_000_000,
+            Gpus:
+            [
+                new GpuInfo(
+                    GpuVendor.Nvidia,
+                    "NVIDIA Test GPU",
+                    GpuVisibleMemoryBytes: 128_000_000_000,
+                    FreeGpuVisibleMemoryBytes: 128_000_000_000,
+                    DriverVersion: "620.0",
+                    CudaMajorVersion: 13,
+                    StableId: "GPU-test"),
+            ],
+            VulkanAvailable: false);
+
+    private static LocalAiRuntimeSnapshot CreateInstalledSnapshot(
+        LocalAiRuntimeState state = LocalAiRuntimeState.Healthy)
+    {
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        string modelId = LocalModelCatalog.Models[0].Id;
+        return new LocalAiRuntimeSnapshot(
+            state,
+            LocalAiOwnership.CompanionManaged,
+            new Uri("http://127.0.0.1:18080"),
+            "test",
+            modelId,
+            new LocalAiModelEvidence(
+                LocalAiModelAvailabilityState.Verified,
+                now,
+                new string('0', 64),
+                sizeBytes: 1),
+            ProcessId: 1234,
+            ProcessStartedAtUtc: now,
+            Detail: null,
+            UpdatedAtUtc: now);
+    }
+
+    private sealed class FixedHardwareProbe(HostHardwareInfo hardware) : IHostHardwareProbe
+    {
+        public HostHardwareInfo Probe() => hardware;
+    }
+
+    private sealed class SequencedHardwareProbe(params Func<HostHardwareInfo>[] attempts) : IHostHardwareProbe
+    {
+        private readonly Queue<Func<HostHardwareInfo>> _attempts = new(attempts);
+
+        public HostHardwareInfo Probe()
+        {
+            if (_attempts.Count == 0)
+                throw new InvalidOperationException("No probe attempts configured.");
+            return _attempts.Dequeue().Invoke();
+        }
+    }
+
+    private sealed class BlockingFirstHardwareProbe(Func<HostHardwareInfo> secondAttempt) : IHostHardwareProbe
+    {
+        private readonly TaskCompletionSource _firstProbeStarted =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _releaseFirstProbe =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _attempts;
+
+        public TaskCompletionSource FirstProbeStarted => _firstProbeStarted;
+
+        public HostHardwareInfo Probe()
+        {
+            if (Interlocked.Increment(ref _attempts) == 1)
+            {
+                _firstProbeStarted.TrySetResult();
+                _releaseFirstProbe.Task.GetAwaiter().GetResult();
+                return HostHardwareInfo.Unknown;
+            }
+
+            return secondAttempt();
+        }
+
+        public void ReleaseFirstProbe() => _releaseFirstProbe.TrySetResult();
+    }
+
+    /// <summary>Harness for the "installed model" (change-model / retry-setup) scenarios, which
+    /// exercise runtime/model state independent of the hardware-availability probe.</summary>
     private sealed class LocalAiHarness : IDisposable
     {
         private readonly FakeLocalAiRuntime _runtime;
@@ -91,7 +621,12 @@ public sealed class LocalAiPageViewModelTests
             _gatewaySource = new PermissionsPageRuntimeSource(gatewayHost);
             Commands = new FakeAppCommands();
             _dispatcher = new RecordingUiDispatcher();
-            ViewModel = new LocalAiPageViewModel(_runtime, _gatewaySource, Commands, _dispatcher);
+            ViewModel = new LocalAiPageViewModel(
+                _runtime,
+                _gatewaySource,
+                Commands,
+                _dispatcher,
+                new FixedHardwareProbe(HostHardwareInfo.Unknown));
         }
 
         public FakeAppCommands Commands { get; }
@@ -147,31 +682,44 @@ public sealed class LocalAiPageViewModelTests
         }
     }
 
-    internal sealed class FakeLocalAiRuntime(LocalAiRuntimeSnapshot snapshot) : ILocalAiRuntime
+    private sealed class FakeLocalAiRuntime(LocalAiRuntimeSnapshot snapshot) : ILocalAiRuntime
     {
         private TaskCompletionSource<LocalAiRuntimeSnapshot>? _startCompletion;
 
-        public LocalAiRuntimeSnapshot Snapshot { get; } = snapshot;
-
+        public LocalAiRuntimeSnapshot Snapshot { get; private set; } = snapshot;
+        public int StartCount { get; private set; }
+        public int StopCount { get; private set; }
+        public int RestartCount { get; private set; }
         public event EventHandler<LocalAiRuntimeSnapshotChangedEventArgs>? StateChanged
         {
             add { }
             remove { }
         }
 
+        /// <summary>Makes <see cref="EnsureStartedAsync"/> await until <see cref="CompleteStart"/> is
+        /// called, so tests can observe view-model state while a start is still in flight.</summary>
         public void BlockStart() =>
             _startCompletion = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public void CompleteStart() => _startCompletion?.TrySetResult(Snapshot);
 
-        public Task<LocalAiRuntimeSnapshot> EnsureStartedAsync(CancellationToken cancellationToken = default) =>
-            _startCompletion?.Task ?? Task.FromResult(Snapshot);
+        public Task<LocalAiRuntimeSnapshot> EnsureStartedAsync(CancellationToken cancellationToken = default)
+        {
+            StartCount++;
+            return _startCompletion?.Task ?? Task.FromResult(Snapshot);
+        }
 
-        public Task<LocalAiRuntimeSnapshot> StopAsync(CancellationToken cancellationToken = default) =>
-            Task.FromResult(Snapshot);
+        public Task<LocalAiRuntimeSnapshot> StopAsync(CancellationToken cancellationToken = default)
+        {
+            StopCount++;
+            return Task.FromResult(Snapshot);
+        }
 
-        public Task<LocalAiRuntimeSnapshot> RestartAsync(CancellationToken cancellationToken = default) =>
-            Task.FromResult(Snapshot);
+        public Task<LocalAiRuntimeSnapshot> RestartAsync(CancellationToken cancellationToken = default)
+        {
+            RestartCount++;
+            return Task.FromResult(Snapshot);
+        }
 
         public Task<LocalAiRuntimeSnapshot> RefreshAsync(CancellationToken cancellationToken = default) =>
             Task.FromResult(Snapshot);

--- a/tests/OpenClaw.Tray.Tests/Presentation/LocalAiPageViewModelTests.cs
+++ b/tests/OpenClaw.Tray.Tests/Presentation/LocalAiPageViewModelTests.cs
@@ -39,7 +39,7 @@ public sealed class LocalAiPageViewModelTests
         Assert.True(viewModel.IsAvailabilityKnown);
         Assert.False(viewModel.IsLocalAiAvailable);
         Assert.False(viewModel.IsSetupAvailable);
-        Assert.Contains("NVIDIA GPU", viewModel.LocalAiUnavailableReason);
+        Assert.Equal(LocalInferenceUnavailableReasonKind.NoNvidiaGpu, viewModel.LocalAiUnavailableReason?.Kind);
         Assert.False(viewModel.CanStart);
         Assert.True(viewModel.CanStop);
         Assert.True(viewModel.CanRestart);
@@ -193,7 +193,7 @@ public sealed class LocalAiPageViewModelTests
         Assert.False(viewModel.IsLocalAiAvailable);
         Assert.True(viewModel.HasAvailabilityProbeError);
         Assert.True(viewModel.CanRecheckAvailability);
-        Assert.Contains("could not read", viewModel.LocalAiUnavailableReason, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(LocalInferenceUnavailableReasonKind.HardwareFactsIncomplete, viewModel.LocalAiUnavailableReason?.Kind);
     }
 
     [Fact]
@@ -223,7 +223,7 @@ public sealed class LocalAiPageViewModelTests
         Assert.True(viewModel.IsSetupAvailable);
         Assert.True(viewModel.CanRetrySetup);
         Assert.True(viewModel.CanRecheckAvailability);
-        Assert.Contains("could not read", viewModel.LocalAiUnavailableReason, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(LocalInferenceUnavailableReasonKind.HardwareFactsIncomplete, viewModel.LocalAiUnavailableReason?.Kind);
 
         Assert.True(viewModel.RecheckAvailability());
         await WaitForAsync(viewModel, () => viewModel.IsAvailabilityKnown);
@@ -410,7 +410,7 @@ public sealed class LocalAiPageViewModelTests
         Assert.False(viewModel.IsLocalAiAvailable);
         Assert.True(viewModel.HasAvailabilityProbeError);
         Assert.True(viewModel.CanRecheckAvailability);
-        Assert.Contains("could not read", viewModel.LocalAiUnavailableReason, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(LocalInferenceUnavailableReasonKind.HardwareFactsIncomplete, viewModel.LocalAiUnavailableReason?.Kind);
     }
 
     [Theory]

--- a/tests/OpenClaw.Tray.Tests/Presentation/PresentationTestDoubles.cs
+++ b/tests/OpenClaw.Tray.Tests/Presentation/PresentationTestDoubles.cs
@@ -64,18 +64,23 @@ internal sealed class FakeAppCommands : IAppCommands, IDisposable
     public List<string> Navigations { get; } = new();
     public IReadOnlyList<string> OperationLog => _operationLog;
     public bool Disposed { get; private set; }
+    public int ReconnectCount { get; private set; }
+    public int ShowChatCount { get; private set; }
+    public int ShowOnboardingCount { get; private set; }
+    public int OpenLocalAiLogsCount { get; private set; }
 
     public void ClearOperationLog() => _operationLog.Clear();
 
     public void OpenDashboard(string? path = null) { }
     public void Navigate(string pageTag) => Navigations.Add(pageTag);
-    public void Reconnect() { }
+    public void Reconnect() => ReconnectCount++;
     public void Disconnect() { }
     public void ShowVoiceOverlay() { }
-    public void ShowChat() { }
+    public void ShowChat() => ShowChatCount++;
     public void CheckForUpdates() { }
     public void ShowOnboarding() => ShowOnboardingCount++;
     public void ShowGatewayWizard() => ShowGatewayWizardCount++;
+    public void OpenLocalAiLogs() => OpenLocalAiLogsCount++;
     public void ShowConnectionStatus() { }
     public void NotifySettingsSaved()
     {
@@ -95,7 +100,6 @@ internal sealed class FakeAppCommands : IAppCommands, IDisposable
     public SettingsWriteOrigin? LastAutoStartOrigin { get; private set; }
     public bool? AutoStartApplied { get; private set; }
     public int AutoStartApplyCount { get; private set; }
-    public int ShowOnboardingCount { get; private set; }
     public int ShowGatewayWizardCount { get; private set; }
 
     /// <summary>Result returned by <see cref="ApplyAutoStart"/> so tests can simulate OS-write failure.</summary>


### PR DESCRIPTION
## Summary

Clean replacement for #1204 (`karkarl-refine-local-ai-setup-ux`), built directly on current `main`. That branch's history mixes unrelated, already-landed commits with the real contribution, so this PR recomputes the true diff (merge-base `911f3686` to PR head `568db5c1`) and rebases it onto today's `main` instead of rewriting/force-pushing the original branch. Rebased twice more since as `main` kept advancing on the same files (`#1203`, `#1254`, and others); each rebase was validated fresh.

- share Local AI eligibility diagnostics between setup and the Hub via a new `LocalAiSetupAvailabilityCoordinator` and locale-neutral `LocalInferenceEligibilityDiagnostics`
- place unavailable Local AI guidance above dependent setup content; the native `InfoBar.ActionButton` keeps **See why** independently usable and on the message line
- show a green Local AI availability badge beside **Recommended** on the local WSL gateway choice
- center the Local AI Hub page at wide window sizes using the same finite-width Grid/900px pattern as other Hub pages
- gray/disable unavailable setup choices while preserving controls for an already installed managed runtime
- hide Local AI-only progress groups when Local AI is unavailable, keeping the WSL installation stage active
- localize all new setup/Hub copy (en-us, fr-fr, nl-nl, zh-cn, zh-tw) — see below
- gate Local AI availability on device-level eligibility, not the selected model, and never dead-end step 3 — see "Round 2" below

## What changed vs. #1204 (retained vs. discarded)

**Retained (all 24 files, ~1.6k LOC):** the entire real contribution from #1204 applies here, nothing was dropped as "already landed" or unrelated. Verified by grepping current `main` for the PR's new symbols (`LocalAiSetupAvailabilityCoordinator`, `IsLocalAiOnlyGroup`, `LocalInferenceEligibilityDiagnostics`, `LocalAiUnavailablePanel`) before starting: none existed, confirming every touched file carries a real, non-trivial diff against `main`.

**Discarded:** only the stale, already-merged commits that #1204's branch carried from its outdated base (e.g. #1111, #1226, #1229, #1210, #1230, #1234, already on `main` independently). None of that reappears here.

**Fixed beyond #1204's last pushed head**, all covered by focused tests:

1. **Delayed-dispatch race in the Hub view model.** A queued UI-thread update could be silently dropped if `DispatcherQueue.TryEnqueue` genuinely deferred the callback; the result is now applied and the probe's cancellation released together, gated by one currency check.
2. **Setup toggle clobbered a configured selection while checking.** The toggle now mirrors the current config value during a check instead of forcing off; only a completed probe changes the selection.
3. **Primary button could stay stuck disabled** after a definitive unsupported result (`ShowLocalAiUnavailable` was missing the `UpdatePrimaryButtonState()` call its siblings had).
4. **Availability tied to the wrong model.** The Hub's device-availability probe now evaluates the best catalog model this hardware can run instead of the currently selected/installed model, so a stale/removed model no longer blocks Retry Setup.
5. **Incomplete hardware facts treated as permanent.** A partial/transient NVML read is now routed through the same retryable/probe-error path as a thrown probe failure, in both the setup page and the Hub.
6. **Change Model bypassed the availability gate** (`CanChangeModel`, added independently by `main`'s #1254 while this branch was being rebased, didn't check `IsSetupAvailable` like `CanRetrySetup` does).
7. **Setup toggle also clobbered a configured selection on a retryable probe *failure*** (`ShowLocalAiProbeUnknown`, the sibling of fix #2 above): a transient failure unconditionally cleared `LocalAi.Enabled`, so a successful recheck afterward initialized from the already-cleared value instead of restoring the prior selection.
8. **All new availability copy was hardcoded English** (ClawSweeper review on this PR): the setup InfoBar title/message/action, the checking/probe-error state messages and accessibility help text, the detailed diagnostic reason shown in the setup dialog and the Hub tip, and the Welcome-page "Local AI available" badge/accessible name. See the dedicated section below.

Each fix has a dedicated regression test.

## Round 2 (external Codex + Opus review on this PR)

- **Device-level gating, not model-level (Codex HIGH).** `CapabilitiesPage`/`WelcomePage` now gate device availability on `LocalInferenceEligibility.Evaluate(hardware)` first, then reconcile the configured `SelectedModelId` separately: a model that no longer exists in the catalog, or exists but this specific hardware cannot install at all (`!CanInstall`, i.e. truly `Unsupported`, not merely `EligibleButBusy`), falls back to the recommended/device-eligible model instead of leaving setup stuck on a stale or hardware-incompatible selection. `WelcomePage`'s badge is evaluated device-only (no model parameter).
- **Remaining hardcoded `.wslconfig` failure reason localized (Codex MEDIUM)** through `SetupLocalization` across all 5 locales.
- **Availability-probe CTS could leak or, on a worker-thread path, race a UI-thread cancel (Codex LOW → hardened further by review).** `LocalAiPageViewModel` now guarantees the probe's `CancellationTokenSource` is released/disposed exactly once on every path (dispatched apply, non-enqueued, rejected-enqueue, or already-disposed/inactive), using `Interlocked.Exchange`/`CompareExchange` so a worker thread releasing the token can never race the UI thread's `CancelAvailabilityRefresh()` into a double-cancel/double-dispose. `RecheckAvailability()` also now enforces its own `CanRecheckAvailability` gate instead of only the weaker "not already in flight" check.
- **Step-3 dead end when Local AI is enabled and availability is Checking/ProbeUnknown (Opus HIGH).** Both states now keep the toggle itself genuinely clickable (including restoring `LocalAiOptionContent.IsHitTestVisible`, which a naive re-enable of just the toggle's own `IsEnabled` would not undo) so turning Local AI off is always an escape hatch. Continue's own gate is unchanged and never bypasses eligibility or an as-yet-undetermined WSL networking-consent decision merely because availability is still pending.
- **Hub InfoBar didn't distinguish definitive-unavailable from checking/probe-unknown (Opus MEDIUM x2).** The Hub now shows an explicit "checking" title/message/progress ring while a probe (initial or recheck) is in flight, and a distinct localized title/severity (Warning) for a retryable probe error vs. Informational for a definitive unavailable result — instead of one static title/message and silently hiding all chrome mid-check.
- **`SetupLocalization`/probe failure diagnostics now use `Trace.TraceWarning`, not `Debug.WriteLine` (Opus LOW),** since `Debug.WriteLine` is compiled out entirely in Release builds; `Trace` is not, and its default listener reaches DebugView/ETW.
- **Welcome badge accessible-name suffix made idempotent (Opus LOW):** the base name is captured once so repeated detections don't re-append the suffix, and a `LiveRegionChanged` automation event (with peer creation forced, since one may not exist yet) announces the change.

## Localization (fix #8)

`OpenClaw.Shared`'s `LocalInferenceEligibilityDiagnostics` now returns a `LocalInferenceUnavailableReason` (a kind enum plus plain facts: model name, required/detected GPU memory in GB, driver version) instead of a formatted English sentence, keeping Shared locale-neutral. Each UI owner localizes at its own boundary:

- **`OpenClaw.SetupEngine.UI`** has no `.resw` files of its own and cannot reference the Tray app project (which references it, so the reverse would be circular). It gets a small new `SetupLocalization` helper that resolves resource keys against the same merged app resource map the Tray app's `LocalizationHelper` already reads (the existing `x:Uid="Onboarding_LocalAi_RecheckAvailabilityButton"` binding relies on the same mechanism). `CapabilitiesPage.xaml.cs` now routes every checking/probe-error/unavailable title, message, help text, the "why unavailable" dialog, the `.wslconfig` inspection failure, and the Welcome-page badge/accessible name through it.
- **`LocalAiPageViewModel`** (source-linked into `OpenClaw.Tray.Tests` without a WinUI resource host) exposes the locale-neutral `LocalInferenceUnavailableReason` instead of a formatted string, so it stays testable without `LocalizationHelper`. `LocalAiPage.xaml.cs` (the View, which already has full WinUI/`LocalizationHelper` access) formats it into localized text, including the new checking/probe-unknown title distinction — matching the existing resource-key-on-ViewModel / format-in-View pattern already used for engine/model/gateway status.

Resource keys were added to all five supported locales (en-us, fr-fr, nl-nl, zh-cn, zh-tw), and localization regression coverage was added: contract tests proving the setup page's checking/probe-error/unavailable copy, the "why unavailable" dialog, the Welcome-page badge/accessible name, and the Hub's checking/probe-unknown titles all route through `SetupLocalization`/`LocalizationHelper`/`x:Uid` (not hardcoded English) with matching keys in every locale; a test proving the shared diagnostics stay fact-only while both UI owners localize the same reason kinds; and a source test proving `SetupLocalization` implements the same "Key.Property" → "Key/Property" XAML-resource fallback `LocalizationHelper` already uses.

## Owner boundary (why all these files are one cohesive change)

Everything here belongs to a single seam: "is Local AI available, and does the UI correctly reflect, escape, and localize that during checking/unsupported/error states." `LocalAiSetupAvailabilityCoordinator`, `LocalInferenceEligibilityDiagnostics`, and `SetupLocalization` are the shared policy/diagnostics/localization layer; `CapabilitiesPage`/`WelcomePage`/`ProgressPage` are the setup-time consumers; `LocalAiPage`/`LocalAiPageViewModel` are the Hub-time consumer; the `.resw` files are the copy for both; the test files are 1:1 with the production files they cover.

## Concurrency note

Fetched and diffed against #1204's live head repeatedly during this work; its branch was never touched, read, or force-pushed. #1204 should be closed/superseded only after this PR is reviewed, green, and ready.

## Validation

```
$env:OPENCLAW_REPO_ROOT = '<worktree path>'
.\build.ps1                                                                    # Shared, Cli, WinNodeCli, SetupEngine, WinUI all built (clean, 0 warnings/errors, including a from-scratch obj/bin rebuild of OpenClaw.SetupEngine.UI)
dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj         # 3819 passed, 0 failed, 32 skipped
dotnet test .\tests\OpenClaw.SetupEngine.Tests\OpenClaw.SetupEngine.Tests.csproj # 1025 passed, 0 failed
dotnet test .\tests\OpenClaw.Tray.Tests\...csproj --filter "FullyQualifiedName~LocalAiSetupUxContractTests|...LocalAiPageViewModelTests|...AppRefactorContractTests|...LocalizationValidationTests|...CapabilitiesPageLocalizationCoverageTests|...LocalizationHelperSourceTests"
                                                                                # 154 passed, 0 failed (every file this PR touches, run repeatedly for stability)
```

Full, untargeted `OpenClaw.Tray.Tests` run: still blocked in this environment (hangs with no test output after ~6 minutes; reproduces the same way on a clean pre-fix checkout, so it is a pre-existing environmental blocker in this sandbox, not a regression from this change). Recommend a maintainer/CI run of the full untargeted suite before merge.

## Real behavior proof

- **Setup wizard, fresh isolated data dir:** the WSL gateway choice on the Welcome page shows the "Local AI available" badge beside "Recommended" (accessibility-tree confirmed: `WelcomeInstallLocalGatewayChoice` -> "Recommended" + "Local AI available").
- **Local AI Hub, real hardware (this host has an NVIDIA GeForce RTX 4080 SUPER):** launched directly to `openclaw://hub/local-ai` in an isolated data dir with no prior config. `NotInstalled` state renders correctly, no spurious unavailable banner, "Retry setup or download" enabled, engine/model status all correct, confirming no regression on the common/available happy path.
- **Unavailable / retryable / probe-error / checking / selection-preservation / consent-gate states:** this validation host has real qualifying hardware and cannot naturally exercise the unsupported-device path, so those invariants (including the new checking-progress UI, the toggle escape hatch during pending states, and the networking-consent gate never being bypassed while pending) are proven by the automated `LocalAiPageViewModelTests`/`LocalAiSetupUxContractTests` with controlled fake hardware probes and dispatcher fakes.

## Review

`autoreview` (Codex, gpt-5.6-sol, high reasoning) was run to convergence across this round's fix cycles, each producing a real, verified bug (device/model eligibility gating, wslconfig localization, CTS ownership races across two hardening passes, the step-3 dead end plus its hit-test-visibility follow-up, the pending-state consent-bypass gap, a checking-notification ordering gap, and the model-eligibility reconciliation gap) that was fixed and covered by a new or updated regression test, then re-reviewed clean of that finding. One reviewer-reported finding (a claimed C# definite-assignment compile error for the `eligibility` local on the device-ineligible path) was investigated and rejected: `eligibility` is explicitly initialized to `null` at declaration, and a from-scratch `obj`/`bin` rebuild of `OpenClaw.SetupEngine.UI` compiles with 0 warnings/errors, confirming the finding does not reproduce.

Not verified / blocked: full untargeted Tray suite (environmental hang, see above); WSL install E2E (would require actually installing a WSL distro on a shared host, skipped as out of scope for this validation pass; the setup-flow code paths are covered by the existing `SetupStepsTests`/`WslGlobalConfigManagerTests`/`LocalAiSetupUxContractTests`).

Supersedes #1204.
