### PR TITLE
Fix camera/screen capture consent hang for unattended MCP callers

### DIFF
--- a/src/OpenClaw.Shared/SettingsData.cs
+++ b/src/OpenClaw.Shared/SettingsData.cs
@@ -53,6 +53,18 @@ public record class SettingsData
     public bool CameraRecordingConsentGiven { get; set; } = false;
     public bool NodeLocationEnabled { get; set; } = true;
     public bool LocationConsentGiven { get; set; } = false;
+    /// <summary>
+    /// Maximum time (ms) to wait for a human response to a screen/camera/location
+    /// capture consent prompt before failing closed (treating the capture as
+    /// denied). Protects unattended or non-interactive callers - a local MCP
+    /// HTTP client, an automated agent, a hosted test - from hanging forever on
+    /// a consent window nobody can answer. Never auto-grants: a timeout always
+    /// resolves to denial, the same fail-closed direction Windows' own secure
+    /// desktop consent prompts (UAC) take when nobody responds. A real user who
+    /// takes longer than this to decide can simply retry; the prompt reappears.
+    /// Default 120000ms (2 minutes).
+    /// </summary>
+    public int CaptureConsentTimeoutMs { get; set; } = 120_000;
     public bool NodeBrowserProxyEnabled { get; set; } = true;
 
     /// <summary>

