### PR TITLE
fix(chat): keep flattened tool results with the correct tool

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Chat/AccessibilityHistoryCollisionFixture.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/AccessibilityHistoryCollisionFixture.cs
@@ -1,0 +1,267 @@
+using OpenClaw.Chat;
+using OpenClaw.Shared;
+using OpenClawTray.Services;
+using System.Text.Json;
+
+namespace OpenClawTray.Chat;
+
+internal static class AccessibilityHistoryCollisionFixture
+{
+    internal const string FixtureName = "history-collision";
+    internal const string ThreadId = "accessibility-main";
+    private const string SessionId =
+        "accessibility-history-collision-session";
+
+    internal static OpenClawChatDataProvider Create(
+        string isolatedDataDirectory,
+        Action<Action>? post = null)
+    {
+        ValidateIsolationGate(
+            isolatedDataDirectory,
+            Environment.GetEnvironmentVariable);
+        return CreateCore(isolatedDataDirectory, post).Provider;
+    }
+
+    internal static (
+        OpenClawChatDataProvider Provider,
+        Bridge GatewayBridge) CreateForTesting(
+            string isolatedDataDirectory,
+            Func<string, string?> environmentLookup)
+    {
+        ValidateIsolationGate(
+            isolatedDataDirectory,
+            environmentLookup);
+        return CreateCore(isolatedDataDirectory, post: null);
+    }
+
+    private static (
+        OpenClawChatDataProvider Provider,
+        Bridge GatewayBridge) CreateCore(
+            string isolatedDataDirectory,
+            Action<Action>? post)
+    {
+        Directory.CreateDirectory(isolatedDataDirectory);
+        var toolCachePath = Path.Combine(
+            isolatedDataDirectory,
+            "history-collision-tool-metadata.json");
+        File.WriteAllText(
+            toolCachePath,
+            JsonSerializer.Serialize(
+                new Dictionary<
+                    string,
+                    List<ChatMetadataStore.CachedToolMeta>>
+                {
+                    [SessionId] =
+                    [
+                        new()
+                        {
+                            Ts = 100,
+                            ToolName = "Bash",
+                            Label = "Flattened history command",
+                            ToolCallId = "unverified-flat-id",
+                            RunId = "unverified-flat-run",
+                            ToolArgs = new()
+                            {
+                                ["command"] =
+                                    "synthetic flattened id: history-tool-1",
+                            },
+                            IdentityStrength =
+                                ChatToolIdentityStrength.Specific,
+                        },
+                        new()
+                        {
+                            Ts = 200,
+                            ToolName = "Exec",
+                            Label = "Structured history command",
+                            ToolCallId = "history-tool-0",
+                            IdentityStrength =
+                                ChatToolIdentityStrength.Specific,
+                        },
+                    ],
+                }));
+
+        var bridge = new Bridge();
+        var provider = new OpenClawChatDataProvider(
+            bridge,
+            post,
+            toolCachePath,
+            Path.Combine(
+                isolatedDataDirectory,
+                "history-collision-attachment-metadata.json"),
+            Path.Combine(
+                isolatedDataDirectory,
+                "history-collision-last-chat-state.json"));
+        provider.LoadHistoryAsync(ThreadId).GetAwaiter().GetResult();
+        return (provider, bridge);
+    }
+
+    private static void ValidateIsolationGate(
+        string isolatedDataDirectory,
+        Func<string, string?> environmentLookup)
+    {
+        var configuredDataDirectory =
+            environmentLookup("OPENCLAW_TRAY_DATA_DIR");
+        if (!string.Equals(
+                environmentLookup("OPENCLAW_ACCESSIBILITY_TEST_CHAT"),
+                "1",
+                StringComparison.Ordinal) ||
+            !string.Equals(
+                environmentLookup(
+                    "OPENCLAW_ACCESSIBILITY_TEST_CHAT_FIXTURE"),
+                FixtureName,
+                StringComparison.Ordinal) ||
+            string.IsNullOrWhiteSpace(configuredDataDirectory) ||
+            !string.Equals(
+                Path.GetFullPath(isolatedDataDirectory),
+                Path.GetFullPath(configuredDataDirectory),
+                StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                "The history collision fixture requires isolated accessibility test data.");
+        }
+    }
+
+    internal sealed class Bridge : IChatGatewayBridge
+    {
+        private static readonly SessionInfo[] Sessions =
+        [
+            new()
+            {
+                Key = ThreadId,
+                IsMain = true,
+                DisplayName = "History collision proof",
+                Status = "active",
+                Model = "test-model",
+            },
+        ];
+
+        public bool IsConnected => true;
+        public ConnectionStatus CurrentStatus => ConnectionStatus.Connected;
+        public string MainSessionKey => ThreadId;
+        public bool HasHandshakeSnapshot => true;
+        public int HistoryRequestCount { get; private set; }
+
+        public SessionInfo[] GetSessionList() => Sessions;
+        public ModelsListInfo? GetCurrentModelsList() => null;
+        public void StartProactiveBootstrap() { }
+
+        public Task<ChatHistoryInfo> RequestChatHistoryAsync(
+            string? sessionKey)
+        {
+            HistoryRequestCount++;
+            return Task.FromResult(new ChatHistoryInfo
+            {
+                SessionId = SessionId,
+                SessionKey = ThreadId,
+                Messages =
+                [
+                    new ChatMessageInfo
+                    {
+                        Role = "assistant",
+                        Ts = 200,
+                        ToolContent =
+                        [
+                            new ChatToolContentInfo
+                            {
+                                Kind = ChatToolContentKind.Call,
+                                CallId = "history-tool-0",
+                                ToolName = "Exec",
+                            },
+                        ],
+                    },
+                    new ChatMessageInfo
+                    {
+                        Role = "toolresult",
+                        Text =
+                            "flattened output owned by history-tool-1",
+                        Ts = 300,
+                    },
+                ],
+            });
+        }
+
+        public Task SendChatMessageAsync(
+            string message,
+            string? sessionKey,
+            string? sessionId,
+            IReadOnlyList<ChatAttachment>? attachments = null) =>
+            Task.CompletedTask;
+
+        public Task<ChatSendResult> SendChatMessageForRunAsync(
+            string message,
+            string? sessionKey,
+            string? sessionId,
+            IReadOnlyList<ChatAttachment>? attachments = null,
+            string? idempotencyKey = null) =>
+            Task.FromResult(new ChatSendResult());
+
+        public Task<CommandCatalog> ListCommandsAsync(
+            CommandCatalogQuery? query = null) =>
+            Task.FromResult(new CommandCatalog { IsSupported = false });
+
+        public Task PatchSessionModelAsync(
+            string sessionKey,
+            string model) =>
+            Task.CompletedTask;
+
+        public Task ClearSessionModelAsync(string sessionKey) =>
+            Task.CompletedTask;
+
+        public Task PatchSessionThinkingLevelAsync(
+            string sessionKey,
+            string thinkingLevel) =>
+            Task.CompletedTask;
+
+        public Task ClearSessionThinkingLevelAsync(string sessionKey) =>
+            Task.CompletedTask;
+
+        public Task SendChatAbortAsync(
+            string runId,
+            string? sessionKey = null) =>
+            Task.CompletedTask;
+
+        public Task ResolveExecApprovalAsync(
+            string approvalId,
+            string decision) =>
+            Task.CompletedTask;
+
+        public void Dispose() { }
+
+        public event EventHandler<ConnectionStatus>? StatusChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public event EventHandler<SessionInfo[]>? SessionsUpdated
+        {
+            add { }
+            remove { }
+        }
+
+        public event EventHandler<SessionCommandResult>?
+            SessionCommandCompleted
+        {
+            add { }
+            remove { }
+        }
+
+        public event EventHandler<ChatMessageInfo>? ChatMessageReceived
+        {
+            add { }
+            remove { }
+        }
+
+        public event EventHandler<AgentEventInfo>? AgentEventReceived
+        {
+            add { }
+            remove { }
+        }
+
+        public event EventHandler<ModelsListInfo>? ModelsListUpdated
+        {
+            add { }
+            remove { }
+        }
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Chat/ChatHistoryLoader.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ChatHistoryLoader.cs
@@ -793,7 +793,8 @@ internal sealed class ChatHistoryLoader : IDisposable
                     {
                         _ = ChatMetadataStore.TryMatchCachedToolByCallId(
                             cachedTools,
-                            callId);
+                            callId,
+                            message.Ts);
                     }
                     timeline = Apply(
                         timeline,
@@ -828,7 +829,8 @@ internal sealed class ChatHistoryLoader : IDisposable
                     var cached = hasVerifiedCallId
                         ? ChatMetadataStore.TryMatchCachedToolByCallId(
                             cachedTools,
-                            resolvedCallId)
+                            resolvedCallId,
+                            message.Ts)
                         : ChatMetadataStore.TryMatchCachedTool(
                             cachedTools,
                             message.Ts);

--- a/src/OpenClaw.Tray.WinUI/Chat/ChatHistoryLoader.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ChatHistoryLoader.cs
@@ -504,8 +504,26 @@ internal sealed class ChatHistoryLoader : IDisposable
         }
 
         var orderedMessages = OrderHistoryMessages(history.Messages);
