### PR TITLE
fix(update): suppress ordinary extended-stable notices

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -81,6 +81,13 @@ Stable, stable-correction, and alpha tags use the same signed CI release pipelin
   release under OpenClaw correction ordering.
 - `vX.Y.Z-alpha.N` creates a prerelease that stable updater checks do not offer.
 
+Windows companion updates are ordinarily suppressed when the authenticated
+Gateway reports the `extended-stable` effective channel. A security-critical
+Windows release must include `<!-- openclaw-update: security-critical -->` in
+its GitHub release body. Release names or bodies containing `security`, a CVE
+identifier, or a GHSA identifier are also treated as security-critical and are
+offered regardless of the Gateway channel.
+
 Stable correction support begins only with an eligible upstream release tag
 created from `main` after the correction-aware implementation has landed. For
 this rollout, the Windows repository already contains its own annotated

--- a/src/OpenClaw.Shared/GatewayUpdateStatus.cs
+++ b/src/OpenClaw.Shared/GatewayUpdateStatus.cs
@@ -1,0 +1,27 @@
+using System.Text.Json;
+
+namespace OpenClaw.Shared;
+
+/// <summary>
+/// The Gateway's authoritative update track for its installed OpenClaw runtime.
+/// </summary>
+public sealed class GatewayUpdateStatus
+{
+    public string? EffectiveChannel { get; init; }
+}
+
+public static class GatewayUpdateStatusParser
+{
+    /// <summary>
+    /// Parses the additive <c>effectiveChannel</c> field from <c>update.status</c>.
+    /// Older Gateways omit the field, which preserves the companion updater path.
+    /// </summary>
+    public static GatewayUpdateStatus Parse(JsonElement payload) => new()
+    {
+        EffectiveChannel = payload.ValueKind == JsonValueKind.Object &&
+                           payload.TryGetProperty("effectiveChannel", out var channel) &&
+                           channel.ValueKind == JsonValueKind.String
+            ? channel.GetString()
+            : null
+    };
+}

--- a/src/OpenClaw.Shared/IOperatorGatewayClient.cs
+++ b/src/OpenClaw.Shared/IOperatorGatewayClient.cs
@@ -138,6 +138,12 @@ public interface IOperatorGatewayClient
     Task<bool> StopChannelAsync(string channelName);
     /// <summary>Fetch the rich channels.status snapshot from the gateway. Mac/web canonical wire method.</summary>
     Task<ChannelsStatusSnapshot?> GetChannelsStatusAsync(bool probe = false, int timeoutMs = 12000);
+    /// <summary>
+    /// Fetches the Gateway's effective update track (<c>update.status</c>). The
+    /// default preserves compatibility with clients for older Gateways.
+    /// </summary>
+    Task<GatewayUpdateStatus?> GetUpdateStatusAsync(int timeoutMs = 5000) =>
+        Task.FromResult<GatewayUpdateStatus?>(null);
     /// <summary>Log out / unlink a channel (whatsapp, telegram). Sends channels.logout { channel }.</summary>
     Task<bool> LogoutChannelAsync(string channelName, int timeoutMs = 12000);
     /// <summary>Begin a QR linking flow (whatsapp, signal). Sends web.login.start { force, timeoutMs }.</summary>

--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -1869,6 +1869,19 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
         }
     }
 
+    /// <summary>
+    /// Fetches the installed Gateway's effective update channel. RPC failures
+    /// propagate so the update coordinator can apply its explicit fail-safe.
+    /// </summary>
+    public async Task<GatewayUpdateStatus?> GetUpdateStatusAsync(int timeoutMs = 5000)
+    {
+        if (!IsConnected)
+            return null;
+
+        var response = await SendWizardRequestAsync("update.status", new { }, timeoutMs);
+        return GatewayUpdateStatusParser.Parse(response);
+    }
+
     /// <summary>Log out / unlink a channel. Sends <c>channels.logout { channel }</c>.</summary>
     public async Task<bool> LogoutChannelAsync(string channelName, int timeoutMs = 12000)
     {

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -43,11 +43,20 @@ namespace OpenClawTray;
 
 public partial class App : Application, OpenClawTray.Services.IAppCommands, IPermissionsPageRuntimeHost
 {
-    internal static readonly UpdatumManager AppUpdater = new("openclaw", "openclaw-windows-node")
+    internal static readonly UpdatumManager AppUpdater = CreateAppUpdater();
+
+    private static UpdatumManager CreateAppUpdater()
     {
-        FetchOnlyLatestRelease = true,
-        InstallUpdateSingleFileExecutableName = "OpenClaw.Tray.WinUI",
-    };
+        UpdatumManager.GitHubApiOptions.PageSize = 100;
+        UpdatumManager.GitHubApiOptions.PageCount = 1;
+        return new UpdatumManager("openclaw", "openclaw-windows-node")
+        {
+            // Suppression must inspect every eligible release above the installed
+            // version so a newer ordinary release cannot mask a security release.
+            FetchOnlyLatestRelease = false,
+            InstallUpdateSingleFileExecutableName = "OpenClaw.Tray.WinUI",
+        };
+    }
 
     private ITrayController? _trayController;
     private IWindowManager? _windowManager;
@@ -636,6 +645,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands, IPer
             AppUpdater,
             _appState,
             _settings,
+            () => _connectionManager?.OperatorClient,
             () => _windowManager?.DialogXamlRoot,
             refreshStatus: UpdateStatusDetailWindow,
             exit: Exit);
@@ -693,19 +703,6 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands, IPer
         // in-progress download/extraction. We still control shutdown
         // explicitly via Application.Exit().
         DispatcherShutdownMode = DispatcherShutdownMode.OnExplicitShutdown;
-
-        // Check for updates before launching. Skip in test instances — no UI dialogs,
-        // no network calls, no startup delay.
-        if (DataDirOverride is null &&
-            Environment.GetEnvironmentVariable("OPENCLAW_SKIP_UPDATE_CHECK") != "1")
-        {
-            var shouldLaunch = await _updateCoordinator.CheckForUpdatesAsync();
-            if (!shouldLaunch)
-            {
-                Exit();
-                return;
-            }
-        }
 
         // Register toast activation handler
         ToastNotificationManagerCompat.OnActivated += OnToastActivated;
@@ -924,7 +921,16 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands, IPer
             isAutomaticRepairAllowed: gatewayId => _connectionManager?.IsAutomaticReconnectAllowed(gatewayId) ?? false);
         _managedLocalAutoRepairMonitor.Start();
 
