### PR TITLE
fix(audio): bound Piper tar extract WaitForExit

### DIFF
--- a/src/OpenClaw.Shared/Audio/BoundedProcessWait.cs
+++ b/src/OpenClaw.Shared/Audio/BoundedProcessWait.cs
@@ -1,0 +1,164 @@
+using System.ComponentModel;
+using System.Diagnostics;
+
+namespace OpenClaw.Shared.Audio;
+
+internal sealed record BoundedProcessResult(
+    int ExitCode,
+    string StandardOutput,
+    string StandardError);
+
+/// <summary>
+/// Waits for a short-lived child and its redirected output using one deadline.
+/// Timeout and cancellation cleanup is best effort, bounded, and observes any
+/// read failures caused by closing inherited pipe handles.
+/// </summary>
+internal static class BoundedProcessWait
+{
+    internal static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(120);
+    internal static readonly TimeSpan CleanupTimeout = TimeSpan.FromSeconds(1);
+
+    internal static async Task<BoundedProcessResult> WaitAsync(
+        Process process,
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(process);
+        if (timeout <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(timeout), "Timeout must be positive.");
+
+        var stdoutTask = StartDrain(process, standardOutput: true);
+        var stderrTask = StartDrain(process, standardOutput: false);
+        var exitTask = process.WaitForExitAsync(CancellationToken.None);
+        var completionTask = Task.WhenAll(exitTask, stdoutTask, stderrTask);
+
+        using var timeoutSource = new CancellationTokenSource(timeout);
+        using var deadlineSource = CancellationTokenSource.CreateLinkedTokenSource(
+            cancellationToken,
+            timeoutSource.Token);
+
+        try
+        {
+            await completionTask.WaitAsync(deadlineSource.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (
+            cancellationToken.IsCancellationRequested || timeoutSource.IsCancellationRequested)
+        {
+            await CleanupAsync(process, exitTask, stdoutTask, stderrTask).ConfigureAwait(false);
+
+            if (cancellationToken.IsCancellationRequested)
+                throw new OperationCanceledException(cancellationToken);
+
+            throw new TimeoutException($"Process did not exit and drain output within {timeout.TotalMilliseconds:F0}ms.");
+        }
+
+        return new BoundedProcessResult(
+            process.ExitCode,
+            await stdoutTask.ConfigureAwait(false),
+            await stderrTask.ConfigureAwait(false));
+    }
+
+    private static Task<string> StartDrain(Process process, bool standardOutput)
+    {
+        if (standardOutput)
+        {
+            return process.StartInfo.RedirectStandardOutput
+                ? process.StandardOutput.ReadToEndAsync()
+                : Task.FromResult(string.Empty);
+        }
+
+        return process.StartInfo.RedirectStandardError
+            ? process.StandardError.ReadToEndAsync()
+            : Task.FromResult(string.Empty);
+    }
+
+    private static async Task CleanupAsync(
+        Process process,
+        Task exitTask,
+        Task stdoutTask,
+        Task stderrTask)
+    {
+        var killTask = Task.Run(() => TryKillTree(process));
+        ObserveFault(killTask);
+        ObserveFault(exitTask);
+        ObserveFault(stdoutTask);
+        ObserveFault(stderrTask);
+
+        DisposeRedirectedReaders(process);
+
+        var cleanupTask = Task.WhenAll(killTask, exitTask, stdoutTask, stderrTask);
+        ObserveFault(cleanupTask);
+        await Task.WhenAny(cleanupTask, Task.Delay(CleanupTimeout)).ConfigureAwait(false);
+    }
+
+    private static void TryKillTree(Process process)
+    {
+        try
+        {
+            // Process can only enumerate and terminate descendants while the
+            // root is alive. Closing our readers still bounds inherited pipes.
+            if (!process.HasExited)
+                process.Kill(entireProcessTree: true);
+        }
+        catch (InvalidOperationException ex)
+        {
+            TraceCleanupFailure("kill", ex);
+        }
+        catch (Win32Exception ex)
+        {
+            TraceCleanupFailure("kill", ex);
+        }
+        catch (NotSupportedException ex)
+        {
+            TraceCleanupFailure("kill", ex);
+        }
+    }
+
+    private static void DisposeRedirectedReaders(Process process)
+    {
+        if (process.StartInfo.RedirectStandardOutput)
+        {
+            try
+            {
+                process.StandardOutput.Dispose();
+            }
+            catch (InvalidOperationException ex)
+            {
+                TraceCleanupFailure("stdout close", ex);
+            }
+            catch (IOException ex)
+            {
+                TraceCleanupFailure("stdout close", ex);
+            }
+        }
+
+        if (process.StartInfo.RedirectStandardError)
+        {
+            try
+            {
+                process.StandardError.Dispose();
+            }
+            catch (InvalidOperationException ex)
+            {
+                TraceCleanupFailure("stderr close", ex);
+            }
+            catch (IOException ex)
+            {
+                TraceCleanupFailure("stderr close", ex);
+            }
+        }
+    }
+
+    internal static void ObserveFault(Task task)
+    {
+        _ = task.ContinueWith(
+            static completed => { _ = completed.Exception; },
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
+
+    private static void TraceCleanupFailure(string operation, Exception exception) =>
+        Trace.WriteLine(
+            $"BoundedProcessWait: {operation} failed: {exception.GetType().Name}: {exception.Message}");
+}

--- a/src/OpenClaw.Shared/Audio/PiperVoiceManager.cs
+++ b/src/OpenClaw.Shared/Audio/PiperVoiceManager.cs
@@ -208,7 +208,7 @@ public sealed class PiperVoiceManager
             await VerifyHashAsync(tarballPath, info.Sha256, info.VoiceId, cancellationToken);
 
             _logger.Info($"Extracting Piper voice '{info.VoiceId}'");
-            ExtractTarBz2(tarballPath, voiceDir, cancellationToken);
+            await ExtractTarBz2Async(tarballPath, voiceDir, cancellationToken).ConfigureAwait(false);
 
             // Verify the extraction produced the files we expect; if not,
             // tear the half-extracted dir down so a retry starts clean.
@@ -283,7 +283,7 @@ public sealed class PiperVoiceManager
     }
 
     /// <summary>
-    /// Probe the bundled OS tar.exe used by <see cref="ExtractTarBz2"/>.
+    /// Probe the bundled OS tar.exe used by <see cref="ExtractTarBz2Async"/>.
     /// Throws a clear error before any network I/O happens so users on
     /// downlevel Windows aren't left with a half-downloaded tarball.
     /// </summary>
@@ -335,7 +335,12 @@ public sealed class PiperVoiceManager
     /// transitive dependency via PiperSharp's ecosystem, but explicit here)
     /// so we don't need to shell out to tar.exe.
     /// </summary>
-    private static void ExtractTarBz2(string archivePath, string destinationDir, CancellationToken cancellationToken)
+    internal static async Task ExtractTarBz2Async(
+        string archivePath,
+        string destinationDir,
+        CancellationToken cancellationToken,
+        string extractorFileName = "tar",
+        TimeSpan? timeout = null)
     {
         // SharpCompress isn't a direct dep of OpenClaw.Shared today; we
         // intentionally use the BCL .tar reader on top of a bzip2 stream
@@ -349,24 +354,38 @@ public sealed class PiperVoiceManager
         // which transparently handles bz2.
         var psi = new System.Diagnostics.ProcessStartInfo
         {
-            FileName = "tar",
+            FileName = extractorFileName,
             ArgumentList = { "-xjf", archivePath, "-C", destinationDir, "--strip-components=1" },
             UseShellExecute = false,
             CreateNoWindow = true,
+            RedirectStandardOutput = true,
             RedirectStandardError = true,
         };
+        cancellationToken.ThrowIfCancellationRequested();
         using var proc = System.Diagnostics.Process.Start(psi)
             ?? throw new InvalidOperationException("Could not start tar to extract Piper voice");
 
-        // Cancellation: kill the tar process if requested. Static context — no logger;
-        // best-effort kill, the cancellation surfaces via the awaited WaitForExit.
-        using var reg = cancellationToken.Register(() => { try { proc.Kill(entireProcessTree: true); } catch (Exception ex) { System.Diagnostics.Trace.WriteLine($"PiperVoiceManager: tar cancellation kill failed: {ex.GetType().Name}: {ex.Message}"); } });
-
-        proc.WaitForExit();
-        if (proc.ExitCode != 0)
+        BoundedProcessResult result;
+        try
         {
-            var err = proc.StandardError.ReadToEnd();
-            throw new InvalidOperationException($"tar extraction failed (exit {proc.ExitCode}): {err}");
+            result = await BoundedProcessWait.WaitAsync(
+                proc,
+                timeout ?? BoundedProcessWait.DefaultTimeout,
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (TimeoutException ex)
+        {
+            throw new InvalidOperationException(
+                "tar extraction timed out while unpacking the Piper voice.", ex);
+        }
+
+        if (result.ExitCode != 0)
+        {
+            var output = string.IsNullOrWhiteSpace(result.StandardError)
+                ? result.StandardOutput
+                : result.StandardError;
+            throw new InvalidOperationException(
+                $"tar extraction failed (exit {result.ExitCode}): {output}");
         }
     }
 

--- a/tests/OpenClaw.Shared.TestHost/Program.cs
+++ b/tests/OpenClaw.Shared.TestHost/Program.cs
@@ -1,9 +1,31 @@
 using OpenClaw.Shared;
+using System.Diagnostics;
+using System.Reflection;
 using System.Text.Json;
 
 if (args is ["--echo-args", .. var echoedArgs])
 {
     Console.WriteLine(JsonSerializer.Serialize(echoedArgs));
+    return 0;
+}
+
+if (args is ["--process-fixture", .. var fixtureArgs])
+{
+    return await RunProcessFixtureAsync(fixtureArgs);
+}
+
+if (args is ["-xjf", var fixtureArchive, "-C", var fixtureDestination, "--strip-components=1"]
+    && fixtureArchive == "fixture-hold")
+{
+    Directory.CreateDirectory(fixtureDestination);
+    File.WriteAllText(
+        Path.Combine(fixtureDestination, "fixture.pid"),
+        Environment.ProcessId.ToString());
+    Console.Out.Write("fixture-stdout");
+    Console.Error.Write("fixture-stderr");
+    Console.Out.Flush();
+    Console.Error.Flush();
+    await Task.Delay(TimeSpan.FromSeconds(30));
     return 0;
 }
 
@@ -25,4 +47,74 @@ catch (DeviceIdentityLoadException ex)
 {
     Console.Error.WriteLine(ex.Message);
     return 2;
+}
+
+static async Task<int> RunProcessFixtureAsync(string[] args)
+{
+    if (args is ["success"])
+    {
+        Console.Out.Write("stdout-first");
+        Console.Error.Write("stderr-first");
+        await Task.Delay(25);
+        Console.Out.Write("-stdout-last");
+        Console.Error.Write("-stderr-last");
+        return 0;
+    }
+
+    if (args is ["late-output", var delayText] && int.TryParse(delayText, out var delayMs))
+    {
+        await Task.Delay(delayMs);
+        Console.Out.Write("late-stdout");
+        Console.Error.Write("late-stderr");
+        return 0;
+    }
+
+    if (args is ["hold", var holdText] && int.TryParse(holdText, out var holdMs))
+    {
+        Console.Out.Write("holding-stdout");
+        Console.Error.Write("holding-stderr");
+        Console.Out.Flush();
+        Console.Error.Flush();
+        await Task.Delay(holdMs);
+        return 0;
+    }
+
+    if (args is ["inherit-handles", var childHoldText, var pidFile]
+        && int.TryParse(childHoldText, out var childHoldMs))
+    {
+        using var child = StartSelf("--process-fixture", "hold", childHoldMs.ToString());
+        File.WriteAllText(pidFile, child.Id.ToString());
+        Console.Out.Write("parent-stdout");
+        Console.Error.Write("parent-stderr");
+        return 0;
+    }
+
+    Console.Error.WriteLine("Unknown process fixture.");
+    return 64;
+}
+
+static Process StartSelf(params string[] arguments)
+{
+    var processPath = Environment.ProcessPath
+        ?? throw new InvalidOperationException("Current process path is unavailable.");
+    var startInfo = new ProcessStartInfo
+    {
+        FileName = processPath,
+        UseShellExecute = false,
+        CreateNoWindow = true,
+    };
+
+    if (string.Equals(
+        Path.GetFileNameWithoutExtension(processPath),
+        "dotnet",
+        StringComparison.OrdinalIgnoreCase))
+    {
+        startInfo.ArgumentList.Add(Assembly.GetExecutingAssembly().Location);
+    }
+
+    foreach (var argument in arguments)
+        startInfo.ArgumentList.Add(argument);
+
+    return Process.Start(startInfo)
+        ?? throw new InvalidOperationException("Could not start process fixture child.");
 }

--- a/tests/OpenClaw.Shared.Tests/BoundedProcessWaitTests.cs
+++ b/tests/OpenClaw.Shared.Tests/BoundedProcessWaitTests.cs
@@ -1,0 +1,244 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Reflection;
+using OpenClaw.Shared.Audio;
+
+namespace OpenClaw.Shared.Tests;
+
+public sealed class BoundedProcessWaitTests
+{
+    [Fact]
+    public async Task WaitAsync_ReturnsCompleteOutput_WhenProcessSucceeds()
+    {
+        using var process = StartFixture("success");
+
+        var result = await BoundedProcessWait.WaitAsync(process, TimeSpan.FromSeconds(5));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("stdout-first-stdout-last", result.StandardOutput);
+        Assert.Equal("stderr-first-stderr-last", result.StandardError);
+    }
+
+    [Fact]
+    public async Task WaitAsync_TimesOutAndKillsProcess()
+    {
+        using var process = StartFixture("hold", "30000");
+        var stopwatch = Stopwatch.StartNew();
+
+        await Assert.ThrowsAsync<TimeoutException>(
+            () => BoundedProcessWait.WaitAsync(process, TimeSpan.FromMilliseconds(200)));
+
+        stopwatch.Stop();
+        Assert.True(process.HasExited);
+        Assert.True(
+            stopwatch.Elapsed < TimeSpan.FromSeconds(3),
+            $"Timeout cleanup took {stopwatch.ElapsedMilliseconds} ms.");
+    }
+
+    [Fact]
+    public async Task WaitAsync_CancellationKillsProcessWithoutUsingTimeoutBudget()
+    {
+        using var process = StartFixture("hold", "30000");
+        using var cancellation = new CancellationTokenSource();
+        var wait = BoundedProcessWait.WaitAsync(
+            process,
+            BoundedProcessWait.DefaultTimeout,
+            cancellation.Token);
+        await Task.Delay(100);
+        var stopwatch = Stopwatch.StartNew();
+
+        cancellation.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => wait);
+
+        stopwatch.Stop();
+        Assert.True(process.HasExited);
+        Assert.True(
+            stopwatch.Elapsed < TimeSpan.FromSeconds(3),
+            $"Cancellation cleanup took {stopwatch.ElapsedMilliseconds} ms.");
+    }
+
+    [Fact]
+    public async Task WaitAsync_AlreadyCanceledTokenStillKillsStartedProcess()
+    {
+        using var process = StartFixture("hold", "30000");
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => BoundedProcessWait.WaitAsync(
+                process,
+                BoundedProcessWait.DefaultTimeout,
+                cancellation.Token));
+
+        Assert.True(process.HasExited);
+    }
+
+    [Fact]
+    public async Task WaitAsync_PreservesOutputWrittenLateWithinDeadline()
+    {
+        using var process = StartFixture("late-output", "250");
+
+        var result = await BoundedProcessWait.WaitAsync(process, TimeSpan.FromSeconds(3));
+
+        Assert.Equal("late-stdout", result.StandardOutput);
+        Assert.Equal("late-stderr", result.StandardError);
+    }
+
+    [Fact]
+    public async Task WaitAsync_CancellationDoesNotWaitForInheritedPipeHandles()
+    {
+        var pidFile = Path.GetTempFileName();
+        var childPid = 0;
+        try
+        {
+            using var process = StartFixture("inherit-handles", "30000", pidFile);
+            using var cancellation = new CancellationTokenSource();
+            var wait = BoundedProcessWait.WaitAsync(
+                process,
+                BoundedProcessWait.DefaultTimeout,
+                cancellation.Token);
+            await process.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.False(wait.IsCompleted);
+            childPid = await ReadChildPidAsync(pidFile);
+            var stopwatch = Stopwatch.StartNew();
+
+            cancellation.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => wait);
+
+            stopwatch.Stop();
+            Assert.True(
+                stopwatch.Elapsed < TimeSpan.FromSeconds(3),
+                $"Inherited-handle cancellation took {stopwatch.ElapsedMilliseconds} ms.");
+        }
+        finally
+        {
+            KillProcessTree(childPid);
+            File.Delete(pidFile);
+        }
+    }
+
+    [Fact]
+    public void ObserveFault_ConsumesAbandonedTaskException()
+    {
+        var marker = Guid.NewGuid().ToString();
+        var unobserved = new ConcurrentQueue<Exception>();
+        EventHandler<UnobservedTaskExceptionEventArgs> handler = (_, args) =>
+        {
+            foreach (var exception in args.Exception.Flatten().InnerExceptions)
+            {
+                if (exception.Message == marker)
+                    unobserved.Enqueue(exception);
+            }
+
+            args.SetObserved();
+        };
+        TaskScheduler.UnobservedTaskException += handler;
+
+        try
+        {
+            var taskReference = CreateObservedFault(marker);
+            for (var attempt = 0; attempt < 10 && taskReference.IsAlive; attempt++)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+                Thread.Sleep(10);
+            }
+
+            Assert.False(taskReference.IsAlive);
+            Assert.Empty(unobserved);
+        }
+        finally
+        {
+            TaskScheduler.UnobservedTaskException -= handler;
+        }
+    }
+
+    private static WeakReference CreateObservedFault(string marker)
+    {
+        var task = Task.FromException(new InvalidOperationException(marker));
+        BoundedProcessWait.ObserveFault(task);
+        return new WeakReference(task);
+    }
+
+    private static Process StartFixture(params string[] arguments)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = FindTestHost(),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        startInfo.ArgumentList.Add("--process-fixture");
+        foreach (var argument in arguments)
+            startInfo.ArgumentList.Add(argument);
+
+        return Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Could not start process fixture.");
+    }
+
+    private static string FindTestHost()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null
+            && !File.Exists(Path.Combine(current.FullName, "openclaw-windows-node.slnx")))
+        {
+            current = current.Parent;
+        }
+
+        Assert.NotNull(current);
+        var configuration = Assembly.GetExecutingAssembly()
+            .GetCustomAttribute<AssemblyConfigurationAttribute>()?
+            .Configuration;
+        Assert.False(string.IsNullOrWhiteSpace(configuration));
+        var executableName = OperatingSystem.IsWindows()
+            ? "OpenClaw.Shared.TestHost.exe"
+            : "OpenClaw.Shared.TestHost";
+        var hostPath = Path.Combine(
+            current.FullName,
+            "tests",
+            "OpenClaw.Shared.TestHost",
+            "bin",
+            configuration,
+            "net10.0",
+            executableName);
+        Assert.True(File.Exists(hostPath), $"Process test host was not built: {hostPath}");
+        return hostPath;
+    }
+
+    private static async Task<int> ReadChildPidAsync(string pidFile)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (DateTime.UtcNow < deadline)
+        {
+            var text = await File.ReadAllTextAsync(pidFile);
+            if (int.TryParse(text, out var processId))
+                return processId;
+
+            await Task.Delay(10);
+        }
+
+        throw new TimeoutException("Inherited-handle fixture did not publish its child PID.");
+    }
+
+    private static void KillProcessTree(int processId)
+    {
+        if (processId <= 0)
+            return;
+
+        try
+        {
+            using var process = Process.GetProcessById(processId);
+            process.Kill(entireProcessTree: true);
+            process.WaitForExit(2_000);
+        }
+        catch (ArgumentException)
+        {
+        }
+        catch (InvalidOperationException)
+        {
+        }
+    }
+}