-        foreach (var replayPart in
-                 ChatHistoryReplayProjection.Project(orderedMessages))
+        var replayParts =
+            ChatHistoryReplayProjection.Project(orderedMessages).ToArray();
+        var reservedToolCallIds = replayParts
+            .SelectMany(static part => part.ToolContent)
+            .Select(static tool => tool.CallId)
+            .Where(static callId => !string.IsNullOrWhiteSpace(callId))
+            .ToHashSet(StringComparer.Ordinal);
+
+        string AllocateSyntheticToolCallId()
+        {
+            while (true)
+            {
+                var candidate =
+                    $"history-tool-{syntheticToolCallSequence++}";
+                if (reservedToolCallIds.Add(candidate))
+                    return candidate;
+            }
+        }
+
+        foreach (var replayPart in replayParts)
         {
             var message = replayPart.Message;
             if (suppressedAbortedAssistant is not null)
@@ -654,6 +672,8 @@ internal sealed class ChatHistoryLoader : IDisposable
                             var cached = ChatMetadataStore.TryMatchCachedTool(
                                 cachedTools,
                                 message.Ts);
+                            var assistantHistoryCallId =
+                                AllocateSyntheticToolCallId();
                             var kind = cached?.ToolName ??
                                 NativeToolProjector.ClassifyFlattenedToolOutput(text);
                             var label = cached?.Label ??
@@ -664,18 +684,16 @@ internal sealed class ChatHistoryLoader : IDisposable
                                     label,
                                     kind,
                                     ToolArgs: cached?.ToolArgs,
-                                    ToolCallId: cached?.ToolCallId,
+                                    ToolCallId: assistantHistoryCallId,
                                     IdentityStrength: cached?.IdentityStrength ??
                                         NativeToolProjector.ClassifyHistoryIdentityStrength(
-                                            kind),
-                                    RunId: cached?.RunId),
+                                            kind)),
                                 entryMetadata);
                             timeline = Apply(
                                 timeline,
                                 new ChatToolOutputEvent(
                                     text,
-                                    ToolCallId: cached?.ToolCallId,
-                                    RunId: cached?.RunId),
+                                    ToolCallId: assistantHistoryCallId),
                                 entryMetadata);
                         }
                         else
@@ -710,6 +728,8 @@ internal sealed class ChatHistoryLoader : IDisposable
                         var cachedTool = ChatMetadataStore.TryMatchCachedTool(
                             cachedTools,
                             message.Ts);
+                        var toolResultHistoryCallId =
+                            AllocateSyntheticToolCallId();
                         var toolKind = cachedTool?.ToolName ??
                             NativeToolProjector.ClassifyFlattenedToolOutput(text);
                         var toolLabel = cachedTool?.Label ??
@@ -720,18 +740,16 @@ internal sealed class ChatHistoryLoader : IDisposable
                                 toolLabel,
                                 toolKind,
                                 ToolArgs: cachedTool?.ToolArgs,
-                                ToolCallId: cachedTool?.ToolCallId,
+                                ToolCallId: toolResultHistoryCallId,
                                 IdentityStrength: cachedTool?.IdentityStrength ??
                                     NativeToolProjector.ClassifyHistoryIdentityStrength(
-                                        toolKind),
-                                RunId: cachedTool?.RunId),
+                                        toolKind)),
                             entryMetadata);
                         timeline = Apply(
                             timeline,
                             new ChatToolOutputEvent(
                                 text,
-                                ToolCallId: cachedTool?.ToolCallId,
-                                RunId: cachedTool?.RunId),
+                                ToolCallId: toolResultHistoryCallId),
                             entryMetadata);
                         break;
                     case "system":
@@ -759,18 +777,23 @@ internal sealed class ChatHistoryLoader : IDisposable
             {
                 if (toolBlock.Kind == ChatToolContentKind.Call)
                 {
-                    _ = ChatMetadataStore.TryMatchCachedTool(
-                        cachedTools,
-                        message.Ts);
                     var args =
                         ChatHistoryReplayProjection.ProjectToolArgs(
                             toolBlock.Args);
                     var callId = toolBlock.CallId;
                     if (string.IsNullOrWhiteSpace(callId))
                     {
-                        callId =
-                            $"history-tool-{syntheticToolCallSequence++}";
+                        _ = ChatMetadataStore.TryMatchCachedTool(
+                            cachedTools,
+                            message.Ts);
+                        callId = AllocateSyntheticToolCallId();
                         pendingUnkeyedToolCalls.Enqueue(callId);
+                    }
+                    else
+                    {
+                        _ = ChatMetadataStore.TryMatchCachedToolByCallId(
+                            cachedTools,
+                            callId);
                     }
                     timeline = Apply(
                         timeline,
@@ -786,22 +809,29 @@ internal sealed class ChatHistoryLoader : IDisposable
                 }
 
                 var resultCallId = toolBlock.CallId;
-                if (string.IsNullOrWhiteSpace(resultCallId))
+                var hasVerifiedCallId =
+                    !string.IsNullOrWhiteSpace(resultCallId);
+                if (!hasVerifiedCallId)
                 {
                     resultCallId =
                         pendingUnkeyedToolCalls.Count > 0
                             ? pendingUnkeyedToolCalls.Dequeue()
-                            : $"history-tool-{syntheticToolCallSequence++}";
+                            : AllocateSyntheticToolCallId();
                 }
+                var resolvedCallId = resultCallId!;
                 var correlationKey = new ChatToolCorrelationKey(
                     RunId: null,
                     LegacyTurn: timeline.ToolLegacyTurn,
-                    ToolCallId: resultCallId);
+                    ToolCallId: resolvedCallId);
                 if (!timeline.ActiveToolCalls.ContainsKey(correlationKey))
                 {
-                    var cached = ChatMetadataStore.TryMatchCachedTool(
-                        cachedTools,
-                        message.Ts);
+                    var cached = hasVerifiedCallId
+                        ? ChatMetadataStore.TryMatchCachedToolByCallId(
+                            cachedTools,
+                            resolvedCallId)
+                        : ChatMetadataStore.TryMatchCachedTool(
+                            cachedTools,
+                            message.Ts);
                     var toolName =
                         cached?.ToolName ?? toolBlock.ToolName;
                     timeline = Apply(
@@ -809,7 +839,12 @@ internal sealed class ChatHistoryLoader : IDisposable
                         new ChatToolStartEvent(
                             cached?.Label ?? toolName,
                             toolName,
-                            ToolCallId: resultCallId),
+                            ToolArgs: cached?.ToolArgs,
+                            ToolCallId: resolvedCallId,
+                            IdentityStrength:
+                                cached?.IdentityStrength ??
+                                NativeToolProjector.ClassifyHistoryIdentityStrength(
+                                    toolName)),
                         entryMetadata);
                 }
                 var output = NativeToolProjector.TruncateToolOutput(
@@ -819,10 +854,10 @@ internal sealed class ChatHistoryLoader : IDisposable
                     toolBlock.IsError
                         ? new ChatToolErrorEvent(
                             output,
-                            resultCallId)
+                            resolvedCallId)
                         : new ChatToolOutputEvent(
                             output,
-                            resultCallId),
+                            resolvedCallId),
                     entryMetadata);
             }
         }

--- a/src/OpenClaw.Tray.WinUI/Chat/ChatHistoryLoader.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ChatHistoryLoader.cs
@@ -462,12 +462,19 @@ internal sealed class ChatHistoryLoader : IDisposable
             history.SessionId,
             threadId,
             resetGeneration);
+        var positionalToolMetadataTrusted = true;
         var attachmentMatcher = _metadata.CreateAttachmentMatcher(
             history.SessionId,
             threadId,
             resetGeneration);
         var nextAssistantIsAborted = false;
         var pendingUnkeyedToolCalls = new Queue<string>();
+        var pendingVerifiedCallLookups =
+            new Dictionary<string, int>(StringComparer.Ordinal);
+        var pendingVerifiedResultLookups =
+            new Dictionary<string, int>(StringComparer.Ordinal);
+        var seenVerifiedResults =
+            new HashSet<string>(StringComparer.Ordinal);
         var syntheticToolCallSequence = 0;
         ChatMessageInfo? suppressedAbortedAssistant = null;
 
@@ -521,6 +528,55 @@ internal sealed class ChatHistoryLoader : IDisposable
                 if (reservedToolCallIds.Add(candidate))
                     return candidate;
             }