-        InitializeGatewayClient();
+        var startupConnectKind = InitializeGatewayClient();
+        if (AutomaticUpdateCheckPolicy.PlanStartup(startupConnectKind) ==
+            AutomaticUpdateCheckStartupPlan.AwaitOperatorHandshakeWithDeadline)
+        {
+            StartAutomaticUpdateCheckGatewayDeadline();
+        }
+        else
+        {
+            StartAutomaticUpdateCheckWithoutGateway();
+        }
 
         // Pre-warm chat window (WebView2 init takes 1-3s, do it now so left-click is instant)
         if (_settings != null &&
@@ -1741,9 +1747,11 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands, IPer
 
     #region Gateway Client
 
-    private void InitializeGatewayClient(bool useBootstrapHandoffAuth = false)
+    private StartupGatewayConnectKind InitializeGatewayClient(
+        bool useBootstrapHandoffAuth = false)
     {
-        if (_settings == null || _connectionManager == null || _gatewayRegistry == null) return;
+        if (_settings == null || _connectionManager == null || _gatewayRegistry == null)
+            return StartupGatewayConnectKind.None;
         // SSH tunnel lifecycle is now handled by the connection manager.
 
         var gatewayUrl = _settings.GetEffectiveGatewayUrl();
@@ -1752,31 +1760,35 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands, IPer
         var activeRecord = _gatewayRegistry.GetActive();
         if (activeRecord != null)
         {
-            if (!TryConnectGatewayIfCredentialAvailable(activeRecord, "startup"))
+            var connectKind =
+                TryConnectGatewayIfCredentialAvailable(activeRecord, "startup");
+            if (connectKind == StartupGatewayConnectKind.None)
             {
                 // Still start MCP-only node if enabled — the active record may be stale
                 // and MCP-only mode must work without gateway credentials.
                 TryStartLocalMcpOnlyNode();
             }
-            return;
+            return connectKind;
         }
 
         TryMigrateLegacyGatewaySettings(gatewayUrl, new AppLogger());
         activeRecord = _gatewayRegistry.GetActive();
         if (activeRecord != null)
         {
-            if (!TryConnectGatewayIfCredentialAvailable(activeRecord, "legacy migration"))
+            var connectKind =
+                TryConnectGatewayIfCredentialAvailable(activeRecord, "legacy migration");
+            if (connectKind == StartupGatewayConnectKind.None)
                 TryStartLocalMcpOnlyNode();
-            return;
+            return connectKind;
         }
 
         if (string.IsNullOrWhiteSpace(gatewayUrl))
         {
             if (TryStartLocalMcpOnlyNode())
-                return;
+                return StartupGatewayConnectKind.None;
 
             Logger.Info("Gateway URL not configured — skipping client initialization");
-            return;
+            return StartupGatewayConnectKind.None;
         }
 
         // Bridge: create/update a GatewayRecord from current settings URL.
@@ -1801,16 +1813,16 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands, IPer
                 Logger.Error($"Stored device identity load failed during startup: {ex.InnerException?.Message}");
                 ShowTransientConnectionError(ex.Message);
                 TryStartLocalMcpOnlyNode();
-                return;
+                return StartupGatewayConnectKind.None;
             }
 
             if (!hasStoredDeviceToken)
             {
                 if (TryStartLocalMcpOnlyNode())
-                    return;
+                    return StartupGatewayConnectKind.None;
 
                 Logger.Info("No stored device token — skipping startup connect (use Setup Code)");
-                return;
+                return StartupGatewayConnectKind.None;
             }
 
             var recordId = Guid.NewGuid().ToString();
@@ -1859,18 +1871,23 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands, IPer
 
         // Delegate to connection manager — it creates the client, fires OperatorClientChanged,
         // and our handler re-wires the 27 event subscriptions
-        if (!TryConnectGatewayIfCredentialAvailable(migratedRecord, "startup bridge"))
+        var migratedConnectKind =
+            TryConnectGatewayIfCredentialAvailable(migratedRecord, "startup bridge");
+        if (migratedConnectKind == StartupGatewayConnectKind.None)
             TryStartLocalMcpOnlyNode();
+        return migratedConnectKind;
     }
 
     /// <summary>
     /// Connects only when the active gateway has a usable operator credential:
     /// device token, shared gateway token, or bootstrap token.
     /// </summary>
-    private bool TryConnectGatewayIfCredentialAvailable(GatewayRecord record, string context)
+    private StartupGatewayConnectKind TryConnectGatewayIfCredentialAvailable(
+        GatewayRecord record,
+        string context)
     {
         if (_connectionManager == null || _gatewayRegistry == null)
-            return false;
+            return StartupGatewayConnectKind.None;
 
         record = SyncGatewayBrowserProxyForward(record);
         var resolver = new CredentialResolver(DeviceIdentityFileReader.Instance);
@@ -1884,7 +1901,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands, IPer
         {
             Logger.Error($"Stored device identity load failed during {context}: {ex.InnerException?.Message}");
             ShowTransientConnectionError(ex.Message);
-            return false;
+            return StartupGatewayConnectKind.None;
         }
 
         if (credential == null)
@@ -1898,7 +1915,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands, IPer
             {
                 Logger.Error($"Stored node identity load failed during {context}: {ex.InnerException?.Message}");
                 ShowTransientConnectionError(ex.Message);
-                return false;
+                return StartupGatewayConnectKind.None;
             }
 
             if (nodeCredential != null && IsGatewayNodeEnabled())
@@ -1908,11 +1925,11 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands, IPer
                 ObserveBackgroundFault(
                     _connectionManager.ConnectNodeOnlyAsync(record.Id),
                     $"[App] Startup node-only gateway connect failed during {context}");
-                return true;
+                return StartupGatewayConnectKind.NodeOnly;
             }
 
             Logger.Info($"Active gateway has no usable credential — skipping {context} connect");
-            return false;
+            return StartupGatewayConnectKind.None;
         }
 
         var connectionKind = record.LastConnected.HasValue
@@ -1924,7 +1941,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands, IPer
             $"[App] Startup gateway connect failed during {context}");
         if (!IsGatewayNodeEnabled())
             TryStartLocalMcpOnlyNode();
-        return true;
+        return StartupGatewayConnectKind.Operator;
     }
 
     private void ReconnectWithSyncedBrowserProxyForward()
@@ -2186,6 +2203,16 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands, IPer
     /// </summary>
     private void OnOperatorClientChanged(object? sender, OperatorClientChangedEventArgs e)
     {
+        // Subscribe before UI dispatch. A local Gateway can complete hello-ok
+        // before the remaining UI-side client wiring runs.
+        if (e.OldClient != null)
+            e.OldClient.HandshakeSucceeded -= OnGatewayUpdateCheckHandshakeSucceeded;
+        if (e.NewClient != null)
+        {
+            e.NewClient.HandshakeSucceeded -= OnGatewayUpdateCheckHandshakeSucceeded;
+            e.NewClient.HandshakeSucceeded += OnGatewayUpdateCheckHandshakeSucceeded;
+        }
+
         if (_dispatcherQueue is { HasThreadAccess: false } dispatcher)
         {
             if (!dispatcher.TryEnqueue(() => OnOperatorClientChanged(sender, e)))
@@ -2220,6 +2247,53 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands, IPer
         // Update UI references
         if (_appState != null)
             _appState.GatewaySelf = null;
+    }
+
+    private void OnGatewayUpdateCheckHandshakeSucceeded(object? sender, EventArgs e)
+    {
+        if (sender is not IOperatorGatewayClient client ||
+            !ReferenceEquals(client, _connectionManager?.OperatorClient) ||
+            DataDirOverride is not null ||
+            Environment.GetEnvironmentVariable("OPENCLAW_SKIP_UPDATE_CHECK") == "1")
+        {
+            return;
+        }
+
+        OnUiThread(
+            () => _ = _updateCoordinator?
+                .CheckForAutomaticUpdatesAfterGatewayResolutionAsync());
+    }
+
+    private void StartAutomaticUpdateCheckWithoutGateway()
+    {
+        if (DataDirOverride is not null ||
+            Environment.GetEnvironmentVariable("OPENCLAW_SKIP_UPDATE_CHECK") == "1")
+        {
+            return;
+        }
+
+        OnUiThread(
+            () => _ = _updateCoordinator?
+                .CheckForAutomaticUpdatesAfterGatewayResolutionAsync());
+    }
+
+    private void StartAutomaticUpdateCheckGatewayDeadline()
+    {
+        if (DataDirOverride is not null ||
+            Environment.GetEnvironmentVariable("OPENCLAW_SKIP_UPDATE_CHECK") == "1")
+        {
+            return;
+        }
+
+        ObserveBackgroundFault(
+            RunAutomaticUpdateCheckGatewayDeadlineAsync(),
+            "[Update] Gateway status resolution deadline failed");
+    }
+
+    private async Task RunAutomaticUpdateCheckGatewayDeadlineAsync()
+    {
+        await Task.Delay(AutomaticUpdateCheckPolicy.GatewayResolutionDeadline);
+        StartAutomaticUpdateCheckWithoutGateway();
     }
 
     private void RaiseChatProviderChanged()
@@ -2260,6 +2334,12 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands, IPer
         else
         {
             _lastManagerConnectedSideEffectsKey = null;
+        }
+
+        if (AutomaticUpdateCheckPolicy.IsGatewayStatusTerminallyUnavailable(
+                snap.OperatorState))
+        {
+            StartAutomaticUpdateCheckWithoutGateway();
         }
     }
 