--- a/tests/OpenClaw.Shared.Tests/PiperVoiceExtractionTests.cs
+++ b/tests/OpenClaw.Shared.Tests/PiperVoiceExtractionTests.cs
@@ -1,0 +1,178 @@
+using System.Diagnostics;
+using System.Reflection;
+using OpenClaw.Shared.Audio;
+
+namespace OpenClaw.Shared.Tests;
+
+public sealed class PiperVoiceExtractionTests
+{
+    [Fact]
+    public async Task ExtractTarBz2Async_ExtractsArchiveWithWindowsTar()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        using var directory = new TemporaryDirectory();
+        var packageDirectory = Directory.CreateDirectory(
+            Path.Combine(directory.Path, "source", "package"));
+        var destinationDirectory = Directory.CreateDirectory(
+            Path.Combine(directory.Path, "destination"));
+        var archivePath = Path.Combine(directory.Path, "voice.tar.bz2");
+        await File.WriteAllTextAsync(
+            Path.Combine(packageDirectory.FullName, "voice.onnx"),
+            "model-bytes");
+        await File.WriteAllTextAsync(
+            Path.Combine(packageDirectory.FullName, "voice.onnx.json"),
+            "{\"audio\":{\"sample_rate\":22050}}");
+        await CreateTarBz2Async(
+            archivePath,
+            packageDirectory.Parent!.FullName,
+            packageDirectory.Name);
+
+        await PiperVoiceManager.ExtractTarBz2Async(
+            archivePath,
+            destinationDirectory.FullName,
+            CancellationToken.None);
+
+        Assert.Equal(
+            "model-bytes",
+            await File.ReadAllTextAsync(Path.Combine(destinationDirectory.FullName, "voice.onnx")));
+        Assert.True(File.Exists(Path.Combine(destinationDirectory.FullName, "voice.onnx.json")));
+    }
+
+    [Fact]
+    public async Task ExtractTarBz2Async_TimeoutIsBoundedAndKillsExtractor()
+    {
+        using var directory = new TemporaryDirectory();
+        var stopwatch = Stopwatch.StartNew();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => PiperVoiceManager.ExtractTarBz2Async(
+                "fixture-hold",
+                directory.Path,
+                CancellationToken.None,
+                FindTestHost(),
+                TimeSpan.FromSeconds(2)));
+
+        stopwatch.Stop();
+        Assert.IsType<TimeoutException>(exception.InnerException);
+        Assert.True(
+            stopwatch.Elapsed < TimeSpan.FromSeconds(5),
+            $"Piper timeout cleanup took {stopwatch.ElapsedMilliseconds} ms.");
+        await AssertFixtureExitedAsync(directory.Path);
+    }
+
+    [Fact]
+    public async Task ExtractTarBz2Async_CancellationIsBoundedAndKillsExtractor()
+    {
+        using var directory = new TemporaryDirectory();
+        using var cancellation = new CancellationTokenSource();
+        var extraction = PiperVoiceManager.ExtractTarBz2Async(
+            "fixture-hold",
+            directory.Path,
+            cancellation.Token,
+            FindTestHost(),
+            BoundedProcessWait.DefaultTimeout);
+        await ReadFixturePidAsync(directory.Path);
+        var stopwatch = Stopwatch.StartNew();
+
+        cancellation.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => extraction);
+
+        stopwatch.Stop();
+        Assert.True(
+            stopwatch.Elapsed < TimeSpan.FromSeconds(3),
+            $"Piper cancellation cleanup took {stopwatch.ElapsedMilliseconds} ms.");
+        await AssertFixtureExitedAsync(directory.Path);
+    }
+
+    private static async Task CreateTarBz2Async(
+        string archivePath,
+        string sourceDirectory,
+        string packageName)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "tar",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        startInfo.ArgumentList.Add("-cjf");
+        startInfo.ArgumentList.Add(archivePath);
+        startInfo.ArgumentList.Add("-C");
+        startInfo.ArgumentList.Add(sourceDirectory);
+        startInfo.ArgumentList.Add(packageName);
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Could not start tar archive fixture.");
+
+        var result = await BoundedProcessWait.WaitAsync(process, TimeSpan.FromSeconds(15));
+
+        Assert.True(
+            result.ExitCode == 0,
+            $"tar fixture creation failed (exit {result.ExitCode}): {result.StandardError}");
+    }
+
+    private static async Task AssertFixtureExitedAsync(string directory)
+    {
+        var processId = await ReadFixturePidAsync(directory);
+        Assert.Throws<ArgumentException>(() => Process.GetProcessById(processId));
+    }
+
+    private static async Task<int> ReadFixturePidAsync(string directory)
+    {
+        var pidPath = Path.Combine(directory, "fixture.pid");
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(3);
+        while (!File.Exists(pidPath) && DateTime.UtcNow < deadline)
+            await Task.Delay(10);
+
+        Assert.True(File.Exists(pidPath), "Piper extractor fixture did not publish its PID.");
+        return int.Parse(await File.ReadAllTextAsync(pidPath));
+    }
+
+    private static string FindTestHost()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null
+            && !File.Exists(Path.Combine(current.FullName, "openclaw-windows-node.slnx")))
+        {
+            current = current.Parent;
+        }
+
+        Assert.NotNull(current);
+        var configuration = Assembly.GetExecutingAssembly()
+            .GetCustomAttribute<AssemblyConfigurationAttribute>()?
+            .Configuration;
+        Assert.False(string.IsNullOrWhiteSpace(configuration));
+        var executableName = OperatingSystem.IsWindows()
+            ? "OpenClaw.Shared.TestHost.exe"
+            : "OpenClaw.Shared.TestHost";
+        var hostPath = Path.Combine(
+            current.FullName,
+            "tests",
+            "OpenClaw.Shared.TestHost",
+            "bin",
+            configuration,
+            "net10.0",
+            executableName);
+        Assert.True(File.Exists(hostPath), $"Process test host was not built: {hostPath}");
+        return hostPath;
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        internal TemporaryDirectory()
+        {
+            Path = Directory.CreateTempSubdirectory("openclaw-piper-extract-").FullName;
+        }
+
+        internal string Path { get; }
+
+        public void Dispose()
+        {
+            Directory.Delete(Path, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users downloading a Piper voice from Voice Settings would freeze the Settings window when `tar -xjf` hung or filled its redirected stderr pipe. Extract used unbounded `WaitForExit()` after the download finished, so the 2 second `tar --version` probe did not protect this path. Settings then sat on the extract step until the child exited or the operator killed the app.

A first-round bound still left cancellation waiting on a post-exit stderr drain if a descendant kept the pipe open. Voice Settings cancels the prior Piper request before starting a new download, so that drain could still stall the UI.

## Why This Change Was Made

Piper extract now waits for process exit plus complete stdout and stderr drain on one linked caller and timeout deadline. Timeout or cancel starts process-tree termination, closes local readers that inherited handles can hold, and bounds cleanup to one second. A timed-out extract fails closed and the existing download cleanup still deletes the partial voice directory. This does not change the SHA-256 check, the catalog, or the `tar --version` preflight.

## User Impact

Operators can download a Piper voice without Voice Settings hanging when the OS `tar` child sticks. A timeout surfaces as a failed extract so they can retry. Cancel still stops the child instead of leaving `tar` running, including when a descendant still holds redirected pipes.

## Evidence

Current-head `BoundedProcessWait.WaitAsync` against the inherit-handles fixture: the parent exits, a child keeps both redirected pipes, then cancel returns in 3ms instead of waiting the 120s extract budget.

```console
$ cd /tmp/wn-1268-head-proof && dotnet run
current_head_helper=OpenClaw.Shared.Audio.BoundedProcessWait
parent_exited=True
wait_completed_before_cancel=False
wait_status=canceled
elapsed_ms=3
child_pid=71189
```

Piper extract now calls `BoundedProcessWait.WaitAsync` from `ExtractTarBz2Async` instead of unbounded `WaitForExit()` plus blocking `StandardError.ReadToEnd()`.

## Change Type

- [x] Bug fix

## Scope

- [x] Tray or WinUI UX

## Required proof pools

- `none`: the hang is the Voice Settings Piper `tar` extract wait. A hung child plus the current-head helper is enough. No installer, WSL, or interactive WinUI host is required.

## Validation

- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --filter FullyQualifiedName~BoundedProcessWaitTests|FullyQualifiedName~PiperVoiceExtractionTests`
- 10 passed, 0 failed (Windows `tar.exe` extract case returns on non-Windows)
- Current-head inherit-handle cancel: `elapsed_ms=3`
- `dotnet format` on the changed helper, Piper extract, TestHost fixture, and tests
- WinUI project and `./build.ps1` were not run on this macOS host

## Real behavior proof

- **Behavior or issue addressed:** Voice Settings Piper download extract blocked forever on unbounded `WaitForExit()` with stderr redirected. After the first bound, cancel could still wait on a descendant-held drain.
- **Real environment tested:** macOS 26.6.2, Darwin, .NET 10.0.400, branch `fix/f003-piper-tar-timeout` replayed onto `origin/main` `09bc834`, invoked with `dotnet run` from `/tmp/wn-1268-head-proof` against current-head `BoundedProcessWait`.
- **Exact steps or command run after this patch:**

  ```bash
  cd /tmp/wn-1268-head-proof
  dotnet run
  ```

- **Evidence after fix:** terminal output from the current-head helper:

  ```console
  current_head_helper=OpenClaw.Shared.Audio.BoundedProcessWait
  parent_exited=True
  wait_completed_before_cancel=False
  wait_status=canceled
  elapsed_ms=3
  ```

- **Observed result after fix:** After the fixture parent exited, `WaitAsync` was still pending on inherited pipes. Cancel returned in 3ms and did not consume the 120s extract budget.
- **What was not tested:** Interactive Voice Settings download on a Windows host against a real hung `tar.exe`.

## Security Impact

- New permissions or capabilities? (`No`)
- Secrets or tokens handling changed? (`No`)
- New or changed network calls? (`No`)
- Command or tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

Extract still launches the same OS `tar -xjf` command on the already hashed tarball. Only the wait, stream drain, and kill-on-timeout behavior changed.

## Compatibility and Migration

- Backward compatible? (`Yes`)
- Config or environment changes? (`No`)
- Migration needed? (`No`)

## Review Conversations

- [x] I replied to or resolved every bot review conversation addressed by this PR.
- [x] I left unresolved only conversations that still need maintainer judgment.

## Related

- Introduced in [#288](https://github.com/openclaw/openclaw-windows-node/pull/288) (2026-05-07). The unbounded extract wait has been present for 118 days.
- Same hang class as [#1168](https://github.com/openclaw/openclaw-windows-node/pull/1168) (bounded drain after WaitForExit) and [#1267](https://github.com/openclaw/openclaw-windows-node/pull/1267) (Tailscale status ReadToEnd before WaitForExit).
- This remains the first PR for F003. It now includes the Claw P2 drain-cancel repair (interrupt readers after the immediate process exits).
