### PR TITLE
fix(audio): unify Piper extraction deadline

### DIFF
--- a/src/OpenClaw.Shared/Audio/BoundedProcessWait.cs
+++ b/src/OpenClaw.Shared/Audio/BoundedProcessWait.cs
@@ -1,0 +1,132 @@
+using System.Diagnostics;
+
+namespace OpenClaw.Shared.Audio;
+
+/// <summary>
+/// Wait for a short-lived child with a budget, drain redirected stderr
+/// asynchronously, and kill the process tree on timeout or cancel.
+/// Synchronous WaitForExit with stderr redirected and unread can hang
+/// when the child never exits or fills the pipe.
+/// </summary>
+internal static class BoundedProcessWait
+{
+    internal const int DefaultTimeoutMs = 120_000;
+    private const int MinDrainMs = 250;
+    private const int KillWaitMs = 1_000;
+
+    internal static (int ExitCode, string StandardError) Wait(
+        Process process,
+        int timeoutMs,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(process);
+        ArgumentOutOfRangeException.ThrowIfNegative(timeoutMs);
+
+        var stderrTask = TryStartStderrDrain(process);
+        using var reg = cancellationToken.Register(() => TryKillTree(process));
+        if (cancellationToken.IsCancellationRequested)
+        {
+            TryKillTree(process);
+            AbandonRead(process, stderrTask);
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+
+        var sw = Stopwatch.StartNew();
+        if (!process.WaitForExit(timeoutMs))
+        {
+            TryKillTree(process);
+            AbandonRead(process, stderrTask);
+            throw new TimeoutException($"Process did not exit within {timeoutMs}ms.");
+        }
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            AbandonRead(process, stderrTask);
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+
+        var elapsedMs = (int)Math.Min(sw.ElapsedMilliseconds, timeoutMs);
+        var drainBudgetMs = Math.Max(timeoutMs - elapsedMs, MinDrainMs);
+        var stderr = DrainStderr(stderrTask, process, drainBudgetMs);
+
+        try
+        {
+            return (process.HasExited ? process.ExitCode : -1, stderr);
+        }
+        catch (InvalidOperationException)
+        {
+            return (-1, stderr);
+        }
+    }
+
+    private static Task<string>? TryStartStderrDrain(Process process)
+    {
+        try
+        {
+            if (process.StartInfo.RedirectStandardError)
+                return process.StandardError.ReadToEndAsync();
+        }
+        catch (InvalidOperationException)
+        {
+        }
+
+        return null;
+    }
+
+    private static string DrainStderr(Task<string>? stderrTask, Process process, int drainBudgetMs)
+    {
+        if (stderrTask is null)
+            return string.Empty;
+
+        try
+        {
+            if (!stderrTask.Wait(drainBudgetMs))
+            {
+                TryKillTree(process);
+                AbandonRead(process, stderrTask);
+                return string.Empty;
+            }
+
+            return stderrTask.Status == TaskStatus.RanToCompletion
+                ? stderrTask.Result
+                : string.Empty;
+        }
+        catch (AggregateException)
+        {
+            return string.Empty;
+        }
+    }
+
+    private static void TryKillTree(Process process)
+    {
+        try { process.Kill(entireProcessTree: true); }
+        catch (Exception ex)
+        {
+            Trace.WriteLine($"BoundedProcessWait.TryKillTree: {ex.GetType().Name}: {ex.Message}");
+        }
+
+        try { process.WaitForExit(KillWaitMs); }
+        catch (Exception ex)
+        {
+            Trace.WriteLine($"BoundedProcessWait.WaitForExit: {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    private static void AbandonRead(Process process, Task? readTask)
+    {
+        if (readTask is not null)
+        {
+            _ = readTask.ContinueWith(
+                static t => { _ = t.Exception; },
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+        }
+
+        try { process.StandardError.Dispose(); }
+        catch (Exception ex)
+        {
+            Trace.WriteLine($"BoundedProcessWait.AbandonRead: {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+}

--- a/src/OpenClaw.Shared/Audio/BoundedProcessWait.cs
+++ b/src/OpenClaw.Shared/Audio/BoundedProcessWait.cs
@@ -1,132 +1,164 @@
+using System.ComponentModel;
 using System.Diagnostics;
 
 namespace OpenClaw.Shared.Audio;
 
+internal sealed record BoundedProcessResult(
+    int ExitCode,
+    string StandardOutput,
+    string StandardError);
+
 /// <summary>
-/// Wait for a short-lived child with a budget, drain redirected stderr
-/// asynchronously, and kill the process tree on timeout or cancel.
-/// Synchronous WaitForExit with stderr redirected and unread can hang
-/// when the child never exits or fills the pipe.
+/// Waits for a short-lived child and its redirected output using one deadline.
+/// Timeout and cancellation cleanup is best effort, bounded, and observes any
+/// read failures caused by closing inherited pipe handles.
 /// </summary>
 internal static class BoundedProcessWait
 {
-    internal const int DefaultTimeoutMs = 120_000;
-    private const int MinDrainMs = 250;
-    private const int KillWaitMs = 1_000;
+    internal static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(120);
+    internal static readonly TimeSpan CleanupTimeout = TimeSpan.FromSeconds(1);
 
-    internal static (int ExitCode, string StandardError) Wait(
+    internal static async Task<BoundedProcessResult> WaitAsync(
         Process process,
-        int timeoutMs,
+        TimeSpan timeout,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(process);
-        ArgumentOutOfRangeException.ThrowIfNegative(timeoutMs);
+        if (timeout <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(timeout), "Timeout must be positive.");
 
-        var stderrTask = TryStartStderrDrain(process);
-        using var reg = cancellationToken.Register(() => TryKillTree(process));
-        if (cancellationToken.IsCancellationRequested)
-        {
-            TryKillTree(process);
-            AbandonRead(process, stderrTask);
-            cancellationToken.ThrowIfCancellationRequested();
-        }
+        var stdoutTask = StartDrain(process, standardOutput: true);
+        var stderrTask = StartDrain(process, standardOutput: false);
+        var exitTask = process.WaitForExitAsync(CancellationToken.None);
+        var completionTask = Task.WhenAll(exitTask, stdoutTask, stderrTask);
 
-        var sw = Stopwatch.StartNew();
-        if (!process.WaitForExit(timeoutMs))
-        {
-            TryKillTree(process);
-            AbandonRead(process, stderrTask);
-            throw new TimeoutException($"Process did not exit within {timeoutMs}ms.");
-        }
-
-        if (cancellationToken.IsCancellationRequested)
-        {
-            AbandonRead(process, stderrTask);
-            cancellationToken.ThrowIfCancellationRequested();
-        }
-
-        var elapsedMs = (int)Math.Min(sw.ElapsedMilliseconds, timeoutMs);
-        var drainBudgetMs = Math.Max(timeoutMs - elapsedMs, MinDrainMs);
-        var stderr = DrainStderr(stderrTask, process, drainBudgetMs);
+        using var timeoutSource = new CancellationTokenSource(timeout);
+        using var deadlineSource = CancellationTokenSource.CreateLinkedTokenSource(
+            cancellationToken,
+            timeoutSource.Token);
 
         try
         {
-            return (process.HasExited ? process.ExitCode : -1, stderr);
+            await completionTask.WaitAsync(deadlineSource.Token).ConfigureAwait(false);
         }
-        catch (InvalidOperationException)
+        catch (OperationCanceledException) when (
+            cancellationToken.IsCancellationRequested || timeoutSource.IsCancellationRequested)
         {
-            return (-1, stderr);
+            await CleanupAsync(process, exitTask, stdoutTask, stderrTask).ConfigureAwait(false);
+
+            if (cancellationToken.IsCancellationRequested)
+                throw new OperationCanceledException(cancellationToken);
+
+            throw new TimeoutException($"Process did not exit and drain output within {timeout.TotalMilliseconds:F0}ms.");
         }
+
+        return new BoundedProcessResult(
+            process.ExitCode,
+            await stdoutTask.ConfigureAwait(false),
+            await stderrTask.ConfigureAwait(false));
     }
 
-    private static Task<string>? TryStartStderrDrain(Process process)
+    private static Task<string> StartDrain(Process process, bool standardOutput)
     {
-        try
+        if (standardOutput)
         {
-            if (process.StartInfo.RedirectStandardError)
-                return process.StandardError.ReadToEndAsync();
-        }
-        catch (InvalidOperationException)
-        {
+            return process.StartInfo.RedirectStandardOutput
+                ? process.StandardOutput.ReadToEndAsync()
+                : Task.FromResult(string.Empty);
         }
 
-        return null;
+        return process.StartInfo.RedirectStandardError
+            ? process.StandardError.ReadToEndAsync()
+            : Task.FromResult(string.Empty);
     }
 
-    private static string DrainStderr(Task<string>? stderrTask, Process process, int drainBudgetMs)
+    private static async Task CleanupAsync(
+        Process process,
+        Task exitTask,
+        Task stdoutTask,
+        Task stderrTask)
     {
-        if (stderrTask is null)
-            return string.Empty;
+        var killTask = Task.Run(() => TryKillTree(process));
+        ObserveFault(killTask);
+        ObserveFault(exitTask);
+        ObserveFault(stdoutTask);
+        ObserveFault(stderrTask);
 
-        try
-        {
-            if (!stderrTask.Wait(drainBudgetMs))
-            {
-                TryKillTree(process);
-                AbandonRead(process, stderrTask);
-                return string.Empty;
-            }
+        DisposeRedirectedReaders(process);
 
-            return stderrTask.Status == TaskStatus.RanToCompletion
-                ? stderrTask.Result
-                : string.Empty;
-        }
-        catch (AggregateException)
-        {
-            return string.Empty;
-        }
+        var cleanupTask = Task.WhenAll(killTask, exitTask, stdoutTask, stderrTask);
+        ObserveFault(cleanupTask);
+        await Task.WhenAny(cleanupTask, Task.Delay(CleanupTimeout)).ConfigureAwait(false);
     }
 
     private static void TryKillTree(Process process)
     {
-        try { process.Kill(entireProcessTree: true); }
-        catch (Exception ex)
+        try
         {
-            Trace.WriteLine($"BoundedProcessWait.TryKillTree: {ex.GetType().Name}: {ex.Message}");
+            // Process can only enumerate and terminate descendants while the
+            // root is alive. Closing our readers still bounds inherited pipes.
+            if (!process.HasExited)
+                process.Kill(entireProcessTree: true);
         }
-
-        try { process.WaitForExit(KillWaitMs); }
-        catch (Exception ex)
+        catch (InvalidOperationException ex)
         {
-            Trace.WriteLine($"BoundedProcessWait.WaitForExit: {ex.GetType().Name}: {ex.Message}");
+            TraceCleanupFailure("kill", ex);
+        }
+        catch (Win32Exception ex)
+        {
+            TraceCleanupFailure("kill", ex);
+        }
+        catch (NotSupportedException ex)
+        {
+            TraceCleanupFailure("kill", ex);
         }
     }
 
-    private static void AbandonRead(Process process, Task? readTask)
+    private static void DisposeRedirectedReaders(Process process)
     {
-        if (readTask is not null)
+        if (process.StartInfo.RedirectStandardOutput)
         {
-            _ = readTask.ContinueWith(
-                static t => { _ = t.Exception; },
-                CancellationToken.None,
-                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
-                TaskScheduler.Default);
+            try
+            {
+                process.StandardOutput.Dispose();
+            }
+            catch (InvalidOperationException ex)
+            {
+                TraceCleanupFailure("stdout close", ex);
+            }
+            catch (IOException ex)
+            {
+                TraceCleanupFailure("stdout close", ex);
+            }
         }
 
-        try { process.StandardError.Dispose(); }
-        catch (Exception ex)
+        if (process.StartInfo.RedirectStandardError)
         {
-            Trace.WriteLine($"BoundedProcessWait.AbandonRead: {ex.GetType().Name}: {ex.Message}");
+            try
+            {
+                process.StandardError.Dispose();
+            }
+            catch (InvalidOperationException ex)
+            {
+                TraceCleanupFailure("stderr close", ex);
+            }
+            catch (IOException ex)
+            {
+                TraceCleanupFailure("stderr close", ex);
+            }
         }
     }
+
+    internal static void ObserveFault(Task task)
+    {
+        _ = task.ContinueWith(
+            static completed => { _ = completed.Exception; },
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
+
+    private static void TraceCleanupFailure(string operation, Exception exception) =>
+        Trace.WriteLine(
+            $"BoundedProcessWait: {operation} failed: {exception.GetType().Name}: {exception.Message}");
 }

--- a/src/OpenClaw.Shared/Audio/BoundedProcessWait.cs
+++ b/src/OpenClaw.Shared/Audio/BoundedProcessWait.cs
@@ -9,7 +9,7 @@ internal sealed record BoundedProcessResult(
     string StandardError);
 
 /// <summary>
-/// Waits for a short-lived child and its redirected output using one deadline.
+/// Waits for a short-lived child process and its redirected output using one deadline.
 /// Timeout and cancellation cleanup is best effort, bounded, and observes any
 /// read failures caused by closing inherited pipe handles.
 /// </summary>
@@ -50,6 +50,11 @@ internal static class BoundedProcessWait
                 throw new OperationCanceledException(cancellationToken);
 
             throw new TimeoutException($"Process did not exit and drain output within {timeout.TotalMilliseconds:F0}ms.");
+        }
+        catch
+        {
+            await CleanupAsync(process, exitTask, stdoutTask, stderrTask).ConfigureAwait(false);
+            throw;
         }
 
         return new BoundedProcessResult(

--- a/src/OpenClaw.Shared/Audio/PiperVoiceManager.cs
+++ b/src/OpenClaw.Shared/Audio/PiperVoiceManager.cs
@@ -355,18 +355,25 @@ public sealed class PiperVoiceManager
             CreateNoWindow = true,
             RedirectStandardError = true,
         };
+        cancellationToken.ThrowIfCancellationRequested();
         using var proc = System.Diagnostics.Process.Start(psi)
             ?? throw new InvalidOperationException("Could not start tar to extract Piper voice");
 
-        // Cancellation: kill the tar process if requested. Static context — no logger;
-        // best-effort kill, the cancellation surfaces via the awaited WaitForExit.
-        using var reg = cancellationToken.Register(() => { try { proc.Kill(entireProcessTree: true); } catch (Exception ex) { System.Diagnostics.Trace.WriteLine($"PiperVoiceManager: tar cancellation kill failed: {ex.GetType().Name}: {ex.Message}"); } });
-
-        proc.WaitForExit();
-        if (proc.ExitCode != 0)
+        (int ExitCode, string StandardError) result;
+        try
         {
-            var err = proc.StandardError.ReadToEnd();
-            throw new InvalidOperationException($"tar extraction failed (exit {proc.ExitCode}): {err}");
+            result = BoundedProcessWait.Wait(proc, BoundedProcessWait.DefaultTimeoutMs, cancellationToken);
+        }
+        catch (TimeoutException ex)
+        {
+            throw new InvalidOperationException(
+                "tar extraction timed out while unpacking the Piper voice.", ex);
+        }
+
+        if (result.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"tar extraction failed (exit {result.ExitCode}): {result.StandardError}");
         }
     }
 

--- a/src/OpenClaw.Shared/Audio/PiperVoiceManager.cs
+++ b/src/OpenClaw.Shared/Audio/PiperVoiceManager.cs
@@ -208,7 +208,7 @@ public sealed class PiperVoiceManager
             await VerifyHashAsync(tarballPath, info.Sha256, info.VoiceId, cancellationToken);
 
             _logger.Info($"Extracting Piper voice '{info.VoiceId}'");
-            ExtractTarBz2(tarballPath, voiceDir, cancellationToken);
+            await ExtractTarBz2Async(tarballPath, voiceDir, cancellationToken).ConfigureAwait(false);
 
             // Verify the extraction produced the files we expect; if not,
             // tear the half-extracted dir down so a retry starts clean.
@@ -283,7 +283,7 @@ public sealed class PiperVoiceManager
     }
 
     /// <summary>
-    /// Probe the bundled OS tar.exe used by <see cref="ExtractTarBz2"/>.
+    /// Probe the bundled OS tar.exe used by <see cref="ExtractTarBz2Async"/>.
     /// Throws a clear error before any network I/O happens so users on
     /// downlevel Windows aren't left with a half-downloaded tarball.
     /// </summary>
@@ -335,7 +335,12 @@ public sealed class PiperVoiceManager
     /// transitive dependency via PiperSharp's ecosystem, but explicit here)
     /// so we don't need to shell out to tar.exe.
     /// </summary>
-    private static void ExtractTarBz2(string archivePath, string destinationDir, CancellationToken cancellationToken)
+    internal static async Task ExtractTarBz2Async(
+        string archivePath,
+        string destinationDir,
+        CancellationToken cancellationToken,
+        string extractorFileName = "tar",
+        TimeSpan? timeout = null)
     {
         // SharpCompress isn't a direct dep of OpenClaw.Shared today; we
         // intentionally use the BCL .tar reader on top of a bzip2 stream
@@ -349,20 +354,24 @@ public sealed class PiperVoiceManager
         // which transparently handles bz2.
         var psi = new System.Diagnostics.ProcessStartInfo
         {
-            FileName = "tar",
+            FileName = extractorFileName,
             ArgumentList = { "-xjf", archivePath, "-C", destinationDir, "--strip-components=1" },
             UseShellExecute = false,
             CreateNoWindow = true,
+            RedirectStandardOutput = true,
             RedirectStandardError = true,
         };
         cancellationToken.ThrowIfCancellationRequested();
         using var proc = System.Diagnostics.Process.Start(psi)
             ?? throw new InvalidOperationException("Could not start tar to extract Piper voice");
 
-        (int ExitCode, string StandardError) result;
+        BoundedProcessResult result;
         try
         {
-            result = BoundedProcessWait.Wait(proc, BoundedProcessWait.DefaultTimeoutMs, cancellationToken);
+            result = await BoundedProcessWait.WaitAsync(
+                proc,
+                timeout ?? BoundedProcessWait.DefaultTimeout,
+                cancellationToken).ConfigureAwait(false);
         }
         catch (TimeoutException ex)
         {
@@ -372,8 +381,11 @@ public sealed class PiperVoiceManager
 
         if (result.ExitCode != 0)
         {
+            var output = string.IsNullOrWhiteSpace(result.StandardError)
+                ? result.StandardOutput
+                : result.StandardError;
             throw new InvalidOperationException(
-                $"tar extraction failed (exit {result.ExitCode}): {result.StandardError}");
+                $"tar extraction failed (exit {result.ExitCode}): {output}");
         }
     }
 

--- a/src/OpenClaw.Shared/Audio/PiperVoiceManager.cs
+++ b/src/OpenClaw.Shared/Audio/PiperVoiceManager.cs
@@ -34,6 +34,7 @@ namespace OpenClaw.Shared.Audio;
 /// </summary>
 public sealed class PiperVoiceManager
 {
+    private const string InstallMarkerSuffix = ".installing";
     private readonly string _voicesDirectory;
     private readonly IOpenClawLogger _logger;
     // Per-voice single-flight gate: prevents racing the same voice download
@@ -113,9 +114,8 @@ public sealed class PiperVoiceManager
     {
         try
         {
-            return File.Exists(GetModelPath(voiceId))
-                && File.Exists(GetTokensPath(voiceId))
-                && Directory.Exists(GetEspeakDataDir(voiceId));
+            return !File.Exists(GetInstallMarkerPath(voiceId))
+                && HasExpectedVoiceLayout(voiceId);
         }
         catch (Exception ex)
         {
@@ -173,12 +173,16 @@ public sealed class PiperVoiceManager
         }
 
         var voiceDir = Path.Combine(_voicesDirectory, info.VoiceId);
-        Directory.CreateDirectory(voiceDir);
+        var installMarkerPath = GetInstallMarkerPath(info.VoiceId);
         var tarballPath = Path.Combine(voiceDir, $"{info.VoiceId}.tar.bz2.tmp");
+        var hadExpectedLayout = HasExpectedVoiceLayout(info.VoiceId);
+        var extractionVerified = false;
         _logger.Info($"Downloading Piper voice '{info.VoiceId}' from {info.DownloadUrl}");
 
         try
         {
+            Directory.CreateDirectory(voiceDir);
+            File.WriteAllText(installMarkerPath, string.Empty);
             using var httpClient = new HttpClient();
             httpClient.Timeout = TimeSpan.FromMinutes(10);
             using var response = await httpClient.GetAsync(info.DownloadUrl, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
@@ -212,12 +216,14 @@ public sealed class PiperVoiceManager
 
             // Verify the extraction produced the files we expect; if not,
             // tear the half-extracted dir down so a retry starts clean.
-            if (!IsVoiceDownloaded(info.VoiceId))
+            if (!HasExpectedVoiceLayout(info.VoiceId))
             {
                 throw new InvalidOperationException(
                     $"Extraction of Piper voice '{info.VoiceId}' did not produce the expected layout.");
             }
 
+            extractionVerified = true;
+            File.Delete(installMarkerPath);
             _logger.Info($"Piper voice '{info.VoiceId}' verified and ready at {voiceDir}");
         }
         catch
@@ -226,7 +232,13 @@ public sealed class PiperVoiceManager
             // leftover partial files.
             try { if (File.Exists(tarballPath)) File.Delete(tarballPath); }
             catch (Exception cleanupEx) { _logger.Debug($"PiperVoiceManager: post-failure tarball cleanup failed: {cleanupEx.Message}"); }
-            try { if (Directory.Exists(voiceDir) && !IsVoiceDownloaded(info.VoiceId)) Directory.Delete(voiceDir, recursive: true); }
+            try
+            {
+                if (!extractionVerified && !hadExpectedLayout && Directory.Exists(voiceDir))
+                    Directory.Delete(voiceDir, recursive: true);
+                if (!Directory.Exists(voiceDir) && File.Exists(installMarkerPath))
+                    File.Delete(installMarkerPath);
+            }
             catch (Exception cleanupEx) { _logger.Debug($"PiperVoiceManager: post-failure voiceDir cleanup failed: {cleanupEx.Message}"); }
             throw;
         }
@@ -236,6 +248,14 @@ public sealed class PiperVoiceManager
             catch (Exception cleanupEx) { _logger.Debug($"PiperVoiceManager: finally tarball cleanup failed: {cleanupEx.Message}"); }
         }
     }
+
+    private string GetInstallMarkerPath(string voiceId) =>
+        $"{GetVoiceDirectory(voiceId)}{InstallMarkerSuffix}";
+
+    private bool HasExpectedVoiceLayout(string voiceId) =>
+        File.Exists(GetModelPath(voiceId))
+        && File.Exists(GetTokensPath(voiceId))
+        && Directory.Exists(GetEspeakDataDir(voiceId));
 
     /// <summary>
     /// Compute SHA-256 of <paramref name="filePath"/> and compare to
@@ -261,8 +281,19 @@ public sealed class PiperVoiceManager
     {
         var info = FindVoice(voiceId);
         var dir = Path.Combine(_voicesDirectory, info.VoiceId);
-        if (!Directory.Exists(dir)) return false;
-        Directory.Delete(dir, recursive: true);
+        var markerPath = GetInstallMarkerPath(info.VoiceId);
+        var deleted = false;
+        if (Directory.Exists(dir))
+        {
+            Directory.Delete(dir, recursive: true);
+            deleted = true;
+        }
+        if (File.Exists(markerPath))
+        {
+            File.Delete(markerPath);
+            deleted = true;
+        }
+        if (!deleted) return false;
         _logger.Info($"Deleted Piper voice '{info.VoiceId}'");
         return true;
     }

--- a/tests/OpenClaw.Shared.TestHost/Program.cs
+++ b/tests/OpenClaw.Shared.TestHost/Program.cs
@@ -1,9 +1,31 @@
 using OpenClaw.Shared;
+using System.Diagnostics;
+using System.Reflection;
 using System.Text.Json;
 
 if (args is ["--echo-args", .. var echoedArgs])
 {
     Console.WriteLine(JsonSerializer.Serialize(echoedArgs));
+    return 0;
+}
+
+if (args is ["--process-fixture", .. var fixtureArgs])
+{
+    return await RunProcessFixtureAsync(fixtureArgs);
+}
+
+if (args is ["-xjf", var fixtureArchive, "-C", var fixtureDestination, "--strip-components=1"]
+    && fixtureArchive == "fixture-hold")
+{
+    Directory.CreateDirectory(fixtureDestination);
+    File.WriteAllText(
+        Path.Combine(fixtureDestination, "fixture.pid"),
+        Environment.ProcessId.ToString());
+    Console.Out.Write("fixture-stdout");
+    Console.Error.Write("fixture-stderr");
+    Console.Out.Flush();
+    Console.Error.Flush();
+    await Task.Delay(TimeSpan.FromSeconds(30));
     return 0;
 }
 
@@ -25,4 +47,74 @@ catch (DeviceIdentityLoadException ex)
 {
     Console.Error.WriteLine(ex.Message);
     return 2;
+}
+
+static async Task<int> RunProcessFixtureAsync(string[] args)
+{
+    if (args is ["success"])
+    {
+        Console.Out.Write("stdout-first");
+        Console.Error.Write("stderr-first");
+        await Task.Delay(25);
+        Console.Out.Write("-stdout-last");
+        Console.Error.Write("-stderr-last");
+        return 0;
+    }
+
+    if (args is ["late-output", var delayText] && int.TryParse(delayText, out var delayMs))
+    {
+        await Task.Delay(delayMs);
+        Console.Out.Write("late-stdout");
+        Console.Error.Write("late-stderr");
+        return 0;
+    }
+
+    if (args is ["hold", var holdText] && int.TryParse(holdText, out var holdMs))
+    {
+        Console.Out.Write("holding-stdout");
+        Console.Error.Write("holding-stderr");
+        Console.Out.Flush();
+        Console.Error.Flush();
+        await Task.Delay(holdMs);
+        return 0;
+    }
+
+    if (args is ["inherit-handles", var childHoldText, var pidFile]
+        && int.TryParse(childHoldText, out var childHoldMs))
+    {
+        using var child = StartSelf("--process-fixture", "hold", childHoldMs.ToString());
+        File.WriteAllText(pidFile, child.Id.ToString());
+        Console.Out.Write("parent-stdout");
+        Console.Error.Write("parent-stderr");
+        return 0;
+    }
+
+    Console.Error.WriteLine("Unknown process fixture.");
+    return 64;
+}
+
+static Process StartSelf(params string[] arguments)
+{
+    var processPath = Environment.ProcessPath
+        ?? throw new InvalidOperationException("Current process path is unavailable.");
+    var startInfo = new ProcessStartInfo
+    {
+        FileName = processPath,
+        UseShellExecute = false,
+        CreateNoWindow = true,
+    };
+
+    if (string.Equals(
+        Path.GetFileNameWithoutExtension(processPath),
+        "dotnet",
+        StringComparison.OrdinalIgnoreCase))
+    {
+        startInfo.ArgumentList.Add(Assembly.GetExecutingAssembly().Location);
+    }
+
+    foreach (var argument in arguments)
+        startInfo.ArgumentList.Add(argument);
+
+    return Process.Start(startInfo)
+        ?? throw new InvalidOperationException("Could not start process fixture child.");
 }

--- a/tests/OpenClaw.Shared.Tests/BoundedProcessWaitTests.cs
+++ b/tests/OpenClaw.Shared.Tests/BoundedProcessWaitTests.cs
@@ -1,0 +1,108 @@
+using System.Diagnostics;
+using OpenClaw.Shared.Audio;
+
+namespace OpenClaw.Shared.Tests;
+
+public sealed class BoundedProcessWaitTests
+{
+    [Fact]
+    public async Task Wait_TimesOutAndKillsWhenProcessDoesNotExit()
+    {
+        var (fileName, arguments) = LongRunningCommand();
+        using var process = Process.Start(new ProcessStartInfo
+        {
+            FileName = fileName,
+            Arguments = arguments,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        });
+        Assert.NotNull(process);
+
+        var helper = Task.Run(() =>
+            BoundedProcessWait.Wait(process, timeoutMs: 400));
+
+        var completed = await Task.WhenAny(helper, Task.Delay(TimeSpan.FromSeconds(3)));
+        Assert.Same(helper, completed);
+        await Assert.ThrowsAsync<TimeoutException>(() => helper);
+        Assert.True(process.HasExited);
+    }
+
+    [Fact]
+    public async Task Wait_ThrowsWhenCanceledAndKillsProcess()
+    {
+        var (fileName, arguments) = LongRunningCommand();
+        using var process = Process.Start(new ProcessStartInfo
+        {
+            FileName = fileName,
+            Arguments = arguments,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        });
+        Assert.NotNull(process);
+
+        using var cts = new CancellationTokenSource();
+        var helper = Task.Run(
+            () => BoundedProcessWait.Wait(process, timeoutMs: 30_000, cts.Token),
+            CancellationToken.None);
+        cts.Cancel();
+
+        var completed = await Task.WhenAny(helper, Task.Delay(TimeSpan.FromSeconds(3)));
+        Assert.Same(helper, completed);
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => helper);
+        Assert.True(process.HasExited);
+    }
+
+    [Fact]
+    public void Wait_ReturnsExitCodeAndStderrFromFailingProcess()
+    {
+        var (fileName, arguments) = FailWithStderrCommand("extract-failed");
+        using var process = Process.Start(new ProcessStartInfo
+        {
+            FileName = fileName,
+            Arguments = arguments,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        });
+        Assert.NotNull(process);
+
+        var result = BoundedProcessWait.Wait(process, timeoutMs: 5_000);
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Contains("extract-failed", result.StandardError);
+    }
+
+    [Fact]
+    public void Wait_ReturnsZeroFromExitingProcess()
+    {
+        using var process = StartExitingProcess();
+        Assert.NotNull(process);
+
+        var result = BoundedProcessWait.Wait(process, timeoutMs: 5_000);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(string.Empty, result.StandardError);
+    }
+
+    private static Process StartExitingProcess() =>
+        Process.Start(new ProcessStartInfo
+        {
+            FileName = OperatingSystem.IsWindows() ? "cmd.exe" : "/bin/sh",
+            Arguments = OperatingSystem.IsWindows() ? "/d /c exit 0" : "-c \"exit 0\"",
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        })!;
+
+    private static (string FileName, string Arguments) LongRunningCommand() =>
+        OperatingSystem.IsWindows()
+            ? ("cmd.exe", "/d /c ping 127.0.0.1 -n 20")
+            : ("/bin/sh", "-c \"sleep 20\"");
+
+    private static (string FileName, string Arguments) FailWithStderrCommand(string text) =>
+        OperatingSystem.IsWindows()
+            ? ("cmd.exe", $"/d /c echo {text} 1>&2 & exit 7")
+            : ("/bin/sh", $"-c \"printf '%s\\n' '{text}' >&2; exit 7\"");
+}

--- a/tests/OpenClaw.Shared.Tests/BoundedProcessWaitTests.cs
+++ b/tests/OpenClaw.Shared.Tests/BoundedProcessWaitTests.cs
@@ -1,4 +1,6 @@
+using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Reflection;
 using OpenClaw.Shared.Audio;
 
 namespace OpenClaw.Shared.Tests;
@@ -6,103 +8,237 @@ namespace OpenClaw.Shared.Tests;
 public sealed class BoundedProcessWaitTests
 {
     [Fact]
-    public async Task Wait_TimesOutAndKillsWhenProcessDoesNotExit()
+    public async Task WaitAsync_ReturnsCompleteOutput_WhenProcessSucceeds()
     {
-        var (fileName, arguments) = LongRunningCommand();
-        using var process = Process.Start(new ProcessStartInfo
-        {
-            FileName = fileName,
-            Arguments = arguments,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            CreateNoWindow = true,
-        });
-        Assert.NotNull(process);
+        using var process = StartFixture("success");
 
-        var helper = Task.Run(() =>
-            BoundedProcessWait.Wait(process, timeoutMs: 400));
-
-        var completed = await Task.WhenAny(helper, Task.Delay(TimeSpan.FromSeconds(3)));
-        Assert.Same(helper, completed);
-        await Assert.ThrowsAsync<TimeoutException>(() => helper);
-        Assert.True(process.HasExited);
-    }
-
-    [Fact]
-    public async Task Wait_ThrowsWhenCanceledAndKillsProcess()
-    {
-        var (fileName, arguments) = LongRunningCommand();
-        using var process = Process.Start(new ProcessStartInfo
-        {
-            FileName = fileName,
-            Arguments = arguments,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            CreateNoWindow = true,
-        });
-        Assert.NotNull(process);
-
-        using var cts = new CancellationTokenSource();
-        var helper = Task.Run(
-            () => BoundedProcessWait.Wait(process, timeoutMs: 30_000, cts.Token),
-            CancellationToken.None);
-        cts.Cancel();
-
-        var completed = await Task.WhenAny(helper, Task.Delay(TimeSpan.FromSeconds(3)));
-        Assert.Same(helper, completed);
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => helper);
-        Assert.True(process.HasExited);
-    }
-
-    [Fact]
-    public void Wait_ReturnsExitCodeAndStderrFromFailingProcess()
-    {
-        var (fileName, arguments) = FailWithStderrCommand("extract-failed");
-        using var process = Process.Start(new ProcessStartInfo
-        {
-            FileName = fileName,
-            Arguments = arguments,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            CreateNoWindow = true,
-        });
-        Assert.NotNull(process);
-
-        var result = BoundedProcessWait.Wait(process, timeoutMs: 5_000);
-
-        Assert.NotEqual(0, result.ExitCode);
-        Assert.Contains("extract-failed", result.StandardError);
-    }
-
-    [Fact]
-    public void Wait_ReturnsZeroFromExitingProcess()
-    {
-        using var process = StartExitingProcess();
-        Assert.NotNull(process);
-
-        var result = BoundedProcessWait.Wait(process, timeoutMs: 5_000);
+        var result = await BoundedProcessWait.WaitAsync(process, TimeSpan.FromSeconds(5));
 
         Assert.Equal(0, result.ExitCode);
-        Assert.Equal(string.Empty, result.StandardError);
+        Assert.Equal("stdout-first-stdout-last", result.StandardOutput);
+        Assert.Equal("stderr-first-stderr-last", result.StandardError);
     }
 
-    private static Process StartExitingProcess() =>
-        Process.Start(new ProcessStartInfo
+    [Fact]
+    public async Task WaitAsync_TimesOutAndKillsProcess()
+    {
+        using var process = StartFixture("hold", "30000");
+        var stopwatch = Stopwatch.StartNew();
+
+        await Assert.ThrowsAsync<TimeoutException>(
+            () => BoundedProcessWait.WaitAsync(process, TimeSpan.FromMilliseconds(200)));
+
+        stopwatch.Stop();
+        Assert.True(process.HasExited);
+        Assert.True(
+            stopwatch.Elapsed < TimeSpan.FromSeconds(3),
+            $"Timeout cleanup took {stopwatch.ElapsedMilliseconds} ms.");
+    }
+
+    [Fact]
+    public async Task WaitAsync_CancellationKillsProcessWithoutUsingTimeoutBudget()
+    {
+        using var process = StartFixture("hold", "30000");
+        using var cancellation = new CancellationTokenSource();
+        var wait = BoundedProcessWait.WaitAsync(
+            process,
+            BoundedProcessWait.DefaultTimeout,
+            cancellation.Token);
+        await Task.Delay(100);
+        var stopwatch = Stopwatch.StartNew();
+
+        cancellation.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => wait);
+
+        stopwatch.Stop();
+        Assert.True(process.HasExited);
+        Assert.True(
+            stopwatch.Elapsed < TimeSpan.FromSeconds(3),
+            $"Cancellation cleanup took {stopwatch.ElapsedMilliseconds} ms.");
+    }
+
+    [Fact]
+    public async Task WaitAsync_AlreadyCanceledTokenStillKillsStartedProcess()
+    {
+        using var process = StartFixture("hold", "30000");
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => BoundedProcessWait.WaitAsync(
+                process,
+                BoundedProcessWait.DefaultTimeout,
+                cancellation.Token));
+
+        Assert.True(process.HasExited);
+    }
+
+    [Fact]
+    public async Task WaitAsync_PreservesOutputWrittenLateWithinDeadline()
+    {
+        using var process = StartFixture("late-output", "250");
+
+        var result = await BoundedProcessWait.WaitAsync(process, TimeSpan.FromSeconds(3));
+
+        Assert.Equal("late-stdout", result.StandardOutput);
+        Assert.Equal("late-stderr", result.StandardError);
+    }
+
+    [Fact]
+    public async Task WaitAsync_CancellationDoesNotWaitForInheritedPipeHandles()
+    {
+        var pidFile = Path.GetTempFileName();
+        var childPid = 0;
+        try
         {
-            FileName = OperatingSystem.IsWindows() ? "cmd.exe" : "/bin/sh",
-            Arguments = OperatingSystem.IsWindows() ? "/d /c exit 0" : "-c \"exit 0\"",
+            using var process = StartFixture("inherit-handles", "30000", pidFile);
+            using var cancellation = new CancellationTokenSource();
+            var wait = BoundedProcessWait.WaitAsync(
+                process,
+                BoundedProcessWait.DefaultTimeout,
+                cancellation.Token);
+            await process.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.False(wait.IsCompleted);
+            childPid = await ReadChildPidAsync(pidFile);
+            var stopwatch = Stopwatch.StartNew();
+
+            cancellation.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => wait);
+
+            stopwatch.Stop();
+            Assert.True(
+                stopwatch.Elapsed < TimeSpan.FromSeconds(3),
+                $"Inherited-handle cancellation took {stopwatch.ElapsedMilliseconds} ms.");
+        }
+        finally
+        {
+            KillProcessTree(childPid);
+            File.Delete(pidFile);
+        }
+    }
+
+    [Fact]
+    public void ObserveFault_ConsumesAbandonedTaskException()
+    {
+        var marker = Guid.NewGuid().ToString();
+        var unobserved = new ConcurrentQueue<Exception>();
+        EventHandler<UnobservedTaskExceptionEventArgs> handler = (_, args) =>
+        {
+            foreach (var exception in args.Exception.Flatten().InnerExceptions)
+            {
+                if (exception.Message == marker)
+                    unobserved.Enqueue(exception);
+            }
+
+            args.SetObserved();
+        };
+        TaskScheduler.UnobservedTaskException += handler;
+
+        try
+        {
+            var taskReference = CreateObservedFault(marker);
+            for (var attempt = 0; attempt < 10 && taskReference.IsAlive; attempt++)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+                Thread.Sleep(10);
+            }
+
+            Assert.False(taskReference.IsAlive);
+            Assert.Empty(unobserved);
+        }
+        finally
+        {
+            TaskScheduler.UnobservedTaskException -= handler;
+        }
+    }
+
+    private static WeakReference CreateObservedFault(string marker)
+    {
+        var task = Task.FromException(new InvalidOperationException(marker));
+        BoundedProcessWait.ObserveFault(task);
+        return new WeakReference(task);
+    }
+
+    private static Process StartFixture(params string[] arguments)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = FindTestHost(),
+            RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,
             CreateNoWindow = true,
-        })!;
+        };
+        startInfo.ArgumentList.Add("--process-fixture");
+        foreach (var argument in arguments)
+            startInfo.ArgumentList.Add(argument);
 
-    private static (string FileName, string Arguments) LongRunningCommand() =>
-        OperatingSystem.IsWindows()
-            ? ("cmd.exe", "/d /c ping 127.0.0.1 -n 20")
-            : ("/bin/sh", "-c \"sleep 20\"");
+        return Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Could not start process fixture.");
+    }
 