+        }
+
+        ChatMetadataStore.CachedToolMeta? MatchPositionalToolMetadata(
+            long historyTsMs) =>
+            positionalToolMetadataTrusted
+                ? ChatMetadataStore.TryMatchCachedTool(
+                    cachedTools,
+                    historyTsMs)
+                : null;
+
+        ChatMetadataStore.CachedToolMeta? MatchVerifiedToolMetadata(
+            string toolCallId,
+            long historyTsMs,
+            bool isCall)
+        {
+            var counterpartLookups = isCall
+                ? pendingVerifiedResultLookups
+                : pendingVerifiedCallLookups;
+            if (counterpartLookups.TryGetValue(
+                    toolCallId,
+                    out var counterpartCount))
+            {
+                if (counterpartCount == 1)
+                    counterpartLookups.Remove(toolCallId);
+                else
+                    counterpartLookups[toolCallId] = counterpartCount - 1;
+                if (!isCall)
+                    seenVerifiedResults.Add(toolCallId);
+                return null;
+            }
+
+            if (!isCall && !seenVerifiedResults.Add(toolCallId))
+                return null;
+
+            var lookup = ChatMetadataStore.TryMatchCachedToolByCallId(
+                cachedTools,
+                toolCallId,
+                historyTsMs);
+            var ownLookups = isCall
+                ? pendingVerifiedCallLookups
+                : pendingVerifiedResultLookups;
+            ownLookups.TryGetValue(toolCallId, out var ownCount);
+            ownLookups[toolCallId] = ownCount + 1;
+            if (lookup.Outcome ==
+                ChatMetadataStore.CachedToolLookupOutcome.Unmatched)
+            {
+                positionalToolMetadataTrusted = false;
+            }
+            return lookup.Match;
         }
 
         foreach (var replayPart in replayParts)
