### PR TITLE
docs: add OpenClaw global triage skill

### DIFF
--- a/.agents/skills/global-repo-triage/README.md
+++ b/.agents/skills/global-repo-triage/README.md
@@ -1,0 +1,28 @@
+# OpenClaw Windows Node Global Triage
+
+This portable skill reproduces the full maintainer sweep used for
+`openclaw/openclaw-windows-node`. It combines the repository's scheduled
+read-only triage report with source review, proof-pool scheduling, active-owner
+auditing, adversarial review, landing order, and release planning.
+
+## Install
+
+Unzip the package so this file exists:
+
+```text
+%USERPROFILE%\.copilot\skills\global-repo-triage\SKILL.md
+```
+
+Restart Copilot if the skill is not discovered immediately.
+
+## Recommended prompt
+
+```text
+Run the OpenClaw Windows Node global triage. Read every open issue and PR,
+compare with the previous report, identify what can safely land today, audit
+active ownership, schedule required proof pools, and save the full Markdown
+report plus execution handoff. Do not mutate GitHub until I approve the queue.
+```
+
+The `examples` folder contains the two real reports that established the format.
+

--- a/.agents/skills/global-repo-triage/SKILL.md
+++ b/.agents/skills/global-repo-triage/SKILL.md
@@ -1,0 +1,335 @@
+---
+name: global-repo-triage
+description: "Run complete OpenClaw Windows Node issue and PR triage, including landing queues, proof pools, ownership audits, and release planning."
+---
+
+# OpenClaw Windows Node Global Triage
+
+Run a complete maintainer triage of `openclaw/openclaw-windows-node`. Read every
+open issue and pull request, identify safe landing lanes, schedule OpenClaw's
+Windows proof pools, and produce the same evidence-backed Markdown report used
+for the August 27 and September 1 maintainer sweeps.
+
+This skill is repository-specific. If the current repository is not
+`openclaw/openclaw-windows-node`, stop and say that this skill applies only to
+the OpenClaw Windows Node repository.
+
+## Trigger
+
+Use when the user asks for:
+
+- global triage, backlog triage, or a full repository sweep
+- today's OpenClaw landing queue
+- low-hanging issues or PRs
+- what Karen or another maintainer can do in parallel
+- release-train contents or a correction-release decision
+- a comparison with a prior OpenClaw triage report
+
+## Required output
+
+Create these session artifacts:
+
+```text
+global-triage-YYYY-MM-DD.md
+triage-YYYY-MM-DD\issues-summary.csv
+triage-YYYY-MM-DD\prs-summary.csv
+triage-YYYY-MM-DD\pr-<number>.patch
+```
+
+Keep raw JSON when practical. Do not add triage artifacts to the repository.
+Use `templates\global-triage-report.md` as the report skeleton and
+`examples\global-triage-2026-08-27.md` plus
+`examples\global-triage-2026-09-01.md` as quality references.
+
+## Ground rules
+
+1. **Read-only unless explicitly authorized.** Do not merge, close, label,
+   comment, push, rerun CI, or create sessions from a triage request alone.
+2. **Cover the entire backlog.** Fetch every open issue and PR. A report is not
+   global if fetched and classified counts differ.
+3. **Read discussions and code.** For every item that could be taken, closed,
+   repaired, or assigned, inspect the body, comments, reviews, inline threads,
+   timeline, checks, files, commits, and patch.
+4. **Use the 90% TAKE bar.** Safe-looking is not enough. TAKE requires clear
+   value, bounded scope, current-head validation, and no missing custom proof.
+5. **ClawSweeper is advisory.** Read its durable review comment and labels, then
+   independently verify each finding. Do not wait solely for bot wording when
+   exact-head source review, proof, required validation, and branch protection
+   establish safety.
+6. **Do not blame a PR for a baseline flake.** Compare a failing test with the
+   changed surface, the exact base commit, nearby `main` runs, and focused local
+   reproduction. Rerun only after identifying the likely owner.
+7. **Never treat unavailable proof as passed.** Report it as
+   `NEEDS_HUMAN_TEST` or `Not verified / blocked`.
+8. **Do not revive stale architecture wholesale.** Transplant the smallest
+   useful fix onto current owners rather than rebasing obsolete god-object or
+   pre-ledger branches.
+
+## Decision vocabulary
+
+| Decision | OpenClaw meaning |
+|---|---|
+| TAKE | At least 90% take confidence; validated and safe to land. |
+| TAKE_AFTER_CHECKS | Likely landable after ordinary exact-head CI, tests, or a small maintainer edit. |
+| NEEDS_HUMAN_TEST | Requires a named Windows proof pool, hardware, signing, installer, UI, Gateway, or MXC environment. |
+| NEEDS_INFO | Current repro, route, topology, logs, ownership, or product decision is missing. |
+| HOLD_FOR_AUTHOR | Direction is useful, but code, conflicts, scope, or proof must change. |
+| DECLINE | Superseded, stale, unsafe, duplicative, speculative, or not worth maintaining. |
+
+Report both **take confidence** and **recommendation confidence**. A confident
+HOLD or DECLINE is not a high take-confidence item.
+
+## 1. Start from the repository's own triage data
+
+Read:
+
+- `AGENTS.md`
+- `docs\REPOSITORY_TRIAGE.md`
+- `docs\PROOF_POOLS.md`
+- `docs\TEST_COVERAGE.md`
+- `docs\ARCHITECTURE.md`
+- `docs\RELEASING.md` when a release is in scope
+
+Confirm the deterministic triage implementation is healthy:
+
+```powershell
+node --test .github\scripts\repository-triage.test.cjs
+```
+
+Prefer the latest successful scheduled `Repository Triage Report` artifact as
+the inventory baseline:
+
+```powershell
+$repo = "openclaw/openclaw-windows-node"
+gh run list --repo $repo --workflow repository-triage.yml --limit 10
+gh run download <run-id> --repo $repo --name repository-triage-report `
+  --dir <session-artifact-dir>\triage-YYYY-MM-DD\scheduled
+```
+
+If the artifact is missing, stale, or partial, fetch directly with `gh`. Preserve
+collection warnings. Never silently omit an item after an API failure.
+
+## 2. Build complete summaries
+
+Fetch all open work with pagination:
+
+```powershell
+gh issue list --repo $repo --state open --limit 1000 `
+  --json number,title,author,labels,assignees,createdAt,updatedAt,url,comments
+gh pr list --repo $repo --state open --limit 1000 `
+  --json number,title,author,labels,createdAt,updatedAt,url,reviewDecision,mergeable,isDraft,baseRefName,headRefName,additions,deletions,changedFiles,statusCheckRollup
+```
+
+Write CSV summaries matching the proven artifacts.
+
+PR columns:
+
+```text
+N,Title,Author,Draft,Merge,Review,Files,Delta,Failed,Pending,Labels
+```
+
+Issue columns:
+
+```text
+N,Title,Author,Labels,Comments,Updated
+```
+
+For every potentially actionable PR:
+
+```powershell
+gh pr view <number> --repo $repo `
+  --json number,title,author,body,url,state,isDraft,mergeable,mergeStateStatus,reviewDecision,baseRefName,headRefName,headRefOid,additions,deletions,changedFiles,files,commits,comments,reviews,statusCheckRollup,labels,createdAt,updatedAt
+gh pr diff <number> --repo $repo --patch > <artifact-dir>\pr-<number>.patch
+```
+
+Also inspect unresolved inline threads and relevant timeline events. A
+ClawSweeper comment may be edited in place, so use its current `updated_at` and
+reviewed head SHA rather than assuming the oldest comment body is stale.
+
+## 3. Classify OpenClaw-specific risk
+
+Apply the repository's current owners and guardrails:
+
+| Changed surface | Required scrutiny |
+|---|---|
+| `App.xaml.cs`, `ConnectionPage.xaml.cs`, chat provider/state | Read `docs\ARCHITECTURE.md`; reject reintroduced closed responsibilities. |
+| Gateway registry, credentials, pairing, setup | Read connection/onboarding/setup docs; protect device-token precedence and setup-managed ownership. |
+| `system.run`, MXC, exec approvals | Treat as a security boundary; require real `validate-mxc-e2e.ps1` proof without `-AllowSkip`. |
+| New/changed node command or MCP output | Require capability registration, MCP description, `winnode` docs/tests, discovery, and invocation proof. |
+| WinUI behavior | Require current-head visible proof using isolated tray data and `windows-winui-interactive`. |
+| Installer, signing, packaging, update policy | Treat as release risk; require signed-artifact and clean upgrade proof. |
+| Local AI GPU/model/runtime | Require affected hardware proof, not only mocked detection. |
+| Localization | Run all-locale key/placeholder/all-or-none tests and obtain visual proof or an explicit blocker. |
+
+Bot, Copilot, repo-assist, and ClawSweeper-authored PRs are untrusted
+contributions. Do not lower the bar because automation produced them.
+
+## 4. Map required proof pools
+
+Select every applicable pool from `.github\proof-pools.json`:
+
+| Pool | Use |
+|---|---|
+| `windows-11-sac-on` | Signed installer and Smart App Control acceptance |
+| `windows-wsl-mxc` | Gateway to Windows node `system.run` containment |
+| `windows-11-arm64` | Native ARM64 build and runtime behavior |
+| `windows-wsl-dgx-blackwell` | Local AI GPU setup, restart, and inference |
+| `windows-clean-installer-upgrade` | Install, upgrade, repair, and uninstall |
+| `windows-wsl-gateway-e2e` | Product WSL setup, pairing, recovery, and invocation |
+| `windows-winui-interactive` | Visual, accessibility, consent, and diagnostics |
+
+PR bodies must contain:
+
+- `## Required proof pools`
+- `## Validation`
+- `## Real behavior proof`
+
+Proof declarations schedule work. They do not prove it ran.
+
+## 5. Apply the OpenClaw validation floor
+
+Every code change needs:
+
+```powershell
+$env:OPENCLAW_REPO_ROOT = (Get-Location).Path
+.\build.ps1
+dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore
+dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore
+```
+
+Fresh worktrees must restore or build a test project before trusting
+`--no-restore`.
+
+Add the focused owner suite:
+
+- connection: `OpenClaw.Connection.Tests`
+- setup: `OpenClaw.SetupEngine.Tests`
+- WinUI: focused Tray tests plus UI/accessibility proof
+- node/MCP docs or output: `OpenClaw.WinNode.Cli.Tests`
+- setup/connect/recovery: relevant `OpenClaw.E2ETests` shard
+- MXC or `system.run`: `.\scripts\validate-mxc-e2e.ps1`
+
+For non-trivial setup, pairing, UI, MCP, permission, security, or diagnostics
+work, require rubber-duck review and final autoreview.
+
+## 6. Audit ownership and duplicate work
+
+`status: 🚢 actively landing` means a maintainer or delegated agent is actively
+implementing, validating, or merging now.
+
+In the report:
+
+- name the owner or label actor
+- identify linked open PRs
+- warn against duplicate fixes
+- flag ownership with no trusted human activity for 7 full days
+- never suggest automatic removal for P0, security, `no-stale`, assigned, or
+  provenance-incomplete items
+
+Do not mutate labels during report-only triage. If the user authorizes cleanup,
+use the repository workflow's guarded
+`remove-expired-active-ownership` operation rather than ad hoc label removal.
+
+## 7. Review likely landing candidates
+
+Use direct review for small changes. Invoke `hanselman-code-review` for:
+
+- more than 300 changed lines
+- security, auth, setup, storage, release, signing, installer, shell, MXC,
+  concurrency, or data-loss risk
+- bot/repo-assist changes beyond a trivial dependency bump
+- conflicting GitHub state or disputed findings
+- any candidate below 95% recommendation confidence that might still be taken
+
+Cross-reference both reviewers in the report, then verify each accepted finding
+against the code. Do not paste raw reviewer output as the decision.
+
+## 8. Build the landing and release plan
+
+Order work by dependency, not PR number:
+
+1. release blockers and current user breakage
+2. small green fixes with clear ownership
+3. coordinated trains where one PR changes the next PR's base
+4. repair/transplant lanes
+5. custom proof lanes
+6. closure and stale-label cleanup
+
+Use one isolated worktree/session per PR. Keep dependent PRs serial. Parallelize
+independent implementation and human proof. Do not force-push contributor
+branches; use a current-main maintainer replacement when the original branch
+cannot be advanced safely.
+
+For each active landing:
+
+- apply `status: 🚢 actively landing`
+- merge current `origin/main` when the base changed
+- rerun exact-head validation and proof
+- update the PR body
+- resolve or explicitly disposition review findings
+- verify GitHub state after merge
+- remove the active label and archive the work session
+
+If CI fails only in unchanged infrastructure:
+
+1. inspect the exact failed test and log
+2. compare with the exact base or nearby main run
+3. run the focused test locally
+4. check whether a fix has since landed on main
+5. refresh the branch before rerunning stale-base CI
+
+For release planning:
+
+- compare the latest tag with `main`
+- list which candidate PRs are already shipped
+- prefer a narrow correction for a bounded user-facing fix
+- exclude broad localization, feature, refactor, conflicted, or unproven work
+- tag only exact `origin/main`
+- never move or reuse a published tag
+- require x64/ARM64 signed installer and portable ZIP verification
+
+## 9. Write the proven report format
+
+The Markdown report must use this order:
+
+1. `# OpenClaw Windows Node global triage`
+2. Snapshot sentence with exact open issue and PR counts plus collection scope
+3. `## Change since <prior date>`
+4. `## Executive queue`
+5. `## Pull requests`
+6. `## Issues`
+7. `## Active ownership audit`
+8. `## Adversarial review` for selected risky candidates
+9. `## Day plan`
+10. `## Automation and testability`
+
+The PR table columns are:
+
+```text
+Item | Type / signal | Decision | Take confidence |
+Recommendation confidence | Effort | Risk | Owner / required validation
+```
+
+The issue table columns are:
+
+```text
+Item | Signal | Decision | Take confidence |
+Recommendation confidence | Effort | Risk | Owner / next action
+```
+
+Every row needs a concrete owner and next action. Cover all open items, including
+low-priority and declined work.
+
+## Completion bar
+
+Do not call the triage complete until:
+
+- open issue and PR counts match the report rows
+- actionable discussions, reviews, checks, and patches were inspected
+- current-head versus stale-head evidence is distinguished
+- issue-to-PR ownership and duplicate risks are mapped
+- active ownership is audited
+- proof pools and human hosts are scheduled explicitly
+- a numbered day plan identifies safe parallelism and dependency order
+- release contents and exclusions are explicit when a release is discussed
+- the Markdown report, CSV summaries, and reviewed PR patches are saved