-    private static (string FileName, string Arguments) FailWithStderrCommand(string text) =>
-        OperatingSystem.IsWindows()
-            ? ("cmd.exe", $"/d /c echo {text} 1>&2 & exit 7")
-            : ("/bin/sh", $"-c \"printf '%s\\n' '{text}' >&2; exit 7\"");
+    private static string FindTestHost()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null
+            && !File.Exists(Path.Combine(current.FullName, "openclaw-windows-node.slnx")))
+        {
+            current = current.Parent;
+        }
+
+        Assert.NotNull(current);
+        var configuration = Assembly.GetExecutingAssembly()
+            .GetCustomAttribute<AssemblyConfigurationAttribute>()?
+            .Configuration;
+        Assert.False(string.IsNullOrWhiteSpace(configuration));
+        var executableName = OperatingSystem.IsWindows()
+            ? "OpenClaw.Shared.TestHost.exe"
+            : "OpenClaw.Shared.TestHost";
+        var hostPath = Path.Combine(
+            current.FullName,
+            "tests",
+            "OpenClaw.Shared.TestHost",
+            "bin",
+            configuration,
+            "net10.0",
+            executableName);
+        Assert.True(File.Exists(hostPath), $"Process test host was not built: {hostPath}");
+        return hostPath;
+    }
+
+    private static async Task<int> ReadChildPidAsync(string pidFile)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (DateTime.UtcNow < deadline)
+        {
+            var text = await File.ReadAllTextAsync(pidFile);
+            if (int.TryParse(text, out var processId))
+                return processId;
+
+            await Task.Delay(10);
+        }
+
+        throw new TimeoutException("Inherited-handle fixture did not publish its child PID.");
+    }
+
+    private static void KillProcessTree(int processId)
+    {
+        if (processId <= 0)
+            return;
+
+        try
+        {
+            using var process = Process.GetProcessById(processId);
+            process.Kill(entireProcessTree: true);
+            process.WaitForExit(2_000);
+        }
+        catch (ArgumentException)
+        {
+        }
+        catch (InvalidOperationException)
+        {
+        }
+    }
 }