--- a/src/OpenClaw.Tray.WinUI/Services/ConsentPromptTimeoutGate.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/ConsentPromptTimeoutGate.cs
@@ -1,0 +1,45 @@
+namespace OpenClawTray.Services;
+
+/// <summary>
+/// Bounds how long a capture consent prompt (screen/camera/location) may wait
+/// for a human response. Fails closed: if nobody answers within
+/// <paramref name="timeout"/> (in <see cref="WithTimeout"/>), the result is
+/// treated as "denied", never "granted". This is what stops an unattended
+/// caller - a local MCP HTTP client, an automated agent, a hosted test with
+/// no human at the keyboard - from hanging forever on a consent window
+/// nobody can answer, while still letting a real interactive user take their
+/// time to decide (up to the configured timeout) without ever being silently
+/// bypassed.
+///
+/// The returned task is bound only by <paramref name="timeout"/> and
+/// <paramref name="promptTask"/> itself - it deliberately does not accept a
+/// caller <see cref="CancellationToken"/>. Capture consent prompts are
+/// shared across concurrent callers of the same type
+/// (NodeService's _screen/_camera/_locationConsentInFlight), so the timeout
+/// must keep running even if the request that originally created the prompt
+/// is canceled or disconnects; a caller that wants to additionally honor its
+/// own cancellation should layer `.WaitAsync(cancellationToken)` on top of
+/// the task this method returns, which lets that caller stop waiting without
+/// tearing down the shared timeout for any other waiter.
+/// </summary>
+internal static class ConsentPromptTimeoutGate
+{
+    public static async Task<bool> WithTimeout(
+        Task<bool> promptTask,
+        TimeSpan timeout,
+        Action onTimedOut)
+    {
+        ArgumentNullException.ThrowIfNull(promptTask);
+        ArgumentNullException.ThrowIfNull(onTimedOut);
+
+        var timeoutTask = Task.Delay(timeout);
+        var completed = await Task.WhenAny(promptTask, timeoutTask).ConfigureAwait(false);
+        if (completed == promptTask)
+        {
+            return await promptTask.ConfigureAwait(false);
+        }
+
+        onTimedOut();
+        return false;
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
@@ -2314,16 +2314,43 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
         var clearPrompt = true;
         try
         {
-            var dialogTask = ShowCaptureConsentDialogAsync(type);
+            var dialogTask = ShowCaptureConsentDialogAsync(type, out var closeDialog);
+            var consentTimeout = TimeSpan.FromMilliseconds(
+                Math.Max(1000, _settings?.CaptureConsentTimeoutMs ?? 120_000));
+
+            // Bind the fail-closed timeout to the prompt itself, not to this
+            // caller's cancellationToken: the prompt (and ownedConsentPrompt)
+            // are shared with any other concurrent caller of the same
+            // consent type via _screen/_camera/_locationConsentInFlight, so
+            // the timeout must keep running even if this owning caller is
+            // canceled/disconnects first. Layering .WaitAsync(cancellationToken)
+            // below lets this caller stop waiting on its own cancellation
+            // without tearing down the shared bounded task other waiters (or
+            // the abandoned-prompt observer below) still depend on.
+            var boundedConsentTask = ConsentPromptTimeoutGate.WithTimeout(
+                dialogTask,
+                consentTimeout,
+                onTimedOut: () =>
+                {
+                    _logger.Warn(
+                        $"[CaptureConsent] {type} consent prompt timed out after " +
+                        $"{consentTimeout.TotalSeconds:F0}s with no response; denying (fail-closed).");
+                    closeDialog();
+                });
+
             bool consented;
             try
             {
-                consented = await dialogTask.WaitAsync(cancellationToken);
+                // Fail closed if nobody answers within consentTimeout: an
+                // unattended caller (local MCP, an automated agent, a hosted
+                // test) must never hang the underlying request forever waiting
+                // on a window no human can see or click.
+                consented = await boundedConsentTask.WaitAsync(cancellationToken);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
                 clearPrompt = false;
-                ObserveAbandonedConsentPrompt(dialogTask, type, ownedConsentPrompt!);
+                ObserveAbandonedConsentPrompt(boundedConsentTask, type, ownedConsentPrompt!);
                 throw;
             }
 
@@ -2432,16 +2459,73 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
         }
     }
 
-    private Task<bool> ShowCaptureConsentDialogAsync(CaptureConsentType type)
+    private Task<bool> ShowCaptureConsentDialogAsync(CaptureConsentType type, out Action closeDialog)
     {
         var dialogTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var dialogGate = new object();
+        Dialogs.RecordingConsentDialog? dialog = null;
+        var closeRequested = false;
+
+        // Lets EnsureCaptureConsentAsync force this prompt closed on timeout
+        // (fail-closed denial) instead of leaving an unattended window open
+        // forever. Best-effort: if the dialog hasn't been created yet, the
+        // creation callback below checks closeRequested and skips showing it.
+        closeDialog = () =>
+        {
+            Dialogs.RecordingConsentDialog? toClose;
+            lock (dialogGate)
+            {
+                closeRequested = true;
+                toClose = dialog;
+            }
+            if (toClose == null) return;
+            _dispatcherQueue.TryEnqueue(() =>
+            {
+                try { toClose.Close(); }
+                catch (Exception ex) { _logger.Debug($"[CaptureConsent] Timed-out dialog close failed: {ex.Message}"); }
+            });
+        };
 
         if (!_dispatcherQueue.TryEnqueue(async () =>
         {
             try
             {
-                var dialog = new Dialogs.RecordingConsentDialog(type);
-                var consented = await dialog.ShowAsync();
+                var created = new Dialogs.RecordingConsentDialog(type);
+                bool alreadyTimedOut;
+                lock (dialogGate)
+                {
+                    alreadyTimedOut = closeRequested;
+                    dialog = created;
+                }
+                if (alreadyTimedOut)
+                {
+                    // Consent already timed out before the dialog could be
+                    // created; never show a prompt whose answer no longer
+                    // matters.
+                    dialogTcs.TrySetResult(false);
+                    created.Close();
+                    return;
+                }
+
+                var consented = await created.ShowAsync();
+
+                bool timedOutWhileAwaitingAnswer;
+                lock (dialogGate)
+                {
+                    timedOutWhileAwaitingAnswer = closeRequested;
+                }
+                if (timedOutWhileAwaitingAnswer)
+                {
+                    // The consent timeout already committed this prompt to a
+                    // fail-closed denial (and requested the window close)
+                    // before ShowAsync() returned. A click that was already
+                    // in flight at that instant must not persist a "late"
+                    // grant for an outcome the caller already received as
+                    // denied - keep the timeout's result and settings state
+                    // consistent instead of racing a stray late click.
+                    dialogTcs.TrySetResult(false);
+                    return;
+                }
 
                 if (consented && _settings != null)
                 {

--- a/src/OpenClaw.Tray.WinUI/Services/SettingsManager.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/SettingsManager.cs
@@ -107,6 +107,8 @@ public class SettingsManager
     public bool CameraRecordingConsentGiven { get => _data.CameraRecordingConsentGiven; set => _data = _data with { CameraRecordingConsentGiven = value }; }
     public bool NodeLocationEnabled { get => _data.NodeLocationEnabled; set => _data = _data with { NodeLocationEnabled = value }; }
     public bool LocationConsentGiven { get => _data.LocationConsentGiven; set => _data = _data with { LocationConsentGiven = value }; }
+    /// <summary>Fail-closed timeout (ms) for an unanswered capture consent prompt. See <see cref="SettingsData.CaptureConsentTimeoutMs"/>.</summary>
+    public int CaptureConsentTimeoutMs { get => _data.CaptureConsentTimeoutMs; set => _data = _data with { CaptureConsentTimeoutMs = value }; }
     public bool NodeBrowserProxyEnabled { get => _data.NodeBrowserProxyEnabled; set => _data = _data with { NodeBrowserProxyEnabled = value }; }
     /// <summary>
     /// Master switch for the <c>system.run</c> / <c>system.run.prepare</c>

--- a/tests/OpenClaw.Tray.IntegrationTests/TrayAppFixture.cs
+++ b/tests/OpenClaw.Tray.IntegrationTests/TrayAppFixture.cs
@@ -166,6 +166,13 @@ public sealed class TrayAppFixture : IAsyncLifetime
         // Disable the MXC sandbox for these tray/MCP wiring smokes because hosted
         // CI does not provide MXC; fail-closed sandbox behavior is covered by
         // OpenClaw.Shared.Tests.Mxc.
+        // CaptureConsentTimeoutMs is cut way down from the 120s production default:
+        // screen.snapshot/camera.snap now require recording consent (see
+        // NodeService.EnsureCaptureConsentAsync), and no human is present in this
+        // hosted process to click the consent prompt. The fail-closed timeout
+        // still denies (never auto-grants) — it just does so in seconds instead
+        // of never, so ScreenSnapshot/CameraSnap integration tests get a
+        // deterministic tool error well inside McpClient's 30s HTTP timeout.
         var settings = new SettingsData
         {
             EnableMcpServer = true,
@@ -175,6 +182,7 @@ public sealed class TrayAppFixture : IAsyncLifetime
             GlobalHotkeyEnabled = false,
             ShowNotifications = false,
             HasSeenActivityStreamTip = true,
+            CaptureConsentTimeoutMs = 3000,
         };
         File.WriteAllText(Path.Combine(DataDir, "settings.json"), settings.ToJson());
     }

--- a/tests/OpenClaw.Tray.Tests/ConsentAndSettingsSaveTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ConsentAndSettingsSaveTests.cs
@@ -109,4 +109,28 @@ public class ConsentAndSettingsSaveTests
             Directory.Delete(tempDir, recursive: true);
         }
     }
+
+    [Fact]
+    public void CaptureConsentTimeoutMs_DefaultsToTwoMinutes_AndPersistsAcrossReload()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"openclaw-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var settings = new SettingsManager(tempDir);
+            // Generous enough for a real interactive user to notice and answer
+            // the prompt, but still bounded - see NodeService.EnsureCaptureConsentAsync.
+            Assert.Equal(120_000, settings.CaptureConsentTimeoutMs);
+
+            settings.CaptureConsentTimeoutMs = 3000;
+            settings.Save();
+
+            var reloaded = new SettingsManager(tempDir);
+            Assert.Equal(3000, reloaded.CaptureConsentTimeoutMs);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
 }

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -132,6 +132,7 @@
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\CaptureOperationGate.cs" Link="Services\CaptureOperationGate.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\CaptureCancellationPolicy.cs" Link="Services\CaptureCancellationPolicy.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\SensitiveCaptureExecutor.cs" Link="Services\SensitiveCaptureExecutor.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\ConsentPromptTimeoutGate.cs" Link="Services\ConsentPromptTimeoutGate.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\BrowserProxyTunnelState.cs" Link="Services\BrowserProxyTunnelState.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\CommandCenterTopologyTunnelResolver.cs" Link="Services\CommandCenterTopologyTunnelResolver.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\CommandCenterTunnelInfoBuilder.cs" Link="Services\CommandCenterTunnelInfoBuilder.cs" />

--- a/tests/OpenClaw.Tray.Tests/Services/ConsentPromptTimeoutGateTests.cs
+++ b/tests/OpenClaw.Tray.Tests/Services/ConsentPromptTimeoutGateTests.cs
@@ -1,0 +1,105 @@
+using OpenClawTray.Services;
+using Xunit;
+
+namespace OpenClaw.Tray.Tests.Services;
+
+/// <summary>
+/// Regression coverage for the root cause behind the camera.snap/screen.snapshot
+/// MCP hang: after 31a8c655/16cb6897 gated those captures behind
+/// EnsureRecordingConsentAsync, an unattended caller (local MCP HTTP client,
+/// automated agent, hosted CI) had no way to answer the interactive consent
+/// window, so the request hung until the caller's own HTTP timeout fired.
+/// ConsentPromptTimeoutGate is the fail-closed fix: it bounds the wait and
+/// always resolves to "denied" on timeout, never "granted".
+/// </summary>
+public sealed class ConsentPromptTimeoutGateTests
+{
+    [Fact]
+    public async Task WithTimeout_DeniesAndInvokesCallback_WhenNoResponseInTime()
+    {
+        // Nothing ever completes this - simulates an unattended consent window
+        // (no human present to click Allow/Deny), the exact shape of the local
+        // MCP integration test hang.
+        var neverAnswered = new TaskCompletionSource<bool>();
+        var timedOutCallbackFired = false;
+
+        var result = await ConsentPromptTimeoutGate.WithTimeout(
+            neverAnswered.Task,
+            TimeSpan.FromMilliseconds(50),
+            onTimedOut: () => timedOutCallbackFired = true);
+
+        // Fail closed: a timeout is always a denial, never an implicit grant.
+        Assert.False(result);
+        Assert.True(timedOutCallbackFired);
+    }
+
+    [Fact]
+    public async Task WithTimeout_ReturnsGrantedResult_WhenAnsweredBeforeTimeout()
+    {
+        var answered = new TaskCompletionSource<bool>();
+        answered.SetResult(true);
+        var timedOutCallbackFired = false;
+
+        var result = await ConsentPromptTimeoutGate.WithTimeout(
+            answered.Task,
+            TimeSpan.FromSeconds(30),
+            onTimedOut: () => timedOutCallbackFired = true);
+
+        Assert.True(result);
+        Assert.False(timedOutCallbackFired);
+    }
+
+    [Fact]
+    public async Task WithTimeout_ReturnsDeniedResult_WhenAnsweredBeforeTimeout()
+    {
+        var answered = new TaskCompletionSource<bool>();
+        answered.SetResult(false);
+        var timedOutCallbackFired = false;
+
+        var result = await ConsentPromptTimeoutGate.WithTimeout(
+            answered.Task,
+            TimeSpan.FromSeconds(30),
+            onTimedOut: () => timedOutCallbackFired = true);
+
+        Assert.False(result);
+        Assert.False(timedOutCallbackFired);
+    }
+
+    [Fact]
+    public async Task WithTimeout_StillResolvesToDenied_AfterCallerAbandonsWaitAsync_BeforeInternalTimeoutElapses()
+    {
+        // NodeService.EnsureCaptureConsentAsync shares a single prompt across
+        // every concurrent caller of the same consent type
+        // (_screen/_camera/_locationConsentInFlight). If the request that
+        // originally created the prompt is canceled (its own caller
+        // disconnects) before the consent timeout elapses, a *different*
+        // concurrent caller may still be relying on this same task to
+        // eventually resolve. The bounded task must NOT be torn down just
+        // because one caller's own cancellation wrapper stopped waiting on
+        // it - it must keep running and still fail-closed once its own
+        // timeout elapses, exactly like the abandoned-prompt path in
+        // NodeService.CompleteAbandonedConsentPromptAsync depends on.
+        var neverAnswered = new TaskCompletionSource<bool>();
+        var timedOutCallbackFired = false;
+
+        var bounded = ConsentPromptTimeoutGate.WithTimeout(
+            neverAnswered.Task,
+            TimeSpan.FromMilliseconds(150),
+            onTimedOut: () => timedOutCallbackFired = true);
+
+        using var ownerCts = new CancellationTokenSource();
+        ownerCts.Cancel();
+
+        // The owning caller's own wrapper observes cancellation immediately...
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => bounded.WaitAsync(ownerCts.Token));
+
+        // ...but the shared bounded task itself is unaffected by that
+        // caller's cancellation and still fail-closes to false once its own
+        // internal timeout elapses, so any other waiter sharing this task
+        // still gets a bounded, well-formed denial instead of hanging.
+        var result = await bounded;
+        Assert.False(result);
+        Assert.True(timedOutCallbackFired);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a current-`main` regression (introduced by 31a8c655 / 16cb6897) where `screen.snapshot`, `camera.snap`, and `location.get` gate on an interactive consent dialog (`RecordingConsentDialog`, a real top-level WinUI window) with **no timeout anywhere** in the wait path. Any unattended caller — a local MCP HTTP client, an automated agent, a hosted CI test — hangs forever waiting for a human who will never click Allow/Deny. This broke `McpHttpServerIntegrationTests.CameraSnap_ReturnsImageOrWellFormedError` and `ScreenSnapshot_ReturnsImageOrWellFormedError` (both only "recovered" when the test's own 30s `HttpClient.Timeout` fired, since the MCP server's own request timeout is 6 minutes) and is currently blocking #1282, #1294, #1295, #1296.

**Security invariant preserved:** consent is never bypassed or auto-granted. A timeout always resolves to a fail-closed **denial**, never a grant. Interactive UI consent (Allow/Deny, persistence) is completely unchanged for a real user who responds in time.

## Root cause

`NodeService.EnsureCaptureConsentAsync` → `ShowCaptureConsentDialogAsync` creates the dialog and awaits its `Task<bool>`, which only completes via the dialog's `Closed` event (i.e. a human click). There was no bound on that wait. Raising the MCP request timeout or the test/client timeout would not be a real fix (explicitly out of scope) — the dialog itself needed a bounded, fail-closed wait.

## Fix

- Added `SettingsData.CaptureConsentTimeoutMs` (default `120_000`ms / 2 minutes), a real product-level configurable safety knob, mirrored in `SettingsManager`.
- Added `ConsentPromptTimeoutGate.WithTimeout(promptTask, timeout, onTimedOut)` — a small pure/testable helper that races the dialog task against `Task.Delay(timeout)` and fail-closes to `false` on timeout, invoking `onTimedOut` to force-close the now-pointless dialog window exactly once.
- `NodeService.EnsureCaptureConsentAsync` now binds this timeout to the prompt itself (not to any single caller's `CancellationToken`), then layers `.WaitAsync(cancellationToken)` on top so an owning caller can still stop waiting on its own cancellation *without* tearing down the shared timeout that other concurrent callers of the same consent type (`_screen/_camera/_locationConsentInFlight`) may still depend on for a bounded result.
- `ShowCaptureConsentDialogAsync` gained a `closeDialog` callback (handles the race where the timeout fires before the dialog window even exists) and now rechecks whether a timeout already fired before persisting a "late" Allow click that raced the force-close, keeping settings state consistent with the outcome already returned to the timed-out caller.
- `TrayAppFixture.WriteSettings()` sets `CaptureConsentTimeoutMs = 3000` (3s) so integration tests get fast, deterministic denials — this is a real settings knob, not a test/client timeout increase.
- New regression tests in `ConsentPromptTimeoutGateTests.cs` cover: fail-closed timeout + callback invocation, pass-through grant/deny when answered before timeout, and (added after rubber-duck review flagged a real bug) that the bounded task still fail-closes for other waiters even after the *owning* caller's own wait is cancelled — the exact shared in-flight-prompt scenario `NodeService`'s abandoned-prompt path relies on.
- `ConsentAndSettingsSaveTests.cs` gained a settings default/persistence test for the new field.

## Required proof pools

- `windows-winui-interactive`: the capture-consent approval dialog's timeout/close behavior changed. Not run as a scheduled pool (no scheduler invoked in this session); substituted with local computer-use proof against the isolated WinUI app driving the real `RecordingConsentDialog` window directly — see Real behavior proof below. `Not verified / blocked`: no maintainer-scheduled pool run was requested/available in this session.

## Validation

```
.\build.ps1
  → Cli, SetupEngine, WinUI, Shared, WinNodeCli — all 5 projects succeeded.

dotnet test tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore
  → Passed: 3873, Failed: 0, Skipped: 32 (environmental Mxc integration tests
    requiring host MXC capability), Total: 3905.

dotnet test tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore
  → Passed: 2829, Failed: 0, Skipped: 0, Total: 2829
    (includes the 4 new ConsentPromptTimeoutGate tests + 1 new settings test).

OPENCLAW_RUN_INTEGRATION=1 dotnet test tests\OpenClaw.Tray.IntegrationTests\OpenClaw.Tray.IntegrationTests.csproj
  → Passed: 22, Failed: 0, Skipped: 0, Total: 22.
    CameraSnap_ReturnsImageOrWellFormedError: passed in ~3s (was: hung to the
    30s HttpClient.Timeout).
    ScreenSnapshot_ReturnsImageOrWellFormedError: passed in ~3s (was: hung to
    the 30s HttpClient.Timeout).
```

## Real behavior proof

Current-head, isolated tray data dir (`OPENCLAW_TRAY_DATA_DIR` set to a temp dir, never touching `%APPDATA%\OpenClawTray`), local MCP server enabled.

**Raw MCP JSON-RPC `tools/call` — unattended (nobody answers), fail-closed denial, not a hang:**

```jsonc
// POST http://127.0.0.1:8765/  {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"screen.snapshot","arguments":{}}}
// CaptureConsentTimeoutMs=5000 for this proof run; elapsed ~5.0s (was: unbounded hang)
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": {
    "content": [ { "type": "text", "text": "Capture failed" } ],
    "isError": true
  }
}
```

Same shape for `camera.snap` (`"Snap failed"`, `isError: true`, bounded elapsed time). `winnode --list-tools` confirms both `camera.snap` and `screen.snapshot` remain correctly advertised.

**Interactive UI consent preserved — computer-use proof:** with `CaptureConsentTimeoutMs=25000`, invoked `camera.snap` via `winnode` and used computer-use automation to click **Allow** on the real, on-screen `RecordingConsentDialog` window ("Allow camera capture?", Deny/Allow buttons) before the timeout elapsed. Confirmed via the accessibility tree that the dialog rendered with the expected copy, the click was processed, and `CameraRecordingConsentGiven` flipped to `true` and persisted to `settings.json` — proving the grant + persistence path is completely unchanged by this fix.

## Rubber-duck review

Ran a rubber-duck review before this PR. It found one real, fixed-here bug: `ObserveAbandonedConsentPrompt` was awaiting the raw (unbounded) dialog task when the *owning* caller canceled, so a second concurrent caller sharing the same in-flight consent prompt could hang indefinitely even though the owning caller's own wait was correctly bounded. Fixed by decoupling the timeout (`ConsentPromptTimeoutGate.WithTimeout`) from any single caller's `CancellationToken`, and added a regression test for it. A secondary non-blocking finding (a late Allow click racing the force-close could persist a stale grant after a request was already denied) was also fixed by rechecking the timeout state before persisting settings. No path was found that lets a timeout resolve to `true`/granted.

Not merging this myself — flagging as ready for maintainer review/merge.
