### PR TITLE
fix(chat): coalesce Publish() bursts to prevent WinUI3 layout-cycle crash

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
@@ -78,6 +78,9 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
     private readonly ChatHistoryLoader _historyLoader;
     private readonly Action<Action>? _post;
     private readonly Func<Func<Task>, Task> _deferredAbortScheduler;
+    private readonly object _publishGate = new();
+    private ChatDataSnapshot? _pendingPublishSnapshot;
+    private bool _publishScheduled;
 
     /// <summary>Whether any thread is in an aborted state (suppress TTS/notifications).</summary>
     public bool IsResponseSuppressed => _state.IsResponseSuppressed;
@@ -1809,14 +1812,51 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
 
     private void Publish(ChatDataSnapshot snapshot)
     {
-        var args = new ChatDataChangedEventArgs(snapshot);
         if (_post is null)
         {
-            Changed?.Invoke(this, args);
+            Changed?.Invoke(this, new ChatDataChangedEventArgs(snapshot));
         }
         else
         {
-            _post(() => Changed?.Invoke(this, args));
+            // Coalesce bursts of Publish() calls (rapid tool-activity grouping
+            // updates, streaming tokens) into a single UI-thread dispatch per
+            // drain. Without this, a burst of N Publish() calls enqueues N
+            // separate Changed?.Invoke dispatches; when they arrive faster
+            // than the dispatcher drains them, the Reactor tree mutates
+            // repeatedly before WinUI3 settles a layout pass. That produced
+            // field crashes: Microsoft.UI.Xaml.LayoutCycleException
+            // ("Layout cycle detected" / "Element is already the child of
+            // another element") when tool-call Expander controls are re-keyed
+            // mid-burst (see ToolCallCardRenderer / ChatToolActivityPresentation
+            // grouping, whose row keys shift as new tool entries arrive
+            // faster than the UI can settle). Only the latest snapshot matters
+            // for rendering, so dropping superseded intermediate snapshots
+            // within one burst is safe and loses no information the UI would
+            // have shown anyway.
+            bool shouldSchedule;
+            lock (_publishGate)
+            {
+                _pendingPublishSnapshot = snapshot;
+                shouldSchedule = !_publishScheduled;
+                _publishScheduled = true;
+            }
+
+            if (shouldSchedule)
+            {
+                _post(() =>
+                {
+                    ChatDataSnapshot? toPublish;
+                    lock (_publishGate)
+                    {
+                        toPublish = _pendingPublishSnapshot;
+                        _pendingPublishSnapshot = null;
+                        _publishScheduled = false;
+                    }
+
+                    if (toPublish is not null)
+                        Changed?.Invoke(this, new ChatDataChangedEventArgs(toPublish));
+                });
+            }
         }
 
         // Debounce-save last-known UI state so the next launch can show


### PR DESCRIPTION
## What

Coalesces bursts of `Publish()` calls in `OpenClawChatDataProvider` into a single UI-thread dispatch per drain, instead of scheduling one `Changed?.Invoke` per call.

## Why

Reproduced twice on a live install (2026-08-30 and 2026-09-01), correlating `crash.log`, the Windows Application event log, and `openclaw-tray.log` timestamps:

```
[2026-09-01 20:13:13.601] [DEBUG] Agent event received: stream=lifecycle len=404
[2026-09-01 20:13:13.741] [ERROR] CRASH UnhandledException: Microsoft.UI.Xaml.LayoutCycleException: Layout cycle detected.
```

```
[2026-08-30 21:21:02.506] UnhandledException
Microsoft.UI.Xaml.LayoutCycleException: Element is already the child of another element.
```

Both crashes landed right after a fast burst of `session.tool` / `agent` (stream=item, stream=command_output) events, immediately followed by a `sessions.changed`-triggered refresh — i.e. multiple tool-activity rows (and their `Expander` controls, keyed by `ChatToolActivityPresentation.ActivityKey`) get regrouped and re-mounted several times within milliseconds. Today's `.NET Runtime` event-log entry shows the fault inside `Microsoft.UI.Reactor.Core.V1Protocol.Handlers.ExpanderHandler.Mount` / `Reconciler.Mount`, which matches `ToolCallCardRenderer.BuildActivityCore`'s `Expander(...)` usage.

Root cause: every `Publish(snapshot)` call independently does `_post(() => Changed?.Invoke(...))`. When several `Publish()` calls land faster than the WinUI3 dispatcher drains them, the Reactor visual tree gets mutated multiple times before one layout pass settles — WinUI3's layout engine detects the cycle and hard-crashes the process (unrecoverable `0xc0000005`/`0xc000027b` native fault).

## Fix

Only the *latest* snapshot matters for rendering — intermediate ones in a burst are immediately superseded. This PR adds a small lock-guarded "pending snapshot + scheduled flag" so a burst of N `Publish()` calls results in at most one `_post(...)` dispatch (draining to the newest snapshot at that point), instead of N queued dispatches. No behavior change for the common non-bursty case (single `Publish()` → single dispatch, same as before).

## Verification

- Root-caused via log/event-log correlation (see stack trace above) rather than a minimal repro harness, since it's timing-dependent on tool-call event bursts.
- Reviewed the change carefully against the existing codebase's other event-coalescing patterns (matches shape used elsewhere, e.g. debounced snapshot persistence just below).
- **I could not complete a local WinUI3 solution build in my sandbox environment** (GitVersion.MsBuild task did not complete in a reasonable time on this box) to run the existing test suite before opening this PR. Flagging that explicitly — please treat CI as the real gate here, and let me know if `dotnet test tests/OpenClaw.Tray.Tests` surfaces anything I should address.
- Change is narrowly scoped: 3 new private fields + one method rewritten, no public API/behavior contract changes.

## Context

Filed by an OpenClaw agent on behalf of the reporter after diagnosing a recurring tray crash during normal chat usage (not caused by gateway/model config, which was independently verified healthy at the time of both crashes).
