### PR TITLE
docs: add uninstall info to README and uninstall skill

### DIFF
--- a/.agents/skills/uninstall/SKILL.md
+++ b/.agents/skills/uninstall/SKILL.md
@@ -28,7 +28,15 @@ distro or Tailscale session actually in use).
    # (build first if it doesn't exist yet: .\build.ps1)
    ```
 
-2. **Dry-run first**, capturing output and exit code (a bare shell invocation can swallow
+2. **Kill any running instance first.** A background `OpenClaw.Tray.WinUI.exe` (e.g. the
+   tray icon) holds its own log/journal files open, which makes later steps fail to
+   delete the AppData Logs directory:
+
+   ```powershell
+   Get-Process OpenClaw.Tray.WinUI -ErrorAction SilentlyContinue | Stop-Process -Force
+   ```
+
+3. **Dry-run first**, capturing output and exit code (a bare shell invocation can swallow
    the exit code for a WinUI apphost; use `Start-Process -Wait -PassThru`):
 
    ```powershell
@@ -43,7 +51,7 @@ distro or Tailscale session actually in use).
    `OpenClawTray-Dev` / `OpenClawGateway-Dev`, separate from a real install's
    `OpenClawTray` / `OpenClawGateway`.
 
-3. **Check for real state the dry-run doesn't surface**, e.g. a live WSL distro:
+4. **Check for real state the dry-run doesn't surface**, e.g. a live WSL distro:
 
    ```powershell
    wsl -l -v
@@ -52,7 +60,7 @@ distro or Tailscale session actually in use).
    If the distro named in step 2's output is present, flag to the user that it will be
    unregistered (`wsl --unregister`), permanently deleting its filesystem.
 
-4. **Confirm with the user**, then run the real uninstall the same way:
+5. **Confirm with the user**, then run the real uninstall the same way:
 
    ```powershell
    $p = Start-Process -FilePath $exe -ArgumentList '--uninstall','--confirm-destructive' -PassThru -Wait `
@@ -61,7 +69,7 @@ distro or Tailscale session actually in use).
    Get-Content out2.log
    ```
 
-5. **Verify** the specific artifacts the engine is supposed to clean up — not the AppData
+6. **Verify** the specific artifacts the engine is supposed to clean up — not the AppData
    roots themselves. `TrayArtifactCleanup` resets/removes selected files in place; it does
    not delete `%APPDATA%\OpenClawTray[-Dev]` or `%LOCALAPPDATA%\OpenClawTray[-Dev]`, so
    asserting those roots are gone will report a successful run as failed:
@@ -73,8 +81,9 @@ distro or Tailscale session actually in use).
    Test-Path "$env:LOCALAPPDATA\OpenClawTray-Dev\run.marker"  # should be False
    ```
 
-   A `Failed to delete AppData Logs directory` warning because the run's own log/journal
-   file is still open is expected and harmless.
+   With step 2's kill done, `%APPDATA%\OpenClawTray-Dev\Logs` should also be gone; if a
+   `Failed to delete AppData Logs directory` warning still shows up, it's the current
+   run's own still-open log/journal file and is harmless.
 
 ## Notes
 

--- a/.agents/skills/uninstall/SKILL.md
+++ b/.agents/skills/uninstall/SKILL.md
@@ -99,7 +99,9 @@ distro or Tailscale session actually in use).
 
    ```powershell
    wsl -l -v   # target distro should no longer be listed
-   Test-Path "$env:APPDATA\OpenClawTray-Dev\Logs"        # should be False
+   # The current run's own log/journal remain under Logs\Setup (they are open during
+   # cleanup); success = that directory holds only uninstall-engine-<this-run> files
+   Get-ChildItem "$env:APPDATA\OpenClawTray-Dev\Logs\Setup"   # only this run's uninstall-engine-* files expected
    Test-Path "$env:LOCALAPPDATA\OpenClawTray-Dev\Logs"   # should be False
    Test-Path "$env:LOCALAPPDATA\OpenClawTray-Dev\run.marker"  # should be False
    Test-Path "$env:APPDATA\OpenClawTray-Dev\exec-approvals.json"  # should be False