--- a/tests/OpenClaw.Shared.Tests/BoundedProcessWaitTests.cs
+++ b/tests/OpenClaw.Shared.Tests/BoundedProcessWaitTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Reflection;
 using OpenClaw.Shared.Audio;
@@ -117,50 +117,6 @@ public sealed class BoundedProcessWaitTests
         }
     }
 
-    [Fact]
-    public void ObserveFault_ConsumesAbandonedTaskException()
-    {
-        var marker = Guid.NewGuid().ToString();
-        var unobserved = new ConcurrentQueue<Exception>();
-        EventHandler<UnobservedTaskExceptionEventArgs> handler = (_, args) =>
-        {
-            foreach (var exception in args.Exception.Flatten().InnerExceptions)
-            {
-                if (exception.Message == marker)
-                    unobserved.Enqueue(exception);
-            }
-
-            args.SetObserved();
-        };
-        TaskScheduler.UnobservedTaskException += handler;
-
-        try
-        {
-            var taskReference = CreateObservedFault(marker);
-            for (var attempt = 0; attempt < 10 && taskReference.IsAlive; attempt++)
-            {
-                GC.Collect();
-                GC.WaitForPendingFinalizers();
-                GC.Collect();
-                Thread.Sleep(10);
-            }
-
-            Assert.False(taskReference.IsAlive);
-            Assert.Empty(unobserved);
-        }
-        finally
-        {
-            TaskScheduler.UnobservedTaskException -= handler;
-        }
-    }
-
-    private static WeakReference CreateObservedFault(string marker)
-    {
-        var task = Task.FromException(new InvalidOperationException(marker));
-        BoundedProcessWait.ObserveFault(task);
-        return new WeakReference(task);
-    }
-
     private static Process StartFixture(params string[] arguments)
     {
         var startInfo = new ProcessStartInfo
@@ -238,6 +194,12 @@ public sealed class BoundedProcessWaitTests
         {
         }
         catch (InvalidOperationException)
+        {
+        }
+        catch (Win32Exception)
+        {
+        }
+        catch (AggregateException)
         {
         }
     }

