### PR TITLE
fix(release): decouple stable correction validation from upstream releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,9 +82,12 @@ jobs:
 
         if ($env:GITHUB_REF.StartsWith("refs/tags/v", [StringComparison]::Ordinal)) {
           $tagVersion = $env:GITHUB_REF_NAME -replace '^v', ''
+          # Match every numeric suffix, including malformed ones such as -0 and
+          # -03, so the correction validator is the single authority that can
+          # accept or reject them.
           $correction = [regex]::Match(
             $tagVersion,
-            '^(?<base>(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*))-(?<revision>[1-9]\d*)$')
+            '^(?<base>(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*))-(?<revision>\d+)$')
 
           if ($correction.Success) {
             $validation = .\scripts\Test-OpenClawStableCorrectionRelease.ps1 `

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,10 @@ jobs:
       shell: pwsh
       run: ./scripts/test-proof-pool-validator.ps1
 
+    - name: Validate stable correction release ordering regressions
+      shell: pwsh
+      run: ./scripts/test-stable-correction-release-validator.ps1
+
     - name: Restore dependencies
       run: dotnet restore
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -80,7 +80,11 @@ Stable, stable-correction, and alpha tags use the same signed CI release pipelin
   candidate to stay on the same `X.Y.Z` base line as the current Windows latest
   release and to carry a strictly greater numeric correction. Same, older, and
   different-line corrections fail closed, so GitHub's Latest release marker can
-  never move backward and a published tag can never be reused.
+  never move backward. The validator also refuses a candidate that already has a
+  published Windows release, and refuses to order against a draft, prerelease,
+  or unpublished latest release, so a published tag can never be reused. Every
+  numeric-suffix tag, including malformed ones such as `-0` and `-03`, is routed
+  through the validator rather than silently classified by GitVersion.
 - `vX.Y.Z-alpha.N` creates a prerelease that stable updater checks do not offer.
 
 The validator has no dependency on another repository's release API. Run it

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -31,7 +31,7 @@ build/sign/publish release artifacts.
 
    ```powershell
    # Stable: vX.Y.Z
-   # Stable correction matching the OpenClaw monorepo: vX.Y.Z-N
+   # Stable correction on the current Windows latest line: vX.Y.Z-N
    # Prerelease: vX.Y.Z-alpha.N
    $tag = "vX.Y.Z"
    if ((git rev-parse HEAD) -ne (git rev-parse origin/main)) {
@@ -72,31 +72,51 @@ Stable, stable-correction, and alpha tags use the same signed CI release pipelin
 
 - `vX.Y.Z` creates a normal release eligible to become latest.
 - `vX.Y.Z-N` creates a stable correction release eligible to become latest. The
-  numeric correction suffix intentionally follows the OpenClaw monorepo release
-  convention and is not treated as a SemVer prerelease. Only publish a
-  correction for the current latest stable line; publishing one for an older
-  line would incorrectly move GitHub's Latest release marker backward. CI
-  enforces both constraints: the exact tag must already be a published stable
-  `openclaw/openclaw` release, and it must advance the current Windows latest
-  release under OpenClaw correction ordering.
+  numeric correction suffix intentionally follows the OpenClaw release
+  convention and is not treated as a SemVer prerelease. Windows Hub release tags
+  are their own version domain: a correction is a correction of the Windows
+  latest release, not a mirror of any other repository's release. CI enforces
+  that in `scripts\Test-OpenClawStableCorrectionRelease.ps1`, which requires the
+  candidate to stay on the same `X.Y.Z` base line as the current Windows latest
+  release and to carry a strictly greater numeric correction. Same, older, and
+  different-line corrections fail closed, so GitHub's Latest release marker can
+  never move backward and a published tag can never be reused.
 - `vX.Y.Z-alpha.N` creates a prerelease that stable updater checks do not offer.
 
-Stable correction support begins only with an eligible upstream release tag
-created from `main` after the correction-aware implementation has landed. For
-this rollout, the Windows repository already contains its own annotated
-`v2026.7.1-2` tag, separate from the matching upstream tag, and it points to a
-commit that predates the implementation. It is not a correction-aware artifact
-and must not be moved, rebuilt from a different commit, or reused as a recovery
-release.
+The validator has no dependency on another repository's release API. Run it
+offline against an explicit current release to preview a decision:
 
-If the first post-merge Windows release is another numeric correction, users on
-the matching unsuffixed version need to install that new release manually.
-Older Windows clients use Updatum's default parser, which removes the numeric
-correction suffix before comparison. If the first post-merge release is a newer
-unsuffixed stable version, ordinary Updatum ordering can deliver it without the
-manual correction transition. Once any correction-aware Windows build is
-installed, later corrections and stable base versions are compared using
-OpenClaw release ordering.
+```powershell
+# Accepted: same 2026.7.1 line, correction 3 > 2
+.\scripts\Test-OpenClawStableCorrectionRelease.ps1 `
+  -Tag v2026.7.1-3 -CurrentWindowsTag v2026.7.1-2
+
+# Rejected: reuse of a published tag
+.\scripts\Test-OpenClawStableCorrectionRelease.ps1 `
+  -Tag v2026.7.1-2 -CurrentWindowsTag v2026.7.1-2
+```
+
+`scripts\test-stable-correction-release-validator.ps1` runs the full accept and
+reject matrix deterministically and is also enforced in CI.
+
+The live `v2026.7.1-2` annotated tag dereferences to commit `f46400aa`, which is
+the correction-aware implementation ("Support upstream stable correction release
+versions", #1266). Release run 33221425381 built and signed that release's
+assets, so `v2026.7.1-2` is the current correction-aware Windows latest release.
+Never move, rebuild, or reuse that tag; the next correction on this line is a new
+`v2026.7.1-3` tag.
+
+Clients on older unsuffixed `2026.7.1` builds predate the correction-aware
+update path. They use Updatum's default parser, which drops the numeric
+correction suffix before comparison, so they may need a manual transition to a
+correction release. Clients already on `2026.7.1-2` are correction-aware: even
+though Updatum 1.3.4's default parsing does not rank `2026.7.1-3` above
+`2026.7.1-2`, the `OpenClawReleaseVersion` fallback in the update check pipeline
+compares releases under OpenClaw correction ordering and discovers `2026.7.1-3`.
+
+Gateway versions are a separate, independently pinned domain. A Windows Hub
+correction release does not change `GatewayReleasePolicy.RecommendedVersion` or
+its evidence gates; see [`adr/0001-gateway-release-policy.md`](adr/0001-gateway-release-policy.md).
 
 ```powershell
 git tag -a vX.Y.Z-alpha.N -m "OpenClaw Windows Hub vX.Y.Z-alpha.N"

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -95,12 +95,16 @@ continue to use the GitVersion result directly.
 
 That validator resolves only this repository's latest release and then requires
 the candidate to share its `X.Y.Z` base line and carry a strictly greater
-correction. It performs no other repository's release lookup, and
-`-CurrentWindowsTag` runs the same decision offline.
+correction. It also rejects a candidate that already has a published Windows
+release. It performs no other repository's release lookup, and
+`-CurrentWindowsTag` evaluates the ordering rule offline.
 `scripts\test-stable-correction-release-validator.ps1` covers the accept and
-reject matrix deterministically in CI. The release job revalidates the same
-ordering after signing and before publication, so a correction that stopped
-being the next release while the build ran cannot be published as latest.
+reject matrix plus the workflow's tag classification deterministically in CI.
+Every numeric-suffix tag is routed to the validator, so malformed corrections
+such as `X.Y.Z-0` cannot be published as an ordinary prerelease instead. The
+release job revalidates the same ordering after signing and before publication,
+so a correction that stopped being the next release while the build ran cannot
+be published as latest.
 
 Release build jobs must check out full git history (`fetch-depth: 0`) so
 GitVersion can see tags.

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -14,9 +14,16 @@ Canonical release tags use:
 Numeric correction suffixes are an intentional stable-channel exception to
 SemVer's usual prerelease interpretation. Corrections sort after their
 unsuffixed base release and then by numeric correction: `vX.Y.Z` <
-`vX.Y.Z-1` < `vX.Y.Z-2`. A correction tag must not be published if that exact
-tag already exists or a newer stable/correction release has already been
-published.
+`vX.Y.Z-1` < `vX.Y.Z-2`. A correction must stay on the current Windows latest
+release line and strictly advance that line's correction number. A correction
+tag must not be published if that exact tag already exists or a newer
+stable/correction release has already been published.
+
+Windows Hub release tags are an independent version domain. They are not
+validated against, or required to match, any other repository's releases. The
+Gateway package version is pinned separately by
+`GatewayReleasePolicy.RecommendedVersion` under its own evidence gates, and a
+Windows Hub correction release never changes that pin.
 
 `GitVersion.yml` controls how tag history becomes SemVer. The product build
 imports GitVersion through `src\Directory.Build.props`, so normal `dotnet build`,
@@ -86,6 +93,15 @@ explicit MSBuild version properties are therefore the validated correction tag,
 not an independent version source. Ordinary stable, alpha, and untagged builds
 continue to use the GitVersion result directly.
 
+That validator resolves only this repository's latest release and then requires
+the candidate to share its `X.Y.Z` base line and carry a strictly greater
+correction. It performs no other repository's release lookup, and
+`-CurrentWindowsTag` runs the same decision offline.
+`scripts\test-stable-correction-release-validator.ps1` covers the accept and
+reject matrix deterministically in CI. The release job revalidates the same
+ordering after signing and before publication, so a correction that stopped
+being the next release while the build ran cannot be published as latest.
+
 Release build jobs must check out full git history (`fetch-depth: 0`) so
 GitVersion can see tags.
 
@@ -124,6 +140,8 @@ For example:
 - Keep numeric correction tags behind the stable-ordering validation in both
   release resolution and publication; never classify every hyphenated tag as a
   prerelease without recognizing this exception.
+- Keep the correction validator free of other repositories' release APIs. Windows
+  Hub release tags and the pinned Gateway version are separate domains.
 
 ## References
 

--- a/docs/adr/0001-gateway-release-policy.md
+++ b/docs/adr/0001-gateway-release-policy.md
@@ -31,7 +31,12 @@ evidence.
   an unembedded release; candidate execution requires a reviewed embedded
   `GatewayReleaseStatus.Candidate` policy entry.
 - Numeric correction releases such as `2026.7.1-2` are stable-version syntax,
-  but still require the complete evidence gate.
+  but still require the complete evidence gate. This applies to the Gateway
+  package version only. Windows Hub application release tags are a separate
+  version domain validated by
+  [`../RELEASING.md`](../RELEASING.md); a Windows Hub correction release neither
+  changes `GatewayReleasePolicy.RecommendedVersion` nor supplies any Gateway
+  promotion evidence.
 - Prerelease labels, versions below the floor, missing provenance, missing
   stable upstream attestation, package/tag commit mismatch, unbound candidate
   provenance, and protocol-generation mismatch fail closed.

--- a/scripts/Test-OpenClawStableCorrectionRelease.ps1
+++ b/scripts/Test-OpenClawStableCorrectionRelease.ps1
@@ -15,7 +15,10 @@
       current v2026.7.1-2  + candidate v2026.8.0-1 -> rejected (other line)
 
     The validator deliberately has no dependency on any other repository's
-    release API. Pass -CurrentWindowsTag to validate ordering offline.
+    release API. Online runs also refuse a candidate tag that already has a
+    published Windows release, and refuse to order against a draft, prerelease,
+    or unpublished latest release. Pass -CurrentWindowsTag to evaluate the
+    ordering rule offline.
 #>
 
 [CmdletBinding()]
@@ -95,15 +98,78 @@ if (-not [string]::IsNullOrWhiteSpace($GitHubToken)) {
     $headers.Authorization = "Bearer $GitHubToken"
 }
 
-$currentTag = $CurrentWindowsTag
-if ([string]::IsNullOrWhiteSpace($currentTag)) {
-    $currentWindowsRelease = Invoke-RestMethod `
-        -Headers $headers `
+function Get-ExceptionHttpStatus {
+    param([Parameter(Mandatory)][object]$Exception)
+
+    $response = $null
+    if ($null -ne $Exception.PSObject.Properties["Response"]) {
+        $response = $Exception.Response
+    }
+    if ($null -eq $response -or
+        $null -eq $response.PSObject.Properties["StatusCode"]) {
+        return $null
+    }
+
+    return [int]$response.StatusCode
+}
+
+function Assert-WindowsReleaseTagUnpublished {
+    param(
+        [Parameter(Mandatory)][string]$ReleaseTag,
+        [Parameter(Mandatory)][hashtable]$RequestHeaders
+    )
+
+    try {
+        Invoke-RestMethod `
+            -Headers $RequestHeaders `
+            -Uri "https://api.github.com/repos/openclaw/openclaw-windows-node/releases/tags/$ReleaseTag" |
+            Out-Null
+    } catch {
+        $status = Get-ExceptionHttpStatus -Exception $_.Exception
+        if ($status -eq 404) {
+            return
+        }
+
+        throw "Could not determine whether Windows release '$ReleaseTag' already exists: $($_.Exception.Message)"
+    }
+
+    throw "Stable correction '$ReleaseTag' is already a published Windows release; a published tag must never be moved or reused."
+}
+
+function Get-CurrentWindowsReleaseTag {
+    param([Parameter(Mandatory)][hashtable]$RequestHeaders)
+
+    $release = Invoke-RestMethod `
+        -Headers $RequestHeaders `
         -Uri "https://api.github.com/repos/openclaw/openclaw-windows-node/releases/latest"
-    $currentTag = $currentWindowsRelease.tag_name
-    if ([string]::IsNullOrWhiteSpace($currentTag)) {
+
+    $tagName = $null
+    if ($null -ne $release -and
+        $null -ne $release.PSObject.Properties["tag_name"]) {
+        $tagName = $release.tag_name
+    }
+    if ([string]::IsNullOrWhiteSpace($tagName)) {
         throw "Could not resolve the current openclaw/openclaw-windows-node latest release tag."
     }
+
+    if ($release.PSObject.Properties["draft"] -and $release.draft) {
+        throw "Current Windows latest release '$tagName' is a draft; refusing to order a correction against it."
+    }
+    if ($release.PSObject.Properties["prerelease"] -and $release.prerelease) {
+        throw "Current Windows latest release '$tagName' is a prerelease; refusing to order a correction against it."
+    }
+    if ($null -eq $release.PSObject.Properties["published_at"] -or
+        $null -eq $release.published_at) {
+        throw "Current Windows latest release '$tagName' is not published; refusing to order a correction against it."
+    }
+
+    return $tagName
+}
+
+$currentTag = $CurrentWindowsTag
+if ([string]::IsNullOrWhiteSpace($currentTag)) {
+    Assert-WindowsReleaseTagUnpublished -ReleaseTag $Tag -RequestHeaders $headers
+    $currentTag = Get-CurrentWindowsReleaseTag -RequestHeaders $headers
 }
 
 Assert-SameLineStableCorrection `

--- a/scripts/Test-OpenClawStableCorrectionRelease.ps1
+++ b/scripts/Test-OpenClawStableCorrectionRelease.ps1
@@ -1,10 +1,34 @@
+<#
+.SYNOPSIS
+    Validates that a numeric stable correction tag may be published as an
+    OpenClaw Windows Hub release.
+
+.DESCRIPTION
+    Windows Hub release tags are an independent version domain. A correction is
+    accepted only when it stays on the current Windows latest release line and
+    strictly advances that line's numeric correction:
+
+      current v2026.7.1    + candidate v2026.7.1-1 -> accepted
+      current v2026.7.1-2  + candidate v2026.7.1-3 -> accepted
+      current v2026.7.1-2  + candidate v2026.7.1-2 -> rejected (tag reuse)
+      current v2026.7.1-2  + candidate v2026.7.1-1 -> rejected (backwards)
+      current v2026.7.1-2  + candidate v2026.8.0-1 -> rejected (other line)
+
+    The validator deliberately has no dependency on any other repository's
+    release API. Pass -CurrentWindowsTag to validate ordering offline.
+#>
+
 [CmdletBinding()]
 param(
     [Parameter(Mandatory)]
     [ValidatePattern('^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)-[1-9]\d*$')]
     [string]$Tag,
 
-    [string]$GitHubToken = $env:GITHUB_TOKEN
+    [string]$GitHubToken = $env:GITHUB_TOKEN,
+
+    # Deterministic/offline ordering input. When supplied, the current Windows
+    # latest release tag is not fetched from the GitHub API.
+    [string]$CurrentWindowsTag
 )
 
 Set-StrictMode -Version Latest
@@ -32,7 +56,13 @@ function ConvertTo-StableReleaseVersion {
     )
 }
 
-function Assert-NewerStableRelease {
+function Get-StableReleaseBaseVersion {
+    param([Parameter(Mandatory)][object[]]$Parts)
+
+    return "$($Parts[0]).$($Parts[1]).$($Parts[2])"
+}
+
+function Assert-SameLineStableCorrection {
     param(
         [Parameter(Mandatory)][string]$Candidate,
         [Parameter(Mandatory)][string]$Current
@@ -40,16 +70,20 @@ function Assert-NewerStableRelease {
 
     $candidateParts = ConvertTo-StableReleaseVersion $Candidate
     $currentParts = ConvertTo-StableReleaseVersion $Current
-    for ($index = 0; $index -lt $candidateParts.Count; $index++) {
-        if ($candidateParts[$index] -gt $currentParts[$index]) {
-            return
-        }
-        if ($candidateParts[$index] -lt $currentParts[$index]) {
-            throw "Stable correction '$Candidate' does not advance current Windows release '$Current'."
-        }
+    $candidateBase = Get-StableReleaseBaseVersion $candidateParts
+    $currentBase = Get-StableReleaseBaseVersion $currentParts
+
+    if ($candidateBase -ne $currentBase) {
+        throw "Stable correction '$Candidate' must correct the current Windows latest release line '$currentBase', but targets '$candidateBase'."
     }
 
-    throw "Stable correction '$Candidate' is already the current Windows release."
+    if ($candidateParts[3] -eq $currentParts[3]) {
+        throw "Stable correction '$Candidate' is already the current Windows release '$Current'; a published tag must never be moved or reused."
+    }
+
+    if ($candidateParts[3] -lt $currentParts[3]) {
+        throw "Stable correction '$Candidate' does not advance current Windows release '$Current'."
+    }
 }
 
 $headers = @{
@@ -61,26 +95,27 @@ if (-not [string]::IsNullOrWhiteSpace($GitHubToken)) {
     $headers.Authorization = "Bearer $GitHubToken"
 }
 
-$upstreamRelease = Invoke-RestMethod `
-    -Headers $headers `
-    -Uri "https://api.github.com/repos/openclaw/openclaw/releases/tags/$Tag"
-if ($upstreamRelease.tag_name -cne $Tag -or
-    $upstreamRelease.draft -or
-    $upstreamRelease.prerelease -or
-    $null -eq $upstreamRelease.published_at) {
-    throw "Stable correction '$Tag' must match an exact published stable openclaw/openclaw release."
+$currentTag = $CurrentWindowsTag
+if ([string]::IsNullOrWhiteSpace($currentTag)) {
+    $currentWindowsRelease = Invoke-RestMethod `
+        -Headers $headers `
+        -Uri "https://api.github.com/repos/openclaw/openclaw-windows-node/releases/latest"
+    $currentTag = $currentWindowsRelease.tag_name
+    if ([string]::IsNullOrWhiteSpace($currentTag)) {
+        throw "Could not resolve the current openclaw/openclaw-windows-node latest release tag."
+    }
 }
 
-$currentWindowsRelease = Invoke-RestMethod `
-    -Headers $headers `
-    -Uri "https://api.github.com/repos/openclaw/openclaw-windows-node/releases/latest"
-Assert-NewerStableRelease `
+Assert-SameLineStableCorrection `
     -Candidate $Tag `
-    -Current $currentWindowsRelease.tag_name
+    -Current $currentTag
 
 $parsedTag = ConvertTo-StableReleaseVersion $Tag
+$parsedCurrent = ConvertTo-StableReleaseVersion $currentTag
 [pscustomobject]@{
     Tag = $Tag
-    BaseVersion = "$($parsedTag[0]).$($parsedTag[1]).$($parsedTag[2])"
-    CurrentWindowsTag = $currentWindowsRelease.tag_name
+    BaseVersion = Get-StableReleaseBaseVersion $parsedTag
+    Correction = $parsedTag[3]
+    CurrentWindowsTag = $currentTag
+    CurrentCorrection = $parsedCurrent[3]
 }

--- a/scripts/test-stable-correction-release-validator.ps1
+++ b/scripts/test-stable-correction-release-validator.ps1
@@ -29,6 +29,8 @@ if (-not (Test-Path -LiteralPath $validatorPath)) {
 
 $script:acceptedCount = 0
 $script:rejectedCount = 0
+$script:classificationCount = 0
+$script:workflowCorrectionPattern = $null
 
 function Assert-CorrectionAccepted {
     param(
@@ -108,6 +110,25 @@ function Assert-InvalidTagRejected {
     Write-Host "  rejected: $Name ($Tag)"
 }
 
+function Assert-WorkflowClassification {
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][string]$Tag,
+        [Parameter(Mandatory)][bool]$ExpectedRoutedToValidator
+    )
+
+    $tagVersion = $Tag -replace '^v', ''
+    $routed = [regex]::IsMatch($tagVersion, $script:workflowCorrectionPattern)
+    if ($routed -ne $ExpectedRoutedToValidator) {
+        throw ("Case '$Name': tag '$Tag' routed-to-validator was '$routed' " +
+               "but expected '$ExpectedRoutedToValidator'.")
+    }
+
+    $script:classificationCount++
+    $decision = if ($routed) { "validator" } else { "gitversion" }
+    Write-Host "  classified: $Name ($Tag -> $decision)"
+}
+
 Write-Host "Validating correction release source contract..."
 $validatorSource = Get-Content -LiteralPath $validatorPath -Raw
 if ($validatorSource -match 'repos/openclaw/openclaw/') {
@@ -116,6 +137,38 @@ if ($validatorSource -match 'repos/openclaw/openclaw/') {
 if ($validatorSource -notmatch 'repos/openclaw/openclaw-windows-node/releases/latest') {
     throw "Validator must resolve the current Windows latest release tag."
 }
+
+Write-Host "Validating release workflow correction classification..."
+$workflowPath = Join-Path $repoRootPath ".github\workflows\ci.yml"
+$workflowSource = Get-Content -LiteralPath $workflowPath -Raw
+$patternMatch = [regex]::Match(
+    $workflowSource,
+    "(?m)^\s*'(?<pattern>\^\(\?<base>.*?\)-\(\?<revision>.*?\)\`$)'\s*\)")
+if (-not $patternMatch.Success) {
+    throw "Could not read the release workflow correction classification pattern from '$workflowPath'."
+}
+$script:workflowCorrectionPattern = $patternMatch.Groups["pattern"].Value
+
+Assert-WorkflowClassification `
+    -Name "valid correction reaches the validator" `
+    -Tag "v2026.7.1-3" `
+    -ExpectedRoutedToValidator $true
+Assert-WorkflowClassification `
+    -Name "zero correction cannot bypass the validator" `
+    -Tag "v2026.7.1-0" `
+    -ExpectedRoutedToValidator $true
+Assert-WorkflowClassification `
+    -Name "leading-zero correction cannot bypass the validator" `
+    -Tag "v2026.7.1-03" `
+    -ExpectedRoutedToValidator $true
+Assert-WorkflowClassification `
+    -Name "unsuffixed stable tag stays on GitVersion" `
+    -Tag "v2026.7.1" `
+    -ExpectedRoutedToValidator $false
+Assert-WorkflowClassification `
+    -Name "alpha prerelease stays on GitVersion" `
+    -Tag "v2026.7.2-alpha.19" `
+    -ExpectedRoutedToValidator $false
 
 Write-Host "Validating same-line monotonic correction acceptance..."
 Assert-CorrectionAccepted `
@@ -199,6 +252,7 @@ Assert-InvalidTagRejected `
 
 Write-Host (
     "Stable correction release validator regressions passed: " +
-    "$script:acceptedCount accepted, $script:rejectedCount rejected."
+    "$script:acceptedCount accepted, $script:rejectedCount rejected, " +
+    "$script:classificationCount workflow classifications."
 ) -ForegroundColor Green
 $global:LASTEXITCODE = 0

--- a/scripts/test-stable-correction-release-validator.ps1
+++ b/scripts/test-stable-correction-release-validator.ps1
@@ -1,0 +1,204 @@
+<#
+.SYNOPSIS
+    Deterministic offline regressions for the stable correction release
+    validator.
+
+.DESCRIPTION
+    Every case runs the real validator with an explicit -CurrentWindowsTag so
+    ordering is proven without any network call. The harness also asserts that
+    the validator source has no dependency on another repository's release API.
+#>
+
+[CmdletBinding()]
+param(
+    [string]$RepoRoot
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+if ([string]::IsNullOrWhiteSpace($RepoRoot)) {
+    $RepoRoot = Split-Path -Parent $scriptRoot
+}
+$repoRootPath = [System.IO.Path]::GetFullPath($RepoRoot)
+$validatorPath = Join-Path $repoRootPath "scripts\Test-OpenClawStableCorrectionRelease.ps1"
+if (-not (Test-Path -LiteralPath $validatorPath)) {
+    throw "Correction release validator not found at '$validatorPath'."
+}
+
+$script:acceptedCount = 0
+$script:rejectedCount = 0
+
+function Assert-CorrectionAccepted {
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][string]$Tag,
+        [Parameter(Mandatory)][string]$CurrentWindowsTag,
+        [Parameter(Mandatory)][string]$ExpectedBaseVersion,
+        [Parameter(Mandatory)][long]$ExpectedCorrection
+    )
+
+    $result = & $validatorPath -Tag $Tag -CurrentWindowsTag $CurrentWindowsTag
+    if ($null -eq $result) {
+        throw "Case '$Name': validator produced no result for '$Tag'."
+    }
+    if ($result.Tag -cne $Tag) {
+        throw "Case '$Name': expected Tag '$Tag' but got '$($result.Tag)'."
+    }
+    if ($result.BaseVersion -cne $ExpectedBaseVersion) {
+        throw "Case '$Name': expected BaseVersion '$ExpectedBaseVersion' but got '$($result.BaseVersion)'."
+    }
+    if ([long]$result.Correction -ne $ExpectedCorrection) {
+        throw "Case '$Name': expected Correction '$ExpectedCorrection' but got '$($result.Correction)'."
+    }
+    if ($result.CurrentWindowsTag -cne $CurrentWindowsTag) {
+        throw "Case '$Name': expected CurrentWindowsTag '$CurrentWindowsTag' but got '$($result.CurrentWindowsTag)'."
+    }
+
+    $script:acceptedCount++
+    Write-Host "  accepted: $Name ($CurrentWindowsTag -> $Tag)"
+}
+
+function Assert-CorrectionRejected {
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][string]$Tag,
+        [Parameter(Mandatory)][string]$CurrentWindowsTag,
+        [Parameter(Mandatory)][string]$ExpectedMessage
+    )
+
+    $failure = $null
+    try {
+        & $validatorPath -Tag $Tag -CurrentWindowsTag $CurrentWindowsTag | Out-Null
+    } catch {
+        $failure = $_.Exception.Message
+    }
+
+    if ($null -eq $failure) {
+        throw "Case '$Name': validator accepted '$Tag' against current '$CurrentWindowsTag'."
+    }
+    if ($failure -notlike "*$ExpectedMessage*") {
+        throw "Case '$Name': expected rejection containing '$ExpectedMessage' but got '$failure'."
+    }
+
+    $script:rejectedCount++
+    Write-Host "  rejected: $Name ($CurrentWindowsTag -> $Tag)"
+}
+
+function Assert-InvalidTagRejected {
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][string]$Tag,
+        [Parameter(Mandatory)][string]$CurrentWindowsTag
+    )
+
+    $failure = $null
+    try {
+        & $validatorPath -Tag $Tag -CurrentWindowsTag $CurrentWindowsTag | Out-Null
+    } catch {
+        $failure = $_.Exception.Message
+    }
+
+    if ($null -eq $failure) {
+        throw "Case '$Name': validator accepted malformed tag '$Tag'."
+    }
+
+    $script:rejectedCount++
+    Write-Host "  rejected: $Name ($Tag)"
+}
+
+Write-Host "Validating correction release source contract..."
+$validatorSource = Get-Content -LiteralPath $validatorPath -Raw
+if ($validatorSource -match 'repos/openclaw/openclaw/') {
+    throw "Validator must not depend on the openclaw/openclaw release API."
+}
+if ($validatorSource -notmatch 'repos/openclaw/openclaw-windows-node/releases/latest') {
+    throw "Validator must resolve the current Windows latest release tag."
+}
+
+Write-Host "Validating same-line monotonic correction acceptance..."
+Assert-CorrectionAccepted `
+    -Name "next correction on current release line" `
+    -Tag "v2026.7.1-3" `
+    -CurrentWindowsTag "v2026.7.1-2" `
+    -ExpectedBaseVersion "2026.7.1" `
+    -ExpectedCorrection 3
+Assert-CorrectionAccepted `
+    -Name "first correction over unsuffixed base" `
+    -Tag "v2026.7.1-1" `
+    -CurrentWindowsTag "v2026.7.1" `
+    -ExpectedBaseVersion "2026.7.1" `
+    -ExpectedCorrection 1
+Assert-CorrectionAccepted `
+    -Name "skipped correction number still advances" `
+    -Tag "v2026.7.1-9" `
+    -CurrentWindowsTag "v2026.7.1-2" `
+    -ExpectedBaseVersion "2026.7.1" `
+    -ExpectedCorrection 9
+Assert-CorrectionAccepted `
+    -Name "multi-digit correction ordering is numeric" `
+    -Tag "v2026.7.1-10" `
+    -CurrentWindowsTag "v2026.7.1-9" `
+    -ExpectedBaseVersion "2026.7.1" `
+    -ExpectedCorrection 10
+
+Write-Host "Validating same, older, and different-base rejection..."
+Assert-CorrectionRejected `
+    -Name "reuse of the published latest correction" `
+    -Tag "v2026.7.1-2" `
+    -CurrentWindowsTag "v2026.7.1-2" `
+    -ExpectedMessage "must never be moved or reused"
+Assert-CorrectionRejected `
+    -Name "older correction on the same line" `
+    -Tag "v2026.7.1-1" `
+    -CurrentWindowsTag "v2026.7.1-2" `
+    -ExpectedMessage "does not advance current Windows release"
+Assert-CorrectionRejected `
+    -Name "correction for an older release line" `
+    -Tag "v2026.6.34-1" `
+    -CurrentWindowsTag "v2026.7.1-2" `
+    -ExpectedMessage "must correct the current Windows latest release line"
+Assert-CorrectionRejected `
+    -Name "correction for a newer release line" `
+    -Tag "v2026.8.0-1" `
+    -CurrentWindowsTag "v2026.7.1-2" `
+    -ExpectedMessage "must correct the current Windows latest release line"
+Assert-CorrectionRejected `
+    -Name "correction for an unreleased patch line" `
+    -Tag "v2026.7.2-1" `
+    -CurrentWindowsTag "v2026.7.1-2" `
+    -ExpectedMessage "must correct the current Windows latest release line"
+Assert-CorrectionRejected `
+    -Name "unparsable current latest release" `
+    -Tag "v2026.7.1-3" `
+    -CurrentWindowsTag "v2026.7.1-alpha.4" `
+    -ExpectedMessage "has an unsupported format"
+
+Write-Host "Validating correction tag format rejection..."
+Assert-InvalidTagRejected `
+    -Name "unsuffixed stable tag" `
+    -Tag "v2026.7.1" `
+    -CurrentWindowsTag "v2026.7.1"
+Assert-InvalidTagRejected `
+    -Name "alpha prerelease tag" `
+    -Tag "v2026.7.1-alpha.4" `
+    -CurrentWindowsTag "v2026.7.1"
+Assert-InvalidTagRejected `
+    -Name "zero correction suffix" `
+    -Tag "v2026.7.1-0" `
+    -CurrentWindowsTag "v2026.7.1"
+Assert-InvalidTagRejected `
+    -Name "leading-zero correction suffix" `
+    -Tag "v2026.7.1-03" `
+    -CurrentWindowsTag "v2026.7.1"
+Assert-InvalidTagRejected `
+    -Name "missing v prefix" `
+    -Tag "2026.7.1-3" `
+    -CurrentWindowsTag "v2026.7.1-2"
+
+Write-Host (
+    "Stable correction release validator regressions passed: " +
+    "$script:acceptedCount accepted, $script:rejectedCount rejected."
+) -ForegroundColor Green
+$global:LASTEXITCODE = 0

--- a/tests/OpenClaw.Tray.Tests/VersioningContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/VersioningContractTests.cs
@@ -66,7 +66,7 @@ public sealed class VersioningContractTests
         Assert.Contains("versionSpec: '6.8.x'", workflow);
         Assert.DoesNotContain("versionSpec: '6.4.x'", workflow);
         Assert.Contains(
-            "'^(?<base>(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*))-(?<revision>[1-9]\\d*)$'",
+            "'^(?<base>(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*))-(?<revision>\\d+)$'",
             workflow);
         Assert.Contains("$semVer = $tagVersion", workflow);
         Assert.Contains("$isPrerelease = $false", workflow);
@@ -163,6 +163,9 @@ public sealed class VersioningContractTests
         Assert.Contains("if ($candidateParts[3] -eq $currentParts[3])", validator);
         Assert.Contains("if ($candidateParts[3] -lt $currentParts[3])", validator);
         Assert.Contains("must never be moved or reused", validator);
+        Assert.Contains("function Assert-WindowsReleaseTagUnpublished", validator);
+        Assert.Contains("is already a published Windows release", validator);
+        Assert.Contains("is a prerelease; refusing to order a correction against it", validator);
         Assert.DoesNotContain("function Assert-NewerStableRelease", validator);
     }
 

--- a/tests/OpenClaw.Tray.Tests/VersioningContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/VersioningContractTests.cs
@@ -130,6 +130,69 @@ public sealed class VersioningContractTests
     }
 
     [Fact]
+    public void StableCorrectionValidator_HasNoUpstreamReleaseApiDependency()
+    {
+        var repoRoot = TestRepositoryPaths.GetRepositoryRoot();
+        var validator = File.ReadAllText(Path.Combine(
+            repoRoot,
+            "scripts",
+            "Test-OpenClawStableCorrectionRelease.ps1"));
+
+        Assert.DoesNotContain("repos/openclaw/openclaw/", validator);
+        Assert.DoesNotContain("releases/tags/$Tag", validator);
+        Assert.Contains(
+            "repos/openclaw/openclaw-windows-node/releases/latest",
+            validator);
+        Assert.Contains("[string]$CurrentWindowsTag", validator);
+    }
+
+    [Fact]
+    public void StableCorrectionValidator_RequiresSameLineMonotonicCorrection()
+    {
+        var repoRoot = TestRepositoryPaths.GetRepositoryRoot();
+        var validator = File.ReadAllText(Path.Combine(
+            repoRoot,
+            "scripts",
+            "Test-OpenClawStableCorrectionRelease.ps1"));
+
+        Assert.Contains(
+            "'^v(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)-[1-9]\\d*$'",
+            validator);
+        Assert.Contains("function Assert-SameLineStableCorrection", validator);
+        Assert.Contains("if ($candidateBase -ne $currentBase)", validator);
+        Assert.Contains("if ($candidateParts[3] -eq $currentParts[3])", validator);
+        Assert.Contains("if ($candidateParts[3] -lt $currentParts[3])", validator);
+        Assert.Contains("must never be moved or reused", validator);
+        Assert.DoesNotContain("function Assert-NewerStableRelease", validator);
+    }
+
+    [Fact]
+    public void ReleaseWorkflow_RevalidatesCorrectionOrderingAfterSigningBeforePublish()
+    {
+        var repoRoot = TestRepositoryPaths.GetRepositoryRoot();
+        var workflow = File.ReadAllText(
+            Path.Combine(repoRoot, ".github", "workflows", "ci.yml"));
+
+        var signIndex = workflow.IndexOf("- name: Sign Installers", StringComparison.Ordinal);
+        var revalidateIndex = workflow.IndexOf(
+            "- name: Revalidate stable correction release ordering",
+            StringComparison.Ordinal);
+        var publishIndex = workflow.IndexOf("- name: Create Release", StringComparison.Ordinal);
+
+        Assert.True(signIndex >= 0, "Release workflow must sign installers.");
+        Assert.True(revalidateIndex > signIndex, "Correction ordering must be revalidated after signing.");
+        Assert.True(publishIndex > revalidateIndex, "Correction ordering must be revalidated before publication.");
+
+        Assert.Contains(
+            "make_latest: ${{ needs.test.outputs.isPrerelease == 'true' && 'false' || 'true' }}",
+            workflow);
+        Assert.Contains("$majorMinorPatch = $validation.BaseVersion", workflow);
+        Assert.Contains(
+            "./scripts/test-stable-correction-release-validator.ps1",
+            workflow);
+    }
+
+    [Fact]
     public void ActiveCodeAndTests_DoNotContainStaleReleaseVersion()
     {
         var repoRoot = TestRepositoryPaths.GetRepositoryRoot();


### PR DESCRIPTION
## Summary

The final release blocker for `v2026.7.1-3` is that `scripts\Test-OpenClawStableCorrectionRelease.ps1` required the Windows Hub correction tag to also exist as a published stable release in the separate `openclaw/openclaw` repository. That release does not exist (verified `404`), so the tagged release run would hard-fail before building anything.

Windows Hub application release tags and the Gateway package pin are independent version domains. This PR removes only that cross-repository coupling and tightens everything that remains.

**`GatewayReleasePolicy.RecommendedVersion` stays at `2026.6.34` and its evidence gates are untouched.** No file under `src/OpenClaw.SetupEngine` is modified.

## What changed

**Validator (`scripts\Test-OpenClawStableCorrectionRelease.ps1`)**
- Removed the `openclaw/openclaw` release lookup.
- Ordering is now strictly same-line and monotonic: the candidate must share the current Windows latest release's `X.Y.Z` base line and carry a strictly greater numeric correction. Same, older, and different-line corrections fail closed.
- Online runs additionally reject a candidate that already has a published Windows release, and refuse to order against a draft, prerelease, or unpublished latest release. Any non-404 lookup failure is an error, never an implicit "not published".
- New `-CurrentWindowsTag` input evaluates the ordering rule offline for previews and tests. CI never passes it.

**Workflow (`.github/workflows/ci.yml`)**
- The correction classification regex now matches every `X.Y.Z-<digits>` tag, so a malformed tag such as `v2026.7.1-0` can no longer skip the validator and be published as an ordinary prerelease. The validator's tag pattern is the single accept/reject authority.
- One new step runs the validator regression harness.
- Unchanged: corrections are still classified stable, the exact tag SemVer is still emitted, ordering is still revalidated after signing and before publication, artifacts are still signed, and the release still becomes latest.

**Tests**
- New `scripts\test-stable-correction-release-validator.ps1`: deterministic offline accept/reject matrix plus behavioral workflow-classification coverage that extracts the live regex out of `ci.yml`.
- `VersioningContractTests`: source contracts proving no upstream release API dependency, the same-line monotonic guards, the new fail-closed checks, and that revalidation is ordered after signing and before publication.

**Docs**
- `docs/RELEASING.md`, `docs/VERSIONING.md`: the two version domains, the new rule, offline preview examples, and the `v2026.7.1-2` / `f46400aa` / run `33221425381` facts.
- `docs/adr/0001-gateway-release-policy.md`: clarifies that Gateway upstream evidence is a separate domain and is unchanged.

## Required proof pools

- `none`: release-process only. This change touches release validation scripts, the release workflow's version resolution, contract tests, and docs. It does not change tray UX, WinUI surfaces, installers, ARM64 behavior, MXC/`system.run`, gateway pairing, or node/MCP capabilities, so no capacity-dependent host class is required.

## Validation

| Command | Result |
|---|---|
| `.\build.ps1` | All builds succeeded (Shared, Cli, WinNodeCli, SetupEngine, WinUI) |
| `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore` | Failed: 0, Passed: 3905, Skipped: 32 |
| `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore` | Failed: 0, Passed: 2833, Skipped: 0 |
| `dotnet test .\tests\OpenClaw.Tray.Tests\... --filter "FullyQualifiedName~VersioningContractTests"` | Failed: 0, Passed: 9 |
| `.\scripts\test-stable-correction-release-validator.ps1` (pwsh 7 and Windows PowerShell 5.1) | 4 accepted, 11 rejected, 5 workflow classifications, exit 0 |
| `.\scripts\validate-docs.ps1` | 48 Markdown files checked, exit 0 |

Rubber-duck review: run one raised a blocking workflow-bypass finding (`v2026.7.1-0` skipping the validator) plus two fail-closed gaps. All three are fixed in `07c0ff56`. Re-review verdict: "No remaining blocking or high-severity correctness issues found. The fixes are correct and complete."

## Real behavior proof

**Live GitHub API, actual release decision (pwsh 7 and Windows PowerShell 5.1, identical results):**

```
PS> .\scripts\Test-OpenClawStableCorrectionRelease.ps1 -Tag v2026.7.1-3 -GitHubToken <redacted>

Tag               : v2026.7.1-3
BaseVersion       : 2026.7.1
Correction        : 3
CurrentWindowsTag : v2026.7.1-2
CurrentCorrection : 2

PS> .\scripts\Test-OpenClawStableCorrectionRelease.ps1 -Tag v2026.7.1-2 -GitHubToken <redacted>
Stable correction 'v2026.7.1-2' is already a published Windows release; a published tag must never be moved or reused.
```

The intended release tag is accepted against the live `v2026.7.1-2` latest release, and reusing `v2026.7.1-2` is refused.

**Blocker reproduction (pre-change behavior):**

```
PS> gh api repos/openclaw/openclaw/releases/tags/v2026.7.1-3
gh: Not Found (HTTP 404)
```

**Offline dry-run decisions:**

```
### ACCEPT: v2026.7.1-3 over live latest v2026.7.1-2
Tag: v2026.7.1-3  BaseVersion: 2026.7.1  Correction: 3  CurrentWindowsTag: v2026.7.1-2

### REJECT (reuse published tag): v2026.7.1-2 vs v2026.7.1-2
Stable correction 'v2026.7.1-2' is already the current Windows release 'v2026.7.1-2'; a published tag must never be moved or reused.

### REJECT (older correction): v2026.7.1-1 vs v2026.7.1-2
Stable correction 'v2026.7.1-1' does not advance current Windows release 'v2026.7.1-2'.

### REJECT (different base line): v2026.8.0-1 vs v2026.7.1-2
Stable correction 'v2026.8.0-1' must correct the current Windows latest release line '2026.7.1', but targets '2026.8.0'.
```

**Full offline harness:**

```
Validating release workflow correction classification...
  classified: valid correction reaches the validator (v2026.7.1-3 -> validator)
  classified: zero correction cannot bypass the validator (v2026.7.1-0 -> validator)
  classified: leading-zero correction cannot bypass the validator (v2026.7.1-03 -> validator)
  classified: unsuffixed stable tag stays on GitVersion (v2026.7.1 -> gitversion)
  classified: alpha prerelease stays on GitVersion (v2026.7.2-alpha.19 -> gitversion)
Validating same-line monotonic correction acceptance...
  accepted: next correction on current release line (v2026.7.1-2 -> v2026.7.1-3)
  accepted: first correction over unsuffixed base (v2026.7.1 -> v2026.7.1-1)
  accepted: skipped correction number still advances (v2026.7.1-2 -> v2026.7.1-9)
  accepted: multi-digit correction ordering is numeric (v2026.7.1-9 -> v2026.7.1-10)
Validating same, older, and different-base rejection...
  rejected: reuse of the published latest correction (v2026.7.1-2 -> v2026.7.1-2)
  rejected: older correction on the same line (v2026.7.1-2 -> v2026.7.1-1)
  rejected: correction for an older release line (v2026.7.1-2 -> v2026.6.34-1)
  rejected: correction for a newer release line (v2026.7.1-2 -> v2026.8.0-1)
  rejected: correction for an unreleased patch line (v2026.7.1-2 -> v2026.7.2-1)
  rejected: unparsable current latest release (v2026.7.1-alpha.4 -> v2026.7.1-3)
Validating correction tag format rejection...
  rejected: unsuffixed stable tag (v2026.7.1)
  rejected: alpha prerelease tag (v2026.7.1-alpha.4)
  rejected: zero correction suffix (v2026.7.1-0)
  rejected: leading-zero correction suffix (v2026.7.1-03)
  rejected: missing v prefix (2026.7.1-3)
Stable correction release validator regressions passed: 4 accepted, 11 rejected, 5 workflow classifications.
```

**Release state facts confirmed against the remote:**

```
PS> git ls-remote --tags origin "v2026.7.1*"
42f8365094ad33a3fea56d21d516164a8c07c589  refs/tags/v2026.7.1-2
f46400aab24e835d9f7339b3e94821260a42d3c0  refs/tags/v2026.7.1-2^{}

PS> git log --oneline -1 f46400aa
f46400aa Support upstream stable correction release versions (#1266)

PS> gh run view 33221425381 --json conclusion,headSha
{"conclusion":"success","headSha":"f46400aab24e835d9f7339b3e94821260a42d3c0"}

PS> gh api repos/openclaw/openclaw-windows-node/releases/latest
tag: v2026.7.1-2, prerelease: false,
assets: OpenClawCompanion-Setup-x64.exe, OpenClawCompanion-Setup-arm64.exe,
        OpenClawTray-2026.7.1-2-win-x64.zip, OpenClawTray-2026.7.1-2-win-arm64.zip
```

`v2026.7.1-2` therefore dereferences to the correction-aware commit and its signed assets came from run 33221425381.

**Not verified / blocked:** the tagged release workflow itself cannot run from a PR branch. The publication path is proven only by the validator's live-API decision above, the revalidation-before-publish source contract, and the existing signed run 33221425381. Tagging and publishing are left to the coordinator.

## Client update path

Older unsuffixed `2026.7.1` clients predate the correction-aware update path and use Updatum's default parser, which drops the numeric suffix before comparison, so they may need a manual transition. Clients on `2026.7.1-2` are correction-aware: even though Updatum 1.3.4's default parsing does not rank `2026.7.1-3` above `2026.7.1-2`, the `OpenClawReleaseVersion` fallback in `UpdateCheckPipeline` compares under OpenClaw correction ordering and discovers `2026.7.1-3`.