@@ -669,9 +725,8 @@ internal sealed class ChatHistoryLoader : IDisposable
                         }
                         else if (NativeToolProjector.LooksLikeFlattenedToolOutput(text))
                         {
-                            var cached = ChatMetadataStore.TryMatchCachedTool(
-                                cachedTools,
-                                message.Ts);
+                            var cached =
+                                MatchPositionalToolMetadata(message.Ts);
                             var assistantHistoryCallId =
                                 AllocateSyntheticToolCallId();
                             var kind = cached?.ToolName ??
@@ -725,9 +780,8 @@ internal sealed class ChatHistoryLoader : IDisposable
                     case "tool_result":
                         if (hasStructuredToolContent)
                             break;
-                        var cachedTool = ChatMetadataStore.TryMatchCachedTool(
-                            cachedTools,
-                            message.Ts);
+                        var cachedTool =
+                            MatchPositionalToolMetadata(message.Ts);
                         var toolResultHistoryCallId =
                             AllocateSyntheticToolCallId();
                         var toolKind = cachedTool?.ToolName ??
@@ -783,18 +837,16 @@ internal sealed class ChatHistoryLoader : IDisposable
                     var callId = toolBlock.CallId;
                     if (string.IsNullOrWhiteSpace(callId))
                     {
-                        _ = ChatMetadataStore.TryMatchCachedTool(
-                            cachedTools,
-                            message.Ts);
+                        _ = MatchPositionalToolMetadata(message.Ts);
                         callId = AllocateSyntheticToolCallId();
                         pendingUnkeyedToolCalls.Enqueue(callId);
                     }
                     else
                     {
-                        _ = ChatMetadataStore.TryMatchCachedToolByCallId(
-                            cachedTools,
+                        _ = MatchVerifiedToolMetadata(
                             callId,
-                            message.Ts);
+                            message.Ts,
+                            isCall: true);
                     }
                     timeline = Apply(
                         timeline,
@@ -824,16 +876,17 @@ internal sealed class ChatHistoryLoader : IDisposable
                     RunId: null,
                     LegacyTurn: timeline.ToolLegacyTurn,
                     ToolCallId: resolvedCallId);
+                var verifiedCached = hasVerifiedCallId
+                    ? MatchVerifiedToolMetadata(
+                        resolvedCallId,
+                        message.Ts,
+                        isCall: false)
+                    : null;
                 if (!timeline.ActiveToolCalls.ContainsKey(correlationKey))
                 {
                     var cached = hasVerifiedCallId
-                        ? ChatMetadataStore.TryMatchCachedToolByCallId(
-                            cachedTools,
-                            resolvedCallId,
-                            message.Ts)
-                        : ChatMetadataStore.TryMatchCachedTool(
-                            cachedTools,
-                            message.Ts);
+                        ? verifiedCached
+                        : MatchPositionalToolMetadata(message.Ts);
                     var toolName =
                         cached?.ToolName ?? toolBlock.ToolName;
                     timeline = Apply(

--- a/src/OpenClaw.Tray.WinUI/Chat/ChatMetadataStore.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ChatMetadataStore.cs
@@ -574,7 +574,8 @@ internal sealed class ChatMetadataStore : IDisposable
 
     internal static CachedToolMeta? TryMatchCachedToolByCallId(
         Queue<CachedToolMeta>? cache,
-        string? toolCallId)
+        string? toolCallId,
+        long historyTsMs)
     {
         if (cache is null ||
             cache.Count == 0 ||
@@ -583,28 +584,45 @@ internal sealed class ChatMetadataStore : IDisposable
             return null;
         }
 
-        CachedToolMeta? match = null;
         var entryCount = cache.Count;
+        var entries = new CachedToolMeta[entryCount];
+        var matchIndex = -1;
+        var bestTimestampDistance = double.PositiveInfinity;
         for (var index = 0; index < entryCount; index++)
         {
             var candidate = cache.Dequeue();
-            if (match is null &&
-                !string.IsNullOrWhiteSpace(candidate.ToolCallId) &&
-                string.Equals(
+            entries[index] = candidate;
+            if (string.IsNullOrWhiteSpace(candidate.ToolCallId) ||
+                !string.Equals(
                     candidate.ToolCallId,
                     toolCallId,
                     StringComparison.Ordinal))
             {
-                match = candidate;
                 continue;
             }
 
-            cache.Enqueue(candidate);
+            var timestampDistance =
+                historyTsMs > 0 && candidate.Ts > 0
+                    ? Math.Abs((double)candidate.Ts - historyTsMs)
+                    : double.PositiveInfinity;
+            if (matchIndex < 0 ||
+                timestampDistance < bestTimestampDistance)
+            {
+                matchIndex = index;
+                bestTimestampDistance = timestampDistance;
+            }
         }
 
-        if (match is null)
+        for (var index = 0; index < entryCount; index++)
+        {
+            if (index != matchIndex)
+                cache.Enqueue(entries[index]);
+        }
+
+        if (matchIndex < 0)
             return null;
 
+        var match = entries[matchIndex];
         match.ToolName = NormalizeCachedDisplayText(match.ToolName);
         match.Label = NormalizeCachedDisplayText(match.Label);
         match.ToolArgs = NormalizeCachedToolArgs(match.ToolArgs);

--- a/src/OpenClaw.Tray.WinUI/Chat/ChatMetadataStore.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ChatMetadataStore.cs
@@ -66,6 +66,11 @@ internal sealed class AttachmentMetaMatcher
 /// </summary>
 internal sealed class ChatMetadataStore : IDisposable
 {
+    private readonly record struct CachedToolCorrelationIdentity(
+        string? RunId,
+        string ToolCallId,
+        long LegacyTurn);
+
     internal sealed class CachedToolMeta
     {
         public long Ts { get; set; }
@@ -357,36 +362,66 @@ internal sealed class ChatMetadataStore : IDisposable
 
         lock (_gate)
         {
-            var entries = new List<CachedToolMeta>();
+            IReadOnlyList<CachedToolMeta>? sessionEntries = null;
+            IReadOnlyList<CachedToolMeta>? threadEntries = null;
             if (!string.IsNullOrEmpty(sessionId) &&
-                _toolCache.TryGetValue(sessionId, out var sessionEntries))
+                _toolCache.TryGetValue(sessionId, out var cachedSessionEntries))
             {
-                entries.AddRange(sessionEntries
+                sessionEntries = cachedSessionEntries
                     .Where(entry => !IsOlderResetEntry(
                         entry.ThreadId,
                         entry.ResetGeneration,
                         threadId,
                         resetGeneration))
-                    .Select(Clone));
+                    .ToArray();
             }
 
             if (!string.IsNullOrEmpty(threadId) &&
                 (string.IsNullOrEmpty(sessionId) || !string.Equals(sessionId, threadId, StringComparison.Ordinal)) &&
-                _toolCache.TryGetValue(threadId, out var threadEntries))
+                _toolCache.TryGetValue(threadId, out var cachedThreadEntries))
             {
-                entries.AddRange(threadEntries
+                threadEntries = cachedThreadEntries
                     .Where(entry => !IsOlderResetEntry(
                         entry.ThreadId,
                         entry.ResetGeneration,
                         threadId,
                         resetGeneration))
-                    .Select(Clone));
+                    .ToArray();
             }
 
-            return entries.Count == 0
-                ? null
-                : new Queue<CachedToolMeta>(entries.OrderBy(entry => entry.Ts));
+            return BuildToolMetadataQueue(sessionEntries, threadEntries);
         }
+    }
+
+    internal static Queue<CachedToolMeta>? BuildToolMetadataQueue(
+        IReadOnlyList<CachedToolMeta>? sessionEntries,
+        IReadOnlyList<CachedToolMeta>? threadEntries)
+    {
+        var merged = new List<CachedToolMeta>();
+        var stableIdentities =
+            new Dictionary<CachedToolCorrelationIdentity, int>();
+        var ordered = (sessionEntries ?? Array.Empty<CachedToolMeta>())
+            .Concat(threadEntries ?? Array.Empty<CachedToolMeta>())
+            .OrderBy(entry => entry.Ts);
+
+        foreach (var source in ordered)
+        {
+            var entry = Clone(source);
+            if (!TryGetCorrelationIdentity(entry, out var identity) ||
+                !stableIdentities.TryGetValue(identity, out var existingIndex))
+            {
+                if (TryGetCorrelationIdentity(entry, out identity))
+                    stableIdentities[identity] = merged.Count;
+                merged.Add(entry);
+                continue;
+            }
+
+            MergeToolMetadata(merged[existingIndex], entry);
+        }
+
+        return merged.Count == 0
+            ? null
+            : new Queue<CachedToolMeta>(merged);
     }
 
     internal AttachmentMetaMatcher CreateAttachmentMatcher(
@@ -531,6 +566,45 @@ internal sealed class ChatMetadataStore : IDisposable
             return null;
 
         var match = cache.Dequeue();
+        match.ToolName = NormalizeCachedDisplayText(match.ToolName);
+        match.Label = NormalizeCachedDisplayText(match.Label);
+        match.ToolArgs = NormalizeCachedToolArgs(match.ToolArgs);
+        return match;
+    }
+
+    internal static CachedToolMeta? TryMatchCachedToolByCallId(
+        Queue<CachedToolMeta>? cache,
+        string? toolCallId)
+    {
+        if (cache is null ||
+            cache.Count == 0 ||
+            string.IsNullOrWhiteSpace(toolCallId))
+        {
+            return null;
+        }
+
+        CachedToolMeta? match = null;
+        var entryCount = cache.Count;
+        for (var index = 0; index < entryCount; index++)
+        {
+            var candidate = cache.Dequeue();
+            if (match is null &&
+                !string.IsNullOrWhiteSpace(candidate.ToolCallId) &&
+                string.Equals(
+                    candidate.ToolCallId,
+                    toolCallId,
+                    StringComparison.Ordinal))
+            {
+                match = candidate;
+                continue;
+            }
+
+            cache.Enqueue(candidate);
+        }
+
+        if (match is null)
+            return null;
+
         match.ToolName = NormalizeCachedDisplayText(match.ToolName);
         match.Label = NormalizeCachedDisplayText(match.Label);
         match.ToolArgs = NormalizeCachedToolArgs(match.ToolArgs);
@@ -728,6 +802,47 @@ internal sealed class ChatMetadataStore : IDisposable
         ThreadId = entry.ThreadId,
         ResetGeneration = entry.ResetGeneration,
     };
+
+    private static bool TryGetCorrelationIdentity(
+        CachedToolMeta entry,
+        out CachedToolCorrelationIdentity identity)
+    {
+        if (string.IsNullOrWhiteSpace(entry.ToolCallId))
+        {
+            identity = default;
+            return false;
+        }
+
+        var runId = string.IsNullOrWhiteSpace(entry.RunId)
+            ? null
+            : entry.RunId;
+        identity = new CachedToolCorrelationIdentity(
+            runId,
+            entry.ToolCallId,
+            runId is null ? entry.LegacyTurn : 0);
+        return true;
+    }
+
+    private static void MergeToolMetadata(
+        CachedToolMeta existing,
+        CachedToolMeta incoming)
+    {
+        if (incoming.IdentityStrength > existing.IdentityStrength)
+        {
+            existing.ToolName = incoming.ToolName;
+            existing.IdentityStrength = incoming.IdentityStrength;
+        }
+        else if (string.IsNullOrWhiteSpace(existing.ToolName))
+        {
+            existing.ToolName = incoming.ToolName;
+        }
+
+        if (!string.IsNullOrWhiteSpace(incoming.Label))
+            existing.Label = incoming.Label;
+        existing.ToolArgs = MergeCachedToolArgs(
+            existing.ToolArgs,
+            incoming.ToolArgs);
+    }
 
     private static CachedAttachmentMeta Clone(CachedAttachmentMeta entry) => new()
     {

--- a/src/OpenClaw.Tray.WinUI/Chat/ChatMetadataStore.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ChatMetadataStore.cs
@@ -66,6 +66,17 @@ internal sealed class AttachmentMetaMatcher
 /// </summary>
 internal sealed class ChatMetadataStore : IDisposable
 {
+    internal enum CachedToolLookupOutcome
+    {
+        NoCandidates,
+        Matched,
+        Unmatched,
+    }
+
+    internal readonly record struct CachedToolLookup(
+        CachedToolMeta? Match,
+        CachedToolLookupOutcome Outcome);
+
     private readonly record struct CachedToolCorrelationIdentity(
         string? RunId,
         string ToolCallId,
@@ -572,7 +583,7 @@ internal sealed class ChatMetadataStore : IDisposable
         return match;
     }
 
-    internal static CachedToolMeta? TryMatchCachedToolByCallId(
+    internal static CachedToolLookup TryMatchCachedToolByCallId(
         Queue<CachedToolMeta>? cache,
         string? toolCallId,
         long historyTsMs)
@@ -581,7 +592,7 @@ internal sealed class ChatMetadataStore : IDisposable
             cache.Count == 0 ||
             string.IsNullOrWhiteSpace(toolCallId))
         {
-            return null;
+            return new(null, CachedToolLookupOutcome.NoCandidates);
         }
 
         var entryCount = cache.Count;
@@ -620,13 +631,13 @@ internal sealed class ChatMetadataStore : IDisposable
         }
 
         if (matchIndex < 0)
-            return null;
+            return new(null, CachedToolLookupOutcome.Unmatched);
 
         var match = entries[matchIndex];
         match.ToolName = NormalizeCachedDisplayText(match.ToolName);
         match.Label = NormalizeCachedDisplayText(match.Label);
         match.ToolArgs = NormalizeCachedToolArgs(match.ToolArgs);
-        return match;
+        return new(match, CachedToolLookupOutcome.Matched);
     }
 
     internal void Flush()

--- a/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml.cs
@@ -354,8 +354,20 @@ public sealed partial class ChatPage : Page
         // test flag so Axe scans the real Reactor timeline and composer,
         // not merely the disconnected page shell.
         if (Environment.GetEnvironmentVariable("OPENCLAW_ACCESSIBILITY_TEST_CHAT") == "1"
-            && Environment.GetEnvironmentVariable("OPENCLAW_TRAY_DATA_DIR") is { Length: > 0 })
+            && Environment.GetEnvironmentVariable("OPENCLAW_TRAY_DATA_DIR") is { Length: > 0 } dataDirectory)
         {
+            if (string.Equals(
+                    Environment.GetEnvironmentVariable(
+                        "OPENCLAW_ACCESSIBILITY_TEST_CHAT_FIXTURE"),
+                    AccessibilityHistoryCollisionFixture.FixtureName,
+                    StringComparison.Ordinal))
+            {
+                return _accessibilityTestProvider ??=
+                    AccessibilityHistoryCollisionFixture.Create(
+                        dataDirectory,
+                        action => DispatcherQueue.TryEnqueue(() => action()));
+            }
+
             return _accessibilityTestProvider ??= new AccessibilityChatDataProvider();
         }
 

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -61,6 +61,7 @@
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Chat\ChatContentFormatting.cs" Link="Chat\ChatContentFormatting.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Chat\ChatEventMapper.cs" Link="Chat\ChatEventMapper.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Chat\ChatHistoryLoader.cs" Link="Chat\ChatHistoryLoader.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Chat\AccessibilityHistoryCollisionFixture.cs" Link="Chat\AccessibilityHistoryCollisionFixture.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Chat\ChatHistoryState.cs" Link="Chat\ChatHistoryState.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Chat\ChatLifecycleState.cs" Link="Chat\ChatLifecycleState.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Chat\ChatMetadataStore.cs" Link="Chat\ChatMetadataStore.cs" />

--- a/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
@@ -7340,6 +7340,205 @@ public class OpenClawChatDataProviderTests
     }
 
     [Fact]
+    public async Task LoadHistoryAsync_KeyedCallAndFlattenedResult_AvoidIdentityCollision()
+    {
+        using var tempDir = new TempDirectory();
+        var cachePath = Path.Combine(
+            tempDir.DirectoryPath,
+            "tool-metadata.json");
+        File.WriteAllText(
+            cachePath,
+            JsonSerializer.Serialize(
+                new Dictionary<string, List<ChatMetadataStore.CachedToolMeta>>
+                {
+                    ["session-1"] =
+                    [
+                        new()
+                        {
+                            Ts = 100,
+                            ToolName = "Bash",
+                            Label = "cached flattened command",
+                            ToolCallId = "unverified-flat-id",
+                            RunId = "unverified-flat-run",
+                            ToolArgs = new JsonObject
+                            {
+                                ["command"] = "echo flattened",
+                            },
+                            IdentityStrength =
+                                ChatToolIdentityStrength.Specific,
+                        },
+                        new()
+                        {
+                            Ts = 200,
+                            ToolName = "Exec",
+                            Label = "cached structured command",
+                            ToolCallId = "history-tool-0",
+                            IdentityStrength =
+                                ChatToolIdentityStrength.Specific,
+                        },
+                    ],
+                }));
+        var (bridge, provider, snapshots, _) = CreateProvider(
+            [MainSession()],
+            toolMetaCachePath: cachePath);
+        bridge.HistoryBehavior = _ => Task.FromResult(new ChatHistoryInfo
+        {
+            SessionKey = "main",
+            SessionId = "session-1",
+            Messages =
+            [
+                new ChatMessageInfo
+                {
+                    Role = "assistant",
+                    Ts = 200,
+                    ToolContent =
+                    [
+                        new ChatToolContentInfo
+                        {
+                            Kind = ChatToolContentKind.Call,
+                            CallId = "history-tool-0",
+                            ToolName = "Exec",
+                        },
+                    ],
+                },
+                new ChatMessageInfo
+                {
+                    Role = "toolresult",
+                    Text = "flattened output",
+                    Ts = 300,
+                },
+            ],
+        });
+
+        await provider.LoadHistoryAsync("main");
+
+        Assert.Collection(
+            snapshots[^1].Timelines["main"].Entries,
+            structured =>
+            {
+                Assert.Equal("history-tool-0", structured.ToolCallId);
+                Assert.Equal("Exec", structured.ToolName);
+                Assert.Equal(
+                    ChatToolCallStatus.Interrupted,
+                    structured.ToolResult);
+                Assert.Null(structured.ToolOutput);
+            },
+            flattened =>
+            {
+                Assert.Equal("history-tool-1", flattened.ToolCallId);
+                Assert.NotEqual(
+                    "unverified-flat-id",
+                    flattened.ToolCallId);
+                Assert.Null(flattened.ToolRunId);
+                Assert.Equal("Bash", flattened.ToolName);
+                Assert.Equal(
+                    "echo flattened",
+                    flattened.ToolArgs?["command"]?.GetValue<string>());
+                Assert.Equal("flattened output", flattened.ToolOutput);
+                Assert.Equal(ChatToolCallStatus.Success, flattened.ToolResult);
+            });
+    }
+
+    [Fact]
+    public async Task LoadHistoryAsync_SyntheticToolIdsSkipReservedStructuredIds()
+    {
+        var (bridge, provider, snapshots, _) =
+            CreateProvider([MainSession()]);
+        bridge.HistoryBehavior = _ => Task.FromResult(new ChatHistoryInfo
+        {
+            SessionKey = "main",
+            Messages =
+            [
+                new ChatMessageInfo
+                {
+                    Role = "assistant",
+                    Ts = 100,
+                    ToolContent =
+                    [
+                        new ChatToolContentInfo
+                        {
+                            Kind = ChatToolContentKind.Call,
+                            CallId = "history-tool-0",
+                            ToolName = "Exec",
+                        },
+                        new ChatToolContentInfo
+                        {
+                            Kind = ChatToolContentKind.Call,
+                            CallId = "history-tool-2",
+                            ToolName = "Read",
+                        },
+                    ],
+                },
+                new ChatMessageInfo
+                {
+                    Role = "toolresult",
+                    Text = "first flattened",
+                    Ts = 200,
+                },
+                new ChatMessageInfo
+                {
+                    Role = "toolresult",
+                    Text = "second flattened",
+                    Ts = 300,
+                },
+            ],
+        });
+
+        await provider.LoadHistoryAsync("main");
+
+        var flattened = snapshots[^1].Timelines["main"].Entries
+            .Where(entry => entry.ToolOutput is not null)
+            .ToArray();
+        Assert.Equal(
+            ["history-tool-1", "history-tool-3"],
+            flattened.Select(entry => entry.ToolCallId));
+        Assert.Equal(
+            ["first flattened", "second flattened"],
+            flattened.Select(entry => entry.ToolOutput));
+    }
+
+    [Fact]
+    public async Task AccessibilityHistoryCollisionFixture_UsesCurrentHistoryOwners()
+    {
+        using var tempDir = new TempDirectory();
+        var (provider, bridge) =
+            AccessibilityHistoryCollisionFixture.CreateForTesting(
+                tempDir.DirectoryPath,
+                name => name switch
+                {
+                    "OPENCLAW_ACCESSIBILITY_TEST_CHAT" => "1",
+                    "OPENCLAW_ACCESSIBILITY_TEST_CHAT_FIXTURE" =>
+                        AccessibilityHistoryCollisionFixture.FixtureName,
+                    "OPENCLAW_TRAY_DATA_DIR" => tempDir.DirectoryPath,
+                    _ => null,
+                });
+        await using var providerScope = provider;
+
+        var snapshot = await provider.LoadAsync();
+
+        Assert.Equal(1, bridge.HistoryRequestCount);
+        Assert.Collection(
+            snapshot.Timelines[
+                AccessibilityHistoryCollisionFixture.ThreadId].Entries,
+            structured =>
+            {
+                Assert.Equal("history-tool-0", structured.ToolCallId);
+                Assert.Equal("Exec", structured.ToolName);
+                Assert.Equal(
+                    ChatToolCallStatus.Interrupted,
+                    structured.ToolResult);
+            },
+            flattened =>
+            {
+                Assert.Equal("history-tool-1", flattened.ToolCallId);
+                Assert.Equal("Bash", flattened.ToolName);
+                Assert.Equal(
+                    "flattened output owned by history-tool-1",
+                    flattened.ToolOutput);
+            });
+    }
+
+    [Fact]
     public async Task LoadHistoryAsync_StringEncodedToolArguments_PreservesSafeInput()
     {
         var (bridge, provider, snapshots, _) = CreateProvider(new[] { MainSession() });

--- a/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
@@ -7440,6 +7440,205 @@ public class OpenClawChatDataProviderTests
     }
 
     [Fact]
+    public async Task LoadHistoryAsync_VerifiedIdMissStopsPositionalEnrichment()
+    {
+        using var tempDir = new TempDirectory();
+        var cachePath = Path.Combine(
+            tempDir.DirectoryPath,
+            "tool-metadata.json");
+        File.WriteAllText(
+            cachePath,
+            JsonSerializer.Serialize(
+                new Dictionary<string, List<ChatMetadataStore.CachedToolMeta>>
+                {
+                    ["session-1"] =
+                    [
+                        new()
+                        {
+                            Ts = 100,
+                            ToolName = "Bash",
+                            Label = "stale positional command",
+                            ToolArgs = new JsonObject
+                            {
+                                ["command"] = "stale command",
+                            },
+                            IdentityStrength =
+                                ChatToolIdentityStrength.Specific,
+                        },
+                        new()
+                        {
+                            Ts = 200,
+                            ToolName = "Read",
+                            ToolCallId = "call-b",
+                            IdentityStrength =
+                                ChatToolIdentityStrength.Specific,
+                        },
+                    ],
+                }));
+        var (bridge, provider, snapshots, _) = CreateProvider(
+            [MainSession()],
+            toolMetaCachePath: cachePath);
+        bridge.HistoryBehavior = _ => Task.FromResult(new ChatHistoryInfo
+        {
+            SessionKey = "main",
+            SessionId = "session-1",
+            Messages =
+            [
+                new ChatMessageInfo
+                {
+                    Role = "assistant",
+                    Ts = 100,
+                    ToolContent =
+                    [
+                        new ChatToolContentInfo
+                        {
+                            Kind = ChatToolContentKind.Call,
+                            CallId = "call-a",
+                            ToolName = "Exec",
+                        },
+                    ],
+                },
+                new ChatMessageInfo
+                {
+                    Role = "assistant",
+                    Ts = 200,
+                    ToolContent =
+                    [
+                        new ChatToolContentInfo
+                        {
+                            Kind = ChatToolContentKind.Call,
+                            CallId = "call-b",
+                            ToolName = "Read",
+                        },
+                    ],
+                },
+                new ChatMessageInfo
+                {
+                    Role = "toolresult",
+                    Text = "unrelated flattened output",
+                    Ts = 300,
+                },
+            ],
+        });
+
+        await provider.LoadHistoryAsync("main");
+
+        var flattened = Assert.Single(
+            snapshots[^1].Timelines["main"].Entries,
+            entry => entry.ToolOutput == "unrelated flattened output");
+        Assert.NotEqual("Bash", flattened.ToolName);
+        Assert.NotEqual(
+            "stale positional command",
+            flattened.Text);
+        Assert.Null(flattened.ToolArgs);
+        Assert.Equal("history-tool-0", flattened.ToolCallId);
+    }
+
+    [Fact]
+    public async Task LoadHistoryAsync_PairedDuplicateResultsKeepPositionalEnrichment()
+    {
+        using var tempDir = new TempDirectory();
+        var cachePath = Path.Combine(
+            tempDir.DirectoryPath,
+            "tool-metadata.json");
+        File.WriteAllText(
+            cachePath,
+            JsonSerializer.Serialize(
+                new Dictionary<string, List<ChatMetadataStore.CachedToolMeta>>
+                {
+                    ["session-1"] =
+                    [
+                        new()
+                        {
+                            Ts = 100,
+                            ToolName = "Read",
+                            ToolCallId = "call-x",
+                        },
+                        new()
+                        {
+                            Ts = 250,
+                            ToolName = "Bash",
+                            Label = "flattened command",
+                            ToolArgs = new JsonObject
+                            {
+                                ["command"] = "echo flattened",
+                            },
+                        },
+                    ],
+                }));
+        var (bridge, provider, snapshots, _) = CreateProvider(
+            [MainSession()],
+            toolMetaCachePath: cachePath);
+        bridge.HistoryBehavior = _ => Task.FromResult(new ChatHistoryInfo
+        {
+            SessionKey = "main",
+            SessionId = "session-1",
+            Messages =
+            [
+                new ChatMessageInfo
+                {
+                    Role = "assistant",
+                    Ts = 100,
+                    ToolContent =
+                    [
+                        new ChatToolContentInfo
+                        {
+                            Kind = ChatToolContentKind.Call,
+                            CallId = "call-x",
+                            ToolName = "Read",
+                        },
+                    ],
+                },
+                new ChatMessageInfo
+                {
+                    Role = "developer",
+                    Text = "turn boundary",
+                    Ts = 150,
+                },
+                new ChatMessageInfo
+                {
+                    Role = "toolresult",
+                    Ts = 200,
+                    ToolContent =
+                    [
+                        new ChatToolContentInfo
+                        {
+                            Kind = ChatToolContentKind.Result,
+                            CallId = "call-x",
+                            ToolName = "Read",
+                            Text = "read output",
+                        },
+                        new ChatToolContentInfo
+                        {
+                            Kind = ChatToolContentKind.Result,
+                            CallId = "call-x",
+                            ToolName = "Read",
+                            Text = "more read output",
+                        },
+                    ],
+                },
+                new ChatMessageInfo
+                {
+                    Role = "toolresult",
+                    Text = "flattened output",
+                    Ts = 300,
+                },
+            ],
+        });
+
+        await provider.LoadHistoryAsync("main");
+
+        var flattened = Assert.Single(
+            snapshots[^1].Timelines["main"].Entries,
+            entry => entry.ToolOutput == "flattened output");
+        Assert.Equal("Bash", flattened.ToolName);
+        Assert.Equal("flattened command", flattened.Text);
+        Assert.Equal(
+            "echo flattened",
+            flattened.ToolArgs?["command"]?.GetValue<string>());
+    }
+
+    [Fact]
     public async Task LoadHistoryAsync_SyntheticToolIdsSkipReservedStructuredIds()
     {
         var (bridge, provider, snapshots, _) =

--- a/tests/OpenClaw.Tray.Tests/ToolMetaCacheTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ToolMetaCacheTests.cs
@@ -144,7 +144,8 @@ public class ToolMetaCacheTests
 
         var match = ChatMetadataStore.TryMatchCachedToolByCallId(
             cache,
-            "call-b");
+            "call-b",
+            historyTsMs: 200);
 
         Assert.Equal("bash", match!.ToolName);
         Assert.Equal("middle", match.Label);
@@ -164,11 +165,35 @@ public class ToolMetaCacheTests
 
         var match = ChatMetadataStore.TryMatchCachedToolByCallId(
             cache,
-            "missing");
+            "missing",
+            historyTsMs: 200);
 
         Assert.Null(match);
         Assert.Equal(
             ["call-a", "call-b"],
+            cache.Select(entry => entry.ToolCallId));
+    }
+
+    [Fact]
+    public void TryMatchByCallId_ReusedIdChoosesNearestTimestampAndPreservesOrder()
+    {
+        var cache = new Queue<ChatMetadataStore.CachedToolMeta>(
+        [
+            new() { Ts = 0, ToolName = "read", Label = "old", ToolCallId = "same" },
+            new() { Ts = 200, ToolName = "write", Label = "other", ToolCallId = "other" },
+            new() { Ts = 300, ToolName = "bash", Label = "current", ToolCallId = "same" },
+            new() { Ts = 400, ToolName = "edit", Label = "last", ToolCallId = "last" },
+        ]);
+
+        var match = ChatMetadataStore.TryMatchCachedToolByCallId(
+            cache,
+            "same",
+            historyTsMs: 290);
+
+        Assert.Equal("bash", match!.ToolName);
+        Assert.Equal("current", match.Label);
+        Assert.Equal(
+            ["same", "other", "last"],
             cache.Select(entry => entry.ToolCallId));
     }
 