--- a/tests/OpenClaw.Shared.Tests/PiperVoiceExtractionTests.cs
+++ b/tests/OpenClaw.Shared.Tests/PiperVoiceExtractionTests.cs
@@ -1,0 +1,178 @@
+using System.Diagnostics;
+using System.Reflection;
+using OpenClaw.Shared.Audio;
+
+namespace OpenClaw.Shared.Tests;
+
+public sealed class PiperVoiceExtractionTests
+{
+    [Fact]
+    public async Task ExtractTarBz2Async_ExtractsArchiveWithWindowsTar()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        using var directory = new TemporaryDirectory();
+        var packageDirectory = Directory.CreateDirectory(
+            Path.Combine(directory.Path, "source", "package"));
+        var destinationDirectory = Directory.CreateDirectory(
+            Path.Combine(directory.Path, "destination"));
+        var archivePath = Path.Combine(directory.Path, "voice.tar.bz2");
+        await File.WriteAllTextAsync(
+            Path.Combine(packageDirectory.FullName, "voice.onnx"),
+            "model-bytes");
+        await File.WriteAllTextAsync(
+            Path.Combine(packageDirectory.FullName, "voice.onnx.json"),
+            "{\"audio\":{\"sample_rate\":22050}}");
+        await CreateTarBz2Async(
+            archivePath,
+            packageDirectory.Parent!.FullName,
+            packageDirectory.Name);
+
+        await PiperVoiceManager.ExtractTarBz2Async(
+            archivePath,
+            destinationDirectory.FullName,
+            CancellationToken.None);
+
+        Assert.Equal(
+            "model-bytes",
+            await File.ReadAllTextAsync(Path.Combine(destinationDirectory.FullName, "voice.onnx")));
+        Assert.True(File.Exists(Path.Combine(destinationDirectory.FullName, "voice.onnx.json")));
+    }
+
+    [Fact]
+    public async Task ExtractTarBz2Async_TimeoutIsBoundedAndKillsExtractor()
+    {
+        using var directory = new TemporaryDirectory();
+        var stopwatch = Stopwatch.StartNew();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => PiperVoiceManager.ExtractTarBz2Async(
+                "fixture-hold",
+                directory.Path,
+                CancellationToken.None,
+                FindTestHost(),
+                TimeSpan.FromSeconds(2)));
+
+        stopwatch.Stop();
+        Assert.IsType<TimeoutException>(exception.InnerException);
+        Assert.True(
+            stopwatch.Elapsed < TimeSpan.FromSeconds(5),
+            $"Piper timeout cleanup took {stopwatch.ElapsedMilliseconds} ms.");
+        await AssertFixtureExitedAsync(directory.Path);
+    }
+
+    [Fact]
+    public async Task ExtractTarBz2Async_CancellationIsBoundedAndKillsExtractor()
+    {
+        using var directory = new TemporaryDirectory();
+        using var cancellation = new CancellationTokenSource();
+        var extraction = PiperVoiceManager.ExtractTarBz2Async(
+            "fixture-hold",
+            directory.Path,
+            cancellation.Token,
+            FindTestHost(),
+            BoundedProcessWait.DefaultTimeout);
+        await ReadFixturePidAsync(directory.Path);
+        var stopwatch = Stopwatch.StartNew();
+
+        cancellation.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => extraction);
+
+        stopwatch.Stop();
+        Assert.True(
+            stopwatch.Elapsed < TimeSpan.FromSeconds(3),
+            $"Piper cancellation cleanup took {stopwatch.ElapsedMilliseconds} ms.");
+        await AssertFixtureExitedAsync(directory.Path);
+    }
+
+    private static async Task CreateTarBz2Async(
+        string archivePath,
+        string sourceDirectory,
+        string packageName)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "tar",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        startInfo.ArgumentList.Add("-cjf");
+        startInfo.ArgumentList.Add(archivePath);
+        startInfo.ArgumentList.Add("-C");
+        startInfo.ArgumentList.Add(sourceDirectory);
+        startInfo.ArgumentList.Add(packageName);
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Could not start tar archive fixture.");
+
+        var result = await BoundedProcessWait.WaitAsync(process, TimeSpan.FromSeconds(15));
+
+        Assert.True(
+            result.ExitCode == 0,
+            $"tar fixture creation failed (exit {result.ExitCode}): {result.StandardError}");
+    }
+
+    private static async Task AssertFixtureExitedAsync(string directory)
+    {
+        var processId = await ReadFixturePidAsync(directory);
+        Assert.Throws<ArgumentException>(() => Process.GetProcessById(processId));
+    }
+
+    private static async Task<int> ReadFixturePidAsync(string directory)
+    {
+        var pidPath = Path.Combine(directory, "fixture.pid");
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(3);
+        while (!File.Exists(pidPath) && DateTime.UtcNow < deadline)
+            await Task.Delay(10);
+
+        Assert.True(File.Exists(pidPath), "Piper extractor fixture did not publish its PID.");
+        return int.Parse(await File.ReadAllTextAsync(pidPath));
+    }
+
+    private static string FindTestHost()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null
+            && !File.Exists(Path.Combine(current.FullName, "openclaw-windows-node.slnx")))
+        {
+            current = current.Parent;
+        }
+
+        Assert.NotNull(current);
+        var configuration = Assembly.GetExecutingAssembly()
+            .GetCustomAttribute<AssemblyConfigurationAttribute>()?
+            .Configuration;
+        Assert.False(string.IsNullOrWhiteSpace(configuration));
+        var executableName = OperatingSystem.IsWindows()
+            ? "OpenClaw.Shared.TestHost.exe"
+            : "OpenClaw.Shared.TestHost";
+        var hostPath = Path.Combine(
+            current.FullName,
+            "tests",
+            "OpenClaw.Shared.TestHost",
+            "bin",
+            configuration,
+            "net10.0",
+            executableName);
+        Assert.True(File.Exists(hostPath), $"Process test host was not built: {hostPath}");
+        return hostPath;
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        internal TemporaryDirectory()
+        {
+            Path = Directory.CreateTempSubdirectory("openclaw-piper-extract-").FullName;
+        }
+
+        internal string Path { get; }
+
+        public void Dispose()
+        {
+            Directory.Delete(Path, recursive: true);
+        }
+    }
+}