@@ -110,9 +112,11 @@ distro or Tailscale session actually in use).
    # should error/be absent (autostart registry key removed)
    ```
 
-   With step 2's kill done, `%APPDATA%\OpenClawTray-Dev\Logs` should also be gone; if a
-   `Failed to delete AppData Logs directory` warning still shows up, it's the current
-   run's own still-open log/journal file and is harmless.
+   The current run's own active log and journal under `%APPDATA%\OpenClawTray-Dev\Logs\Setup`
+   are expected to remain: the Setup Engine still holds them open when
+   `TrayArtifactCleanup` runs, so the `Failed to delete AppData Logs directory` warning
+   is normal. A `Failed to delete...` warning naming any other file, or leftover files
+   from earlier runs, means a process is still holding them open (see step 2).
 
 ## Notes
 

--- a/.agents/skills/uninstall/SKILL.md
+++ b/.agents/skills/uninstall/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uninstall
-description: Run the headless CLI uninstall path for a local OpenClaw Companion dev build (--uninstall --dry-run, then --confirm-destructive) to remove the WSL gateway distro, CLI, and AppData state. Use when the user asks to uninstall, clean up, or reset a local dev install/gateway, or to test the uninstall engine.
+description: Run the headless CLI uninstall path for a local OpenClaw Companion dev build (--uninstall --dry-run, then --confirm-destructive) to remove the WSL gateway distro, gateway CLI/service, gateway identity/tokens, exec approvals, autostart entries, node-context state, Local AI, Tailscale state, and other AppData artifacts. Use when the user asks to uninstall, clean up, or reset a local dev install/gateway, or to test the uninstall engine.
 ---
 
 # Uninstall (dev build)
@@ -17,23 +17,39 @@ distro or Tailscale session actually in use).
 
 ## Procedure
 
-1. **Find the matching-architecture build.** The exe is a framework-dependent apphost;
-   it must match the machine's CPU architecture (check with `systeminfo | findstr
-   "System Type"`; ARM64 machines need the `win-arm64` output, not `win-x64`, even if
-   `dotnet --list-runtimes` shows a runtime installed):
+1. **Build with the dev identity, for the matching architecture.** `.\build.ps1`
+   alone defaults to release identity even in a Debug configuration, and a
+   release-identity exe would unregister the real `OpenClawGateway` distro and mutate
+   `%APPDATA%\OpenClawTray` instead of the `-Dev` copies below (the output path is
+   identical either way, so nothing later in this procedure would catch that
+   mistake). Always build with `-DevBuild`, and verify the marker before proceeding:
 
    ```powershell
-   $arch = if ((Get-CimInstance Win32_OperatingSystem).OSArchitecture -match 'ARM') { 'win-arm64' } else { 'win-x64' }
-   $exe = "src\OpenClaw.Tray.WinUI\bin\Debug\net10.0-windows10.0.22621.0\$arch\OpenClaw.Tray.WinUI.exe"
-   # (build first if it doesn't exist yet: .\build.ps1)
+   .\build.ps1 -DevBuild   # skip only if you already built with -DevBuild
+
+   $arm64 = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq
+       [System.Runtime.InteropServices.Architecture]::Arm64
+   $arch = if ($arm64) { 'win-arm64' } else { 'win-x64' }
+   $outDir = "src\OpenClaw.Tray.WinUI\bin\Debug\net10.0-windows10.0.22621.0\$arch"
+   $exe = "$outDir\OpenClaw.Tray.WinUI.exe"
+
+   $identity = (Get-Content "$outDir\app-identity.txt" -Raw).Trim()
+   if ($identity -ne 'dev') { throw "Build output identity is '$identity', not 'dev' - rebuild with -DevBuild." }
    ```
 
-2. **Kill any running instance first.** A background `OpenClaw.Tray.WinUI.exe` (e.g. the
-   tray icon) holds its own log/journal files open, which makes later steps fail to
-   delete the AppData Logs directory:
+2. **Stop only the dev instance, by PID.** A background `OpenClaw.Tray.WinUI.exe`
+   (e.g. the tray icon) holds its own log/journal files open, which makes later steps
+   fail to delete the AppData Logs directory. A release-identity tray can share the
+   same process name, so match on the resolved `$exe` path and confirm before
+   stopping; this repo kills processes by PID only, never by name
+   (see `scripts/dev-reset-rebuild-launch.ps1`):
 
    ```powershell
