### PR TITLE
Support upstream stable correction release versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Install GitVersion
       uses: gittools/actions/gitversion/setup@v4
       with:
-        versionSpec: '6.4.x'
+        versionSpec: '6.8.x'
 
     - name: Determine Version
       id: gitversion

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,15 +67,42 @@ jobs:
       id: gitversion
       uses: gittools/actions/gitversion/execute@v4
 
-    - name: Verify tag version output
-      if: startsWith(github.ref, 'refs/tags/v')
+    - name: Resolve release version
+      id: release_version
       shell: pwsh
+      env:
+        GITVERSION_SEMVER: ${{ steps.gitversion.outputs.semVer }}
+        GITVERSION_MAJOR_MINOR_PATCH: ${{ steps.gitversion.outputs.majorMinorPatch }}
+        GH_TOKEN: ${{ github.token }}
       run: |
-        $expected = "${{ github.ref_name }}" -replace '^v', ''
-        $actual = "${{ steps.gitversion.outputs.semVer }}"
-        if ($actual -ne $expected) {
-          throw "GitVersion SemVer '$actual' did not match tag '$expected'."
+        $semVer = $env:GITVERSION_SEMVER
+        $majorMinorPatch = $env:GITVERSION_MAJOR_MINOR_PATCH
+        $isPrerelease = $semVer.Contains("-")
+        $isStableCorrection = $false
+
+        if ($env:GITHUB_REF.StartsWith("refs/tags/v", [StringComparison]::Ordinal)) {
+          $tagVersion = $env:GITHUB_REF_NAME -replace '^v', ''
+          $correction = [regex]::Match(
+            $tagVersion,
+            '^(?<base>(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*))-(?<revision>[1-9]\d*)$')
+
+          if ($correction.Success) {
+            $validation = .\scripts\Test-OpenClawStableCorrectionRelease.ps1 `
+              -Tag $env:GITHUB_REF_NAME `
+              -GitHubToken $env:GH_TOKEN
+            $semVer = $tagVersion
+            $majorMinorPatch = $validation.BaseVersion
+            $isPrerelease = $false
+            $isStableCorrection = $true
+          } elseif ($semVer -ne $tagVersion) {
+            throw "GitVersion SemVer '$semVer' did not match tag '$tagVersion'."
+          }
         }
+
+        "semVer=$semVer" >> $env:GITHUB_OUTPUT
+        "majorMinorPatch=$majorMinorPatch" >> $env:GITHUB_OUTPUT
+        "isPrerelease=$($isPrerelease.ToString().ToLowerInvariant())" >> $env:GITHUB_OUTPUT
+        "isStableCorrection=$($isStableCorrection.ToString().ToLowerInvariant())" >> $env:GITHUB_OUTPUT
 
     - name: Validate documentation
       shell: pwsh
@@ -299,8 +326,10 @@ jobs:
         if-no-files-found: warn
 
     outputs:
-      semVer: ${{ steps.gitversion.outputs.semVer }}
-      majorMinorPatch: ${{ steps.gitversion.outputs.majorMinorPatch }}
+      semVer: ${{ steps.release_version.outputs.semVer }}
+      majorMinorPatch: ${{ steps.release_version.outputs.majorMinorPatch }}
+      isPrerelease: ${{ steps.release_version.outputs.isPrerelease }}
+      isStableCorrection: ${{ steps.release_version.outputs.isStableCorrection }}
 
   e2etests:
     needs: repo-hygiene
@@ -448,6 +477,8 @@ jobs:
   build:
     needs: [test, e2etests]
     runs-on: ${{ matrix.rid == 'win-arm64' && 'windows-11-arm' || 'windows-latest' }}
+    env:
+      OPENCLAW_BUILD_VERSION: ${{ needs.test.outputs.semVer }}
     strategy:
       matrix:
         rid: [win-x64, win-arm64]
@@ -474,10 +505,10 @@ jobs:
       run: dotnet restore src/OpenClaw.Tray.WinUI -r ${{ matrix.rid }}
 
     - name: Build WinUI Tray App (Release)
-      run: dotnet build src/OpenClaw.Tray.WinUI --no-restore -c Release -r ${{ matrix.rid }}
+      run: dotnet build src/OpenClaw.Tray.WinUI --no-restore -c Release -r ${{ matrix.rid }} -p:Version=$env:OPENCLAW_BUILD_VERSION -p:InformationalVersion=$env:OPENCLAW_BUILD_VERSION
 
     - name: Publish WinUI Tray App
-      run: dotnet publish src/OpenClaw.Tray.WinUI -c Release -r ${{ matrix.rid }} --self-contained --no-restore -o publish
+      run: dotnet publish src/OpenClaw.Tray.WinUI -c Release -r ${{ matrix.rid }} --self-contained --no-restore -o publish -p:Version=$env:OPENCLAW_BUILD_VERSION -p:InformationalVersion=$env:OPENCLAW_BUILD_VERSION
 
     - name: Verify x64 Native Runtime Payload
       if: matrix.rid == 'win-x64'
@@ -617,6 +648,9 @@ jobs:
       actions: read
       contents: write
       id-token: write
+    concurrency:
+      group: openclaw-windows-node-release
+      cancel-in-progress: false
 
     steps:
     - uses: actions/checkout@v7
@@ -773,7 +807,7 @@ jobs:
         copy artifacts/tray-win-x64/* publish-x64/ -Recurse
         .\scripts\Test-ReleaseNativeDependencies.ps1 -PayloadPath publish-x64 -RequireAppLocalVCRuntime -RequireInstallerVCRedist -InstallerVCRedistPath vc_redist.x64.exe
         # Build installer
-        & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /DMyAppVersion=${{ needs.test.outputs.majorMinorPatch }} /DMyAppArch=x64 /Dpublish=publish-x64 /DvcRedist=vc_redist.x64.exe installer.iss
+        & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /DMyAppVersion=${{ needs.test.outputs.semVer }} /DMyAppArch=x64 /Dpublish=publish-x64 /DvcRedist=vc_redist.x64.exe installer.iss
 
     - name: Build arm64 Installer
       run: |
@@ -785,7 +819,7 @@ jobs:
         #                             LoadLibrary an arm64 DLL.
         .\scripts\Test-ReleaseNativeDependencies.ps1 -PayloadPath publish-arm64 -RequireAppLocalVCRuntime -RequireInstallerVCRedist -InstallerVCRedistPath vc_redist.arm64.exe -SkipNativeLoadProbe
         # Build installer
-        & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /DMyAppVersion=${{ needs.test.outputs.majorMinorPatch }} /DMyAppArch=arm64 /Dpublish=publish-arm64 /DvcRedist=vc_redist.arm64.exe installer.iss
+        & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /DMyAppVersion=${{ needs.test.outputs.semVer }} /DMyAppArch=arm64 /Dpublish=publish-arm64 /DvcRedist=vc_redist.arm64.exe installer.iss
 
     - name: Sign Installers
       uses: azure/artifact-signing-action@v2
@@ -799,6 +833,17 @@ jobs:
         timestamp-rfc3161: http://timestamp.acs.microsoft.com
         timestamp-digest: SHA256
 
+    - name: Revalidate stable correction release ordering
+      if: needs.test.outputs.isStableCorrection == 'true'
+      shell: pwsh
+      env:
+        GH_TOKEN: ${{ github.token }}
+        RELEASE_TAG: ${{ github.ref_name }}
+      run: >
+        .\scripts\Test-OpenClawStableCorrectionRelease.ps1
+        -Tag $env:RELEASE_TAG
+        -GitHubToken $env:GH_TOKEN
+
     - name: Create Release
       uses: softprops/action-gh-release@v3
       with:
@@ -808,8 +853,8 @@ jobs:
           Output/OpenClawCompanion-Setup-arm64.exe
           OpenClawTray-${{ needs.test.outputs.semVer }}-win-x64.zip
           OpenClawTray-${{ needs.test.outputs.semVer }}-win-arm64.zip
-        prerelease: ${{ contains(github.ref_name, '-') }}
-        make_latest: ${{ contains(github.ref_name, '-') && 'false' || 'true' }}
+        prerelease: ${{ needs.test.outputs.isPrerelease }}
+        make_latest: ${{ needs.test.outputs.isPrerelease == 'true' && 'false' || 'true' }}
         body: |
           ## OpenClaw Windows Hub ${{ github.ref_name }}
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -81,12 +81,22 @@ Stable, stable-correction, and alpha tags use the same signed CI release pipelin
   release under OpenClaw correction ordering.
 - `vX.Y.Z-alpha.N` creates a prerelease that stable updater checks do not offer.
 
-The first Windows release that adopts stable correction ordering requires a
-manual upgrade from the matching unsuffixed version. Older Windows clients use
-Updatum's default parser, which removes the numeric correction suffix before
-comparison. Once a correction-aware Windows build is installed, later
-corrections and the next stable base version are compared using OpenClaw release
-ordering.
+Stable correction support begins only with an eligible upstream release tag
+created from `main` after the correction-aware implementation has landed. For
+this rollout, the Windows repository already contains its own annotated
+`v2026.7.1-2` tag, separate from the matching upstream tag, and it points to a
+commit that predates the implementation. It is not a correction-aware artifact
+and must not be moved, rebuilt from a different commit, or reused as a recovery
+release.
+
+If the first post-merge Windows release is another numeric correction, users on
+the matching unsuffixed version need to install that new release manually.
+Older Windows clients use Updatum's default parser, which removes the numeric
+correction suffix before comparison. If the first post-merge release is a newer
+unsuffixed stable version, ordinary Updatum ordering can deliver it without the
+manual correction transition. Once any correction-aware Windows build is
+installed, later corrections and stable base versions are compared using
+OpenClaw release ordering.
 
 ```powershell
 git tag -a vX.Y.Z-alpha.N -m "OpenClaw Windows Hub vX.Y.Z-alpha.N"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -26,11 +26,14 @@ build/sign/publish release artifacts.
      "MSIX distribution is paused"
    ```
 
-3. Create a new stable or prerelease tag from `origin/main`. Never move a
-   previously published tag.
+3. Create a new stable, stable correction, or prerelease tag from `origin/main`.
+   Never move a previously published tag.
 
    ```powershell
-   $tag = "vX.Y.Z" # or vX.Y.Z-alpha.N for a prerelease
+   # Stable: vX.Y.Z
+   # Stable correction matching the OpenClaw monorepo: vX.Y.Z-N
+   # Prerelease: vX.Y.Z-alpha.N
+   $tag = "vX.Y.Z"
    if ((git rev-parse HEAD) -ne (git rev-parse origin/main)) {
        throw "HEAD is not origin/main; do not tag."
    }
@@ -65,10 +68,25 @@ build/sign/publish release artifacts.
 
 ## Release channel policy
 
-Stable and alpha tags use the same signed CI release pipeline:
+Stable, stable-correction, and alpha tags use the same signed CI release pipeline:
 
 - `vX.Y.Z` creates a normal release eligible to become latest.
+- `vX.Y.Z-N` creates a stable correction release eligible to become latest. The
+  numeric correction suffix intentionally follows the OpenClaw monorepo release
+  convention and is not treated as a SemVer prerelease. Only publish a
+  correction for the current latest stable line; publishing one for an older
+  line would incorrectly move GitHub's Latest release marker backward. CI
+  enforces both constraints: the exact tag must already be a published stable
+  `openclaw/openclaw` release, and it must advance the current Windows latest
+  release under OpenClaw correction ordering.
 - `vX.Y.Z-alpha.N` creates a prerelease that stable updater checks do not offer.
+
+The first Windows release that adopts stable correction ordering requires a
+manual upgrade from the matching unsuffixed version. Older Windows clients use
+Updatum's default parser, which removes the numeric correction suffix before
+comparison. Once a correction-aware Windows build is installed, later
+corrections and the next stable base version are compared using OpenClaw release
+ordering.
 
 ```powershell
 git tag -a vX.Y.Z-alpha.N -m "OpenClaw Windows Hub vX.Y.Z-alpha.N"

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -8,7 +8,15 @@ project files must not hardcode release versions with `<Version>` elements.
 Canonical release tags use:
 
 - Stable: `vX.Y.Z`
+- Stable correction: `vX.Y.Z-N`, where `N` is a positive integer
 - Alpha: `vX.Y.Z-alpha.N`
+
+Numeric correction suffixes are an intentional stable-channel exception to
+SemVer's usual prerelease interpretation. Corrections sort after their
+unsuffixed base release and then by numeric correction: `vX.Y.Z` <
+`vX.Y.Z-1` < `vX.Y.Z-2`. A correction tag must not be published if that exact
+tag already exists or a newer stable/correction release has already been
+published.
 
 `GitVersion.yml` controls how tag history becomes SemVer. The product build
 imports GitVersion through `src\Directory.Build.props`, so normal `dotnet build`,
@@ -28,6 +36,7 @@ release-blocking guard against version drift.
 Tagged releases must resolve to the exact tag SemVer:
 
 - `vX.Y.Z` -> `X.Y.Z`
+- `vX.Y.Z-N` -> `X.Y.Z-N`
 - `vX.Y.Z-alpha.N` -> `X.Y.Z-alpha.N`
 
 Untagged `master` checkouts are still prerelease builds. After an alpha tag,
@@ -63,17 +72,30 @@ diagnostics.
 ## CI release flow
 
 The release workflow computes GitVersion in the `test` job for workflow outputs
-and artifact naming. Product builds themselves also use GitVersion-backed
-MSBuild metadata; CI should not pass a competing hardcoded `-p:Version=...`
-value that could hide drift.
+and artifact naming. It then passes that resolved value to product builds as
+`Version` and `InformationalVersion`, keeping assembly metadata and artifacts on
+one exact identity. CI must not pass a competing hardcoded version literal that
+could hide drift.
+
+GitVersion interprets `X.Y.Z-N` as a prerelease, so numeric stable corrections
+use one narrow exception: the release-version step recognizes the correction
+tag, validates its stable ordering with
+`scripts\Test-OpenClawStableCorrectionRelease.ps1`, and replaces the GitVersion
+workflow outputs with the exact tag-derived value before the build. The build's
+explicit MSBuild version properties are therefore the validated correction tag,
+not an independent version source. Ordinary stable, alpha, and untagged builds
+continue to use the GitVersion result directly.
 
 Release build jobs must check out full git history (`fetch-depth: 0`) so
 GitVersion can see tags.
 
-Tagged CI runs verify that `github.ref_name` and GitVersion's `SemVer` output
-match before build artifacts are published. If a release tag is
-`v0.6.0-alpha.5`, CI must produce `0.6.0-alpha.5`; a derived value such as
-`0.6.0-alpha.6` or `0.6.0-712` is a release-blocking error.
+Tagged CI runs verify that `github.ref_name` and the resolved release version
+match before build artifacts are published. For stable and alpha tags, the
+resolved version must equal GitVersion's `SemVer`. For numeric corrections, the
+resolved version must equal the validated tag even though GitVersion classifies
+the suffix as a prerelease. If a release tag is `v0.6.0-alpha.5`, CI must produce
+`0.6.0-alpha.5`; a derived value such as `0.6.0-alpha.6` or `0.6.0-712` is a
+release-blocking error.
 
 ## Local scripts
 
@@ -99,6 +121,9 @@ For example:
 - Keep release tags and `GitVersion.yml` as the versioning contract.
 - Keep `GitVersion.yml` configured so exact alpha tags resolve to their tag
   SemVer, and keep CI's tag/version verification enabled.
+- Keep numeric correction tags behind the stable-ordering validation in both
+  release resolution and publication; never classify every hyphenated tag as a
+  prerelease without recognizing this exception.
 
 ## References
 

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -26,10 +26,10 @@ from the same tag history.
 The repository-local tool manifest (`.config\dotnet-tools.json`) and MSBuild
 package reference (`src\Directory.Build.props`) are the authoritative local
 tool/package pins and currently target GitVersion 6.8.2. The CI workflow's
-`gittools/actions/gitversion/setup` step currently pins `6.4.x` for workflow
-output computation; if workflow files are being changed, prefer aligning that
-setup action to `6.8.x`. Until then, CI's tag/SemVer verification remains the
-release-blocking guard against version drift.
+`gittools/actions/gitversion/setup` step tracks the matching `6.8.x` line for
+workflow output computation. Keep the workflow action on the same major/minor
+line as the repository pins so the value injected into product metadata is
+computed by the same GitVersion release.
 
 ## Tagged and untagged builds
 

--- a/scripts/Test-OpenClawStableCorrectionRelease.ps1
+++ b/scripts/Test-OpenClawStableCorrectionRelease.ps1
@@ -1,0 +1,86 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidatePattern('^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)-[1-9]\d*$')]
+    [string]$Tag,
+
+    [string]$GitHubToken = $env:GITHUB_TOKEN
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function ConvertTo-StableReleaseVersion {
+    param([Parameter(Mandatory)][string]$Value)
+
+    $match = [regex]::Match(
+        $Value,
+        '^v?(?<year>0|[1-9]\d*)\.(?<month>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:-(?<revision>[1-9]\d*))?$')
+    if (-not $match.Success) {
+        throw "Stable release version '$Value' has an unsupported format."
+    }
+
+    return @(
+        [long]$match.Groups["year"].Value,
+        [long]$match.Groups["month"].Value,
+        [long]$match.Groups["patch"].Value,
+        $(if ($match.Groups["revision"].Success) {
+            [long]$match.Groups["revision"].Value
+        } else {
+            0L
+        })
+    )
+}
+
+function Assert-NewerStableRelease {
+    param(
+        [Parameter(Mandatory)][string]$Candidate,
+        [Parameter(Mandatory)][string]$Current
+    )
+
+    $candidateParts = ConvertTo-StableReleaseVersion $Candidate
+    $currentParts = ConvertTo-StableReleaseVersion $Current
+    for ($index = 0; $index -lt $candidateParts.Count; $index++) {
+        if ($candidateParts[$index] -gt $currentParts[$index]) {
+            return
+        }
+        if ($candidateParts[$index] -lt $currentParts[$index]) {
+            throw "Stable correction '$Candidate' does not advance current Windows release '$Current'."
+        }
+    }
+
+    throw "Stable correction '$Candidate' is already the current Windows release."
+}
+
+$headers = @{
+    Accept = "application/vnd.github+json"
+    "User-Agent" = "openclaw-windows-node-release"
+    "X-GitHub-Api-Version" = "2022-11-28"
+}
+if (-not [string]::IsNullOrWhiteSpace($GitHubToken)) {
+    $headers.Authorization = "Bearer $GitHubToken"
+}
+
+$upstreamRelease = Invoke-RestMethod `
+    -Headers $headers `
+    -Uri "https://api.github.com/repos/openclaw/openclaw/releases/tags/$Tag"
+if ($upstreamRelease.tag_name -cne $Tag -or
+    $upstreamRelease.draft -or
+    $upstreamRelease.prerelease -or
+    $null -eq $upstreamRelease.published_at) {
+    throw "Stable correction '$Tag' must match an exact published stable openclaw/openclaw release."
+}
+
+$currentWindowsRelease = Invoke-RestMethod `
+    -Headers $headers `
+    -Uri "https://api.github.com/repos/openclaw/openclaw-windows-node/releases/latest"
+Assert-NewerStableRelease `
+    -Candidate $Tag `
+    -Current $currentWindowsRelease.tag_name
+
+$parsedTag = ConvertTo-StableReleaseVersion $Tag
+[pscustomobject]@{
+    Tag = $Tag
+    BaseVersion = "$($parsedTag[0]).$($parsedTag[1]).$($parsedTag[2])"
+    CurrentWindowsTag = $currentWindowsRelease.tag_name
+}

--- a/scripts/build-inno-local.ps1
+++ b/scripts/build-inno-local.ps1
@@ -109,6 +109,7 @@ function Publish-ArchitecturePayload {
     )
     if ($PublishVersion) {
         $trayPublishArgs += "-p:Version=$PublishVersion"
+        $trayPublishArgs += "-p:InformationalVersion=$PublishVersion"
     }
 
     dotnet publish @trayPublishArgs

--- a/src/OpenClaw.Shared/OpenClawReleaseVersion.cs
+++ b/src/OpenClaw.Shared/OpenClawReleaseVersion.cs
@@ -1,0 +1,69 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace OpenClaw.Shared;
+
+public readonly record struct OpenClawReleaseVersion(
+    int Year,
+    int Month,
+    int Patch,
+    int Correction) : IComparable<OpenClawReleaseVersion>
+{
+    private static readonly Regex StableVersionPattern = new(
+        @"^v?(?<year>0|[1-9]\d*)\.(?<month>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:-(?<correction>[1-9]\d*))?$",
+        RegexOptions.CultureInvariant,
+        TimeSpan.FromSeconds(1));
+
+    public static bool TryParseStable(string? value, out OpenClawReleaseVersion version)
+    {
+        version = default;
+        if (string.IsNullOrWhiteSpace(value))
+            return false;
+
+        var match = StableVersionPattern.Match(value.Trim());
+        if (!match.Success ||
+            !TryParseComponent(match.Groups["year"].Value, out var year) ||
+            !TryParseComponent(match.Groups["month"].Value, out var month) ||
+            !TryParseComponent(match.Groups["patch"].Value, out var patch))
+        {
+            return false;
+        }
+
+        var correctionGroup = match.Groups["correction"];
+        var correction = 0;
+        if (correctionGroup.Success &&
+            !TryParseComponent(correctionGroup.Value, out correction))
+        {
+            return false;
+        }
+
+        version = new OpenClawReleaseVersion(year, month, patch, correction);
+        return true;
+    }
+
+    public static bool IsNewerStableRelease(string? candidateTag, string? currentVersion)
+        => TryParseStable(candidateTag, out var candidate) &&
+           TryParseStable(currentVersion, out var current) &&
+           candidate.CompareTo(current) > 0;
+
+    public int CompareTo(OpenClawReleaseVersion other)
+    {
+        var year = Year.CompareTo(other.Year);
+        if (year != 0)
+            return year;
+
+        var month = Month.CompareTo(other.Month);
+        if (month != 0)
+            return month;
+
+        var patch = Patch.CompareTo(other.Patch);
+        return patch != 0 ? patch : Correction.CompareTo(other.Correction);
+    }
+
+    private static bool TryParseComponent(string value, out int component)
+        => int.TryParse(
+            value,
+            NumberStyles.None,
+            CultureInfo.InvariantCulture,
+            out component);
+}

--- a/src/OpenClaw.Tray.WinUI/Services/UpdateCheckPipeline.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/UpdateCheckPipeline.cs
@@ -1,0 +1,59 @@
+using OpenClaw.Shared;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace OpenClawTray.Services;
+
+internal sealed record UpdateReleaseCandidate(
+    string? TagName,
+    bool Draft,
+    bool Prerelease,
+    bool Published,
+    Func<bool> HasCompatibleAsset,
+    Action Activate);
+
+internal interface IUpdateCheckBoundary
+{
+    Task<bool> CheckForUpdatesAsync();
+
+    IEnumerable<UpdateReleaseCandidate> GetReleaseCandidates();
+}
+
+internal sealed record UpdateCheckOutcome(
+    bool UpdateFound,
+    string? ActivatedFallbackTag = null);
+
+internal static class UpdateCheckPipeline
+{
+    public static async Task<UpdateCheckOutcome> CheckAsync(
+        IUpdateCheckBoundary boundary,
+        string currentVersion)
+    {
+        ArgumentNullException.ThrowIfNull(boundary);
+
+        if (await boundary.CheckForUpdatesAsync())
+            return new UpdateCheckOutcome(UpdateFound: true);
+
+        foreach (var release in boundary.GetReleaseCandidates())
+        {
+            if (release.Draft ||
+                release.Prerelease ||
+                !release.Published ||
+                !OpenClawReleaseVersion.IsNewerStableRelease(
+                    release.TagName,
+                    currentVersion) ||
+                !release.HasCompatibleAsset())
+            {
+                continue;
+            }
+
+            release.Activate();
+            return new UpdateCheckOutcome(
+                UpdateFound: true,
+                ActivatedFallbackTag: release.TagName);
+        }
+
+        return new UpdateCheckOutcome(UpdateFound: false);
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Services/UpdateCoordinator.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/UpdateCoordinator.cs
@@ -104,6 +104,8 @@ internal sealed class UpdateCoordinator(
                 CheckedAt = DateTime.UtcNow
             };
             var updateFound = await updater.CheckForUpdatesAsync();
+            if (!updateFound)
+                updateFound = TryActivateStableReleaseFallback();
 
             if (!updateFound)
             {
@@ -312,6 +314,30 @@ internal sealed class UpdateCoordinator(
             Interlocked.Exchange(ref _updateInstallInProgress, 0);
         }
 #endif
+    }
+
+    private bool TryActivateStableReleaseFallback()
+    {
+        foreach (var release in updater.Releases)
+        {
+            if (release.Draft ||
+                release.Prerelease ||
+                release.PublishedAt is null ||
+                !OpenClawReleaseVersion.IsNewerStableRelease(
+                    release.TagName,
+                    AppVersionInfo.Version) ||
+                updater.GetCompatibleReleaseAsset(release) is null)
+            {
+                continue;
+            }
+
+            updater.ForceTriggerUpdateFromRelease(release);
+            Logger.Info(
+                $"Using OpenClaw stable correction ordering for update {release.TagName}");
+            return true;
+        }
+
+        return false;
     }
 
     // Re-entrancy guard: the button/menu/deep-link are all fire-and-forget

--- a/src/OpenClaw.Tray.WinUI/Services/UpdateCoordinator.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/UpdateCoordinator.cs
@@ -4,6 +4,7 @@ using OpenClaw.Shared;
 using OpenClawTray.Dialogs;
 using OpenClawTray.Helpers;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -22,9 +23,12 @@ internal sealed class UpdateCoordinator(
     SettingsManager? settings,
     Func<XamlRoot?> getXamlRoot,
     Action refreshStatus,
-    Action exit)
+    Action exit,
+    IUpdateCheckBoundary? updateCheckBoundary = null)
 {
     private readonly SettingsManager? _settings = settings;
+    private readonly IUpdateCheckBoundary _updateCheckBoundary =
+        updateCheckBoundary ?? new UpdatumUpdateCheckBoundary(updater);
 
     // Cross-path concurrency for update checks, split into two phases:
     //  - _updateCheckGate: held only during the metadata/network check.
@@ -103,9 +107,15 @@ internal sealed class UpdateCoordinator(
                 CurrentVersion = AppVersionInfo.Version,
                 CheckedAt = DateTime.UtcNow
             };
-            var updateFound = await updater.CheckForUpdatesAsync();
-            if (!updateFound)
-                updateFound = TryActivateStableReleaseFallback();
+            var checkOutcome = await UpdateCheckPipeline.CheckAsync(
+                _updateCheckBoundary,
+                AppVersionInfo.Version);
+            var updateFound = checkOutcome.UpdateFound;
+            if (checkOutcome.ActivatedFallbackTag is not null)
+            {
+                Logger.Info(
+                    $"Using OpenClaw stable correction ordering for update {checkOutcome.ActivatedFallbackTag}");
+            }
 
             if (!updateFound)
             {
@@ -316,30 +326,6 @@ internal sealed class UpdateCoordinator(
 #endif
     }
 
-    private bool TryActivateStableReleaseFallback()
-    {
-        foreach (var release in updater.Releases)
-        {
-            if (release.Draft ||
-                release.Prerelease ||
-                release.PublishedAt is null ||
-                !OpenClawReleaseVersion.IsNewerStableRelease(
-                    release.TagName,
-                    AppVersionInfo.Version) ||
-                updater.GetCompatibleReleaseAsset(release) is null)
-            {
-                continue;
-            }
-
-            updater.ForceTriggerUpdateFromRelease(release);
-            Logger.Info(
-                $"Using OpenClaw stable correction ordering for update {release.TagName}");
-            return true;
-        }
-
-        return false;
-    }
-
     // Re-entrancy guard: the button/menu/deep-link are all fire-and-forget
     // (`_ = CheckForUpdatesUserInitiatedAsync()`), so a double-click would
     // otherwise open two ContentDialogs on the same XamlRoot which throws
@@ -501,6 +487,25 @@ internal sealed class UpdateCoordinator(
         catch (InvalidOperationException)
         {
             // Same as above for other "already-disposed" race variants.
+        }
+    }
+}
+
+internal sealed class UpdatumUpdateCheckBoundary(UpdatumManager updater) : IUpdateCheckBoundary
+{
+    public Task<bool> CheckForUpdatesAsync() => updater.CheckForUpdatesAsync();
+
+    public IEnumerable<UpdateReleaseCandidate> GetReleaseCandidates()
+    {
+        foreach (var release in updater.Releases)
+        {
+            yield return new UpdateReleaseCandidate(
+                release.TagName,
+                release.Draft,
+                release.Prerelease,
+                release.PublishedAt is not null,
+                () => updater.GetCompatibleReleaseAsset(release) is not null,
+                () => updater.ForceTriggerUpdateFromRelease(release));
         }
     }
 }

--- a/tests/OpenClaw.Shared.Tests/OpenClawReleaseVersionTests.cs
+++ b/tests/OpenClaw.Shared.Tests/OpenClawReleaseVersionTests.cs
@@ -1,0 +1,58 @@
+using OpenClaw.Shared;
+
+namespace OpenClaw.Shared.Tests;
+
+public sealed class OpenClawReleaseVersionTests
+{
+    [Theory]
+    [InlineData("2026.7.1", 2026, 7, 1, 0)]
+    [InlineData("v2026.7.1-2", 2026, 7, 1, 2)]
+    [InlineData(" 2026.12.34-15 ", 2026, 12, 34, 15)]
+    public void TryParseStable_AcceptsFinalAndCorrectionVersions(
+        string value,
+        int year,
+        int month,
+        int patch,
+        int correction)
+    {
+        Assert.True(OpenClawReleaseVersion.TryParseStable(value, out var parsed));
+        Assert.Equal(new OpenClawReleaseVersion(year, month, patch, correction), parsed);
+    }
+
+    [Theory]
+    [InlineData("2026.7.1-alpha.2")]
+    [InlineData("2026.7.1-beta.2")]
+    [InlineData("2026.7.1-0")]
+    [InlineData("2026.7.1-02")]
+    [InlineData("2026.07.1-2")]
+    [InlineData("2026.7")]
+    [InlineData("")]
+    public void TryParseStable_RejectsPrereleaseAndMalformedVersions(string value)
+    {
+        Assert.False(OpenClawReleaseVersion.TryParseStable(value, out _));
+    }
+
+    [Theory]
+    [InlineData("v2026.7.1-1", "2026.7.1")]
+    [InlineData("v2026.7.1-3", "2026.7.1-2")]
+    [InlineData("v2026.7.2", "2026.7.1-2")]
+    [InlineData("v2027.1.1", "2026.12.99-9")]
+    public void IsNewerStableRelease_AcceptsMonotonicCorrections(
+        string candidate,
+        string current)
+    {
+        Assert.True(OpenClawReleaseVersion.IsNewerStableRelease(candidate, current));
+    }
+
+    [Theory]
+    [InlineData("v2026.7.1", "2026.7.1")]
+    [InlineData("v2026.7.1-1", "2026.7.1-2")]
+    [InlineData("v2026.7.1-beta.3", "2026.7.1-2")]
+    [InlineData("invalid", "2026.7.1-2")]
+    public void IsNewerStableRelease_RejectsNonNewerOrNonStableCandidates(
+        string candidate,
+        string current)
+    {
+        Assert.False(OpenClawReleaseVersion.IsNewerStableRelease(candidate, current));
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -146,6 +146,7 @@
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\ConnectionDiagnosticsProjection.cs" Link="Services\ConnectionDiagnosticsProjection.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\McpRuntimeStatePolicy.cs" Link="Services\McpRuntimeStatePolicy.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\UsageCostApplicationPolicy.cs" Link="Services\UsageCostApplicationPolicy.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\UpdateCheckPipeline.cs" Link="Services\UpdateCheckPipeline.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\SpeechSetupReadiness.cs" Link="Services\SpeechSetupReadiness.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Helpers\CanvasGatewayUrlRewriter.cs" Link="Helpers\CanvasGatewayUrlRewriter.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Helpers\DiagnosticsGate.cs" Link="Helpers\DiagnosticsGate.cs" />

--- a/tests/OpenClaw.Tray.Tests/UpdateCheckPipelineTests.cs
+++ b/tests/OpenClaw.Tray.Tests/UpdateCheckPipelineTests.cs
@@ -1,0 +1,109 @@
+using OpenClawTray.Services;
+
+namespace OpenClaw.Tray.Tests;
+
+public sealed class UpdateCheckPipelineTests
+{
+    [Fact]
+    public async Task CheckAsync_WhenOrdinaryCheckDeclinesCorrection_ActivatesCompatibleFallback()
+    {
+        var events = new List<string>();
+        var incompatibleActivated = false;
+        var correctionActivated = false;
+        var boundary = new FakeUpdateCheckBoundary(
+            checkForUpdates: () =>
+            {
+                events.Add("ordinary-check-declined");
+                return false;
+            },
+            releases:
+            [
+                Candidate(
+                    "v2026.7.1-3",
+                    hasCompatibleAsset: () =>
+                    {
+                        events.Add("incompatible-asset-rejected");
+                        return false;
+                    },
+                    activate: () => incompatibleActivated = true),
+                Candidate(
+                    "v2026.7.1-2",
+                    hasCompatibleAsset: () =>
+                    {
+                        events.Add("compatible-asset-selected");
+                        return true;
+                    },
+                    activate: () =>
+                    {
+                        events.Add("correction-activated");
+                        correctionActivated = true;
+                    })
+            ]);
+
+        var result = await UpdateCheckPipeline.CheckAsync(boundary, "2026.7.1");
+
+        Assert.True(result.UpdateFound);
+        Assert.Equal("v2026.7.1-2", result.ActivatedFallbackTag);
+        Assert.False(incompatibleActivated);
+        Assert.True(correctionActivated);
+        Assert.Equal(
+            [
+                "ordinary-check-declined",
+                "incompatible-asset-rejected",
+                "compatible-asset-selected",
+                "correction-activated"
+            ],
+            events);
+    }
+
+    [Fact]
+    public async Task CheckAsync_WhenOrdinaryCheckFindsUpdate_DoesNotInspectFallbacks()
+    {
+        var releasesEnumerated = false;
+        var boundary = new FakeUpdateCheckBoundary(
+            checkForUpdates: () => true,
+            releasesFactory: () =>
+            {
+                releasesEnumerated = true;
+                return [Candidate("v2026.7.1-2")];
+            });
+
+        var result = await UpdateCheckPipeline.CheckAsync(boundary, "2026.7.1");
+
+        Assert.True(result.UpdateFound);
+        Assert.Null(result.ActivatedFallbackTag);
+        Assert.False(releasesEnumerated);
+    }
+
+    private static UpdateReleaseCandidate Candidate(
+        string tagName,
+        Func<bool>? hasCompatibleAsset = null,
+        Action? activate = null) =>
+        new(
+            tagName,
+            Draft: false,
+            Prerelease: false,
+            Published: true,
+            hasCompatibleAsset ?? (() => true),
+            activate ?? (() => { }));
+
+    private sealed class FakeUpdateCheckBoundary : IUpdateCheckBoundary
+    {
+        private readonly Func<bool> _checkForUpdates;
+        private readonly Func<IEnumerable<UpdateReleaseCandidate>> _releasesFactory;
+
+        public FakeUpdateCheckBoundary(
+            Func<bool> checkForUpdates,
+            IEnumerable<UpdateReleaseCandidate>? releases = null,
+            Func<IEnumerable<UpdateReleaseCandidate>>? releasesFactory = null)
+        {
+            _checkForUpdates = checkForUpdates;
+            _releasesFactory = releasesFactory ?? (() => releases ?? []);
+        }
+
+        public Task<bool> CheckForUpdatesAsync() => Task.FromResult(_checkForUpdates());
+
+        public IEnumerable<UpdateReleaseCandidate> GetReleaseCandidates() =>
+            _releasesFactory();
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/VersioningContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/VersioningContractTests.cs
@@ -56,6 +56,51 @@ public sealed class VersioningContractTests
     }
 
     [Fact]
+    public void ReleaseWorkflow_TreatsNumericCorrectionsAsStableExactVersions()
+    {
+        var repoRoot = TestRepositoryPaths.GetRepositoryRoot();
+        var workflow = File.ReadAllText(
+            Path.Combine(repoRoot, ".github", "workflows", "ci.yml"));
+
+        Assert.Contains("- name: Resolve release version", workflow);
+        Assert.Contains(
+            "'^(?<base>(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*))-(?<revision>[1-9]\\d*)$'",
+            workflow);
+        Assert.Contains("$semVer = $tagVersion", workflow);
+        Assert.Contains("$isPrerelease = $false", workflow);
+        Assert.Contains(
+            ".\\scripts\\Test-OpenClawStableCorrectionRelease.ps1",
+            workflow);
+        Assert.Contains(
+            "isStableCorrection: ${{ steps.release_version.outputs.isStableCorrection }}",
+            workflow);
+        Assert.Contains(
+            "group: openclaw-windows-node-release",
+            workflow);
+        Assert.Contains(
+            "- name: Revalidate stable correction release ordering",
+            workflow);
+        Assert.Contains(
+            "if: needs.test.outputs.isStableCorrection == 'true'",
+            workflow);
+        Assert.Contains(
+            "semVer: ${{ steps.release_version.outputs.semVer }}",
+            workflow);
+        Assert.Contains(
+            "isPrerelease: ${{ steps.release_version.outputs.isPrerelease }}",
+            workflow);
+        Assert.Contains(
+            "-p:Version=$env:OPENCLAW_BUILD_VERSION",
+            workflow);
+        Assert.Contains(
+            "prerelease: ${{ needs.test.outputs.isPrerelease }}",
+            workflow);
+        Assert.DoesNotContain(
+            "prerelease: ${{ contains(github.ref_name, '-') }}",
+            workflow);
+    }
+
+    [Fact]
     public void BuildScript_PreflightsGitVersionRepositoryHistory()
     {
         var repoRoot = TestRepositoryPaths.GetRepositoryRoot();
@@ -65,6 +110,21 @@ public sealed class VersioningContractTests
         Assert.Contains("rev-parse --is-shallow-repository", buildScript);
         Assert.Contains("GitVersion requires full git history", buildScript);
         Assert.Contains("git fetch --unshallow --tags origin", buildScript);
+    }
+
+    [Fact]
+    public void LocalInstallerBuild_PreservesExplicitInformationalVersion()
+    {
+        var repoRoot = TestRepositoryPaths.GetRepositoryRoot();
+        var buildScript = File.ReadAllText(
+            Path.Combine(repoRoot, "scripts", "build-inno-local.ps1"));
+
+        Assert.Contains(
+            "$trayPublishArgs += \"-p:Version=$PublishVersion\"",
+            buildScript);
+        Assert.Contains(
+            "$trayPublishArgs += \"-p:InformationalVersion=$PublishVersion\"",
+            buildScript);
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/VersioningContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/VersioningContractTests.cs
@@ -63,6 +63,8 @@ public sealed class VersioningContractTests
             Path.Combine(repoRoot, ".github", "workflows", "ci.yml"));
 
         Assert.Contains("- name: Resolve release version", workflow);
+        Assert.Contains("versionSpec: '6.8.x'", workflow);
+        Assert.DoesNotContain("versionSpec: '6.4.x'", workflow);
         Assert.Contains(
             "'^(?<base>(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*))-(?<revision>[1-9]\\d*)$'",
             workflow);


### PR DESCRIPTION
## Summary

- treat upstream numeric correction tags such as `v2026.7.1-2` as stable releases instead of SemVer prereleases
- preserve the exact correction version in product metadata, portable assets, and installers
- add correction-aware updater ordering for builds that include this change
- require an exact published stable `openclaw/openclaw` release, reject non-advancing corrections, serialize release jobs, and revalidate immediately before publication
- align CI with the repository-pinned GitVersion 6.8 series and document the safe one-time transition from the pre-feature Windows `v2026.7.1-2` tag

## Validation

- [exact-head Windows CI (`f3747d52`)](https://github.com/openclaw/openclaw-windows-node/actions/runs/33218925636) passed after retrying one unrelated MXC cleanup timing flake: full build/test matrix, repo hygiene, three gateway E2E partitions, accessibility, and x64/ARM64 release artifact builds
- CodeQL passed for C#, Python, and Actions
- focused production-boundary tests cover Updatum declining the ordinary check, rejection of an incompatible newer correction, and activation of the compatible numeric correction
- structured autoreview passed with no findings (confidence 0.96)
- earlier implementation-head local validation passed `./build.ps1`, Shared tests (3,840 passed, 32 skipped), Tray tests (2,805 passed), and `./scripts/Test-OpenClawStableCorrectionRelease.ps1 -Tag v2026.7.1-2`
- current-head local rerun was unavailable on the macOS host because PowerShell and the .NET SDK are not installed; exact-head Windows CI above provides the executable validation

## Real behavior proof

- the current-head updater boundary test proves the ordinary Updatum check can decline before the correction fallback selects and activates a compatible numeric correction
- earlier implementation-head ARM64 release proof compiled with `./scripts/build-inno-local.ps1 -Arch arm64 -Version 2026.7.1-2 -Fast`, produced `Output/OpenClawCompanion-Setup-arm64.exe`, and reported `ProductVersion: 2026.7.1-2`
- current-head CI successfully built and published both x64 and ARM64 tray artifacts and verified their GitVersion assembly metadata

Existing `v2026.7.1` Windows clients use Updatum's old suffix-stripping comparison and cannot discover the first eligible numeric correction automatically. They require a one-time manual upgrade. Builds containing this change use OpenClaw correction ordering for later corrections and subsequent stable versions. The pre-feature Windows `v2026.7.1-2` tag must not be moved, rebuilt, or reused; support begins with the first eligible upstream stable release after this PR merges.