--- a/tests/OpenClaw.Shared.Tests/PiperVoiceExtractionTests.cs
+++ b/tests/OpenClaw.Shared.Tests/PiperVoiceExtractionTests.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Reflection;
 using OpenClaw.Shared.Audio;
@@ -6,6 +7,30 @@ namespace OpenClaw.Shared.Tests;
 
 public sealed class PiperVoiceExtractionTests
 {
+    [Fact]
+    public void IsVoiceDownloaded_RejectsIncompleteInstall_AndDeleteVoiceRemovesMarker()
+    {
+        using var directory = new TemporaryDirectory();
+        var voice = PiperVoiceManager.AvailableVoices[0];
+        var manager = new PiperVoiceManager(directory.Path, NullLogger.Instance);
+        var voiceDirectory = Directory.CreateDirectory(manager.GetVoiceDirectory(voice.VoiceId));
+        File.WriteAllText(manager.GetModelPath(voice.VoiceId), "partial-model");
+        File.WriteAllText(manager.GetTokensPath(voice.VoiceId), "tokens");
+        Directory.CreateDirectory(manager.GetEspeakDataDir(voice.VoiceId));
+        var markerPath = $"{voiceDirectory.FullName}.installing";
+        File.WriteAllText(markerPath, string.Empty);
+
+        Assert.False(manager.IsVoiceDownloaded(voice.VoiceId));
+
+        File.Delete(markerPath);
+        Assert.True(manager.IsVoiceDownloaded(voice.VoiceId));
+
+        File.WriteAllText(markerPath, string.Empty);
+        Assert.True(manager.DeleteVoice(voice.VoiceId));
+        Assert.False(Directory.Exists(voiceDirectory.FullName));
+        Assert.False(File.Exists(markerPath));
+    }
+
     [Fact]
     public async Task ExtractTarBz2Async_ExtractsArchiveWithWindowsTar()
     {
@@ -44,22 +69,34 @@ public sealed class PiperVoiceExtractionTests
     public async Task ExtractTarBz2Async_TimeoutIsBoundedAndKillsExtractor()
     {
         using var directory = new TemporaryDirectory();
+        using var cancellation = new CancellationTokenSource();
         var stopwatch = Stopwatch.StartNew();
+        var processId = 0;
+        var extraction = PiperVoiceManager.ExtractTarBz2Async(
+            "fixture-hold",
+            directory.Path,
+            cancellation.Token,
+            FindTestHost(),
+            TimeSpan.FromSeconds(2));
 
-        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => PiperVoiceManager.ExtractTarBz2Async(
-                "fixture-hold",
-                directory.Path,
-                CancellationToken.None,
-                FindTestHost(),
-                TimeSpan.FromSeconds(2)));
+        try
+        {
+            processId = await ReadFixturePidAsync(directory.Path);
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => extraction);
 
-        stopwatch.Stop();
-        Assert.IsType<TimeoutException>(exception.InnerException);
-        Assert.True(
-            stopwatch.Elapsed < TimeSpan.FromSeconds(5),
-            $"Piper timeout cleanup took {stopwatch.ElapsedMilliseconds} ms.");
-        await AssertFixtureExitedAsync(directory.Path);
+            stopwatch.Stop();
+            Assert.IsType<TimeoutException>(exception.InnerException);
+            Assert.True(
+                stopwatch.Elapsed < TimeSpan.FromSeconds(5),
+                $"Piper timeout cleanup took {stopwatch.ElapsedMilliseconds} ms.");
+            await AssertFixtureExitedAsync(processId);
+        }
+        finally
+        {
+            await AwaitFixtureCleanupAsync(extraction, cancellation);
+            KillProcessTree(processId);
+        }
     }
 
     [Fact]