--- a/.agents/skills/global-repo-triage/examples/global-triage-2026-08-27.md
+++ b/.agents/skills/global-repo-triage/examples/global-triage-2026-08-27.md
@@ -1,0 +1,153 @@
+# OpenClaw Windows Node global triage
+
+Snapshot: 2026-08-27, 71 open issues and 31 open pull requests.
+
+## Executive queue
+
+1. **PR #1205** is the closest merge. CI and proof are green and both adversarial reviewers found no critical/high defects. Before merging, keep **More options** available during slow wizard startup and correct the documentation to distinguish the missing `wizard.back` RPC from Gateway-provided in-band `__back` options.
+2. **PRs #1202 then #1203** are green, mergeable, and actively landing. Treat them as one WSL recovery/readiness train and validate the rebased second PR after the first lands.
+3. **PR #1225** is a small, valuable archive-traversal hardening patch. Resolve its two-file conflict, rerun normal validation, and land it.
+4. **PR #1130** is the owned fix for issue #894. Resolve its chat-owner conflicts and rerun its existing proof.
+5. **PR #1166** is technically plausible but cannot cross the 90% bar without real MXC E2E proof.
+6. Queue new narrow fixes for **#1243**, **#1218**, and **#980**. They reuse established routes/contracts and avoid new architecture.
+7. Close or decline superseded PRs **#1237, #1222, #1206, #1174, #1116, #1073**. Confirm and close locally completed issues **#1184, #840, #881**.
+
+No PR should be merged untouched from this snapshot. PR #1205 is one small maintainer edit away; #1202/#1203 are already in an active landing lane.
+
+## Pull requests
+
+| Item | Decision | Take confidence | Effort / risk | Owner and next action |
+| --- | --- | ---: | --- | --- |
+| #1239 Shared-memory capacity semantics | HOLD_FOR_AUTHOR | 45% | Moderate / High | Remove or split the unused PCI join; provide exact-head DGX proof. |
+| #1237 DGX Spark investigation | DECLINE | 0% | Quick / High | Close as research-only and superseded by #1239. |
+| #1232 Resume Local AI setup with a new model | HOLD_FOR_AUTHOR | 35% | Large / High | Preserve prior-install provenance across restart and reject combined GPU/model changes before replacement. |
+| #1225 Reject archive traversal before extraction | TAKE_AFTER_CHECKS | 88% | Quick / Medium | Maintainer resolves two-file conflict, reruns build/tests/CodeQL. |
+| #1222 Require verified Local AI evidence | DECLINE | 10% | Quick / Medium | Close as superseded by #1212. |
+| #1212 Prevent routing to unverified model | NEEDS_HUMAN_TEST | 65% | Moderate / High | Diagnose red CI and prove real llama-server/WSL withdrawal and recovery. |
+| #1207 Preserve trailing command output | NEEDS_HUMAN_TEST | 72% | Moderate / Medium | Rebase and prove complete output plus bounded inherited-pipe behavior in real WSL. |
+| #1206 Preserve installed runtime controls | DECLINE | 5% | Quick / Low | Close as already incorporated into #1204. |
+| #1205 Fix onboarding Back desynchronization | TAKE_AFTER_CHECKS | 94% | Quick / Low-Medium | Small maintainer edit for startup recovery affordance and accurate protocol wording, then merge. |
+| #1204 Clarify unavailable Local AI states | HOLD_FOR_AUTHOR | 30% | Large / High | Rebuild from current main with only intended Local AI commits. |
+| #1203 Gate Local AI on WSL readiness | TAKE_AFTER_CHECKS | 89% | Moderate / Medium | Land after #1202, rebase, validate combined disabled-feature states. |
+| #1202 Recover uninitialized WSL automatically | TAKE_AFTER_CHECKS | 90% | Quick / Medium | Land first in coordinated WSL train; refresh exact-head proof metadata. |
+| #1201 Bind WSL relay trust to package | NEEDS_INFO | 40% | Moderate / High | Define trusted signer/package provenance; do not accept Developer signatures generically. |
+| #1175 Retry failed WSL setup | HOLD_FOR_AUTHOR | 15% | Moderate / High | Remove destructive no-clean behavior or add explicit deletion confirmation; rebase and prove recovery. |
+| #1174 llama.cpp serving WIP | DECLINE | 1% | Large / High | Close as superseded by newer Local AI work. |
+| #1166 Bound MXC termination/output cleanup | NEEDS_HUMAN_TEST | 88% | Quick / Medium | Run required validation and `validate-mxc-e2e.ps1` without `-AllowSkip`. |
+| #1164 Permissioned Codex session access | HOLD_FOR_AUTHOR | 20% | Large / High | Decide Core versus extension ownership before rebase or implementation. |
+| #1160 Truthful capability readiness | NEEDS_INFO | 48% | Large / High | Decide status schema v2, then rebase after #1157 and prove MCP/Gateway/UI transitions. |
+| #1159 Guide channel readiness handoff | HOLD_FOR_AUTHOR | 55% | Moderate / Medium | Rebase onto current routing, localize copy, prove setup-to-Channels handoff. |
+| #1158 Bound streaming UI dispatch | HOLD_FOR_AUTHOR | 58% | Large / High | Rebase onto current chat ownership and capture sustained streaming responsiveness proof. |
+| #1157 Browser proxy readiness | NEEDS_HUMAN_TEST | 86% | Moderate / Medium | Prove successful MCP action and guided blocked state on Windows. |
+| #1141 Extended-stable update suppression | TAKE_AFTER_CHECKS | 87% | Moderate / Medium | Resolve conflicts without duplicating connection ownership; refresh Gateway/UI proof. |
+| #1130 Preserve history cache correlation | TAKE_AFTER_CHECKS | 89% | Moderate / Medium | Resolve current chat-owner conflicts; rerun history-collision UI proof. |
+| #1128 Upgrade legacy Gateways to Tailscale auth | TAKE_AFTER_CHECKS | 86% | Large / High | Approve security contract, resolve conflicts, rerun positive/negative Tailscale proof. |
+| #1116 Clean Windows validation infrastructure | DECLINE | 5% | Very large / High | Close omnibus PR; split into independently owned validation lanes. |
+| #1073 Single MSIX lifecycle proposal | DECLINE | 10% | Large / High | Close stale patch; preserve useful research in a narrow current proposal. |
+| #1071 Wake phrase voice assistant | HOLD_FOR_AUTHOR | 10% | Large / High | Resolve microphone bug and product sponsorship; rebase and provide live proof. |
+| #1068 Replaceable node runtime/sidecar proof | HOLD_FOR_AUTHOR | 15% | Large / High | Wait for upstream protocol, then split runtime seam, dispatcher, and adapter. |
+| #1002 Trimmed winnode publishing experiment | HOLD_FOR_AUTHOR | 65% | Quick / Medium | Decide whether standalone distribution is supported; if yes, add MCP/published-tool proof. |
+| #962 Seed design system | HOLD_FOR_AUTHOR | 20% | Moderate / Medium | Make native UI canonical and remove stale React/catalog guidance. |
+| #938 Native Windows and WSL gateway modes | HOLD_FOR_AUTHOR | 20% | Large / High | Rebase and define endpoint/runtime ownership and containment before further validation. |
+
+## Issues
+
+| Item | Decision | Take confidence | Effort / risk | Owner and next action |
+| --- | --- | ---: | --- | --- |
+| #1251 Intermittent Local AI provider-auth error | NEEDS_INFO | 25% | Moderate / Medium | Capture effective route and redacted failure output from second setup. |
+| #1250 Local AI audit warning severity | NEEDS_HUMAN_TEST | 15% | Moderate / Low | Reassess after #1204; maintainer chooses severity/copy. |
+| #1249 Back/Restart/Cancel during model download | NEEDS_INFO | 20% | Moderate / Medium | Define partial-artifact retention and cancellation semantics first. |
+| #1248 Refresh Local AI model catalog | NEEDS_INFO | 15% | Moderate / Medium | Approve artifact revisions and hardware-tier matrix. |
+| #1247 Preselect Local AI on eligible systems | NEEDS_INFO | 20% | Moderate / Medium | Product decision on explicit opt-in and durable choice. |
+| #1246 Cannot safely back out after Gateway install | TAKE_AFTER_CHECKS | 75% | Moderate / Medium | Review existing fix branch; test navigation, disposal, and history reset. |
+| #1245 Local AI port error on rerun | NEEDS_HUMAN_TEST | 35% | Moderate / Medium | Identify listener ownership before adding recovery. |
+| #1244 Fresh-system WSL inspection error | TAKE_AFTER_CHECKS | 80% | Small / Low | Route pre-reboot/fresh-install states to installer or restart before inspection. |
+| #1243 Change Local AI setup after install | TAKE | 92% | Small / Low | Agent: add localized page action that reuses existing setup/onboarding route. |
+| #1242 ARM64/Blackwell llama runtime crash | NEEDS_HUMAN_TEST | 88% | Small / Medium | Bump qualified llama runtime and validate on affected ARM64 Spark hardware. |
+| #1236 Session-backed OpenClaw architecture | DECLINE | 5% | Large / High | Retain current WSL boundary; no parallel architecture. |
+| #1220 Show response duration | NEEDS_INFO | 25% | Moderate / Low | Define timing authority and persistence contract. |
+| #1219 Markdown tables render raw | TAKE_AFTER_CHECKS | 80% | Moderate / Medium | Reuse GFM table renderer in Reactor path; add narrow-width/code-fence coverage. |
+| #1218 Start-menu launch does not restore tray window | TAKE_AFTER_CHECKS | 88% | Small / Low | Agent: route no-argument secondary launch through existing hub activation. |
+| #1216 Add ClawHub catalog page | DECLINE | 10% | Large / High | Needs upstream catalog and trust design; do not create parallel installer. |
+| #1214 llama-server unload latency | NEEDS_INFO | 30% | Moderate / Medium | Define warm-residency policy and GPU memory budget. |
+| #1213 llama-server parallelism | NEEDS_INFO | 20% | Large / Medium | Document serial default; qualify concurrency separately. |
+| #1211 Prefill Local AI system prompt | NEEDS_INFO | 25% | Moderate / Medium | Define Gateway-owned warmup and invalidation contract. |
+| #1200 Qwen cold load failure | HOLD_FOR_AUTHOR | 60% | Small / Medium | Carry micro-batch fix and cold-load proof in active Local AI work. |
+| #1199 Node favoring/routing investigation | NEEDS_INFO | 15% | Unknown / Unknown | Request concrete host-selection/node-state trace. |
+| #1197 NVIDIA remediation links | NEEDS_INFO | 20% | Moderate / Medium | Approve owner and allowlisted redirect policy. |
+| #1196 Explicit NVIDIA GPU selection | DECLINE | 10% | Large / High | Defer until runtime lifecycle is defined. |
+| #1195 Per-device CUDA capability | HOLD_FOR_AUTHOR | 55% | Moderate / Medium | Carry in active Local AI work; fail closed when capability unavailable. |
+| #1194 Preserve trailing command output | HOLD_FOR_AUTHOR | 85% | Moderate / Medium | Keep open; #1235 reduced the race but #1207 owns complete drain semantics. |
+| #1192 Verified model evidence before publish | HOLD_FOR_AUTHOR | 80% | Moderate / Medium | Covered by #1212; do not start duplicate fix. |
+| #1191 Do not count DXGI shared memory | HOLD_FOR_AUTHOR | 80% | Moderate / Medium | Carry in active Local AI/DGX work with discrete/unified coverage. |
+| #1190 system.run Gateway timeout | NEEDS_HUMAN_TEST | 85% | Moderate / High | Prove cancellation and MXC path; never fall back from slow sandbox to host. |
+| #1189 MXC backend unavailable/job object failure | NEEDS_HUMAN_TEST | 75% | Moderate / High | Reproduce on MXC-capable host before changing fallback policy. |
+| #1184 Cloud provider setup in onboarding | TAKE | 96% | None / Low | Close as satisfied by released Gateway-owned provider/OAuth flow. |
+| #1183 Chat/session switching UX clarification | NEEDS_INFO | 40% | Moderate / Medium | Request exact journey/screenshot before choosing UX. |
+| #1173 Reactor access-violation crash loop | NEEDS_HUMAN_TEST | 78% | Moderate / High | Capture protected WER/WinDbg evidence on current head. |
+| #1172 Wizard Back desynchronization | TAKE_AFTER_CHECKS | 94% | Small / Low-Medium | PR #1205 owns it; apply two small review fixes, then merge/close. |
+| #1167 Session-switch WinUI hang | NEEDS_HUMAN_TEST | 80% | Moderate / Medium | Capture current-head trace with about 200 history messages. |
+| #1161 Session maintenance settings UI | NEEDS_INFO | 75% | Moderate / Low | Decide schema-guided editor versus dedicated typed surface. |
+| #1156 Terminal-required setup guidance | HOLD_FOR_AUTHOR | 72% | Moderate / Low | PR #1159 must rebase and provide native handoff proof. |
+| #1155 Truthful capability state | HOLD_FOR_AUTHOR | 68% | Large / Medium | Decide authoritative projection shape; PR #1160 is draft. |
+| #1154 Browser proxy readiness | NEEDS_HUMAN_TEST | 85% | Small / Low | PR #1157 needs Windows MCP/Gateway recovery proof. |
+| #1153 Smart App Control unsigned DLL | NEEDS_HUMAN_TEST | 92% | Validation / Medium | Install signed prerelease on SAC-On Windows 11 and capture acceptance proof. |
+| #1152 CJK clipping | NEEDS_HUMAN_TEST | 65% | Small / Low | Recheck current Reactor renderer; close if no longer reproducible. |
+| #1150 Agent event stream hang | HOLD_FOR_AUTHOR | 92% | Moderate / Medium | PR #1158 owns it; rebase and provide stress responsiveness proof. |
+| #1148 Chat auto-scroll | NEEDS_INFO | 70% | Small / Low | Confirm current native behavior and whether a return-to-bottom action is desired. |
+| #1146 MXC doubled granted paths | NEEDS_HUMAN_TEST | 55% | Moderate / High | Reproduce on real MXC 0.7 host with allowed/denied controls. |
+| #1145 Chat right-edge clipping | NEEDS_HUMAN_TEST | 68% | Small / Low | Recheck current Reactor renderer and close if resolved. |
+| #1144 Chat text selection | NEEDS_INFO | 60% | Small / Low | Clarify native Companion versus Gateway WebView2 surface. |
+| #1124 Voice Talk Mode proposal | HOLD_FOR_AUTHOR | 15% | Large / High | Product decision after wake reliability work. |
+| #1122 Consolidated audit handoff | TAKE_AFTER_CHECKS | 65% | Moderate / Medium | Split already-fixed, narrow Windows, and upstream findings; start only clear seams. |
+| #1121 Future telemetry enhancements | DECLINE | 5% | Moderate / Low | Close speculative proposal until a concrete need exists. |
+| #1118 Cron UI FunctionalUI cleanup | HOLD_FOR_AUTHOR | 25% | Large / Medium | Confirm current ownership and narrow scope after renderer changes. |
+| #1117 Tailscale identity adoption | HOLD_FOR_AUTHOR | 50% | Small / Medium | Security contract decision; #1128 owns implementation. |
+| #1115 Reactor timeline coverage | HOLD_FOR_AUTHOR | 40% | Small / Low | Define stable timeline behavior contract before test-only work. |
+| #1087 Simplified Chinese STT output | NEEDS_INFO | 30% | Small / Low | Decide opt-in script conversion and MCP override policy. |
+| #1009 Edge TTS support | DECLINE | 10% | Moderate / Medium | Do not add unauthenticated cloud text egress without provider policy. |
+| #1000 Stable/beta release alignment | TAKE_AFTER_CHECKS | 55% | Moderate / Medium | Extract only thin integration fixes after upstream Core behavior is known. |
+| #995 Cross-control chat selection | HOLD_FOR_AUTHOR | 35% | Large / Medium | Decide whether per-message selection is sufficient. |
+| #980 Restore reasoning after Off | TAKE_AFTER_CHECKS | 88% | Small / Low | Agent: add Default action that sends the existing null-clear contract; upstream metadata remains separate. |
+| #953 Large session-list scaling | HOLD_FOR_AUTHOR | 40% | Moderate / Medium | Choose searchable virtualized picker and bounded paging contract. |
+| #908 QR generation failure | HOLD_FOR_AUTHOR | 10% | Large / Low | Monitor upstream dependency; retest when resolved. |
+| #907 Mobile pairing failure | NEEDS_INFO | 5% | Moderate / Medium | Obtain current mobile/gateway repro and logs. |
+| #906 Battery drain and slowdown | HOLD_FOR_AUTHOR | 15% | Large / High | Requires performance trace and architecture investigation. |
+| #901 WSL Gateway version lockstep | HOLD_FOR_AUTHOR | 20% | Moderate / Medium | Maintainer defines version/upgrade strategy. |
+| #894 Native versus browser tool rendering | TAKE_AFTER_CHECKS | 89% | Moderate / Medium | PR #1130 owns remaining history correlation fix; resolve conflicts and land it. |
+| #881 Completed session clutter | TAKE | 96% | None / Low | Close Windows issue as locally completed; keep ACP lifecycle upstream. |
+| #871 Workspace file rail gaps | HOLD_FOR_AUTHOR | 25% | Large / Medium | Product prioritization needed. |
+| #863 Agent creation/sync UX | HOLD_FOR_AUTHOR | 20% | Moderate / Medium | Define journey and ownership before implementation. |
+| #859 Improve chat experience | HOLD_FOR_AUTHOR | 20% | Moderate / Medium | Split broad request into concrete current defects. |
+| #847 Automation validation wizards | HOLD_FOR_AUTHOR | 25% | Moderate / Medium | Define automation test scope and ownership. |
+| #844 Connection/pairing reliability | NEEDS_INFO | 10% | Large / High | Narrow environment and current failure mode. |
+| #843 First-run onboarding defaults | HOLD_FOR_AUTHOR | 30% | Moderate / Low | Product decision; parts overlap shipped WSL onboarding. |
+| #840 Default local gateway | TAKE | 95% | None / Low | Close if app-owned WSL is accepted as the intended local default. |
+| #554 App/ConnectionPage god files | HOLD_FOR_AUTHOR | 35% | Large / High | Keep canonical tracker; select one ledger-backed seam at a time. |
+| #246 Packaging and auto-update strategy | HOLD_FOR_AUTHOR | 15% | Large / High | Strategic packaging/signing decision, not a quick fix. |
+
+## PR #1205 adversarial consensus
+
+| Finding | Opus | Codex | Consensus | Final assessment |
+| --- | --- | --- | --- | --- |
+| No critical/high correctness or security defect | Clean | Clean | High | Architecture/state fix is sound. |
+| Protocol wording ignores in-band Gateway back options | Medium | Not raised | Low | Valid documentation issue; fix before merge. |
+| No interactive recovery control during slow wizard startup | Medium | Not raised | Low | Valid UX regression; keep More options available before merge. |
+| No direct route back to Welcome | Low | Not raised | Low | Deliberate compatibility tradeoff; optional follow-up if cancel-first navigation is desired. |
+| Proof is preview-only and body is stale | Low | Not raised | Low | Update PR body/proof record, but CI and deletion-only patch reduce risk. |
+
+## Day plan
+
+1. Top queue: make two small corrections to PR #1205 and merge it; land green PRs #1202 then #1203 as a coordinated WSL train; repair conflicts in #1225; queue narrow fixes for #1243, #1218, and #980; close six superseded PRs and three locally completed issues.
+2. Close the six superseded PRs and three locally completed issues after posting concise disposition comments.
+3. Reserve human/custom environments for #1153 SAC-On, #1166 MXC, #1242 ARM64 Spark, and crash/hang traces.
+
+## Automation opportunities
+
+| Opportunity | Why | Owner | Effort |
+| --- | --- | --- | --- |
+| Auto-report PR mergeability, stale base, checks, proof labels, and active owner | Removes most daily inventory work without auto-merging | Agent/workflow | Quick |
+| Route docs-only and small dependency PRs to a low-risk lane | Reduces noise while retaining human merge authority | Workflow | Quick |
+| Add expiry checks for `actively landing` labels | Prevents abandoned ownership from blocking parallel fixes | Workflow | Quick |
+| Track issue-to-open-PR ownership explicitly | Makes duplicate-fix prevention reliable | Workflow | Moderate |
+| Maintain named Windows proof pools (SAC-On, MXC, ARM64/DGX, clean installer) | Makes custom validation schedulable instead of ad hoc | Maintainer | Moderate |

