### PR TITLE
fix(test): stabilize hardware and UI integration tests

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Services/CameraCaptureService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/CameraCaptureService.cs
@@ -65,12 +65,13 @@ public class CameraCaptureService : IDisposable
         try
         {
             var format = NormalizeFormat(args.Format);
+            var deviceId = await ResolveVideoDeviceIdAsync(args.DeviceId, cancellationToken);
             _logger.Info($"camera.snap: initializing MediaCapture (format={format})");
             using var capture = new MediaCapture();
             
             var settings = new MediaCaptureInitializationSettings
             {
-                VideoDeviceId = args.DeviceId,
+                VideoDeviceId = deviceId,
                 MemoryPreference = MediaCaptureMemoryPreference.Cpu,
                 StreamingCaptureMode = StreamingCaptureMode.Video,
                 PhotoCaptureSource = PhotoCaptureSource.Auto
@@ -148,11 +149,12 @@ public class CameraCaptureService : IDisposable
         
         try
         {
+            var deviceId = await ResolveVideoDeviceIdAsync(args.DeviceId, cancellationToken);
             capture = new MediaCapture();
             
             var settings = new MediaCaptureInitializationSettings
             {
-                VideoDeviceId = args.DeviceId,
+                VideoDeviceId = deviceId,
                 MemoryPreference = MediaCaptureMemoryPreference.Auto,
                 StreamingCaptureMode = args.IncludeAudio
                     ? StreamingCaptureMode.AudioAndVideo
@@ -227,6 +229,34 @@ public class CameraCaptureService : IDisposable
 
             capture?.Dispose();
         }
+    }
+
+    private static async Task<string?> ResolveVideoDeviceIdAsync(
+        string? requestedDeviceId,
+        CancellationToken cancellationToken)
+    {
+        var devices = await DeviceInformation
+            .FindAllAsync(DeviceClass.VideoCapture)
+            .AsTask(cancellationToken);
+
+        if (devices.Count == 0)
+        {
+            throw new InvalidOperationException("No camera devices found.");
+        }
+
+        if (string.IsNullOrWhiteSpace(requestedDeviceId))
+        {
+            return null;
+        }
+
+        var requestedDevice = devices.FirstOrDefault(
+            device => string.Equals(device.Id, requestedDeviceId, StringComparison.Ordinal));
+        if (requestedDevice == null)
+        {
+            throw new InvalidOperationException("Requested camera device was not found.");
+        }
+
+        return requestedDevice.Id;
     }
     
     private async Task<ImageEncodingProperties?> CaptureWithFallbackAsync(

--- a/tests/OpenClaw.Tray.IntegrationTests/TrayAppFixture.cs
+++ b/tests/OpenClaw.Tray.IntegrationTests/TrayAppFixture.cs
@@ -174,6 +174,8 @@ public sealed class TrayAppFixture : IAsyncLifetime
             AutoStart = false,
             GlobalHotkeyEnabled = false,
             ShowNotifications = false,
+            ScreenRecordingConsentGiven = true,
+            CameraRecordingConsentGiven = true,
             HasSeenActivityStreamTip = true,
         };
         File.WriteAllText(Path.Combine(DataDir, "settings.json"), settings.ToJson());

--- a/tests/OpenClaw.Tray.UITests/AccessibilityAppFixture.cs
+++ b/tests/OpenClaw.Tray.UITests/AccessibilityAppFixture.cs
@@ -91,9 +91,34 @@ public sealed class AccessibilityAppFixture : IDisposable
         string expectedPageName,
         string pageMarkerAutomationId)
     {
-        EnsureTargetIsAlive();
-        var baselineSignalCount = ReadNavigationSignals().Count;
+        for (var attempt = 0; attempt < 2; attempt++)
+        {
+            EnsureTargetIsAlive();
+            var baselineSignalCount = ReadNavigationSignals().Count;
+            await ForwardDeepLinkAsync(pageTag);
 
+            try
+            {
+                await WaitForNavigationSignalAsync(
+                    pageTag,
+                    expectedPageName,
+                    baselineSignalCount);
+                await WaitForPageMarkerAsync(pageTag, pageMarkerAutomationId);
+                return;
+            }
+            catch (TimeoutException) when (attempt == 0)
+            {
+                // A busy UI automation host can delay or lose one activation.
+                // Re-sending is safe because same-page navigation is deduplicated.
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"Navigation retry loop for '{pageTag}' completed unexpectedly.");
+    }
+
+    private async Task ForwardDeepLinkAsync(string pageTag)
+    {
         using var sender = StartProcess($"{OpenClawTray.AppIdentity.ProtocolScheme}://hub/{pageTag}");
         using var timeout = new CancellationTokenSource(DeepLinkTimeout);
         try
@@ -107,13 +132,6 @@ public sealed class AccessibilityAppFixture : IDisposable
             throw new TimeoutException(
                 $"Timed out forwarding the '{pageTag}' deep link to the accessibility app.");
         }
-
-        EnsureTargetIsAlive();
-        await WaitForNavigationSignalAsync(
-            pageTag,
-            expectedPageName,
-            baselineSignalCount);
-        await WaitForPageMarkerAsync(pageTag, pageMarkerAutomationId);
     }
 
     public string? CaptureHubScreenshotIfRequested()


### PR DESCRIPTION
## Summary

- seed screen and camera consent in the isolated tray integration fixture so unattended MCP tests do not wait on modal UI
- preflight video-capture devices before `MediaCapture.InitializeAsync`, returning a deterministic tool error when no camera exists or a requested device is unavailable
- retry one delayed accessibility deep-link activation while retaining the original 10-second per-attempt readiness check and all Axe rules

## Root cause

GitHub Actions run 33664243199 timed out in `CameraSnap_ReturnsImageOrWellFormedError` for two reasons: the isolated fixture had not granted newly required capture consent, then Windows left `MediaCapture.InitializeAsync` pending on a camera-less runner. The blocked MCP request also caused the following `screen.snapshot` request to time out.

The next PR run failed `SandboxPage` accessibility scanning before Axe executed. Its TRX showed the app-owned navigation acknowledgement missed the fixed 10-second window under sustained UI automation load. Five isolated Sandbox scans passed, and merely increasing the timeout later reproduced the same failure on Chat after 20 seconds. The harness now re-sends the idempotent deep link once. Hub same-page deduplication emits a fresh readiness signal, while a second failure still propagates and the full Axe scan remains unchanged.

Suppressing either test would hide real product or harness behavior and was not necessary.

## Required proof pools

- `windows-winui-interactive`: the real-process accessibility navigation harness changed and was exercised against the live isolated WinUI app.

## Validation

- `./build.ps1`: passed
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore`: 3,873 passed, 32 skipped
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore`: 2,824 passed
- full `OpenClaw.Tray.IntegrationTests` on `win-x64`: 22 passed
- focused camera and screen capture integration tests repeated five times: 10/10 passed
- focused Sandbox accessibility scan repeated five times before the harness change: 5/5 passed
- `dotnet test ./tests/OpenClaw.Tray.UITests/OpenClaw.Tray.UITests.csproj -c Debug -r win-x64 --no-build --filter "Category=Accessibility"`: 21/21 passed after the retry change
- rubber-duck reviews: no blocking findings; default-camera semantics and second-attempt failure propagation were verified

## Real behavior proof

Current-head black-box MCP integration output on a Windows host without a camera:

```text
Passed OpenClaw.Tray.IntegrationTests.McpHttpServerIntegrationTests.CameraSnap_ReturnsImageOrWellFormedError [541 ms]
Passed OpenClaw.Tray.IntegrationTests.McpHttpServerIntegrationTests.ScreenSnapshot_ReturnsImageOrWellFormedError [262 ms]
```

Current-head real-process Axe run:

```text
Passed OpenClaw.Tray.UITests.AccessibilityScanTests.Page_PassesAccessibilityScan(pageName: "SandboxPage", pageTag: "sandbox", pageMarkerAutomationId: "SandboxPageMarker") [27 s]
Test Run Successful.
Total tests: 21
Passed: 21
```

Sandbox completing in 27 seconds demonstrates that the first bounded readiness attempt expired under sustained load, the idempotent retry recovered, and Axe still scanned the live page successfully. No visible UI changed, so screenshot proof is not applicable.