@@ -67,24 +104,33 @@ public sealed class PiperVoiceExtractionTests
     {
         using var directory = new TemporaryDirectory();
         using var cancellation = new CancellationTokenSource();
+        var processId = 0;
         var extraction = PiperVoiceManager.ExtractTarBz2Async(
             "fixture-hold",
             directory.Path,
             cancellation.Token,
             FindTestHost(),
             BoundedProcessWait.DefaultTimeout);
-        await ReadFixturePidAsync(directory.Path);
-        var stopwatch = Stopwatch.StartNew();
+        try
+        {
+            processId = await ReadFixturePidAsync(directory.Path);
+            var stopwatch = Stopwatch.StartNew();
 
-        cancellation.Cancel();
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            () => extraction);
+            cancellation.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => extraction);
 
-        stopwatch.Stop();
-        Assert.True(
-            stopwatch.Elapsed < TimeSpan.FromSeconds(3),
-            $"Piper cancellation cleanup took {stopwatch.ElapsedMilliseconds} ms.");
-        await AssertFixtureExitedAsync(directory.Path);
+            stopwatch.Stop();
+            Assert.True(
+                stopwatch.Elapsed < TimeSpan.FromSeconds(3),
+                $"Piper cancellation cleanup took {stopwatch.ElapsedMilliseconds} ms.");
+            await AssertFixtureExitedAsync(processId);
+        }
+        finally
+        {
+            await AwaitFixtureCleanupAsync(extraction, cancellation);
+            KillProcessTree(processId);
+        }
     }
 
     private static async Task CreateTarBz2Async(
@@ -115,21 +161,83 @@ public sealed class PiperVoiceExtractionTests
             $"tar fixture creation failed (exit {result.ExitCode}): {result.StandardError}");
     }
 