--- a/src/OpenClaw.Tray.WinUI/Services/AutomaticUpdateCheckPolicy.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/AutomaticUpdateCheckPolicy.cs
@@ -1,0 +1,32 @@
+using OpenClaw.Connection;
+
+namespace OpenClawTray.Services;
+
+internal enum StartupGatewayConnectKind
+{
+    None,
+    Operator,
+    NodeOnly,
+}
+
+internal enum AutomaticUpdateCheckStartupPlan
+{
+    Immediate,
+    AwaitOperatorHandshakeWithDeadline,
+}
+
+internal static class AutomaticUpdateCheckPolicy
+{
+    public static readonly TimeSpan GatewayResolutionDeadline =
+        TimeSpan.FromSeconds(45);
+
+    public static AutomaticUpdateCheckStartupPlan PlanStartup(
+        StartupGatewayConnectKind connectKind) =>
+        connectKind == StartupGatewayConnectKind.Operator
+            ? AutomaticUpdateCheckStartupPlan.AwaitOperatorHandshakeWithDeadline
+            : AutomaticUpdateCheckStartupPlan.Immediate;
+
+    public static bool IsGatewayStatusTerminallyUnavailable(
+        RoleConnectionState operatorState) =>
+        operatorState == RoleConnectionState.PairingRequired;
+}

--- a/src/OpenClaw.Tray.WinUI/Services/UpdateCheckPipeline.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/UpdateCheckPipeline.cs
@@ -7,6 +7,8 @@ namespace OpenClawTray.Services;
 
 internal sealed record UpdateReleaseCandidate(
     string? TagName,
+    string? Name,
+    string? Body,
     bool Draft,
     bool Prerelease,
     bool Published,
@@ -17,12 +19,80 @@ internal interface IUpdateCheckBoundary
 {
     Task<bool> CheckForUpdatesAsync();
 
+    UpdateReleaseCandidate? GetSelectedRelease();
+
     IEnumerable<UpdateReleaseCandidate> GetReleaseCandidates();
+
+    bool IsReleaseHistoryComplete(string currentVersion);
 }
 
 internal sealed record UpdateCheckOutcome(
     bool UpdateFound,
-    string? ActivatedFallbackTag = null);
+    UpdateReleaseCandidate? SelectedRelease = null,
+    string? ActivatedFallbackTag = null,
+    bool HasSecurityCriticalRelease = false)
+{
+    public bool IsSecurityCritical =>
+        UpdateFound &&
+        (HasSecurityCriticalRelease ||
+         UpdateReleasePolicy.IsSecurityCritical(SelectedRelease));
+}
+
+internal static class UpdateReleasePolicy
+{
+    internal const string SecurityCriticalMarker =
+        "<!-- openclaw-update: security-critical -->";
+
+    public static bool IsSecurityCritical(UpdateReleaseCandidate? release)
+    {
+        // An available update that cannot be inspected must never be hidden.
+        if (release is null)
+            return true;
+
+        return ContainsSecuritySignal(release.Name) ||
+               ContainsSecuritySignal(release.Body);
+    }
+
+    private static bool ContainsSecuritySignal(string? value) =>
+        !string.IsNullOrWhiteSpace(value) &&
+        (value.Contains(SecurityCriticalMarker, StringComparison.OrdinalIgnoreCase) ||
+         value.Contains("security", StringComparison.OrdinalIgnoreCase) ||
+         value.Contains("CVE-", StringComparison.OrdinalIgnoreCase) ||
+         value.Contains("GHSA-", StringComparison.OrdinalIgnoreCase));
+}
+
+internal static class CompanionUpdateSuppressionPolicy
+{
+    public static bool ShouldSuppress(
+        GatewayUpdateStatus? gatewayStatus,
+        UpdateCheckOutcome update) =>
+        update.UpdateFound &&
+        !update.IsSecurityCritical &&
+        string.Equals(
+            gatewayStatus?.EffectiveChannel,
+            "extended-stable",
+            StringComparison.OrdinalIgnoreCase);
+}
+
+internal static class GatewayUpdateStatusLookup
+{
+    public static async Task<GatewayUpdateStatus?> TryGetAsync(
+        Func<Task<GatewayUpdateStatus?>> request,
+        Action<Exception>? onUnavailable = null)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        try
+        {
+            return await request();
+        }
+        catch (Exception ex)
+        {
+            onUnavailable?.Invoke(ex);
+            return null;
+        }
+    }
+}
 
 internal static class UpdateCheckPipeline
 {
@@ -33,27 +103,67 @@ internal static class UpdateCheckPipeline
         ArgumentNullException.ThrowIfNull(boundary);
 
         if (await boundary.CheckForUpdatesAsync())
-            return new UpdateCheckOutcome(UpdateFound: true);
-
-        foreach (var release in boundary.GetReleaseCandidates())
         {
-            if (release.Draft ||
-                release.Prerelease ||
-                !release.Published ||
-                !OpenClawReleaseVersion.IsNewerStableRelease(
-                    release.TagName,
-                    currentVersion) ||
-                !release.HasCompatibleAsset())
-            {
-                continue;
-            }
-
-            release.Activate();
+            var selectedRelease = boundary.GetSelectedRelease();
             return new UpdateCheckOutcome(
                 UpdateFound: true,
-                ActivatedFallbackTag: release.TagName);
+                SelectedRelease: selectedRelease,
+                HasSecurityCriticalRelease:
+                    !boundary.IsReleaseHistoryComplete(currentVersion) ||
+                    UpdateReleasePolicy.IsSecurityCritical(selectedRelease) ||
+                    HasEligibleSecurityCriticalRelease(boundary, currentVersion));
+        }
+
+        UpdateReleaseCandidate? fallbackRelease = null;
+        var hasSecurityCriticalRelease =
+            !boundary.IsReleaseHistoryComplete(currentVersion);
+        foreach (var release in boundary.GetReleaseCandidates())
+        {
+            if (!IsEligibleWindowsRelease(release, currentVersion))
+                continue;
+
+            hasSecurityCriticalRelease |=
+                UpdateReleasePolicy.IsSecurityCritical(release);
+            fallbackRelease ??= release;
+        }
+
+        if (fallbackRelease is not null)
+        {
+            fallbackRelease.Activate();
+            return new UpdateCheckOutcome(
+                UpdateFound: true,
+                SelectedRelease: fallbackRelease,
+                ActivatedFallbackTag: fallbackRelease.TagName,
+                HasSecurityCriticalRelease: hasSecurityCriticalRelease);
         }
 
         return new UpdateCheckOutcome(UpdateFound: false);
     }