-   Get-Process OpenClaw.Tray.WinUI -ErrorAction SilentlyContinue | Stop-Process -Force
+   $exePath = (Resolve-Path $exe).Path
+   $devProcs = Get-Process OpenClaw.Tray.WinUI -ErrorAction SilentlyContinue |
+       Where-Object { $_.Path -eq $exePath }
+   $devProcs | Format-Table Id, Path -AutoSize   # confirm these are the dev instance before stopping
+   $devProcs | ForEach-Object { Stop-Process -Id $_.Id -Force }
    ```
 
 3. **Dry-run first**, capturing output and exit code (a bare shell invocation can swallow
@@ -57,8 +73,13 @@ distro or Tailscale session actually in use).
    wsl -l -v
    ```
 
-   If the distro named in step 2's output is present, flag to the user that it will be
+   If the distro named in step 3's output is present, flag to the user that it will be
    unregistered (`wsl --unregister`), permanently deleting its filesystem.
+
+   The dry-run only logs rollback step IDs, not the concrete files each step would
+   touch. If it matters to the user's situation, inspect `%APPDATA%\OpenClawTray-Dev\`
+   directly before consenting (gateway registry, `windows-node-context.json`, Local AI
+   config, Tailscale state).
 
 5. **Confirm with the user**, then run the real uninstall the same way:
 
@@ -69,16 +90,24 @@ distro or Tailscale session actually in use).
    Get-Content out2.log
    ```
 
-6. **Verify** the specific artifacts the engine is supposed to clean up — not the AppData
-   roots themselves. `TrayArtifactCleanup` resets/removes selected files in place; it does
-   not delete `%APPDATA%\OpenClawTray[-Dev]` or `%LOCALAPPDATA%\OpenClawTray[-Dev]`, so
-   asserting those roots are gone will report a successful run as failed:
+6. **Verify** the specific artifacts each rollback step is supposed to clean up: not the
+   AppData roots themselves. `TrayArtifactCleanup` (registry/files/settings only, no WSL
+   calls) and the WSL/gateway rollback steps between them reset or remove selected files
+   and records in place; neither deletes `%APPDATA%\OpenClawTray[-Dev]` or
+   `%LOCALAPPDATA%\OpenClawTray[-Dev]`, so asserting those roots are gone will report a
+   successful run as failed:
 
    ```powershell
    wsl -l -v   # target distro should no longer be listed
    Test-Path "$env:APPDATA\OpenClawTray-Dev\Logs"        # should be False
    Test-Path "$env:LOCALAPPDATA\OpenClawTray-Dev\Logs"   # should be False
    Test-Path "$env:LOCALAPPDATA\OpenClawTray-Dev\run.marker"  # should be False