--- a/tests/OpenClaw.Tray.Tests/ToolMetaCacheTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ToolMetaCacheTests.cs
@@ -2,6 +2,7 @@ using OpenClaw.Chat;
 using OpenClaw.Shared;
 using OpenClawTray.Chat;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Xunit;
 
 namespace OpenClaw.Tray.Tests;
@@ -129,6 +130,46 @@ public class ToolMetaCacheTests
 
         Assert.Equal("first bash", r1!.Label);
         Assert.Equal("second bash", r2!.Label);
+    }
+
+    [Fact]
+    public void TryMatchByCallId_MiddleMatchPreservesUnmatchedOrder()
+    {
+        var cache = new Queue<ChatMetadataStore.CachedToolMeta>(
+        [
+            new() { Ts = 100, ToolName = "read", Label = "first", ToolCallId = "call-a" },
+            new() { Ts = 200, ToolName = "bash", Label = "middle", ToolCallId = "call-b" },
+            new() { Ts = 300, ToolName = "write", Label = "last", ToolCallId = "call-c" },
+        ]);
+
+        var match = ChatMetadataStore.TryMatchCachedToolByCallId(
+            cache,
+            "call-b");
+
+        Assert.Equal("bash", match!.ToolName);
+        Assert.Equal("middle", match.Label);
+        Assert.Equal(
+            ["call-a", "call-c"],
+            cache.Select(entry => entry.ToolCallId));
+    }
+
+    [Fact]
+    public void TryMatchByCallId_MissingMatchPreservesEntireQueue()
+    {
+        var cache = new Queue<ChatMetadataStore.CachedToolMeta>(
+        [
+            new() { Ts = 100, ToolCallId = "call-a" },
+            new() { Ts = 200, ToolCallId = "call-b" },
+        ]);
+
+        var match = ChatMetadataStore.TryMatchCachedToolByCallId(
+            cache,
+            "missing");
+
+        Assert.Null(match);
+        Assert.Equal(
+            ["call-a", "call-b"],
+            cache.Select(entry => entry.ToolCallId));
     }
 
     // ── Constants ──