--- a/.agents/skills/global-repo-triage/examples/global-triage-2026-09-01.md
+++ b/.agents/skills/global-repo-triage/examples/global-triage-2026-09-01.md
@@ -1,0 +1,191 @@
+# OpenClaw Windows Node global triage
+
+Snapshot: 2026-09-01. Read-only review of 60 open issues and 31 open pull requests, including item bodies, discussions, reviews, inline comments, timelines, checks, files, commits, and PR patches.
+
+## Change since August 27
+
+| Change | Items |
+|---|---|
+| New issues | #1280, #1271, #1270, #1256 |
+| Issues no longer open | #1245, #1243, #1219, #1218, #1192, #1184, #1172, #1121, #1117, #1115, #995, #980, #901, #881, #840 |
+| New PRs | #1283, #1282, #1281, #1279, #1277, #1275, #1274, #1273, #1268, #1267, #1265, #1258, #1253 |
+| PRs no longer open | #1237, #1225, #1222, #1212, #1206, #1205, #1204, #1203, #1202, #1174, #1116, #1073, #1071 |
+
+The open backlog dropped from 102 to 91 items. Most of the August execution queue landed or closed. The new work is concentrated in Local AI, setup reliability, one current crash loop, and two platform/security proof lanes.
+
+## Executive queue
+
+1. **TAKE PR #1273.** It is a one-line Windows SDK BuildTools patch update with all CI green. Add the required proof-pool, validation, and not-applicable behavior sections, then merge.
+2. **TAKE_AFTER_CHECKS PR #1283.** It is a one-file Crabbox guidance refresh with strong exact-head validation. Current upstream source independently confirms its local-WSL2 versus native-Windows `--github-runner` hydration contract. Wait for current CI, then merge.
+3. **Repair PR #1265 before validation.** Both reviewers reproduced deterministic localization-policy failures: roughly 410 all-or-none translation violations and two missing Ollama permission keys. Rebase, reconcile the catalog without weakening the gate, then run full Windows CI.
+4. **Redesign PR #1277 before native proof.** Both reviewers require Windows Server and MXC-client proof, and Opus found a concrete sticky-setting path that can persist `SystemRunSandboxEnabled=false` and later bypass guarded HostFallback behavior.
+5. **Repair small active defects:** #1282 needs mixed protected/managed duplicate coverage plus a real setup rerun; #1279 needs its existing queued-delivery tests updated plus latest-snapshot burst proof; #1258/#1267/#1268 need deadline/cancellation fixes.
+6. **Promote issue #1256.** Replace `curl | bash` with bounded download-to-temp, execute only after a complete download, preserve the real curl error, and prove fresh-WSL DNS recovery.
+7. **Repair or close stale PRs:** transplant #1130 and #1141 onto current ownership; obtain proof for #1157; close #938, #962, #1002, #1068, #1164, #1175, #1207, and #1239 rather than spending rebase effort on unsafe or superseded branches.
+8. **Clean stale ownership labels.** Several `actively landing` labels no longer describe active implementation, especially #1153, #1154, #1155, #1157, #1232, and #1141.
+
+## Pull requests
+
+| Item | Type / signal | Decision | Take confidence | Recommendation confidence | Effort | Risk | Owner / required validation |
+|---|---|---|---:|---:|---|---|---|
+| #1283 Refresh Windows Crabbox guidance | Human docs/skill, one file, upstream contract verified | TAKE_AFTER_CHECKS | 93% | 98% | Quick | Low | Current CI must finish. Upstream `openclaw/crabbox` confirms local hydration for Windows WSL2 and `--github-runner` for native Windows. |
+| #1282 Prevent Local AI routing ambiguity after rerun | Human bug fix, 2 files, failing unrelated Axe job | HOLD_FOR_AUTHOR | 82% | 97% | Moderate | Medium | Add mixed protected/managed duplicate regression and real WSL setup-rerun proof; rerun full CI. |
+| #1281 Recommend Qwen3.8 with measured profiles | Human Local AI redesign, 31 files, red CI | HOLD_FOR_AUTHOR | 20% | 99% | Large | High | Restore consent and installed-model migration, settle quality-versus-context policy, then provide real 16/24/32 GiB proof. |
+| #1279 Coalesce Publish bursts | Agent-authored crash mitigation, 1 file | HOLD_FOR_AUTHOR | 76% | 99% | Quick | Medium | Update existing two-callback tests for the changed contract, add latest-snapshot burst coverage, and capture auditable live stress proof. |
+| #1277 Start node when MXC probe is unsupported | Copilot bot, sandbox boundary | HOLD_FOR_AUTHOR | 35% | 99% | Moderate | High | Add a distinct unsupported-SKU outcome that does not persist sandbox-disabled state, retain a controlled probe escape hatch, test the real native detector, then run client MXC E2E and Server fallback/strict-denial proof. |
+| #1275 Add uninstall documentation and skill | Human docs/skill with destructive instructions | HOLD_FOR_AUTHOR | 40% | 99% | Quick | High | Restrict process termination to intended PID/path, fix AppData postconditions, remove prohibited copy, and prove dry-run/full uninstall on disposable state. |
+| #1274 Preselect Local AI on eligible PCs | Human UX change, red CI | DECLINE | 18% | 99% | Moderate | High | Current patch overwrites explicit opt-out and loses choice across restart. Replace with persisted explicit-choice state and full navigation/resume tests. |
+| #1273 Bump Windows SDK BuildTools | Dependabot, one-line patch, green CI | TAKE | 96% | 98% | Quick | Low | Add required proof-pool/validation/real-behavior rationale, then merge. |
+| #1268 Bound Piper extraction wait | Human reliability fix | HOLD_FOR_AUTHOR | 64% | 98% | Moderate | Medium | Make stderr drain cancellation-aware, add lifecycle regression, and prove success/timeout/cancel on Windows. |
+| #1267 Bound Tailscale status read | Human setup reliability fix | HOLD_FOR_AUTHOR | 70% | 98% | Moderate | Medium | Clamp all work to one five-second deadline, add elapsed-time test, and prove a hung Windows Tailscale probe. |
+| #1265 Brazilian Portuguese localization | Human localization, stale catalog, deterministic test failures | HOLD_FOR_AUTHOR | 40% | 99% | Large | Medium | Rebase, add the two Ollama permission keys, reconcile about 410 all-or-none translation violations without weakening the gate, then run full Tray localization tests and a pt-BR UI smoke. |
+| #1258 Retry CLI installer downloads | Human setup reliability fix | HOLD_FOR_AUTHOR | 68% | 96% | Quick | Medium | Add per-transfer timeout and bound total retry amplification; prove managed-WSL success/failure. |
+| #1253 Use CUDA for allocatable GPU memory | Human Local AI capacity work, 18 files | HOLD_FOR_AUTHOR | 40% | 98% | Large | High | Define WDDM/UMA-safe capacity, retain partial facts, and prove allocation plus inference on affected hardware. |
+| #1239 Shared-memory capacity and rollback | Human Local AI follow-up, red CI | DECLINE | 15% | 99% | Moderate | High | Close current patch. Dedicated-memory direction is superseded and rollback can leave llama-server running. |
+| #1232 Resume Local AI setup with new model | Human lifecycle fix, stale active owner | HOLD_FOR_AUTHOR | 45% | 98% | Moderate | High | Persist model transition across process restart and add crash/resume/rollback tests. |
+| #1207 Preserve trailing command output | Draft, conflicting, superseded implementation | DECLINE | 20% | 97% | Moderate | Medium | Close current branch. Reopen narrowly only if current main still demonstrates truncation after the landed drain changes. |
+| #1201 Bind WSL relay trust to installed package | Maintainer security draft | NEEDS_HUMAN_TEST | 84% | 97% | Moderate | High | Natural unsigned ARM64 WSL 2.6.3 proof: package path, ACL, version binding, listener provenance, and spoof rejection. |
+| #1175 Retry failed WSL setup | Draft, conflicting, destructive legacy flow | DECLINE | 20% | 98% | Moderate | High | Close and reimplement only on current ownership/path/live-registration protections if the issue still reproduces. |
+| #1166 Bound MXC termination and drain cleanup | Human focused fix, green CI | NEEDS_HUMAN_TEST | 89% | 98% | Quick | Medium | Run `validate-mxc-e2e.ps1` without skip and capture Gateway-to-node `system.run` proof. |
+| #1164 Permissioned Codex session access | Draft, conflicting, 59 files | DECLINE | 5% | 99% | Large | High | Close branch; preserve design in an issue or extension-sized proposal. |
+| #1160 Truthful node capability readiness | Draft public-schema feature | HOLD_FOR_AUTHOR | 40% | 96% | Large | High | Sponsor schema first, port onto current schema v2, resolve #1157 stacking, and prove MCP/Gateway transitions. |
+| #1159 Guide channel readiness handoff | Draft, current routing drift | HOLD_FOR_AUTHOR | 42% | 97% | Moderate | Medium | Port to ActivationRouter/WindowManager, localize copy, and prove setup completion to Channels. |
+| #1158 Bound streaming UI dispatch | Draft, stale chat ownership | HOLD_FOR_AUTHOR | 18% | 96% | Large | High | Reimplement against current projector/conversation ownership and stress-test event storms/session switching. |
+| #1157 Preflight browser proxy readiness | Draft, green, proof-only blocker | NEEDS_HUMAN_TEST | 85% | 98% | Moderate | Medium-high | Prove MCP discovery, real `browser.proxy`, Gateway invocation, and Command Center states. Active label appears stale. |
+| #1141 Suppress extended-stable updates | Human fix, conflicting, old proof | HOLD_FOR_AUTHOR | 74% | 97% | Moderate | Medium | Transplant onto current connection ownership and confirm Core `effectiveChannel` contract. Clear stale active label until work resumes. |
+| #1130 Preserve history cache correlation | Human chat fix, conflicting, credible proof | HOLD_FOR_AUTHOR | 84% | 98% | Moderate | Medium-high | Transplant the focused ID-correlation fix onto current provider ownership; rerun collision/UIA proof. |
+| #1128 Upgrade legacy Gateways to Tailscale auth | Human security migration, conflicting | NEEDS_INFO | 68% | 99% | Large | High | Maintainer must approve/reject the legacy trust expansion before rebase and current-head authorization proof. |
+| #1068 Replaceable node runtime/sidecar proof | Draft, conflicting speculative bundle | DECLINE | 4% | 99% | Large | High | Close current branch; it lacks current compatibility propagation and protected IPC proof. |
+| #1002 Trimmed winnode publishing experiment | Maintainer draft experiment | DECLINE | 12% | 99% | Quick | Medium | Close unless standalone distribution is a committed product; `--help` is not MCP proof. |
+| #962 Seed design system | Draft, stale parallel design authority | DECLINE | 3% | 99% | Quick | Medium | Close obsolete guidance and avoid a parallel source of UI truth. |
+| #938 Native Windows and WSL gateway modes | Draft, conflicting, 79 files | DECLINE | 2% | 99% | Large | Critical | Close current branch and redesign as small PRs; endpoint ownership and PATH fallback remain unsafe. |
+
+## Issues
+
+| Item | Signal | Decision | Take confidence | Recommendation confidence | Effort | Risk | Owner / next action |
+|---|---|---|---:|---:|---|---|---|
+| #1280 Stronger model versus reduced context | Product recommendation policy, linked #1281 | HOLD_FOR_AUTHOR | 55% | 95% | Moderate | Medium | Decide quality versus context priority and minimum recommended context; do not merge #1281 first. |
+| #1271 Visible New Chat/New Session action | Source-confirmed UX gap, hidden `/new` path exists | NEEDS_INFO | 75% | 90% | Moderate | Low | Choose placement, default agent behavior, and conditional multi-agent picker. |
+| #1270 LayoutCycleException crash loop | Current-release P0 crash report, missing stack owner | NEEDS_INFO | 55% | 92% | Moderate | High | Obtain sanitized full WER dump/stack and minimized throughput sequence before assigning a renderer owner. |
+| #1256 Fresh-WSL DNS failure is masked | Source-proven P1 setup bug | TAKE_AFTER_CHECKS | 88% | 97% | Moderate | Medium | Manually promote: bounded download-to-temp, execute only after success, preserve curl error, and real fresh-WSL proof. |
+| #1251 Intermittent Local AI provider-auth error | Reproduced on rerun, route still unclear | NEEDS_INFO | 50% | 90% | Moderate | Medium | Capture effective provider/model route, redacted error, and current-main Gateway trace. |
+| #1250 Audit Local AI warning severity/copy | Post-availability UX audit now unblocked | TAKE_AFTER_CHECKS | 82% | 92% | Quick | Low | Audit current #1263 behavior, shorten copy, and align warning severity with definitive versus retryable states. |
+| #1249 Back/Restart/Cancel during download | Source-confirmed UX gap with artifact policy question | NEEDS_INFO | 70% | 92% | Moderate | Medium | Decide partial-download retention and restart/cancel semantics before UI work. |
+| #1248 Refresh managed model catalog | Product/artifact decision, overlaps #1281 | HOLD_FOR_AUTHOR | 55% | 92% | Moderate | Medium | Approve immutable artifacts and hardware/profile policy before catalog replacement. |
+| #1247 Preselect Local AI on eligible systems | Product default change; PR #1274 is unsafe | HOLD_FOR_AUTHOR | 35% | 98% | Moderate | Medium | Define persisted explicit choice and preserve opt-out across Back/restart/resume. |
+| #1246 Safely back out after Gateway install | Source-proven but maintainer chose forward-only for now | HOLD_FOR_AUTHOR | 60% | 92% | Moderate | Medium | Keep current flow; retain candidate branch only as research until product direction changes. |
+| #1244 Fresh-system WSL inspection error | Source-proven P0 onboarding blocker | TAKE_AFTER_CHECKS | 85% | 96% | Moderate | Medium | Classify known fresh/pre-reboot states at Welcome and route to installer/restart before inspection. |
+| #1242 Intermittent ARM64/Blackwell llama crash | P0 release blocker, upstream runtime sensitivity | NEEDS_HUMAN_TEST | 88% | 95% | Moderate | High | Reproduce and qualify current runtime on affected ARM64/DGX/Blackwell hardware; capture native CUDA failure. |
+| #1236 Session-backed Companion architecture | Broad architecture proposal | DECLINE | 10% | 96% | Large | High | Retain current WSL/Gateway ownership; require RFC sponsorship for a new session runtime. |
+| #1220 Show response duration | UX feature, timing authority undefined | NEEDS_INFO | 55% | 90% | Moderate | Low | Define per-entry timing authority and persistence before rendering. |
+| #1216 Add ClawHub catalog page | Broad catalog/trust feature | DECLINE | 10% | 96% | Large | High | Define upstream catalog, provenance, permissions, and install ownership before UI. |
+| #1214 Keep llama-server KV cache warm | Runtime/product policy | NEEDS_INFO | 45% | 90% | Moderate | Medium | Define idle retention and GPU memory budget; collect trace on qualified hardware. |
+| #1213 llama-server parallelism/context | Runtime product policy | NEEDS_INFO | 35% | 90% | Moderate | Medium | Document serial managed default and qualify concurrency separately. |
+| #1211 Prefill Local AI system prompt | Cross-boundary warmup request | NEEDS_INFO | 45% | 92% | Moderate | Medium | Define Gateway-owned warmup and cache invalidation contract. |
+| #1200 Qwen 9B MTP cold-load failure | Reproduced recipe defect in active Local AI work | HOLD_FOR_AUTHOR | 65% | 92% | Quick | Medium | Carry bounded micro-batch recipe and real cold-load proof in current Local AI lane. |
+| #1199 Node favoring/routing investigation | No concrete current failure trace | NEEDS_INFO | 25% | 95% | Unknown | Unknown | Request host selection, node state, route, and failure trace. |
+| #1197 NVIDIA remediation links | Product/redirect policy | NEEDS_INFO | 35% | 92% | Moderate | Medium | Approve owner and allowlisted destination before adding outbound guidance. |
+| #1196 Explicit NVIDIA GPU selection | Runtime lifecycle/product feature | DECLINE | 15% | 94% | Large | High | Defer until managed runtime/device-selection ownership is defined. |
+| #1195 Per-device CUDA capability | Valid requirement, not reproduced on main alone | HOLD_FOR_AUTHOR | 55% | 92% | Moderate | Medium | Fold into safe capacity work with mixed-GPU and missing-query fail-closed coverage. |
+| #1194 Preserve trailing command output | Source-proven class, linked obsolete #1207 | TAKE_AFTER_CHECKS | 70% | 92% | Moderate | Medium | Reconfirm against current main; if still reproducible, create a new narrow fix rather than reviving #1207. |
+| #1191 Do not count DXGI shared memory | Source-proven, linked #1253 | HOLD_FOR_AUTHOR | 60% | 94% | Large | High | Settle WDDM/UMA-safe admission policy and prove on discrete/unified hardware. |
+| #1190 `system.run` exceeds Gateway timeout | Source-proven P1 security/availability | NEEDS_HUMAN_TEST | 85% | 96% | Moderate | High | Define cross-repo deadline/cancellation contract; preserve MXC containment and prove real Gateway path. |
+| #1189 MXC job-object failure on one node | Source-proven P1 platform-specific failure | NEEDS_HUMAN_TEST | 75% | 95% | Moderate | High | Reproduce exact launcher failure on affected host; approve only narrow unavailable classification, not generic fallback. |
+| #1183 Session-switching UX unclear | Broad UX request | NEEDS_INFO | 40% | 90% | Moderate | Low | Specify journey and relationship to #1271 before implementation. |
+| #1173 Reactor access-violation crash loop | P1 crash evidence, needs current dump | NEEDS_HUMAN_TEST | 72% | 94% | Moderate | High | Capture sanitized current-head WinDbg/WER dump and identify mount owner. |
+| #1167 Session switch hangs on 200 messages | P1 hang, current trace absent | NEEDS_HUMAN_TEST | 68% | 92% | Moderate | High | Capture current-head Windows trace and measure history projection/UI bottleneck. |
+| #1161 Session maintenance settings UI | Product choice, no active PR | NEEDS_INFO | 45% | 94% | Moderate | Low | Decide schema-guided editor versus dedicated typed surface; clear stale active label. |
+| #1156 Terminal/channel setup handoff | UX gap, stale draft #1159 | HOLD_FOR_AUTHOR | 55% | 94% | Moderate | Medium | Rebase #1159 only after routing/localization plan; clear active label while paused. |
+| #1155 Truthful capability readiness | Architecture/product contract, draft #1160 | HOLD_FOR_AUTHOR | 45% | 94% | Large | High | Sponsor authoritative schema/projection before implementation; clear stale active label. |
+| #1154 Browser proxy readiness | Source-proven P1, draft #1157 | NEEDS_HUMAN_TEST | 85% | 98% | Moderate | Medium-high | Current-head MCP/Gateway/browser proof; clear active label unless proof is being captured now. |
+| #1153 Smart App Control unsigned DLL | Code/signing fix landed; SAC-On acceptance remains | NEEDS_HUMAN_TEST | 92% | 98% | Quick | High | Install signed candidate on SAC-On Windows 11 and prove app plus OpenClaw.Chat.dll accepted. |
+| #1152 CJK clipping | Old renderer report, current status unclear | NEEDS_INFO | 55% | 92% | Quick | Low | Reproduce on current Reactor renderer with CJK fallback fonts or close as resolved. |
+| #1150 Agent-event stream hang/crash | Source-proven P1, stale draft #1158 | HOLD_FOR_AUTHOR | 75% | 96% | Large | High | Reimplement coalescing against current chat ownership and capture sustained load proof. |
+| #1148 Auto-scroll to latest message | Current code appears to auto-follow | NEEDS_INFO | 60% | 92% | Quick | Low | Confirm active surface/current main and decide whether return-to-bottom button is separate. |
+| #1146 MXC granted paths doubled/unusable | P1 security/data-loss, no capable proof host | NEEDS_HUMAN_TEST | 55% | 97% | Moderate | Critical | Reproduce allowed read/write and denied-write control on real MXC 0.7 host; keep stale/paused. |
+| #1145 Chat text right-edge clipping | Old renderer report | NEEDS_INFO | 58% | 92% | Quick | Low | Recheck current Reactor renderer; close if not reproducible. |
+| #1144 Chat selection unreliable | Surface unspecified | NEEDS_INFO | 50% | 92% | Quick | Low | Clarify native Companion versus Gateway WebView2 before routing. |
+| #1124 Voice Talk Mode proposal | Product/design proposal | HOLD_FOR_AUTHOR | 25% | 94% | Large | High | Sponsor persistent microphone/talk-mode semantics after wake reliability work. |
+| #1122 Consolidated audit handoff | Useful research, stale omnibus tracker | HOLD_FOR_AUTHOR | 40% | 90% | Large | High | Split surviving findings into current narrow issues; close tracker after migration. |
+| #1118 Remove FunctionalUI from Cron | Stale refactor proposal | HOLD_FOR_AUTHOR | 25% | 92% | Large | Medium | Reconfirm current renderer ownership and narrow the change before implementation. |
+| #1087 Simplified Chinese STT output | Valid UX request with output-policy choice | NEEDS_INFO | 50% | 92% | Moderate | Medium | Decide opt-in script conversion and MCP override, then validate Mandarin output. |
+| #1009 Edge TTS support | New cloud text-egress provider | DECLINE | 10% | 95% | Moderate | Medium | Do not add unauthenticated cloud egress without provider/privacy policy. |
+| #1000 Stable/beta release alignment | Cross-repo lifecycle policy | NEEDS_INFO | 45% | 92% | Moderate | High | Wait for Core managed-Gateway contract, then scope thin Windows integration only. |
+| #953 Large session-list scaling | UX/performance contract missing | NEEDS_INFO | 45% | 92% | Large | Medium | Choose searchable virtualized picker and bounded paging. |
+| #908 QR generation mirror | Upstream/context details missing | NEEDS_INFO | 25% | 94% | Quick | Low | Request upstream issue URL, Gateway version, and failed QR output. |
+| #907 Mobile pairing falls back to TUI | P0 report without current trace | NEEDS_INFO | 30% | 95% | Moderate | High | Request client/Gateway versions and pairing transcript. |
+| #906 Battery drain with concurrent sessions | Performance report without workload/budget | NEEDS_INFO | 35% | 94% | Large | High | Capture CPU/wake/refresh trace and define freshness budget. |
+| #894 Native/browser tool identity mismatch | Source-proven, conflicting PR #1130 | HOLD_FOR_AUTHOR | 84% | 98% | Moderate | Medium-high | Transplant #1130’s focused correlation fix onto current chat ownership. |
+| #871 Workspace file rail gaps | Product contract missing | NEEDS_INFO | 35% | 92% | Large | Medium | Define typed artifact and preview/safety policy. |
+| #863 Agent creation and syncing | Gateway mutation/UI contract missing | NEEDS_INFO | 30% | 92% | Large | Medium | Define creation/refresh ownership and target-agent semantics. |
+| #859 Improve chat experience | Broad bucket with some concrete papercuts | HOLD_FOR_AUTHOR | 40% | 90% | Large | Medium | Split current reproducible defects, including identity/avatar fallback, into narrow issues. |
+| #847 Wizard combination validation | Credentialed E2E strategy absent | NEEDS_INFO | 30% | 94% | Large | High | Define approved test accounts, secret handling, and validation matrix. |
+| #844 Local/remote pairing reliability umbrella | Too broad, topology acceptance undefined | NEEDS_INFO | 30% | 94% | Large | High | Split by topology and provide current traces; close umbrella when migrated. |
+| #843 First-run local Gateway onboarding | Largely completed/duplicate direction | DECLINE | 80% | 94% | Quick | Low | Close as covered by current onboarding; keep narrower terminal/channel issues. |
+| #554 App/ConnectionPage god-file tracker | Canonical architecture tracker | HOLD_FOR_AUTHOR | 60% | 96% | Large | High | Keep open; sponsor one ledger-backed ownership seam at a time. |
+| #246 Packaging and auto-update strategy | Security/product strategy | HOLD_FOR_AUTHOR | 40% | 96% | Large | High | Continue MSIX-first decision work with legacy migration and update-isolation proof. |
+
+## Active ownership audit
+
+The September snapshot still shows `status: actively landing` on issues #1194, #1161, #1156, #1155, #1154, #1153, and #1150, and PRs #1232, #1175, #1157, and #1141.
+
+| Item | Assessment |
+|---|---|
+| #1194 | Recent activity and linked PR, but current PR is obsolete/conflicting. Confirm ownership or clear. |
+| #1161 | No active implementation PR. Clear until a product decision is made. |
+| #1156 | Draft #1159 exists but is not actively landing. Clear while author work is paused. |
+| #1155 | Draft #1160 exists but schema decision blocks it. Clear while paused. |
+| #1154 / #1157 | Proof-only lane. Keep active only if a named maintainer is capturing MCP/Gateway proof now. |
+| #1153 | Proof-only SAC-On lane. Keep active only if a SAC-On host is scheduled. |
+| #1150 | Draft #1158 is stale against current ownership. Clear until reimplementation starts. |
+| #1232 | Author work remains; label has not had fresh activity since August 28. Clear unless owner confirms. |
+| #1175 | Branch received recent activity but remains unsafe/conflicting. Active label is plausible only during redesign. |
+| #1141 | Conflicting since August 24. Clear until transplant begins. |
+
+## Adversarial review
+
+### PR #1265 Brazilian Portuguese localization
+
+| Finding | Opus | Codex | Consensus | Final assessment |
+|---|---|---|---|---|
+| About 410 keys violate the repository all-or-none translation invariant | CRITICAL | CRITICAL | HIGH | Blocking. Reconcile values with the established non-English locale consensus; do not weaken the validation rule. |
+| Missing `PermissionsPage_Cap_Ollama_Label` and `PermissionsPage_Cap_Ollama_Description` after main advanced | HIGH | HIGH | HIGH | Blocking. Rebase and add both keys before exact-head validation. |
+| Normal build/Tray localization tests never ran on the PR head | HIGH | MEDIUM | HIGH | Full Windows CI is mandatory after catalog repair. |
+| Translation quality, XML, placeholders, and layout expansion | Clean | Clean | HIGH | The translation craft is good; consistency policy and staleness are the blockers. |
+
+**Decision:** HOLD_FOR_AUTHOR, 40% take confidence. It is not safe to merge after a simple rerun because the deterministic localization tests fail.
+
+### PR #1277 Windows Server MXC probe skip
+
+| Finding | Opus | Codex | Consensus | Final assessment |
+|---|---|---|---|---|
+| No real Windows Server fallback/strict-denial proof and no client MXC E2E | HIGH | HIGH | HIGH | Blocking security-boundary proof. |
+| Native Server SKU detector is not directly tested | HIGH | MEDIUM | HIGH | Add a Windows-only native detector/layout assertion. |
+| Unsupported-SKU result can persist `SystemRunSandboxEnabled=false`, changing later execution from guarded HostFallback to direct Host | HIGH | Not raised | LOW, accepted | Concrete downstream code path. Add a distinct outcome and exclude it from persistent toggle normalization. |
+| Hard-coded SKU skip has no controlled future-support escape hatch | HIGH | Not raised | LOW, accepted | Add an explicit, logged force-probe override or equivalent supported mechanism. |
+| Probe no-throw/log/UI remediation contracts are incomplete | MEDIUM | LOW | LOW | Guard P/Invoke, emit structured outcome, and do not offer Windows Update for unsupported Server SKU. |
+
+**Decision:** HOLD_FOR_AUTHOR, 35% take confidence. Native proof is necessary but not sufficient; the persistent security-setting behavior must be fixed first.
+
+## Day plan
+
+1. Update and merge #1273; merge #1283 after its current CI finishes.
+2. Repair #1265's catalog consistency and missing keys, then run exact-head localization tests and a pt-BR smoke.
+3. Rework #1277's unsupported-SKU state and persistence boundary, then schedule Server and MXC-client proof. Independently schedule proof for #1166, #1201, and #1153.
+4. Repair #1282 and #1279; then address deadline/cancellation findings in #1258, #1267, and #1268.
+5. Manually promote #1256 and #1244 as the best issue-to-PR candidates.
+6. Transplant #1130 and #1141 only if owners want them; do not rebase obsolete ownership wholesale.
+7. Close the nine decline PRs and issue #843 after concise disposition comments.
+8. Clear stale active-landing labels that have no current owner or proof appointment.
+
+## Automation and testability
+
+The repository now has the report-only triage workflow and schema-backed proof pools landed from the August pass. The next automation work should be tuning, not another framework.
+
+| Opportunity | Why | Owner | Effort | Notes |
+|---|---|---|---|---|
+| Run the triage workflow on schedule and inspect `unknown`/warning rates | Validates live GraphQL/report behavior without mutation | Maintainer | Quick | Keep report-only as default. |
+| Add a short proof-pool CI lane separate from the main test critical path | Full schema mutation matrices can delay all builds | Maintainer | Moderate | Preserve PS5/PS7 parity while parallelizing cost. |
+| Use proof-pool reservations for SAC-On, MXC, ARM64/DGX, and clean installer work | Turns custom proof into scheduled capacity | Maintainer | Moderate | Do not treat an unavailable pool as passing evidence. |
+| Auto-suggest clearing stale active ownership | Reduces duplicate-work blocking | Existing triage workflow | Quick | Keep removal manually gated and audited. |
+| Track repeated unrelated UI readiness flakes | Stops each feature PR from rediscovering the same baseline failures | Test owner | Moderate | Repair the test owner, never waive a changed-surface failure. |