+
+    private static bool HasEligibleSecurityCriticalRelease(
+        IUpdateCheckBoundary boundary,
+        string currentVersion)
+    {
+        foreach (var release in boundary.GetReleaseCandidates())
+        {
+            if (IsEligibleWindowsRelease(release, currentVersion) &&
+                UpdateReleasePolicy.IsSecurityCritical(release))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsEligibleWindowsRelease(
+        UpdateReleaseCandidate release,
+        string currentVersion) =>
+        !release.Draft &&
+        !release.Prerelease &&
+        release.Published &&
+        OpenClawReleaseVersion.IsNewerStableRelease(
+            release.TagName,
+            currentVersion) &&
+        release.HasCompatibleAsset();
 }

--- a/src/OpenClaw.Tray.WinUI/Services/UpdateCoordinator.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/UpdateCoordinator.cs
@@ -1,5 +1,6 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using OpenClaw.Connection;
 using OpenClaw.Shared;
 using OpenClawTray.Dialogs;
 using OpenClawTray.Helpers;
@@ -21,6 +22,7 @@ internal sealed class UpdateCoordinator(
     UpdatumManager updater,
     AppState appState,
     SettingsManager? settings,
+    Func<IOperatorGatewayClient?> getGatewayClient,
     Func<XamlRoot?> getXamlRoot,
     Action refreshStatus,
     Action exit,
@@ -29,6 +31,8 @@ internal sealed class UpdateCoordinator(
     private readonly SettingsManager? _settings = settings;
     private readonly IUpdateCheckBoundary _updateCheckBoundary =
         updateCheckBoundary ?? new UpdatumUpdateCheckBoundary(updater);
+    private readonly Func<IOperatorGatewayClient?> _getGatewayClient =
+        getGatewayClient ?? throw new ArgumentNullException(nameof(getGatewayClient));
 
     // Cross-path concurrency for update checks, split into two phases:
     //  - _updateCheckGate: held only during the metadata/network check.
@@ -41,6 +45,7 @@ internal sealed class UpdateCoordinator(
     private int _updateInstallInProgress;
 #endif
     private int _manualUpdateCheckInFlight;
+    private int _automaticUpdateCheckStarted;
 
     public static UpdateCommandCenterInfo BuildInitialInfo() => new()
     {
@@ -72,7 +77,8 @@ internal sealed class UpdateCoordinator(
                 Status = "Skipped",
                 CurrentVersion = AppVersionInfo.Version,
                 CheckedAt = DateTime.UtcNow,
-                Detail = "development build"
+                Detail = LocalizationHelper.GetString(
+                    "Update_Message_Skipped_Dev")
             };
             _updateCheckGate.Release();
             return true;
@@ -87,7 +93,8 @@ internal sealed class UpdateCoordinator(
                 Status = "Skipped",
                 CurrentVersion = AppVersionInfo.Version,
                 CheckedAt = DateTime.UtcNow,
-                Detail = "debug build"
+                Detail = LocalizationHelper.GetString(
+                    "Update_Message_Skipped_Debug")
             };
             return true;
         }
@@ -130,6 +137,35 @@ internal sealed class UpdateCoordinator(
                 return true;
             }
 
+            var gatewayStatus = await TryGetGatewayUpdateStatusAsync(
+                _getGatewayClient());
+            if (CompanionUpdateSuppressionPolicy.ShouldSuppress(
+                    gatewayStatus,
+                    checkOutcome))
+            {
+                Logger.Info(
+                    "Skipping ordinary companion update: Gateway is on extended-stable");
+                appState.UpdateInfo = new UpdateCommandCenterInfo
+                {
+                    Status = "Skipped",
+                    CurrentVersion = AppVersionInfo.Version,
+                    CheckedAt = DateTime.UtcNow,
+                    Detail = LocalizationHelper.GetString(
+                        "Update_Message_Skipped_ExtendedStable")
+                };
+                return true;
+            }
+
+            if (checkOutcome.IsSecurityCritical &&
+                string.Equals(
+                    gatewayStatus?.EffectiveChannel,
+                    "extended-stable",
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                Logger.Info(
+                    "Offering security-critical companion update despite extended-stable Gateway");
+            }
+
             var release = updater.LatestRelease!;
             if (string.IsNullOrEmpty(release.TagName))
             {
@@ -148,7 +184,7 @@ internal sealed class UpdateCoordinator(
             }
 
             releaseTag = release.TagName;
-            changelog = updater.GetChangelog(true) ?? "No release notes available.";
+            changelog = updater.GetChangelog(5, false) ?? "No release notes available.";
             Logger.Info($"Update available: {releaseTag}");
             appState.UpdateInfo = new UpdateCommandCenterInfo
             {
@@ -326,6 +362,39 @@ internal sealed class UpdateCoordinator(
 #endif
     }
 
+    /// <summary>
+    /// Runs the automatic check once, after either an authenticated Gateway
+    /// handshake or a terminal path where Gateway status is unavailable.
+    /// </summary>
+    public async Task CheckForAutomaticUpdatesAfterGatewayResolutionAsync()
+    {
+        if (Interlocked.Exchange(ref _automaticUpdateCheckStarted, 1) != 0)
+            return;
+
+        if (!await CheckForUpdatesAsync())
+            exit();
+    }
+
+    private static async Task<GatewayUpdateStatus?> TryGetGatewayUpdateStatusAsync(
+        IOperatorGatewayClient? gatewayClient)
+    {
+        if (gatewayClient is null)
+            return null;
+
+        if (!OperatorScopeHelper.HasAdminScope(
+                gatewayClient.GrantedOperatorScopes))
+        {
+            Logger.Info(
+                "Gateway update channel unavailable: operator token lacks operator.admin; using companion updater");
+            return null;
+        }
+
+        return await GatewayUpdateStatusLookup.TryGetAsync(
+            () => gatewayClient.GetUpdateStatusAsync(),
+            ex => Logger.Info(
+                $"Gateway update channel unavailable; using companion updater: {ex.Message}"));
+    }
+
     // Re-entrancy guard: the button/menu/deep-link are all fire-and-forget
     // (`_ = CheckForUpdatesUserInitiatedAsync()`), so a double-click would
     // otherwise open two ContentDialogs on the same XamlRoot which throws
@@ -381,6 +450,7 @@ internal sealed class UpdateCoordinator(
                         await ShowUpdateInfoDialogAsync(
                             "Skipped",
                             LocalizationHelper.GetString("Update_Title_Skipped"),
+                            info.Detail ??
                             LocalizationHelper.GetString(
                                 AppIdentity.IsDev
                                     ? "Update_Message_Skipped_Dev"
@@ -495,17 +565,53 @@ internal sealed class UpdatumUpdateCheckBoundary(UpdatumManager updater) : IUpda
 {
     public Task<bool> CheckForUpdatesAsync() => updater.CheckForUpdatesAsync();
 
+    public UpdateReleaseCandidate? GetSelectedRelease() =>
+        updater.LatestRelease is { } release
+            ? CreateCandidate(release)
+            : null;
+
     public IEnumerable<UpdateReleaseCandidate> GetReleaseCandidates()
     {
         foreach (var release in updater.Releases)
-        {
-            yield return new UpdateReleaseCandidate(
-                release.TagName,
-                release.Draft,
-                release.Prerelease,
-                release.PublishedAt is not null,
-                () => updater.GetCompatibleReleaseAsset(release) is not null,
-                () => updater.ForceTriggerUpdateFromRelease(release));
-        }
+            yield return CreateCandidate(release);
     }
+
+    public bool IsReleaseHistoryComplete(string currentVersion)
+    {
+        var fetchCapacity =
+            UpdatumManager.GitHubApiOptions.PageSize *
+            UpdatumManager.GitHubApiOptions.PageCount;
+        if (updater.Releases.Count < fetchCapacity)
+            return true;
+
+        if (!OpenClawReleaseVersion.TryParseStable(
+                currentVersion,
+                out var installedVersion))
+        {
+            return false;
+        }
+
+        foreach (var release in updater.Releases)
+        {
+            if (OpenClawReleaseVersion.TryParseStable(
+                    release.TagName,
+                    out var releaseVersion) &&
+                releaseVersion.CompareTo(installedVersion) <= 0)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private UpdateReleaseCandidate CreateCandidate(Octokit.Release release) => new(
+        release.TagName,
+        release.Name,
+        release.Body,
+        release.Draft,
+        release.Prerelease,
+        release.PublishedAt is not null,
+        () => updater.GetCompatibleReleaseAsset(release) is not null,
+        () => updater.ForceTriggerUpdateFromRelease(release));
 }

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -398,6 +398,9 @@
   <data name="Update_Message_Skipped_Dev" xml:space="preserve">
     <value>Update checks are disabled in development builds.</value>
   </data>
+  <data name="Update_Message_Skipped_ExtendedStable" xml:space="preserve">
+    <value>The connected Gateway uses extended-stable, so this ordinary Windows release update is not offered.</value>
+  </data>
   <data name="Update_OK" xml:space="preserve">
     <value>OK</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -370,6 +370,9 @@
   <data name="Update_Message_Skipped_Dev" xml:space="preserve">
     <value>La vérification des mises à jour est désactivée dans les versions de développement.</value>
   </data>
+  <data name="Update_Message_Skipped_ExtendedStable" xml:space="preserve">
+    <value>La passerelle connectée utilise le canal extended-stable. Cette mise à jour Windows ordinaire n’est donc pas proposée.</value>
+  </data>
   <data name="Update_OK" xml:space="preserve">
     <value>OK</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -371,6 +371,9 @@
   <data name="Update_Message_Skipped_Dev" xml:space="preserve">
     <value>Updatecontroles zijn uitgeschakeld in ontwikkelbuilds.</value>
   </data>
+  <data name="Update_Message_Skipped_ExtendedStable" xml:space="preserve">
+    <value>De verbonden gateway gebruikt extended-stable. Daarom wordt deze gewone Windows-update niet aangeboden.</value>
+  </data>
   <data name="Update_OK" xml:space="preserve">
     <value>OK</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -370,6 +370,9 @@
   <data name="Update_Message_Skipped_Dev" xml:space="preserve">
     <value>开发版本已禁用更新检查。</value>
   </data>
+  <data name="Update_Message_Skipped_ExtendedStable" xml:space="preserve">
+    <value>已连接的网关使用 extended-stable，因此不会提供此普通 Windows 版本更新。</value>
+  </data>
   <data name="Update_OK" xml:space="preserve">
     <value>确定</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -370,6 +370,9 @@
   <data name="Update_Message_Skipped_Dev" xml:space="preserve">
     <value>開發版本已停用更新檢查。</value>
   </data>
+  <data name="Update_Message_Skipped_ExtendedStable" xml:space="preserve">
+    <value>已連線的閘道使用 extended-stable，因此不會提供此一般 Windows 版本更新。</value>
+  </data>
   <data name="Update_OK" xml:space="preserve">
     <value>確定</value>
   </data>

--- a/tests/OpenClaw.Shared.Tests/GatewayProtocolLiveRoundTripTests.cs
+++ b/tests/OpenClaw.Shared.Tests/GatewayProtocolLiveRoundTripTests.cs
@@ -70,7 +70,12 @@ public sealed class GatewayProtocolLiveRoundTripTests : IDisposable
             // when many test classes run in parallel).
             const int rpc = 20000;
 
-            // ── 1. commands.list (typed catalog read) ──
+            // ── 1. update.status (authoritative effective update channel) ──
+            var updateStatus = await client.GetUpdateStatusAsync(timeoutMs: rpc);
+            Assert.Equal("extended-stable", updateStatus?.EffectiveChannel);
+            Assert.Contains("\"method\":\"update.status\"", server.FrameFor("update.status"));
+
+            // ── 2. commands.list (typed catalog read) ──
             var catalog = await client.ListCommandsAsync(timeoutMs: rpc);
             Assert.True(catalog.IsSupported);
             var cmd = Assert.Single(catalog.Commands);
@@ -78,13 +83,13 @@ public sealed class GatewayProtocolLiveRoundTripTests : IDisposable
             var arg = Assert.Single(cmd.Args);
             Assert.Equal("gpt-5", Assert.Single(arg.Choices).Value);
 
-            // ── 2. sessions.files.get (read; param must be sessionKey, response nested under "file") ──
+            // ── 3. sessions.files.get (read; param must be sessionKey, response nested under "file") ──
             var file = await client.GetSessionFileAsync(key, "src/a.cs", timeoutMs: rpc);
             Assert.True(file.Found);
             Assert.Equal("hello world", file.Content);
             Assert.Contains("\"sessionKey\"", server.FrameFor("sessions.files.get"));
 
-            // ── 3. chat.history (real client transcript export path) ──
+            // ── 4. chat.history (real client transcript export path) ──
             var history = await client.RequestChatHistoryAsync(key, timeoutMs: rpc);
             Assert.Equal("sid-1", history.SessionId);
             var message = Assert.Single(history.Messages);
@@ -92,7 +97,7 @@ public sealed class GatewayProtocolLiveRoundTripTests : IDisposable
             Assert.Equal("done", message.Text);
             Assert.Contains("\"sessionKey\"", server.FrameFor("chat.history"));
 
-            // ── 4. sessions.compaction.list + branch (param key/checkpointId; branch returns sourceKey + new key) ──
+            // ── 5. sessions.compaction.list + branch (param key/checkpointId; branch returns sourceKey + new key) ──
             var checkpoints = await client.ListCompactionCheckpointsAsync(key, timeoutMs: rpc);
             Assert.True(checkpoints.IsSupported);
             Assert.Equal("cp1", Assert.Single(checkpoints.Checkpoints).Id);
@@ -103,7 +108,7 @@ public sealed class GatewayProtocolLiveRoundTripTests : IDisposable
             Assert.Equal("agent:main:branch-1", branch.ResultSessionKey);
             Assert.Contains("\"checkpointId\"", server.FrameFor("sessions.compaction.branch"));
 
-            // ── 5. sessions.patch SET then CLEAR (the tri-state proof) ──
+            // ── 6. sessions.patch SET then CLEAR (the tri-state proof) ──
             // PatchSessionAsync is fire-and-tracked (returns on send, not on
             // response), so wait for the captured frame to arrive on the server.
             var setOk = await client.PatchSessionAsync(key, new SessionPatch { Model = "gpt-5", FastMode = SessionFastMode.Auto });
@@ -118,6 +123,37 @@ public sealed class GatewayProtocolLiveRoundTripTests : IDisposable
             Assert.Contains("\"model\":null", clearFrame);
 
             PrintProof(server);
+        }
+        finally
+        {
+            await client.DisconnectAsync();
+        }
+    }
+
+    [Fact]
+    public async Task UpdateStatus_GatewayError_PropagatesForCallerFailSafe()
+    {
+        using var server = new LoopbackGatewayServer();
+        server.OnMethod(
+            "update.status",
+            _ => LoopbackResponse.Fail("unauthorized update.status"));
+        var client = new OpenClawGatewayClient(
+            server.WebSocketUrl,
+            "test-token",
+            new TestLogger(),
+            tokenIsBootstrapToken: false,
+            bootstrapPairAsNode: false,
+            identityPath: _identityDir);
+
+        try
+        {
+            await ConnectAndWaitAsync(client, server);
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => client.GetUpdateStatusAsync(timeoutMs: 20_000));
+
+            Assert.Contains("unauthorized update.status", exception.Message);
+            Assert.Contains("\"method\":\"update.status\"", server.FrameFor("update.status"));
         }
         finally
         {
@@ -222,6 +258,18 @@ public sealed class GatewayProtocolLiveRoundTripTests : IDisposable
         // (health/sessions.list/subscribe/usage/nodes/agents), keeping this test
         // lightweight so it does not add scheduler/socket contention that could
         // destabilize other timing-sensitive socket tests under parallel load.
+
+        server.OnMethod("update.status", parameters =>
+        {
+            Assert.Equal(JsonValueKind.Object, parameters.ValueKind);
+            Assert.Empty(parameters.EnumerateObject());
+            return new
+            {
+                sentinel = (object?)null,
+                updateAvailable = (object?)null,
+                effectiveChannel = "extended-stable"
+            };
+        });
 
         server.OnMethod("commands.list", _ => new
         {

--- a/tests/OpenClaw.Shared.Tests/GatewayProtocolModelsTests.cs
+++ b/tests/OpenClaw.Shared.Tests/GatewayProtocolModelsTests.cs
@@ -36,6 +36,7 @@ public class GatewayProtocolModelsTests
             ("CreateSessionAsync", new[] { typeof(SessionCreateRequest), typeof(int) }),
             ("ResetSessionDetailedAsync", new[] { typeof(string), typeof(int) }),
             ("CompactSessionDetailedAsync", new[] { typeof(string), typeof(int) }),
+            ("GetUpdateStatusAsync", new[] { typeof(int) }),
         };
 
         foreach (var (name, args) in newMembers)
@@ -48,6 +49,21 @@ public class GatewayProtocolModelsTests
     }
 
     private static JsonElement Parse(string json) => JsonDocument.Parse(json).RootElement;
+
+    [Fact]
+    public void GatewayUpdateStatusParser_PreservesOptionalEffectiveChannel()
+    {
+        var extendedStable = GatewayUpdateStatusParser.Parse(
+            Parse("""{"effectiveChannel":"extended-stable"}"""));
+        var missing = GatewayUpdateStatusParser.Parse(
+            Parse("""{"updateAvailable":null}"""));
+        var malformed = GatewayUpdateStatusParser.Parse(
+            Parse("""{"effectiveChannel":42}"""));
+
+        Assert.Equal("extended-stable", extendedStable.EffectiveChannel);
+        Assert.Null(missing.EffectiveChannel);
+        Assert.Null(malformed.EffectiveChannel);
+    }
 
     [Fact]
     public void ParseSessionCreateResult_RequiresAndPreservesGatewayKey()

--- a/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
@@ -32,15 +32,41 @@ public sealed class AppRefactorContractTests
             "AppUserModelIdRegistrar.RegisterCurrentProcess(AppIdentity.AppUserModelId);",
             "appUserModelIdRegistration.Attempted",
             "_settings = new SettingsManager();",
-            "CheckForUpdatesAsync();",
             "ToastNotificationManagerCompat.OnActivated += OnToastActivated;",
             "InitializeTrayIcon();",
             "_gatewayRegistry = new GatewayRegistry",
             "_connectionManager = new GatewayConnectionManager",
             "await ShowOnboardingAsync();",
             "EnsureNodeService(_settings);",
-            "InitializeGatewayClient();",
+            "var startupConnectKind = InitializeGatewayClient();",
+            "StartAutomaticUpdateCheckGatewayDeadline();",
+            "StartAutomaticUpdateCheckWithoutGateway();",
             "await _activationRouter.StartForwardedActivationListenerAsync(this, CancellationToken.None);");
+    }
+
+    [Fact]
+    public void AutomaticUpdates_UseCurrentConnectionManagerClientWithoutParallelOwnership()
+    {
+        var source = ReadAppSources();
+        var clientChanged = ExtractMethod(source, "OnOperatorClientChanged");
+        var handshake = ExtractMethod(source, "OnGatewayUpdateCheckHandshakeSucceeded");
+
+        Assert.Contains(
+            "e.NewClient.HandshakeSucceeded += OnGatewayUpdateCheckHandshakeSucceeded",
+            clientChanged);
+        Assert.Contains(
+            "ReferenceEquals(client, _connectionManager?.OperatorClient)",
+            handshake);
+        Assert.Contains(
+            "CheckForAutomaticUpdatesAfterGatewayResolutionAsync",
+            handshake);
+        Assert.Contains("FetchOnlyLatestRelease = false", source);
+        Assert.Contains("GitHubApiOptions.PageSize = 100", source);
+        Assert.Contains("GitHubApiOptions.PageCount = 1", source);
+        Assert.DoesNotContain("_updateCheckClient", source);
+        Assert.DoesNotMatch(
+            new Regex(@"\bnew\s+OpenClawGatewayClient\s*\(", RegexOptions.Multiline),
+            source);
     }
 
     [Fact]
@@ -405,7 +431,7 @@ public sealed class AppRefactorContractTests
             "catch (DeviceIdentityLoadException ex)",
             "ShowTransientConnectionError(ex.Message)",
             "TryStartLocalMcpOnlyNode()",
-            "return;");
+            "return StartupGatewayConnectKind.None;");
         Assert.Contains("Active gateway has no usable credential", source);
     }
 
@@ -696,7 +722,12 @@ public sealed class AppRefactorContractTests
         Assert.Contains("catch (DeviceIdentityLoadException ex)", connectMethod);
         Assert.Contains("ShowTransientConnectionError(ex.Message)", connectMethod);
         Assert.Equal(2, Regex.Matches(connectMethod, "catch \\(DeviceIdentityLoadException ex\\)").Count);
-        Assert.Equal(2, Regex.Matches(connectMethod, "ShowTransientConnectionError\\(ex.Message\\);\\s*return false;").Count);
+        Assert.Equal(
+            2,
+            Regex.Matches(
+                connectMethod,
+                "ShowTransientConnectionError\\(ex.Message\\);\\s*return StartupGatewayConnectKind\\.None;")
+                .Count);
         Assert.Contains("GatewayCredentialResolutionStatus.Unreadable", resolutionMethod);
         Assert.Contains("GatewayCredentialResolutionStatus.Corrupt", resolutionMethod);
         Assert.Contains("throw new DeviceIdentityLoadException", resolutionMethod);
@@ -2042,7 +2073,7 @@ public sealed class AppRefactorContractTests
 
     private static string ExtractMethod(string source, string methodName, string? parameterHint = null)
     {
-        var pattern = $@"(?m)^\s*(?:(?:private|protected|public|internal)\s+)?(?:static\s+)?(?:async\s+)?(?:Task(?:<[^>]+>)?|System\.Threading\.Tasks\.Task|void|bool|int|string\??|object\??|IntPtr|TrayMenuSnapshot|RollbackResult|OpenClaw\.Connection\.GatewayCredential\?|AppShutdownPlan)\s+(?:[A-Za-z0-9_]+\.)?{Regex.Escape(methodName)}\s*\(";
+        var pattern = $@"(?m)^\s*(?:(?:private|protected|public|internal)\s+)?(?:static\s+)?(?:async\s+)?(?:Task(?:<[^>]+>)?|System\.Threading\.Tasks\.Task|void|bool|int|string\??|object\??|IntPtr|TrayMenuSnapshot|RollbackResult|OpenClaw\.Connection\.GatewayCredential\?|AppShutdownPlan|StartupGatewayConnectKind)\s+(?:[A-Za-z0-9_]+\.)?{Regex.Escape(methodName)}\s*\(";
         var matches = Regex.Matches(source, pattern);
         Assert.True(matches.Count > 0, $"Could not find method {methodName}.");
 

--- a/tests/OpenClaw.Tray.Tests/NodeModeUiStateTests.cs
+++ b/tests/OpenClaw.Tray.Tests/NodeModeUiStateTests.cs
@@ -97,7 +97,9 @@ public sealed class NodeModeUiStateTests
     public void App_GatewayNodeConnection_GatedOnNodeModeOnly_NotMcp()
     {
         var app = ReadSource("src", "OpenClaw.Tray.WinUI", "App.xaml.cs");
-        var connectMethod = ExtractMethodBody(app, "bool TryConnectGatewayIfCredentialAvailable");
+        var connectMethod = ExtractMethodBody(
+            app,
+            "StartupGatewayConnectKind TryConnectGatewayIfCredentialAvailable");
 
         Assert.Contains("isNodeEnabled: IsGatewayNodeEnabled", app);
 

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -148,6 +148,7 @@
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\McpRuntimeStatePolicy.cs" Link="Services\McpRuntimeStatePolicy.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\UsageCostApplicationPolicy.cs" Link="Services\UsageCostApplicationPolicy.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\UpdateCheckPipeline.cs" Link="Services\UpdateCheckPipeline.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\AutomaticUpdateCheckPolicy.cs" Link="Services\AutomaticUpdateCheckPolicy.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\SpeechSetupReadiness.cs" Link="Services\SpeechSetupReadiness.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Helpers\CanvasGatewayUrlRewriter.cs" Link="Helpers\CanvasGatewayUrlRewriter.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Helpers\DiagnosticsGate.cs" Link="Helpers\DiagnosticsGate.cs" />

--- a/tests/OpenClaw.Tray.Tests/UpdateCheckPipelineTests.cs
+++ b/tests/OpenClaw.Tray.Tests/UpdateCheckPipelineTests.cs
@@ -1,9 +1,42 @@
+using OpenClaw.Shared;
+using OpenClaw.Connection;
 using OpenClawTray.Services;
 
 namespace OpenClaw.Tray.Tests;
 
 public sealed class UpdateCheckPipelineTests
 {
+    [Fact]
+    public void AutomaticUpdateCheck_StartupPlanWaitsOnlyForOperatorHandshake()
+    {
+        Assert.Equal(
+            AutomaticUpdateCheckStartupPlan.AwaitOperatorHandshakeWithDeadline,
+            AutomaticUpdateCheckPolicy.PlanStartup(
+                StartupGatewayConnectKind.Operator));
+        Assert.Equal(
+            AutomaticUpdateCheckStartupPlan.Immediate,
+            AutomaticUpdateCheckPolicy.PlanStartup(
+                StartupGatewayConnectKind.NodeOnly));
+        Assert.Equal(
+            AutomaticUpdateCheckStartupPlan.Immediate,
+            AutomaticUpdateCheckPolicy.PlanStartup(
+                StartupGatewayConnectKind.None));
+    }
+
+    [Theory]
+    [InlineData(RoleConnectionState.PairingRequired, true)]
+    [InlineData(RoleConnectionState.Error, false)]
+    [InlineData(RoleConnectionState.Connecting, false)]
+    public void AutomaticUpdateCheck_FallsBackOnlyForTerminalGatewayState(
+        RoleConnectionState state,
+        bool expected)
+    {
+        Assert.Equal(
+            expected,
+            AutomaticUpdateCheckPolicy.IsGatewayStatusTerminallyUnavailable(
+                state));
+    }
+
     [Fact]
     public async Task CheckAsync_WhenOrdinaryCheckDeclinesCorrection_ActivatesCompatibleFallback()
     {
@@ -44,6 +77,7 @@ public sealed class UpdateCheckPipelineTests
 
         Assert.True(result.UpdateFound);
         Assert.Equal("v2026.7.1-2", result.ActivatedFallbackTag);
+        Assert.False(result.IsSecurityCritical);
         Assert.False(incompatibleActivated);
         Assert.True(correctionActivated);
         Assert.Equal(
@@ -57,7 +91,7 @@ public sealed class UpdateCheckPipelineTests
     }
 
     [Fact]
-    public async Task CheckAsync_WhenOrdinaryCheckFindsUpdate_DoesNotInspectFallbacks()
+    public async Task CheckAsync_WhenOrdinaryCheckFindsUpdate_InspectsEligibleReleasesForSecurity()
     {
         var releasesEnumerated = false;
         var boundary = new FakeUpdateCheckBoundary(
@@ -65,22 +99,170 @@ public sealed class UpdateCheckPipelineTests
             releasesFactory: () =>
             {
                 releasesEnumerated = true;
-                return [Candidate("v2026.7.1-2")];
+                return
+                [
+                    Candidate("v2026.8.2", body: "Ordinary maintenance update"),
+                    Candidate("v2026.8.1", body: "Fixes CVE-2026-1234")
+                ];
             });
 
-        var result = await UpdateCheckPipeline.CheckAsync(boundary, "2026.7.1");
+        var result = await UpdateCheckPipeline.CheckAsync(boundary, "2026.8.0");
 
         Assert.True(result.UpdateFound);
         Assert.Null(result.ActivatedFallbackTag);
-        Assert.False(releasesEnumerated);
+        Assert.True(result.IsSecurityCritical);
+        Assert.True(releasesEnumerated);
+        Assert.False(CompanionUpdateSuppressionPolicy.ShouldSuppress(
+            new GatewayUpdateStatus { EffectiveChannel = "extended-stable" },
+            result));
+    }
+
+    [Fact]
+    public async Task CheckAsync_WhenSecurityReleaseIsIneligible_AllowsOrdinarySuppression()
+    {
+        var boundary = new FakeUpdateCheckBoundary(
+            checkForUpdates: () => true,
+            releases:
+            [
+                Candidate(
+                    "v2026.8.1",
+                    body: "Fixes GHSA-abcd-1234-5678",
+                    hasCompatibleAsset: () => false)
+            ]);
+
+        var result = await UpdateCheckPipeline.CheckAsync(boundary, "2026.8.0");
+
+        Assert.True(result.UpdateFound);
+        Assert.False(result.IsSecurityCritical);
+        Assert.True(CompanionUpdateSuppressionPolicy.ShouldSuppress(
+            new GatewayUpdateStatus { EffectiveChannel = "extended-stable" },
+            result));
+    }
+
+    [Fact]
+    public async Task CheckAsync_WhenReleaseHistoryIsTruncated_FailsSafe()
+    {
+        var boundary = new FakeUpdateCheckBoundary(
+            checkForUpdates: () => true,
+            releases:
+            [
+                Candidate("v2026.8.2", body: "Ordinary maintenance update")
+            ],
+            releaseHistoryComplete: false);
+
+        var result = await UpdateCheckPipeline.CheckAsync(boundary, "2026.8.0");
+
+        Assert.True(result.IsSecurityCritical);
+        Assert.False(CompanionUpdateSuppressionPolicy.ShouldSuppress(
+            new GatewayUpdateStatus { EffectiveChannel = "extended-stable" },
+            result));
+    }
+
+    [Fact]
+    public async Task CheckAsync_FallbackScanPreservesInterveningSecurityRelease()
+    {
+        var ordinaryActivated = false;
+        var boundary = new FakeUpdateCheckBoundary(
+            checkForUpdates: () => false,
+            releases:
+            [
+                Candidate(
+                    "v2026.8.2",
+                    body: "Ordinary maintenance update",
+                    activate: () => ordinaryActivated = true),
+                Candidate("v2026.8.1", body: "Security update")
+            ]);
+
+        var result = await UpdateCheckPipeline.CheckAsync(boundary, "2026.8.0");
+
+        Assert.True(ordinaryActivated);
+        Assert.Equal("v2026.8.2", result.ActivatedFallbackTag);
+        Assert.True(result.IsSecurityCritical);
+        Assert.False(CompanionUpdateSuppressionPolicy.ShouldSuppress(
+            new GatewayUpdateStatus { EffectiveChannel = "extended-stable" },
+            result));
+    }
+
+    [Theory]
+    [InlineData("Security update", null)]
+    [InlineData(null, "Fixes CVE-2026-1234")]
+    [InlineData(null, "Advisory GHSA-abcd-1234-5678")]
+    [InlineData(null, "<!-- openclaw-update: security-critical -->")]
+    public void IsSecurityCritical_RecognizesReleaseSafetySignals(
+        string? name,
+        string? body)
+    {
+        Assert.True(UpdateReleasePolicy.IsSecurityCritical(
+            Candidate("v2026.8.1", name: name, body: body)));
+    }
+
+    [Fact]
+    public void IsSecurityCritical_TreatsUnavailableReleaseMetadataAsFailSafe()
+    {
+        Assert.True(UpdateReleasePolicy.IsSecurityCritical(null));
+    }
+
+    [Fact]
+    public void ShouldSuppress_OnlyExtendedStableOrdinaryUpdates()
+    {
+        var ordinary = new UpdateCheckOutcome(
+            UpdateFound: true,
+            SelectedRelease: Candidate("v2026.8.1"));
+        var security = new UpdateCheckOutcome(
+            UpdateFound: true,
+            SelectedRelease: Candidate(
+                "v2026.8.1",
+                body: "Security fix for GHSA-abcd-1234-5678"));
+
+        Assert.True(CompanionUpdateSuppressionPolicy.ShouldSuppress(
+            new GatewayUpdateStatus { EffectiveChannel = "extended-stable" },
+            ordinary));
+        Assert.False(CompanionUpdateSuppressionPolicy.ShouldSuppress(
+            new GatewayUpdateStatus { EffectiveChannel = "stable" },
+            ordinary));
+        Assert.False(CompanionUpdateSuppressionPolicy.ShouldSuppress(null, ordinary));
+        Assert.False(CompanionUpdateSuppressionPolicy.ShouldSuppress(
+            new GatewayUpdateStatus { EffectiveChannel = null },
+            ordinary));
+        Assert.False(CompanionUpdateSuppressionPolicy.ShouldSuppress(
+            new GatewayUpdateStatus { EffectiveChannel = "extended_stable" },
+            ordinary));
+        Assert.False(CompanionUpdateSuppressionPolicy.ShouldSuppress(
+            new GatewayUpdateStatus { EffectiveChannel = "extended-stable" },
+            security));
+        Assert.False(CompanionUpdateSuppressionPolicy.ShouldSuppress(
+            new GatewayUpdateStatus { EffectiveChannel = "extended-stable" },
+            new UpdateCheckOutcome(UpdateFound: true, SelectedRelease: null)));
+    }
+
+    [Theory]
+    [InlineData(typeof(UnauthorizedAccessException))]
+    [InlineData(typeof(InvalidDataException))]
+    [InlineData(typeof(TimeoutException))]
+    public async Task GatewayStatusLookup_FailsSafeForUnavailableStatus(
+        Type exceptionType)
+    {
+        var observed = new List<Exception>();
+
+        var result = await GatewayUpdateStatusLookup.TryGetAsync(
+            () => Task.FromException<GatewayUpdateStatus?>(
+                (Exception)Activator.CreateInstance(exceptionType, "unavailable")!),
+            observed.Add);
+
+        Assert.Null(result);
+        Assert.IsType(exceptionType, Assert.Single(observed));
     }
 
     private static UpdateReleaseCandidate Candidate(
         string tagName,
+        string? name = null,
+        string? body = null,
         Func<bool>? hasCompatibleAsset = null,
         Action? activate = null) =>
         new(
             tagName,
+            name,
+            body,
             Draft: false,
             Prerelease: false,
             Published: true,
@@ -91,19 +273,31 @@ public sealed class UpdateCheckPipelineTests
     {
         private readonly Func<bool> _checkForUpdates;
         private readonly Func<IEnumerable<UpdateReleaseCandidate>> _releasesFactory;
+        private readonly Func<UpdateReleaseCandidate?> _selectedRelease;
+        private readonly bool _releaseHistoryComplete;
 
         public FakeUpdateCheckBoundary(
             Func<bool> checkForUpdates,
             IEnumerable<UpdateReleaseCandidate>? releases = null,
-            Func<IEnumerable<UpdateReleaseCandidate>>? releasesFactory = null)
+            Func<IEnumerable<UpdateReleaseCandidate>>? releasesFactory = null,
+            Func<UpdateReleaseCandidate?>? selectedRelease = null,
+            bool releaseHistoryComplete = true)
         {
             _checkForUpdates = checkForUpdates;
             _releasesFactory = releasesFactory ?? (() => releases ?? []);
+            _selectedRelease = selectedRelease ??
+                (() => Candidate("v2026.8.1"));
+            _releaseHistoryComplete = releaseHistoryComplete;
         }
 
         public Task<bool> CheckForUpdatesAsync() => Task.FromResult(_checkForUpdates());
 
+        public UpdateReleaseCandidate? GetSelectedRelease() => _selectedRelease();
+
         public IEnumerable<UpdateReleaseCandidate> GetReleaseCandidates() =>
             _releasesFactory();
+
+        public bool IsReleaseHistoryComplete(string currentVersion) =>
+            _releaseHistoryComplete;
     }
 }


### PR DESCRIPTION
Supersedes #1141.

## What Problem This Solves

Fixes an issue where Windows companion users following a Gateway's `extended-stable` channel would still receive ordinary companion update prompts before that Gateway channel was ready to advance.

## Why This Change Was Made

This is a clean current-main replacement for #1141. It keeps `GatewayConnectionManager.OperatorClient` as the sole authenticated operator-client owner, consumes Core's optional `update.status.effectiveChannel` contract, and suppresses only a trusted ordinary Windows release after complete release-lineage inspection. It does not add a parallel Gateway client or restore stale App-owned connection fields.

**Pinned invariant:** `extended-stable` suppresses only an ordinary update after trusted Windows release metadata is available. Missing, unauthorized, malformed, error, security, CVE, GHSA, and incomplete-history states remain visible and fail safe.

| Gateway / release state | Result |
|---|---|
| `effectiveChannel=extended-stable` + trusted complete ordinary release metadata | Suppress the ordinary companion prompt |
| Missing or non-string `effectiveChannel` | Keep the update visible |
| Unauthorized / missing `operator.admin` scope | Keep the update visible |
| RPC timeout, transport error, or Gateway error | Keep the update visible |
| Missing or malformed release metadata | Keep the update visible |
| Full release page cannot reach the installed version | Treat lineage as incomplete; keep the update visible |
| Security marker, `security`, `CVE-`, or `GHSA-` in any eligible newer release | Keep the update visible |

Ownership remains unchanged: `GatewayConnectionManager` owns operator/node connection state, `UpdateCoordinator` reads its current `OperatorClient`, and `App` remains the composition root.

## User Impact

Extended-stable users no longer see ordinary Windows companion update prompts ahead of their Gateway channel. Security-sensitive and uncertain updates remain visible.

## Evidence

- Focused policy/ownership suite: 107 passed.
- Focused real WebSocket protocol suite: 4 passed. Wire output included `{"type":"req",...,"method":"update.status","params":{}}`; Gateway errors propagated for caller fail-safe handling.
- Current-head version-spoofed Release process connected through the configured `GatewayConnectionManager` path to a controlled loopback Gateway and completed `hello-ok` with granted `operator.admin, operator.pairing` scopes.
- Final Codex autoreview: clean, no accepted/actionable findings, overall confidence 0.87.
- Final rubber-duck review: clean, no remaining blocking or high-confidence in-scope issues.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs or instructions
- [x] Tests or validation
- [x] Security hardening
- [ ] Chore or infrastructure

## Scope

- [x] Tray or WinUI UX
- [ ] Windows node capability
- [ ] Local MCP or `winnode`
- [x] Gateway, connection, or pairing
- [ ] Setup or onboarding
- [x] Permissions, privacy, or security
- [x] Tests, CI, or docs

## Required proof pools

- `windows-winui-interactive`: the Command Center update state gains a localized visible `Skipped` result for extended-stable suppression.

## Validation

- `.\build.ps1`: passed; Shared, CLI, WinNode CLI, SetupEngine, and WinUI built successfully; documentation gates passed.
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore`: 3,875 passed, 32 skipped, 0 failed.
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore`: 2,841 passed, 0 failed.
- `dotnet test .\tests\OpenClaw.SetupEngine.Tests\OpenClaw.SetupEngine.Tests.csproj --no-restore --no-build`: 1,025 passed, 0 failed. The prebuilt suite bounded an unrelated MSBuild/GitVersion hang seen when rebuilding this project concurrently.
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore --no-build --filter "FullyQualifiedName~GatewayProtocolLiveRoundTripTests"`: 4 passed, 0 failed.
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore --no-build --filter "FullyQualifiedName~UpdateCheckPipelineTests|FullyQualifiedName~AppRefactorContractTests"`: 107 passed, 0 failed.
- `python .agents\skills\autoreview\scripts\autoreview --mode local --stream-engine-output`: clean, no accepted/actionable findings.

## Real Behavior Proof

- Environment tested: Windows 11 x64; isolated tray data; controlled loopback Gateway on `127.0.0.1:18799`.
- PR head or commit tested: `0f4dd6cb22a3911c73e0f2e84916b9e7da974601`.
- Exact steps or command run: built Release with version metadata `0.6.10`, launched the task-built unpackaged app against the controlled Gateway, and ran real WebSocket `update.status` round-trip tests.
- Evidence after fix: runtime log recorded the current worktree Release executable, signed operator connect, `hello-ok`, and granted `operator.admin, operator.pairing`; focused wire proof recorded an `update.status` request and parsed `effectiveChannel=extended-stable` while preserving Gateway errors.
- Observed result: current connection ownership and protocol invocation are proven; policy tests prove suppression only for complete trusted ordinary metadata and visibility for every pinned fail-safe state.
- Screenshot or artifact links verified? `N/A`.
- Not verified or blocked: native UI Automation resolved the installed packaged companion instead of the task-built unpackaged controlled instance, so a current-head screenshot of the final localized `Skipped` Command Center state was not captured. The `windows-winui-interactive` pool remains declared for that visible proof. Gateway/protocol and policy behavior are verified.

## Security Impact

- New permissions or capabilities? `No`
- Secrets or tokens handling changed? `No`
- New or changed network calls? `Yes`
- Command or tool execution surface changed? `No`
- Data access scope changed? `No`
- If any answer is `Yes`, explain the risk and mitigation: the existing authenticated operator client now calls `update.status`. The call requires an already-granted `operator.admin` scope; missing scope and all errors fail safe by leaving updates visible. No user content or credentials are added to telemetry or logs.

## Compatibility and Migration

- Backward compatible? `Yes`
- Config or environment changes? `No`
- Migration needed? `No`
- If yes, list the exact upgrade steps: N/A. Older Gateways that omit `effectiveChannel` retain the existing visible update behavior.

## Review Conversations

- [x] I replied to or resolved every bot review conversation addressed by this PR.
- [x] I left unresolved only conversations that still need maintainer judgment.