@@ -330,6 +371,86 @@ public class ToolMetaCacheTests
             cache!["main"],
             first => Assert.Equal(1, first.LegacyTurn),
             second => Assert.Equal(2, second.LegacyTurn));
+    }
+
+    [Fact]
+    public void BuildToolMetadataQueue_MergesStableCrossKeyIdentity()
+    {
+        var sessionEntries = new[]
+        {
+            new ChatMetadataStore.CachedToolMeta
+            {
+                Ts = 100,
+                ToolName = "Tool",
+                Label = "starting",
+                ToolCallId = "tool-1",
+                RunId = "run-1",
+                IdentityStrength = ChatToolIdentityStrength.Fallback,
+                ToolArgs = new JsonObject { ["command"] = "Get-Date" },
+            },
+        };
+        var threadEntries = new[]
+        {
+            new ChatMetadataStore.CachedToolMeta
+            {
+                Ts = 110,
+                ToolName = "Bash",
+                Label = "finished",
+                ToolCallId = "tool-1",
+                RunId = "run-1",
+                IdentityStrength = ChatToolIdentityStrength.Specific,
+                ToolArgs = new JsonObject { ["path"] = "src" },
+            },
+        };
+
+        var queue = ChatMetadataStore.BuildToolMetadataQueue(
+            sessionEntries,
+            threadEntries);
+
+        var merged = Assert.Single(queue!);
+        Assert.Equal(100, merged.Ts);
+        Assert.Equal("Bash", merged.ToolName);
+        Assert.Equal("finished", merged.Label);
+        Assert.Equal(
+            "Get-Date",
+            merged.ToolArgs!["command"]!.GetValue<string>());
+        Assert.Equal("src", merged.ToolArgs["path"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void BuildToolMetadataQueue_ReusedIdsAcrossScopesRemainDistinct()
+    {
+        var entries = new[]
+        {
+            new ChatMetadataStore.CachedToolMeta
+            {
+                Ts = 1,
+                ToolCallId = "same",
+                RunId = "run-1",
+            },
+            new ChatMetadataStore.CachedToolMeta
+            {
+                Ts = 2,
+                ToolCallId = "same",
+                RunId = "run-2",
+            },
+            new ChatMetadataStore.CachedToolMeta
+            {
+                Ts = 3,
+                ToolCallId = "same",
+                LegacyTurn = 1,
+            },
+            new ChatMetadataStore.CachedToolMeta
+            {
+                Ts = 4,
+                ToolCallId = "same",
+                LegacyTurn = 2,
+            },
+        };
+
+        var queue = ChatMetadataStore.BuildToolMetadataQueue(entries, null);
+
+        Assert.Equal([1L, 2L, 3L, 4L], queue!.Select(entry => entry.Ts));
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/ToolMetaCacheTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ToolMetaCacheTests.cs
@@ -142,11 +142,15 @@ public class ToolMetaCacheTests
             new() { Ts = 300, ToolName = "write", Label = "last", ToolCallId = "call-c" },
         ]);
 
-        var match = ChatMetadataStore.TryMatchCachedToolByCallId(
+        var lookup = ChatMetadataStore.TryMatchCachedToolByCallId(
             cache,
             "call-b",
             historyTsMs: 200);
 
+        Assert.Equal(
+            ChatMetadataStore.CachedToolLookupOutcome.Matched,
+            lookup.Outcome);
+        var match = lookup.Match;
         Assert.Equal("bash", match!.ToolName);
         Assert.Equal("middle", match.Label);
         Assert.Equal(
@@ -163,12 +167,15 @@ public class ToolMetaCacheTests
             new() { Ts = 200, ToolCallId = "call-b" },
         ]);
 
-        var match = ChatMetadataStore.TryMatchCachedToolByCallId(
+        var lookup = ChatMetadataStore.TryMatchCachedToolByCallId(
             cache,
             "missing",
             historyTsMs: 200);
 
-        Assert.Null(match);
+        Assert.Equal(
+            ChatMetadataStore.CachedToolLookupOutcome.Unmatched,
+            lookup.Outcome);
+        Assert.Null(lookup.Match);
         Assert.Equal(
             ["call-a", "call-b"],
             cache.Select(entry => entry.ToolCallId));
@@ -185,16 +192,55 @@ public class ToolMetaCacheTests
             new() { Ts = 400, ToolName = "edit", Label = "last", ToolCallId = "last" },
         ]);
 
-        var match = ChatMetadataStore.TryMatchCachedToolByCallId(
+        var lookup = ChatMetadataStore.TryMatchCachedToolByCallId(
             cache,
             "same",
             historyTsMs: 290);
 
+        Assert.Equal(
+            ChatMetadataStore.CachedToolLookupOutcome.Matched,
+            lookup.Outcome);
+        var match = lookup.Match;
         Assert.Equal("bash", match!.ToolName);
         Assert.Equal("current", match.Label);
         Assert.Equal(
             ["same", "other", "last"],
             cache.Select(entry => entry.ToolCallId));
+    }
+
+    [Fact]
+    public void TryMatchByCallId_EmptyCacheReportsNoCandidates()
+    {
+        var lookup = ChatMetadataStore.TryMatchCachedToolByCallId(
+            new Queue<ChatMetadataStore.CachedToolMeta>(),
+            "call-a",
+            historyTsMs: 100);
+
+        Assert.Equal(
+            ChatMetadataStore.CachedToolLookupOutcome.NoCandidates,
+            lookup.Outcome);
+        Assert.Null(lookup.Match);
+    }
+
+    [Fact]
+    public void TryMatchByCallId_MatchBehindNullIdHeadReportsMatched()
+    {
+        var cache = new Queue<ChatMetadataStore.CachedToolMeta>(
+        [
+            new() { Ts = 100, ToolName = "bash" },
+            new() { Ts = 200, ToolName = "read", ToolCallId = "call-b" },
+        ]);
+
+        var lookup = ChatMetadataStore.TryMatchCachedToolByCallId(
+            cache,
+            "call-b",
+            historyTsMs: 200);
+
+        Assert.Equal(
+            ChatMetadataStore.CachedToolLookupOutcome.Matched,
+            lookup.Outcome);
+        Assert.Equal(200, lookup.Match!.Ts);
+        Assert.Null(Assert.Single(cache).ToolCallId);
     }
 
     // ── Constants ──

--- a/tests/OpenClaw.Tray.UITests/AccessibilityAppFixture.cs
+++ b/tests/OpenClaw.Tray.UITests/AccessibilityAppFixture.cs
@@ -29,6 +29,7 @@ public sealed class AccessibilityAppFixture : IDisposable
 
     private readonly string _dataDirectory;
     private readonly string _executablePath;
+    private readonly string? _chatFixture;
     private readonly string? _nativeChatProofSignalPath;
     private readonly string? _nativeChatProofVisualDirectory;
     private readonly string _navigationSignalPath;
@@ -41,8 +42,11 @@ public sealed class AccessibilityAppFixture : IDisposable
     {
     }
 
-    internal AccessibilityAppFixture(bool initializeAxe)
+    internal AccessibilityAppFixture(
+        bool initializeAxe,
+        string? chatFixture = null)
     {
+        _chatFixture = chatFixture;
         _executablePath = Path.Combine(AppContext.BaseDirectory, "OpenClaw.Tray.WinUI.exe");
         if (!File.Exists(_executablePath))
         {
@@ -367,6 +371,12 @@ public sealed class AccessibilityAppFixture : IDisposable
         startInfo.Environment["OPENCLAW_LANGUAGE"] = "en-US";
         startInfo.Environment["OPENCLAW_ACCESSIBILITY_TEST_CHAT"] = "1";
         startInfo.Environment["OPENCLAW_ACCESSIBILITY_TEST_SESSIONS"] = "1";
+        if (!string.IsNullOrWhiteSpace(_chatFixture))
+        {
+            startInfo.Environment[
+                "OPENCLAW_ACCESSIBILITY_TEST_CHAT_FIXTURE"] =
+                _chatFixture;
+        }
         startInfo.Environment["OPENCLAW_ACCESSIBILITY_NAVIGATION_SIGNAL"] =
             _navigationSignalPath;
         if (_nativeChatProofSignalPath is not null

--- a/tests/OpenClaw.Tray.UITests/NativeToolIdentityScreenshotProofTests.cs
+++ b/tests/OpenClaw.Tray.UITests/NativeToolIdentityScreenshotProofTests.cs
@@ -38,6 +38,36 @@ public sealed class NativeToolIdentityScreenshotFixture : IDisposable
     public void Dispose() => _app.Dispose();
 }
 
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class HistoryCollisionScreenshotCollection :
+    ICollectionFixture<HistoryCollisionScreenshotFixture>
+{
+    public const string Name = "History collision screenshot";
+}
+
+public sealed class HistoryCollisionScreenshotFixture : IDisposable
+{
+    private readonly AccessibilityAppFixture _app = new(
+        initializeAxe: false,
+        chatFixture: "history-collision");
+
+    public IntPtr HubWindowHandle => _app.HubWindowHandle;
+
+    public Task NavigateAsync(
+        string pageTag,
+        string expectedPageName,
+        string pageMarkerAutomationId) =>
+        _app.NavigateAsync(
+            pageTag,
+            expectedPageName,
+            pageMarkerAutomationId);
+
+    public string? CaptureNativeChatVisualIfRequested() =>
+        _app.CaptureHubScreenshotIfRequested();
+
+    public void Dispose() => _app.Dispose();
+}
+
 [Collection(NativeToolIdentityScreenshotCollection.Name)]
 public sealed class NativeToolIdentityScreenshotProofTests
 {
@@ -174,6 +204,7 @@ public sealed class NativeToolIdentityScreenshotProofTests
                 yield return text;
             }
         }
+
     }
 
     private AutomationElement WaitForElement(Condition condition)
@@ -226,6 +257,201 @@ public sealed class NativeToolIdentityScreenshotProofTests
     private static void WriteProofArtifactIfRequested(IEnumerable<string> proof)
     {
         var path = Environment.GetEnvironmentVariable("OPENCLAW_UI_PROOF_ARTIFACT_PATH");
+        if (string.IsNullOrWhiteSpace(path))
+            return;
+
+        path = Path.GetFullPath(path, Environment.CurrentDirectory);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllLines(path, proof);
+    }
+}
+
+[Collection(HistoryCollisionScreenshotCollection.Name)]
+public sealed class HistoryCollisionScreenshotProofTests
+{
+    private static readonly TimeSpan UiTimeout = TimeSpan.FromSeconds(15);
+    private readonly HistoryCollisionScreenshotFixture _app;
+    private readonly ITestOutputHelper _output;
+
+    public HistoryCollisionScreenshotProofTests(
+        HistoryCollisionScreenshotFixture app,
+        ITestOutputHelper output)
+    {
+        _app = app;
+        _output = output;
+    }
+
+    [Fact]
+    [Trait("Category", "Accessibility")]
+    public async Task HistoryReplay_ShowsFlattenedBashIdentityWithoutCollision()
+    {
+        await _app.NavigateAsync(
+            "chat",
+            "ChatPage",
+            "ChatComposerInput");
+
+        var activity = WaitForElement(
+            element => element.Current.AutomationId.StartsWith(
+                "ChatToolActivity_",
+                StringComparison.Ordinal),
+            "history collision tool activity to appear");
+        Assert.True(
+            activity.TryGetCurrentPattern(
+                ExpandCollapsePattern.Pattern,
+                out var rawActivityPattern));
+        var activityPattern =
+            Assert.IsType<ExpandCollapsePattern>(rawActivityPattern);
+        if (activityPattern.Current.ExpandCollapseState ==
+            ExpandCollapseState.Collapsed)
+        {
+            activityPattern.Expand();
+        }
+
+        var bash = WaitForElement(
+            new PropertyCondition(
+                AutomationElement.NameProperty,
+                "Tool call Bash. Done."));
+        Assert.True(
+            bash.TryGetCurrentPattern(
+                ExpandCollapsePattern.Pattern,
+                out var rawPattern));
+        var pattern = Assert.IsType<ExpandCollapsePattern>(rawPattern);
+        if (pattern.Current.ExpandCollapseState ==
+            ExpandCollapseState.Collapsed)
+        {
+            pattern.Expand();
+        }
+
+        var names = WaitForNames(
+            "command: synthetic flattened id: history-tool-1",
+            "flattened output owned by history-tool-1");
+        Assert.DoesNotContain(
+            names,
+            name => name.Contains(
+                "unverified-flat-id",
+                StringComparison.Ordinal));
+        Assert.DoesNotContain(
+            names,
+            name => name.Contains(
+                "unverified-flat-run",
+                StringComparison.Ordinal));
+
+        var proof = new List<string>
+        {
+            $"head={Environment.GetEnvironmentVariable("OPENCLAW_UI_PROOF_HEAD") ?? "local"}",
+            "UIA tool=\"Tool call Bash. Done.\"",
+            "UIA input=\"command: synthetic flattened id: history-tool-1\"",
+            "UIA output=\"flattened output owned by history-tool-1\"",
+            "forbidden unverified-flat-id=absent",
+            "forbidden unverified-flat-run=absent",
+        };
+        if (_app.CaptureNativeChatVisualIfRequested() is { } screenshotPath)
+        {
+            proof.Add(
+                $"screenshot={Path.GetFileName(screenshotPath)} " +
+                $"bytes={new FileInfo(screenshotPath).Length}");
+        }
+        proof.Add("result=pass");
+        foreach (var line in proof)
+            _output.WriteLine(line);
+        WriteProofArtifactIfRequested(proof);
+    }
+
+    private AutomationElement WaitForElement(Condition condition)
+    {
+        AutomationElement? element = null;
+        WaitUntil(() =>
+        {
+            var hub = AutomationElement.FromHandle(_app.HubWindowHandle);
+            element = hub.FindFirst(TreeScope.Descendants, condition);
+            return element is not null;
+        }, "history collision tool row to appear");
+        return element!;
+    }
+
+    private AutomationElement WaitForElement(
+        Func<AutomationElement, bool> predicate,
+        string description)
+    {
+        AutomationElement? element = null;
+        WaitUntil(() =>
+        {
+            var hub = AutomationElement.FromHandle(_app.HubWindowHandle);
+            element = hub.FindAll(
+                    TreeScope.Descendants,
+                    Condition.TrueCondition)
+                .Cast<AutomationElement>()
+                .FirstOrDefault(predicate);
+            return element is not null;
+        }, description);
+        return element!;
+    }
+
+    private HashSet<string> WaitForNames(params string[] expected)
+    {
+        HashSet<string>? names = null;
+        WaitUntil(() =>
+        {
+            var hub = AutomationElement.FromHandle(_app.HubWindowHandle);
+            names = hub.FindAll(
+                    TreeScope.Descendants,
+                    Condition.TrueCondition)
+                .Cast<AutomationElement>()
+                .SelectMany(ReadTextCandidates)
+                .ToHashSet(StringComparer.Ordinal);
+            return expected.All(names.Contains);
+        }, "history collision proof text to appear");
+        return names!;
+    }
+
+    private static IEnumerable<string> ReadTextCandidates(
+        AutomationElement element)
+    {
+        var name = element.Current.Name;
+        if (!string.IsNullOrWhiteSpace(name))
+            yield return name;
+
+        if (element.TryGetCurrentPattern(
+                TextPattern.Pattern,
+                out var rawPattern) &&
+            rawPattern is TextPattern textPattern)
+        {
+            var text = textPattern.DocumentRange
+                .GetText(-1)
+                .TrimEnd('\r', '\n');
+            if (!string.IsNullOrWhiteSpace(text) &&
+                !string.Equals(text, name, StringComparison.Ordinal))
+            {
+                yield return text;
+            }
+        }
+    }
+
+    private static void WaitUntil(
+        Func<bool> predicate,
+        string description)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        while (stopwatch.Elapsed < UiTimeout)
+        {
+            try
+            {
+                if (predicate())
+                    return;
+            }
+            catch (ElementNotAvailableException)
+            {
+            }
+            Thread.Sleep(100);
+        }
+        throw new TimeoutException($"Timed out waiting for {description}.");
+    }
+
+    private static void WriteProofArtifactIfRequested(
+        IEnumerable<string> proof)
+    {
+        var path = Environment.GetEnvironmentVariable(
+            "OPENCLAW_UI_PROOF_ARTIFACT_PATH");
         if (string.IsNullOrWhiteSpace(path))
             return;
 


### PR DESCRIPTION
Related: #894
Replaces: #1130

## What problem this solves

Native Chat history could attach flattened tool output to the wrong structured tool row when cached metadata, reused call IDs, and generated history IDs collided.

## What changed

- `ChatHistoryLoader` reserves structured transcript IDs before allocating synthetic IDs.
- `ChatMetadataStore` merges stable cross-key metadata and matches structured entries by exact ordinal call ID, choosing the nearest timestamp when IDs are reused.
- A verified-ID miss now fails closed: positional cache enrichment becomes untrusted for the rest of that deterministic rebuild, preventing stale tool names or arguments from reaching later flattened rows.
- Per-ID call/result occurrence tracking prevents normal pairs, result-before-call ordering, turn boundaries, and duplicate result blocks from creating false misses.
- Flattened results always receive fresh synthetic IDs and never reuse unverified cached call or run IDs.

Ownership remains consistent with `docs/ARCHITECTURE.md`: history replay stays in `ChatHistoryLoader`, cached correlation stays in `ChatMetadataStore`, and `OpenClawChatDataProvider` remains the facade. Later PR #1301 changes provider snapshot publication/lifetime only; there is no production-file overlap or semantic ownership conflict.

## User impact

Structured and flattened historical tool activity render as separate rows with truthful tool identity, sanitized arguments, status, and output ownership.

## Required proof pools

- `windows-winui-interactive`: current-head native Chat history identity, input, output, and accessibility proof.

## Validation

Exact reviewed head: `ea0dd548f459de8be3fea0c10408c353d66014c3` on base `585c1776e8900c22aa12c2be801db6d6e73ddf9e`.

- `.\build.ps1`: passed, 5 of 5 projects.
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore`: 3,915 passed, 0 failed, 32 skipped.
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore`: 2,852 passed, 0 failed.
- Focused correlation/concurrency/cancellation/disposal selection: 11 passed, 0 failed.
- Final correlation, reused-ID, result-before-call, duplicate-result, and stale-cache selection: 10 passed, 0 failed.
- `HistoryCollisionScreenshotProofTests` with `-r win-x64`: 1 passed, 0 failed.
- Hanselman dual-model review (Claude Opus 5 and GPT-5.3-Codex): one high-consensus stale-cache finding fixed; two follow-up false-latch cases fixed; both final reviewers report no actionable correctness findings.
- One earlier Shared run transiently failed the unrelated `McpHttpServerTests.Dispose_DuringInFlightHandler_DoesNotSurfaceObjectDisposedException`; the isolated rerun and subsequent full required reruns passed.
- Exact-head Build and Test workflow `33863943601`, attempt 2: CI Gate passed. Core/CLI, Tray/setup/integration, UI/accessibility, proof contracts, release metadata, E2E, and publish smoke jobs passed.
- Exact-head CodeQL workflow `33863943703`: passed, including C# and Actions security.

## Real behavior proof

- Environment: Windows 11, isolated tray data, native WinUI app, and UI Automation.
- Exact head tested: `ea0dd548f459de8be3fea0c10408c353d66014c3`.
- Command: `dotnet test .\tests\OpenClaw.Tray.UITests\OpenClaw.Tray.UITests.csproj -r win-x64 --filter "FullyQualifiedName~HistoryCollisionScreenshotProofTests"`.
- UIA found `Tool call Bash. Done.` with input `command: synthetic flattened id: history-tool-1` and output `flattened output owned by history-tool-1`.
- UIA confirmed `unverified-flat-id` and `unverified-flat-run` were absent.
- Screenshot: 3862 x 2499, 377,005 bytes, SHA-256 `7621823E76A10109931DE83BDA6CB5DF8A2003DAD375AE3C99203A6B58AEF1FF`.
- Hosted screenshot bytes were fetched after upload and matched the local SHA-256.
- Not verified / blocked: None.

![Current-head native history collision proof](https://github.com/user-attachments/assets/f3f0ebab-6ca7-4c8a-913a-24aab0bac121)

## Security impact

- New permissions or capabilities: No.
- Secrets or token handling changed: No.
- Network calls changed: No.
- Command execution surface changed: No.
- Cached display arguments remain allowlisted, sanitized, and bounded.

## Compatibility and migration

Backward compatible. No configuration, environment, or migration changes are required.

## Merge

Squash-merged from exact reviewed head as `8e5526bb4b72232cd84e6e1163f019037ff975ee` on `main`.