### PR TITLE
test(connection): stabilize listener output waits

### DIFF
--- a/tests/OpenClaw.Connection.Tests/WindowsTcpListenerSnapshotTests.cs
+++ b/tests/OpenClaw.Connection.Tests/WindowsTcpListenerSnapshotTests.cs
@@ -39,17 +39,39 @@ public sealed class WindowsTcpListenerSnapshotTests
     {
         using var process = StartExitingProcess();
         Assert.True(process.WaitForExit(3_000));
-        var outputTask = Task.Run(async () =>
+        var outputSource = new TaskCompletionSource<string>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        string? output = null;
+        Exception? helperException = null;
+        var helperThread = new Thread(() =>
         {
-            await Task.Delay(100);
-            return "complete output";
-        });
+            try
+            {
+                output = WindowsTcpListenerSnapshot.AwaitRedirectedOutput(
+                    process,
+                    outputSource.Task,
+                    timeoutMs: 5_000);
+            }
+            catch (Exception ex)
+            {
+                helperException = ex;
+            }
+        })
+        {
+            IsBackground = true,
+            Name = "redirected-output-drain-test"
+        };
 
-        var output = WindowsTcpListenerSnapshot.AwaitRedirectedOutput(
-            process,
-            outputTask,
-            timeoutMs: 400);
+        helperThread.Start();
+        Assert.True(
+            SpinWait.SpinUntil(
+                () => helperThread.ThreadState.HasFlag(System.Threading.ThreadState.WaitSleepJoin),
+                TimeSpan.FromSeconds(3)),
+            "Helper never entered the redirected-output drain wait.");
+        outputSource.SetResult("complete output");
 
+        Assert.True(helperThread.Join(TimeSpan.FromSeconds(3)));
+        Assert.Null(helperException);
         Assert.Equal("complete output", output);
     }
 
@@ -76,7 +98,11 @@ public sealed class WindowsTcpListenerSnapshotTests
 
         Assert.Null(output);
         Assert.InRange(stopwatch.Elapsed, TimeSpan.Zero, TimeSpan.FromSeconds(2));
-        await readTask.WaitAsync(TimeSpan.FromSeconds(5));
+        var readException = await Record.ExceptionAsync(
+            () => readTask.WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.True(
+            readException is null or ObjectDisposedException,
+            $"Abandoned stdout read failed unexpectedly: {readException}");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- replace the scheduler-sensitive `Task.Run` plus fixed delay with a dedicated-thread handshake that completes stdout only after the helper reaches its blocking drain wait
- observe the abandoned stdout read and accept `ObjectDisposedException` as the valid result of `AbandonRead` disposing `StandardOutput`
- keep `WindowsTcpListenerSnapshot` production code unchanged; its `Math.Max(remaining, minDrain)` contract intentionally preserves the remaining deadline while guaranteeing one bounded 250 ms minimum drain grace

This addresses the two repeated `WindowsTcpListenerSnapshotTests` failures that blocked #1260.

## Validation

- `.\build.ps1` passed
- `dotnet test .\tests\OpenClaw.Connection.Tests\OpenClaw.Connection.Tests.csproj --no-restore` passed: 705 passed
- focused `WindowsTcpListenerSnapshotTests` passed: 5 passed
- the two formerly flaky tests passed 25 consecutive final-head iterations
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore` passed: 3,819 passed, 32 skipped
- `dotnet test .\tests\OpenClaw.SetupEngine.Tests\OpenClaw.SetupEngine.Tests.csproj --no-restore` passed: 1,022 passed
- final autoreview passed with no accepted or actionable findings
- final rubber-duck review found no blocking issues

The required full Tray suite did not complete on this host. It started successfully but remained alive without a result for more than 13 minutes, reproducing the pre-existing post-run hang already documented on #1260, so the isolated test process was stopped.

## Real behavior proof

The final focused test uses a dedicated OS thread, waits until that thread is blocked in the post-exit output path, then completes the `TaskCompletionSource`. This removes hosted thread-pool scheduling from the assertion while proving completed output is returned. The descendant-pipe test still proves a bounded null return, then explicitly awaits and observes the abandoned read as either successful completion or `ObjectDisposedException`, preventing an unobserved task fault.

No production files changed.