### PR TITLE
fix(setup): bound Tailscale status read so WaitForExit can fire

### DIFF
--- a/src/OpenClaw.SetupEngine.UI/Pages/CapabilitiesPage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/CapabilitiesPage.xaml.cs
@@ -838,11 +838,7 @@ public sealed partial class CapabilitiesPage : Page
                     UseShellExecute = false,
                     CreateNoWindow = true,
                 };
-                using var process = Process.Start(psi);
-                if (process is null) return (ExitCode: -1, Output: string.Empty);
-                var output = process.StandardOutput.ReadToEnd();
-                process.WaitForExit(5000);
-                return (ExitCode: process.ExitCode, Output: output);
+                return BoundedProcessOutput.Read(psi, BoundedProcessOutput.DefaultTimeoutMs);
             });
             string? dnsName = null;
             string? tailnetDnsSuffix = null;

--- a/src/OpenClaw.SetupEngine/BoundedProcessOutput.cs
+++ b/src/OpenClaw.SetupEngine/BoundedProcessOutput.cs
@@ -1,0 +1,108 @@
+using System.Diagnostics;
+
+namespace OpenClaw.SetupEngine;
+
+/// <summary>
+/// Wait for a short-lived setup probe, then drain leftover redirected
+/// stdout. Synchronous ReadToEnd before WaitForExit never reaches the
+/// timeout when the child hangs or a descendant holds the pipe open.
+/// </summary>
+internal static class BoundedProcessOutput
+{
+    internal const int DefaultTimeoutMs = 5_000;
+    private const int MinDrainMs = 250;
+
+    internal static (int ExitCode, string Output) Read(
+        ProcessStartInfo startInfo,
+        int timeoutMs = DefaultTimeoutMs)
+    {
+        ArgumentNullException.ThrowIfNull(startInfo);
+
+        using var process = Process.Start(startInfo);
+        if (process is null)
+            return (-1, string.Empty);
+
+        var stdoutTask = startInfo.RedirectStandardOutput
+            ? process.StandardOutput.ReadToEndAsync()
+            : Task.FromResult(string.Empty);
+        var stderrTask = startInfo.RedirectStandardError
+            ? process.StandardError.ReadToEndAsync()
+            : null;
+
+        var output = AwaitRedirectedOutput(process, stdoutTask, timeoutMs) ?? string.Empty;
+        if (stderrTask is not null)
+            ObserveQuietly(stderrTask);
+
+        try
+        {
+            return (process.HasExited ? process.ExitCode : -1, output);
+        }
+        catch (InvalidOperationException)
+        {
+            return (-1, output);
+        }
+    }
+
+    internal static string? AwaitRedirectedOutput(Process process, Task<string> readTask, int timeoutMs)
+    {
+        ArgumentNullException.ThrowIfNull(process);
+        ArgumentNullException.ThrowIfNull(readTask);
+        if (timeoutMs < 0)
+            throw new ArgumentOutOfRangeException(nameof(timeoutMs));
+
+        var sw = Stopwatch.StartNew();
+        if (!process.WaitForExit(timeoutMs))
+        {
+            TryKillTree(process);
+            AbandonRead(process, readTask);
+            return null;
+        }
+
+        var elapsedMs = (int)Math.Min(sw.ElapsedMilliseconds, timeoutMs);
+        var drainBudgetMs = Math.Max(timeoutMs - elapsedMs, MinDrainMs);
+        try
+        {
+            if (!readTask.Wait(drainBudgetMs))
+            {
+                TryKillTree(process);
+                AbandonRead(process, readTask);
+                return null;
+            }
+        }
+        catch (AggregateException)
+        {
+            return null;
+        }
+
+        return readTask.Status == TaskStatus.RanToCompletion ? readTask.Result : null;
+    }
+
+    private static void TryKillTree(Process process)
+    {
+        try { process.Kill(entireProcessTree: true); }
+        catch (Exception ex)
+        {
+            Trace.WriteLine($"BoundedProcessOutput.TryKillTree: {ex.GetType().Name}: {ex.Message}");
+        }
+
+        try { process.WaitForExit(1_000); }
+        catch (Exception ex)
+        {
+            Trace.WriteLine($"BoundedProcessOutput.WaitForExit: {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    private static void AbandonRead(Process process, Task readTask)
+    {
+        ObserveQuietly(readTask);
+        try { process.StandardOutput.Dispose(); } catch { }
+    }
+
+    private static void ObserveQuietly(Task task) =>
+        _ = task.ContinueWith(
+            static t => { _ = t.Exception; },
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+}
+

--- a/tests/OpenClaw.SetupEngine.Tests/BoundedProcessOutputTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/BoundedProcessOutputTests.cs
@@ -1,0 +1,132 @@
+using System.Diagnostics;
+
+namespace OpenClaw.SetupEngine.Tests;
+
+public sealed class BoundedProcessOutputTests
+{
+    [Fact]
+    public async Task AwaitRedirectedOutput_ReturnsNullWhenStdoutNeverCloses()
+    {
+        using var process = StartExitingProcess();
+        Assert.NotNull(process);
+
+        var never = new TaskCompletionSource<string>(
+            TaskCreationOptions.RunContinuationsAsynchronously).Task;
+        var helper = Task.Run(() =>
+            BoundedProcessOutput.AwaitRedirectedOutput(process, never, timeoutMs: 400));
+
+        var completed = await Task.WhenAny(helper, Task.Delay(TimeSpan.FromSeconds(3)));
+        Assert.Same(helper, completed);
+        Assert.Null(await helper);
+    }
+
+    [Fact]
+    public async Task AwaitRedirectedOutput_ReturnsNullWhenProcessDoesNotExit()
+    {
+        var (fileName, arguments) = LongRunningCommand();
+        using var process = Process.Start(new ProcessStartInfo
+        {
+            FileName = fileName,
+            Arguments = arguments,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        });
+        Assert.NotNull(process);
+
+        var readTask = process.StandardOutput.ReadToEndAsync();
+        var stopwatch = Stopwatch.StartNew();
+        var output = BoundedProcessOutput.AwaitRedirectedOutput(
+            process,
+            readTask,
+            timeoutMs: 400);
+
+        Assert.Null(output);
+        Assert.InRange(stopwatch.Elapsed, TimeSpan.Zero, TimeSpan.FromSeconds(2));
+        Assert.True(process.HasExited);
+        var readException = await Record.ExceptionAsync(
+            () => readTask.WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.True(
+            readException is null or ObjectDisposedException,
+            $"Abandoned stdout read failed unexpectedly: {readException}");
+    }
+
+    [Fact]
+    public void AwaitRedirectedOutput_PreservesOutputCompletedDuringDrainGrace()
+    {
+        using var process = StartExitingProcess();
+        Assert.True(process.WaitForExit(3_000));
+        var outputSource = new TaskCompletionSource<string>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        string? output = null;
+        Exception? helperException = null;
+        var helperThread = new Thread(() =>
+        {
+            try
+            {
+                output = BoundedProcessOutput.AwaitRedirectedOutput(
+                    process,
+                    outputSource.Task,
+                    timeoutMs: 5_000);
+            }
+            catch (Exception ex)
+            {
+                helperException = ex;
+            }
+        })
+        {
+            IsBackground = true,
+            Name = "setup-tailscale-output-drain-test"
+        };
+
+        helperThread.Start();
+        Assert.True(
+            SpinWait.SpinUntil(
+                () => helperThread.ThreadState.HasFlag(System.Threading.ThreadState.WaitSleepJoin),
+                TimeSpan.FromSeconds(3)),
+            "Helper never entered the redirected-output drain wait.");
+        outputSource.SetResult("{\"BackendState\":\"Running\"}");
+
+        Assert.True(helperThread.Join(TimeSpan.FromSeconds(3)));
+        Assert.Null(helperException);
+        Assert.Equal("{\"BackendState\":\"Running\"}", output);
+    }
+
+    [Fact]
+    public void Read_CapturesStdoutFromExitingProcess()
+    {
+        var (fileName, arguments) = EchoCommand("status-ok");
+        var result = BoundedProcessOutput.Read(new ProcessStartInfo
+        {
+            FileName = fileName,
+            Arguments = arguments,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        }, timeoutMs: 5_000);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("status-ok", result.Output);
+    }
+
+    private static Process StartExitingProcess() =>
+        Process.Start(new ProcessStartInfo
+        {
+            FileName = OperatingSystem.IsWindows() ? "cmd.exe" : "/bin/sh",
+            Arguments = OperatingSystem.IsWindows() ? "/d /c exit 0" : "-c \"exit 0\"",
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        })!;
+
+    private static (string FileName, string Arguments) LongRunningCommand() =>
+        OperatingSystem.IsWindows()
+            ? ("cmd.exe", "/d /c ping 127.0.0.1 -n 20")
+            : ("/bin/sh", "-c \"sleep 20\"");
+
+    private static (string FileName, string Arguments) EchoCommand(string text) =>
+        OperatingSystem.IsWindows()
+            ? ("cmd.exe", $"/d /c echo {text}")
+            : ("/bin/sh", $"-c \"printf '%s\\n' '{text}'\"");
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users turning on Tailscale during Companion setup would freeze the Capabilities page when `tailscale.exe status --json` hung or left stdout open. The 5 second wait never ran, because the UI blocked on `StandardOutput.ReadToEnd()` first. Setup then sat on "Checking Windows Tailscale" until the child exited or the operator killed the wizard.

## Why This Change Was Made

The setup Tailscale status probe now waits for the child first, then drains leftover stdout with the remaining budget, and kills the process tree if either step times out. The 5 second bound is unchanged. This does not change Tailscale Serve install or the later preflight step that already uses `CommandRunner`.

## User Impact

Operators can toggle Tailscale on the setup Capabilities page without the wizard hanging when the Windows Tailscale CLI is stuck. A failed or timed-out probe still shows that Windows Tailscale must be installed and signed in.

## Evidence

Live `dotnet run` against a child that never exits (`sleep 20`), using the same ReadToEnd-before-WaitForExit order as setup, then the WaitForExit-first plus kill-tree order this patch uses:

```console
$ cd /tmp/f002-tailscale-bound-proof && dotnet run
=== before: ReadToEnd then WaitForExit ===
ReadToEnd completed within 1500ms: False
elapsed_ms=1505
read_status=WaitingForActivation
child_exited=False

=== after: WaitForExit first, then leftover drain, kill tree ===
WaitForExit(400) returned: False
elapsed_ms=431
read_status=RanToCompletion
child_exited=True
```

Setup now calls `BoundedProcessOutput.Read` from `RefreshWindowsTailscaleStatusAsync` instead of `ReadToEnd()` before `WaitForExit(5000)`.

## Change Type

- [x] Bug fix

## Scope

- [x] Setup or onboarding

## Required proof pools

- `none`: the hang is the setup Tailscale child-process wait/read. A hung child on this host is enough. No installer, WSL, or interactive WinUI host is required.

## Validation

- `dotnet test ./tests/OpenClaw.SetupEngine.Tests/OpenClaw.SetupEngine.Tests.csproj --filter FullyQualifiedName~BoundedProcessOutputTests`
- Red (unbounded `Wait` on stdout first): `AwaitRedirectedOutput_ReturnsNullWhenStdoutNeverCloses` failed after 3.19s (`Assert.Same` helper still `Running`)
- Green (WaitForExit first, leftover drain, kill tree): 4 passed in 1.69s
- `dotnet format --verify-no-changes` on the new helper and tests
- WinUI project and `./build.ps1` were not run on this macOS host

## Real behavior proof

- **Behavior or issue addressed:** Setup Capabilities Tailscale probe blocked forever on `ReadToEnd()` so `WaitForExit(5000)` never ran when `tailscale.exe` hung or kept stdout open.
- **Real environment tested:** macOS 26.6.2, Darwin, Node v26.7.0, .NET 10.0.400, branch `fix/f002-tailscale-read-timeout` at `d92edb7c`, invoked with `dotnet run` from `/tmp/f002-tailscale-bound-proof`.
- **Exact steps or command run after this patch:**

  ```bash
  cd /tmp/f002-tailscale-bound-proof
  dotnet run
  ```

- **Evidence after fix:** terminal output from the patched wait order:

  ```console
  === after: WaitForExit first, then leftover drain, kill tree ===
  WaitForExit(400) returned: False
  elapsed_ms=431
  read_status=RanToCompletion
  child_exited=True
  ```

- **Observed result after fix:** WaitForExit returned in 431ms, the hung child was killed, and the caller continued. The old ReadToEnd path was still waiting at 1505ms with the child alive.
- **What was not tested:** Interactive Setup wizard on a Windows host against a real hung `tailscale.exe`.

## Security Impact

- New permissions or capabilities? (`No`)
- Secrets or tokens handling changed? (`No`)
- New or changed network calls? (`No`)
- Command or tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

The probe still launches the same `tailscale.exe status --json` command. Only the wait and kill-on-timeout behavior changed.

## Compatibility and Migration

- Backward compatible? (`Yes`)
- Config or environment changes? (`No`)
- Migration needed? (`No`)

## Review Conversations

- [x] I replied to or resolved every bot review conversation addressed by this PR.
- [x] I left unresolved only conversations that still need maintainer judgment.

Related: introduced in #967. #1168 bounds a different keepalive command-line drain and does not touch this setup probe.