--- a/.agents/skills/global-repo-triage/templates/global-triage-report.md
+++ b/.agents/skills/global-repo-triage/templates/global-triage-report.md
@@ -1,0 +1,62 @@
+# OpenClaw Windows Node global triage
+
+Snapshot: <YYYY-MM-DD>. Read-only review of <issue count> open issues and
+<PR count> open pull requests, including item bodies, discussions, reviews,
+inline comments, timelines, checks, files, commits, and PR patches.
+
+## Change since <prior date>
+
+| Change | Items |
+|---|---|
+| New issues | |
+| Issues no longer open | |
+| New PRs | |
+| PRs no longer open | |
+
+<One paragraph explaining backlog movement and the dominant current themes.>
+
+## Executive queue
+
+1. **TAKE ...**
+2. **TAKE_AFTER_CHECKS ...**
+3. **Repair ...**
+4. **Schedule proof ...**
+5. **Close or decline ...**
+
+## Pull requests
+
+| Item | Type / signal | Decision | Take confidence | Recommendation confidence | Effort | Risk | Owner / required validation |
+|---|---|---|---:|---:|---|---|---|
+
+## Issues
+
+| Item | Signal | Decision | Take confidence | Recommendation confidence | Effort | Risk | Owner / next action |
+|---|---|---|---:|---:|---|---|---|
+
+## Active ownership audit
+
+| Item | Assessment |
+|---|---|
+
+## Adversarial review
+
+### PR #<number> <title>
+
+| Finding | Reviewer A | Reviewer B | Consensus | Final assessment |
+|---|---|---|---|---|
+
+**Decision:** <decision and confidence with concise rationale>.
+
+## Day plan
+
+1. <First landing lane and its completion condition.>
+2. <Dependent lane.>
+3. <Parallel human-proof lane.>
+4. <Repair/transplant lane.>
+5. <Close/decline and stale-ownership cleanup.>
+
+## Automation and testability
+
+| Opportunity | Why | Owner | Effort | Notes |
+|---|---|---|---|---|
+


### PR DESCRIPTION
## Summary

Adds a repository-scoped `global-repo-triage` skill for `openclaw/openclaw-windows-node`.

The skill turns the proven August 27 and September 1 full-repository triage workflow into a reusable maintainer playbook. It covers complete issue and PR inventory, ClawSweeper advisory review, active-landing ownership, architecture boundaries, proof-pool scheduling, exact-head validation, baseline-flake diagnosis, coordinated landing lanes, and release decisions.

## Required proof pools

- `none`: Repository-only agent instructions and historical Markdown examples. No runtime product behavior changes.

## Validation

- `node --test .github\scripts\repository-triage.test.cjs`: passed, 14/14.
- `.\scripts\validate-docs.ps1`: passed, 48 Markdown files checked.
- `git diff --check`: passed.

## Real behavior proof

The skill includes the actual `global-triage-2026-08-27.md` and `global-triage-2026-09-01.md` reports as examples and references the checked-in repository triage workflow, proof pools, architecture ledger, test inventory, and release process. Runtime proof is not applicable because this change only adds agent instructions and examples.