+   Test-Path "$env:APPDATA\OpenClawTray-Dev\exec-approvals.json"  # should be False
+   Test-Path "$env:LOCALAPPDATA\OpenClawTray-Dev\windows-node-context.json"  # should be False, if it existed
+   # settings.json: GatewayUrl removed; EnableNodeMode/AutoStart reset to false unless
+   # other gateway records remain
+   # Get-ItemProperty 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Run' -Name OpenClawTray-Dev -ErrorAction SilentlyContinue
+   # should error/be absent (autostart registry key removed)
    ```
 
    With step 2's kill done, `%APPDATA%\OpenClawTray-Dev\Logs` should also be gone; if a

--- a/.agents/skills/uninstall/SKILL.md
+++ b/.agents/skills/uninstall/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: uninstall
+description: Run the headless CLI uninstall path for a local OpenClaw Companion dev build (--uninstall --dry-run, then --confirm-destructive) to remove the WSL gateway distro, CLI, and AppData state. Use when the user asks to uninstall, clean up, or reset a local dev install/gateway, or to test the uninstall engine.
+---
+
+# Uninstall (dev build)
+
+`OpenClaw.Tray.WinUI.exe` embeds the SetupEngine and accepts `--uninstall` directly, so
+no installer is required to exercise this path; a local `dotnet build` output works.
+This walks a real (not just installed-via-Inno-Setup) uninstall of dev/test state:
+WSL gateway distro, `openclaw` CLI inside WSL, gateway systemd service, Tailscale
+state, and the tray's AppData files.
+
+This is destructive. Confirm with the user before the final `--confirm-destructive`
+run, and call out anything it will touch that isn't disposable dev state (e.g. a WSL
+distro or Tailscale session actually in use).
+
+## Procedure
+
+1. **Find the matching-architecture build.** The exe is a framework-dependent apphost;
+   it must match the machine's CPU architecture (check with `systeminfo | findstr
+   "System Type"`; ARM64 machines need the `win-arm64` output, not `win-x64`, even if
+   `dotnet --list-runtimes` shows a runtime installed):
+
+   ```powershell
+   $arch = if ((Get-CimInstance Win32_OperatingSystem).OSArchitecture -match 'ARM') { 'win-arm64' } else { 'win-x64' }
+   $exe = "src\OpenClaw.Tray.WinUI\bin\Debug\net10.0-windows10.0.22621.0\$arch\OpenClaw.Tray.WinUI.exe"
+   # (build first if it doesn't exist yet: .\build.ps1)
+   ```
+
+2. **Dry-run first**, capturing output and exit code (a bare shell invocation can swallow
+   the exit code for a WinUI apphost; use `Start-Process -Wait -PassThru`):
+
+   ```powershell
+   $p = Start-Process -FilePath $exe -ArgumentList '--uninstall','--dry-run' -PassThru -Wait `
+       -RedirectStandardOutput out.log -RedirectStandardError err.log
+   $p.ExitCode
+   Get-Content out.log
+   ```
+
+   Review the "Would rollback: ..." lines for each of the ~37 steps. Note the
+   `--data-dir` / `--distro-name` printed at the top; dev-branch builds use
+   `OpenClawTray-Dev` / `OpenClawGateway-Dev`, separate from a real install's
+   `OpenClawTray` / `OpenClawGateway`.
+
+3. **Check for real state the dry-run doesn't surface**, e.g. a live WSL distro:
+
+   ```powershell
+   wsl -l -v
+   ```
+
+   If the distro named in step 2's output is present, flag to the user that it will be
+   unregistered (`wsl --unregister`), permanently deleting its filesystem.
+
+4. **Confirm with the user**, then run the real uninstall the same way:
+
+   ```powershell
+   $p = Start-Process -FilePath $exe -ArgumentList '--uninstall','--confirm-destructive' -PassThru -Wait `
+       -RedirectStandardOutput out2.log -RedirectStandardError err2.log
+   $p.ExitCode
+   Get-Content out2.log
+   ```
+
+5. **Verify** nothing expected survived:
+
+   ```powershell
+   wsl -l -v
+   Test-Path "$env:APPDATA\OpenClawTray-Dev"
+   Test-Path "$env:LOCALAPPDATA\OpenClawTray-Dev"
+   ```
+
+   A `Failed to delete AppData Logs directory` warning because the run's own log/journal
+   file is still open is expected and harmless.
+
+## Notes
+
+- Log and journal for each run are printed at the end of stdout, under
+  `%APPDATA%\OpenClawTray[-Dev]\Logs\Setup\uninstall-engine-<timestamp>.jsonl`.
+- For a real installed app (not a dev build), the user-facing path is **Settings → Apps
+  → Installed apps → OpenClaw Companion → Uninstall**; see `docs/SETUP.md#uninstalling`
+  and the README's Uninstall section. This skill is for exercising the underlying CLI
+  path directly, e.g. for dev cleanup or testing the uninstall engine itself.

