### PR TITLE
fix(setup): preselect Local AI on eligible PCs

### DIFF
--- a/src/OpenClaw.SetupEngine.UI/Pages/CapabilitiesPage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/CapabilitiesPage.xaml.cs
@@ -402,6 +402,10 @@ public sealed partial class CapabilitiesPage : Page
         _localAiSelectionEligible = eligibility.Status == LocalInferenceEligibilityStatus.Eligible;
         _config!.LocalAi.SelectedModelId ??= eligibility.Plan!.Model.Id;
         PopulateLocalAiModels();
+        _config.LocalAi.Enabled = TraySettingsConfig.ResolveLocalAiOnboardingEnabled(
+            _config.UsesBundledDefaultConfig,
+            _config.LocalAi.Enabled,
+            _localAiSelectionEligible);
         _suppressLocalAiToggle = true;
         LocalAiToggle.IsOn = _config!.LocalAi.Enabled;
         _suppressLocalAiToggle = false;

--- a/src/OpenClaw.SetupEngine/SetupContext.cs
+++ b/src/OpenClaw.SetupEngine/SetupContext.cs
@@ -334,6 +334,12 @@ public sealed class TraySettingsConfig
         AtomicFile.WriteAllText(settingsPath, json);
     }
 
+    public static bool ResolveLocalAiOnboardingEnabled(
+        bool usesBundledDefaultConfig,
+        bool configuredEnabled,
+        bool isEligible) =>
+        usesBundledDefaultConfig ? isEligible : configuredEnabled;
+
     public void ApplyCapabilities(CapabilitiesConfig capabilities)
     {
         // Device info has no independent runtime setting; it is always registered

--- a/tests/OpenClaw.SetupEngine.Tests/SetupConfigTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupConfigTests.cs
@@ -497,6 +497,25 @@ public class SetupConfigTests : IDisposable
         Assert.False(result.RootElement.GetProperty("NodeSystemRunEnabled").GetBoolean());
     }
 
+    [Theory]
+    [InlineData(true, false, true, true)]
+    [InlineData(true, true, false, false)]
+    [InlineData(false, true, false, true)]
+    [InlineData(false, false, true, false)]
+    public void TraySettingsConfig_ResolveLocalAiOnboardingEnabled_OnlyDefaultsBundledConfig(
+        bool usesBundledDefaultConfig,
+        bool configuredEnabled,
+        bool isEligible,
+        bool expected)
+    {
+        Assert.Equal(
+            expected,
+            TraySettingsConfig.ResolveLocalAiOnboardingEnabled(
+                usesBundledDefaultConfig,
+                configuredEnabled,
+                isEligible));
+    }
+
     [Fact]
     public void TraySettingsConfig_CorruptExistingFile_BacksUpAndThrows()
     {

--- a/tests/OpenClaw.Tray.Tests/LocalAiSetupUxContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalAiSetupUxContractTests.cs
@@ -372,6 +372,22 @@ public sealed class LocalAiSetupUxContractTests
     }
 
     [Fact]
+    public void EligibleBundledSetup_PreselectsLocalAiWithoutChangingCustomConfig()
+    {
+        string root = TestRepositoryPaths.GetRepositoryRoot();
+        string source = File.ReadAllText(Path.Combine(
+            root, "src", "OpenClaw.SetupEngine.UI", "Pages", "CapabilitiesPage.xaml.cs"));
+
+        Assert.Contains("ResolveLocalAiOnboardingEnabled", source);
+        Assert.Contains("_localAiSelectionEligible", source);
+        AssertInOrder(
+            source,
+            "PopulateLocalAiModels()",
+            "ResolveLocalAiOnboardingEnabled",
+            "LocalAiToggle.IsOn");
+    }
+
+    [Fact]
     public void LocalAiPage_InfoBarPrecedesAndDoesNotDisableReasonAction()
     {
         string root = TestRepositoryPaths.GetRepositoryRoot();


### PR DESCRIPTION
Related: #1247

## Summary

Bundled onboarding derives the initial Local AI toggle from the full eligibility result. Eligible PCs default on, ineligible or busy PCs default off, and custom configurations keep their configured value.

This branch was rebuilt as one topic commit on current `main` (`b8dc6091`). It intentionally implements initial preselection only. Persistence of an explicit opt-out across page reconstruction or app restart remains a maintainer-review decision in the existing thread.

## Required proof pools

- `windows-winui-interactive`: the onboarding Local AI default changed.

## Validation

Current head: `64de1b24dc82229489a3f3ab15cf8670b4a15a04`

- `.\build.ps1`: passed on Windows 11 ARM64; all projects and documentation validation succeeded.
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj`: 3,872 passed, 32 environment-gated skips.
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj`: 2,813 passed.
- `dotnet test .\tests\OpenClaw.SetupEngine.Tests\OpenClaw.SetupEngine.Tests.csproj`: 1,029 passed.
- `git diff --check origin/main...HEAD`: passed.

Current-head tests cover eligible/ineligible bundled setup, enabled/disabled custom configurations, and application of the policy before the toggle renders.

## Real behavior proof

The previous patch-equivalent head was exercised in an isolated Windows 11 app. With an RTX 5090 driver below the app minimum, Local AI stayed off and setup remained skippable. The refreshed commit has the same topic patch on current main, but visible proof was not recaptured from the new commit.

Not verified / blocked: current-head screenshots for both eligible and ineligible states require `windows-winui-interactive`. Explicit opt-out persistence and page-reentry behavior are not claimed by this PR.

## Security and compatibility

- No new permissions, credentials, network calls, or migration are introduced.
- Custom setup configurations retain their explicit values.