-    private static async Task AssertFixtureExitedAsync(string directory)
+    private static async Task AssertFixtureExitedAsync(int processId)
     {
-        var processId = await ReadFixturePidAsync(directory);
-        Assert.Throws<ArgumentException>(() => Process.GetProcessById(processId));
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (IsProcessRunning(processId) && DateTime.UtcNow < deadline)
+            await Task.Delay(25);
+
+        Assert.False(IsProcessRunning(processId), $"Piper extractor process {processId} is still running.");
     }
 
     private static async Task<int> ReadFixturePidAsync(string directory)
     {
         var pidPath = Path.Combine(directory, "fixture.pid");
         var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(3);
-        while (!File.Exists(pidPath) && DateTime.UtcNow < deadline)
-            await Task.Delay(10);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (File.Exists(pidPath))
+            {
+                var text = await File.ReadAllTextAsync(pidPath);
+                if (int.TryParse(text, out var processId))
+                    return processId;
+            }
 
-        Assert.True(File.Exists(pidPath), "Piper extractor fixture did not publish its PID.");
-        return int.Parse(await File.ReadAllTextAsync(pidPath));
+            await Task.Delay(10);
+        }
+
+        throw new TimeoutException("Piper extractor fixture did not publish its PID.");
+    }
+
+    private static bool IsProcessRunning(int processId)
+    {
+        try
+        {
+            using var process = Process.GetProcessById(processId);
+            return !process.HasExited;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+        catch (Win32Exception)
+        {
+            return false;
+        }
+    }
+
+    private static async Task AwaitFixtureCleanupAsync(
+        Task extraction,
+        CancellationTokenSource cancellation)
+    {
+        cancellation.Cancel();
+        await Task.WhenAny(extraction, Task.Delay(TimeSpan.FromSeconds(3)));
+        BoundedProcessWait.ObserveFault(extraction);
+    }
+
+    private static void KillProcessTree(int processId)
+    {
+        if (processId <= 0)
+            return;
+
+        try
+        {
+            using var process = Process.GetProcessById(processId);
+            process.Kill(entireProcessTree: true);
+            process.WaitForExit(2_000);
+        }
+        catch (ArgumentException)
+        {
+        }
+        catch (InvalidOperationException)
+        {
+        }
+        catch (Win32Exception)
+        {
+        }
+        catch (AggregateException)
+        {
+        }
     }
 
     private static string FindTestHost()


### PR DESCRIPTION
## What problem this solves

Piper voice extraction could outlive cancellation or its 120-second timeout because process exit and redirected output drains used separate waits. A descendant inheriting stdout or stderr could keep a drain open after `tar` exited.

This supersedes #1268 because that PR's head branch is in a contributor fork and is not writable by maintainers.

## What changed

- Process exit plus complete stdout and stderr drain share one linked caller/timeout deadline.
- Timeout, cancellation, and unexpected drain failures trigger bounded process-tree cleanup and close inherited pipe readers.
- Partial extraction is guarded by a sibling `.installing` marker, so interrupted or late cleanup cannot make corrupt model files appear installed.
- Existing valid files are preserved during a failed recovery attempt, and voice deletion removes both the model directory and marker.
- Deterministic fixtures cover success, timeout, delayed output, cancellation, pre-cancellation, inherited handles, marker semantics, and process cleanup.

## Required proof pools

- `none`: this is a local Windows `tar.exe` process-lifecycle fix. It does not change installer, gateway, MCP, node capability, or interactive UI contracts.

## Validation

Current head: `e46cf147e201b36080c7b0b3e551109a962b7564`

- `.\build.ps1`: all projects passed.
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore`: 3,915 passed, 32 environment-gated skipped, 0 failed.
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore`: 2,840 passed, 0 failed.
- `dotnet test .\tests\OpenClaw.SetupEngine.Tests\OpenClaw.SetupEngine.Tests.csproj --no-restore`: 1,045 passed, 0 failed.
- Focused Piper, process-wait, asset-hash, and single-flight tests: 19 passed.
- Timeout extraction regression: 30/30 isolated repetitions passed.
- Cancellation extraction regression: 25/25 isolated repetitions passed.
- Hanselman dual-model adversarial review: no remaining MEDIUM, HIGH, or CRITICAL findings.

## Real behavior proof

Environment: native Windows 11, .NET SDK 10.0.303, Windows SDK 10.0.26100.0.

- Real Windows extraction creates a `.tar.bz2` with Windows `tar.exe`, extracts through `PiperVoiceManager.ExtractTarBz2Async`, and verifies expected model files and content.
- Timeout proof runs the exact Piper extraction boundary against a deterministic tar-shaped fixture, surfaces the wrapped timeout within the bounded cleanup budget, and confirms the extractor exits.
- Cancellation proof waits for fixture readiness, cancels against the production 120-second budget, returns promptly, and confirms the extractor exits.
- Inherited-handle proof confirms cancellation does not wait for descendant-held stdout/stderr pipes.
- Partial-install proof confirms a sibling marker blocks incomplete layouts from being treated as installed and is removed by voice deletion.
- The prior remote-head `test` failure was stale camera/screen capture timeout evidence. Those consent-timeout fixes are present through merged #1300 on base SHA `91837de0cc182f2fe6ead8f85e0e6393a8ef064d`.

## Security impact

No new permissions, network calls, command surface, secrets handling, or data scope. Extraction still executes OS `tar -xjf` only after the archive passes its pinned SHA-256 check. Diagnostics do not add prompt, credential, or arbitrary file-content logging.

## Compatibility

Backward compatible. Existing complete voice installs without a marker remain recognized.