--- a/.agents/skills/uninstall/SKILL.md
+++ b/.agents/skills/uninstall/SKILL.md
@@ -61,12 +61,16 @@ distro or Tailscale session actually in use).
    Get-Content out2.log
    ```
 
-5. **Verify** nothing expected survived:
+5. **Verify** the specific artifacts the engine is supposed to clean up — not the AppData
+   roots themselves. `TrayArtifactCleanup` resets/removes selected files in place; it does
+   not delete `%APPDATA%\OpenClawTray[-Dev]` or `%LOCALAPPDATA%\OpenClawTray[-Dev]`, so
+   asserting those roots are gone will report a successful run as failed:
 
    ```powershell
-   wsl -l -v
-   Test-Path "$env:APPDATA\OpenClawTray-Dev"
-   Test-Path "$env:LOCALAPPDATA\OpenClawTray-Dev"
+   wsl -l -v   # target distro should no longer be listed
+   Test-Path "$env:APPDATA\OpenClawTray-Dev\Logs"        # should be False
+   Test-Path "$env:LOCALAPPDATA\OpenClawTray-Dev\Logs"   # should be False
+   Test-Path "$env:LOCALAPPDATA\OpenClawTray-Dev\run.marker"  # should be False
    ```
 
    A `Failed to delete AppData Logs directory` warning because the run's own log/journal

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ On first launch, the setup wizard can install a dedicated local gateway in WSL o
 
 ## Uninstall
 
-Go to **Settings → Apps → Installed apps**, find **OpenClaw Companion**, and click **Uninstall** (or use **Add or Remove Programs** in Control Panel). This also removes the local WSL gateway it set up.
+Go to **Settings → Apps → Installed apps**, find **OpenClaw Companion**, and click **Uninstall** (or use **Add or Remove Programs** in Control Panel). You'll be asked whether to also remove the local WSL gateway; choose **Yes** to unregister its WSL distro and generated state, or **No** to leave the gateway and that state in place.
 
 Your settings file at `%APPDATA%\OpenClawTray\settings.json` and device identity files under `%APPDATA%\OpenClawTray\` are not removed automatically; delete them manually for a fully clean uninstall. See [docs/SETUP.md](docs/SETUP.md#uninstalling) for details, including the headless `--uninstall --confirm-destructive` CLI path used for testing.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ On first launch, the setup wizard can install a dedicated local gateway in WSL o
 
 Go to **Settings → Apps → Installed apps**, find **OpenClaw Companion**, and click **Uninstall** (or use **Add or Remove Programs** in Control Panel). You'll be asked whether to also remove the local WSL gateway; choose **Yes** to unregister its WSL distro and generated state, or **No** to leave the gateway and that state in place.
 
-Your settings file at `%APPDATA%\OpenClawTray\settings.json` and device identity files under `%APPDATA%\OpenClawTray\` are not removed automatically; delete them manually for a fully clean uninstall. See [docs/SETUP.md](docs/SETUP.md#uninstalling) for details, including the headless `--uninstall --confirm-destructive` CLI path used for testing.
+Your settings file at `%APPDATA%\OpenClawTray\settings.json` is not removed automatically, and device identity files for gateways unrelated to the one you removed are preserved. Choosing **Yes** does also remove the removed gateway's own identity directory under `%APPDATA%\OpenClawTray\gateways\` and, if it was your only gateway, clears your root device tokens; delete `%APPDATA%\OpenClawTray\` manually for a fully clean uninstall. See [docs/SETUP.md](docs/SETUP.md#uninstalling) for details, including the headless `--uninstall --confirm-destructive` CLI path used for testing.
 
 ## 🔌 Node mode (agent control)
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Requires Windows 10 20H2 or later, or Windows 11. No source build is required.
 
 On first launch, the setup wizard can install a dedicated local gateway in WSL or connect OpenClaw Companion to an existing gateway. If you do not have a gateway yet, choose **Install a local gateway (WSL)**.
 
+## Uninstall
+
+Go to **Settings → Apps → Installed apps**, find **OpenClaw Companion**, and click **Uninstall** (or use **Add or Remove Programs** in Control Panel). This also removes the local WSL gateway it set up.
+
+Your settings file at `%APPDATA%\OpenClawTray\settings.json` and device identity files under `%APPDATA%\OpenClawTray\` are not removed automatically; delete them manually for a fully clean uninstall. See [docs/SETUP.md](docs/SETUP.md#uninstalling) for details, including the headless `--uninstall --confirm-destructive` CLI path used for testing.
+
 ## 🔌 Node mode (agent control)
 
 Use OpenClaw Companion for normal setup. You should not need to edit `openclaw.json` by hand.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -187,6 +187,8 @@ OpenClaw Companion checks for updates automatically and shows a notification whe
 
 ## Uninstalling
 
-Go to **Settings → Apps → Installed apps**, find **OpenClaw Companion**, and click **Uninstall**. Alternatively, use **Add or Remove Programs** in the Control Panel.
+Go to **Settings → Apps → Installed apps**, find **OpenClaw Companion**, and click **Uninstall**. Alternatively, use **Add or Remove Programs** in the Control Panel. You'll be asked whether to also remove the local WSL gateway; choose **Yes** to unregister its WSL distro and generated state, or **No** to leave the gateway and that state in place.
 
-Your settings file at `%APPDATA%\OpenClawTray\settings.json` and device identity files under `%APPDATA%\OpenClawTray\` (including per-gateway keys at `%APPDATA%\OpenClawTray\gateways\<gateway-id>\device-key-ed25519.json`) are not removed automatically - delete them manually if you want a clean uninstall.
+Your settings file at `%APPDATA%\OpenClawTray\settings.json` is not removed automatically, and device identity files for gateways unrelated to the one you removed (including per-gateway keys at `%APPDATA%\OpenClawTray\gateways\<gateway-id>\device-key-ed25519.json`) are preserved. Choosing **Yes** does also remove the removed gateway's own identity directory and, if it was your only gateway, clears your root device tokens; delete `%APPDATA%\OpenClawTray\` manually if you want a fully clean uninstall.
+
+For a headless CLI uninstall path used for dev/testing (`--uninstall --dry-run`, then `--confirm-destructive`), see `.agents/skills/uninstall/SKILL.md`.


### PR DESCRIPTION
## Summary

- Documents the user-facing uninstall path in the README and setup guide.
- Adds the agent uninstall procedure for a side-by-side dev build (`.agents/skills/uninstall/SKILL.md`).

## Rebase update (2026-09-08): PR is now docs-only

The runtime fix previously included in this PR (cherry-pick `ab5c4b3c`, "Fix uninstall when dev WSL distro is absent") was merged to `main` as `e29bc418` (#1348, `fix(setup): let uninstall recover from absent WSL distro`), including its follow-up hardening (`IsWslUnavailableResult`, `RunAsyncAllowingInheritedPipeHandleEscape`, and the additional regression tests). During the rebase onto current `main`, that commit was dropped as fully superseded; its guard, its regression test `WindowsNodeContext_Rollback_SkipsLegacyCleanupWhenDistroIsAbsent`, and its extension tests are all present on `main` verbatim. No C# changes remain in this PR.

Consequently, the previously requested absent-distro rerun proof applies to code now owned by #1348 on `main`, not to any file in this PR. The destructive-uninstall evidence below was collected against that runtime code while it lived on this branch and remains valid as validation history for the merged fix.

## Required proof pools

- `none` with reason: this PR changes only Markdown documentation (README.md, docs/SETUP.md, .agents/skills/uninstall/SKILL.md). It registers no code paths, commands, or MCP tools; `scripts/validate-docs.ps1` proof-pool validation passes with the declared pools.

## Validation

Tested heads: destructive-uninstall proof at `ab5c4b3c` (then-head, runtime fix included); docs validation re-run at `a2699df7` (current head after rebase).

- `./build.ps1 -DevBuild` at `ab5c4b3c`: passed.
- `dotnet test tests/OpenClaw.Shared.Tests`: 3872 passed, 32 skipped, 0 failed.
- `dotnet test tests/OpenClaw.SetupEngine.Tests`: 1027 passed, 0 failed (includes the missing-distro regression tests, since merged to `main` via #1348).
- `dotnet test tests/OpenClaw.Tray.Tests`: 2812 passed, 0 failed.
- `./scripts/validate-docs.ps1` at `a2699df7`: passed; 47 Markdown files checked, proof-pool validation 7 named pools.

## Real Behavior Proof (validation history for the runtime fix now on main via #1348)

Environment: native Windows x64 dev build (`app-identity.txt` = `dev`), head `ab5c4b3c`. Pre-state: `OpenClawGateway-Dev` WSL2 distro present and running, `%LOCALAPPDATA%\OpenClawTray-Dev` contained `run.marker`, `setup-state.json`, `setup-managed-distro.json`, `windows-node-context.json`, `LocalAI\`, `wsl\`, `wsl-keepalive\`; `%APPDATA%\OpenClawTray-Dev` contained one gateway record (`c293944b4e224c08`) with its `device-key-ed25519.json` identity file.

1. Dry run: `OpenClaw.Tray.WinUI.exe --uninstall --dry-run` exited `0`, listed all 37 rollback steps, ended with `UNINSTALL COMPLETE`.
2. Real run: `--uninstall --confirm-destructive` exited `1`: `1 rollback(s) failed: configure-local-ai-gateway` (pre-existing Local AI manifest validation issue, below). All other rollbacks succeeded, including `wsl --unregister OpenClawGateway-Dev` exit 0, tray-artifact cleanup (`Deleted run.marker`, `Removed autostart scheduled task`, `Reset onboarding settings`), exit code `1`.
3. Post-state: `wsl -l -v` shows `OpenClawGateway-Dev` absent; `run.marker`, `setup-state.json`, `setup-managed-distro.json`, `windows-node-context.json`, `LocalAI\`, `wsl\`, `wsl-keepalive\`, `Logs\`, `exec-approvals.json`, gateway identity dir and `device-key-ed25519.json` all absent; `gateways.json` has 0 gateways; `settings.json` has `GatewayUrl` removed, `EnableNodeMode=false`, `AutoStart=false`; autostart Run-key value and scheduled task absent.
4. The absent-distro rerun scenario (the target of the merged fix) is covered by regression tests now on `main`: `WindowsNodeContext_Rollback_SkipsLegacyCleanupWhenDistroIsAbsent`, `..._SkipsLegacyCleanupWhenWslHasNoDistributions`, `..._SkipsLegacyCleanupWhenWslExeCannotStart`, `..._FailsWhenDistroInspectionIsAmbiguous`, `..._FailsWhenDistroInspectionTimesOut` (SetupEngine.Tests, 1027 passed at `ab5c4b3c`).

### Known issue found during proof (pre-existing, tracked separately)

With `LocalAi.Enabled=false` in the bundled `default-config.json`, a fresh-process uninstall whose machine still has a Local AI gateway provider configured fails the `configure-local-ai-gateway` rollback when a manifest exists but cannot be validated, so uninstall reports exit `1` even though every artifact is cleaned. Tracked separately; not introduced by this PR.