### PR TITLE
ci: publish daily alpha releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     tags: [ 'v*' ]
   pull_request:
     branches: [ main, master ]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -891,7 +891,7 @@ jobs:
           2. Launch from Start Menu or system tray
           3. Right-click tray icon → Settings to configure
 
-    - name: Retain the latest seven alpha releases
+    - name: Retain alpha releases for 30 days
       if: needs.test.outputs.isPrerelease == 'true' && contains(github.ref_name, '-alpha.')
       shell: bash
       env:
@@ -925,11 +925,10 @@ jobs:
             map(select(
               .draft == false and
               .prerelease == true and
-              (.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-alpha\\.[0-9]+$"))
+              (.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-alpha\\.[0-9]+$")) and
+              ((.published_at | fromdateiso8601) < (now - (30 * 24 * 60 * 60)))
             ))
             | sort_by(.published_at)
-            | reverse
-            | .[7:]
             | .[]
             | [.id, .tag_name]
             | @tsv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -890,3 +890,48 @@ jobs:
           1. Run the installer for your architecture
           2. Launch from Start Menu or system tray
           3. Right-click tray icon → Settings to configure
+
+    - name: Retain the latest seven alpha releases
+      if: needs.test.outputs.isPrerelease == 'true' && contains(github.ref_name, '-alpha.')
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+
+        releases_json="$(
+          gh api --paginate "repos/${GITHUB_REPOSITORY}/releases?per_page=100" |
+            jq -s 'add'
+        )"
+        current_release_count="$(
+          jq --arg tag "$GITHUB_REF_NAME" '
+            map(select(.draft == false and .prerelease == true and .tag_name == $tag))
+            | length
+          ' <<< "$releases_json"
+        )"
+        if [[ "$current_release_count" != "1" ]]; then
+          echo "::warning::Current alpha release $GITHUB_REF_NAME is not visible yet; deferring retention cleanup."
+          exit 0
+        fi
+
+        while IFS=$'\t' read -r release_id stale_tag; do
+          if [[ -z "$release_id" ]]; then
+            continue
+          fi
+          echo "Deleting old alpha release $stale_tag; retaining its Git tag."
+          gh api --method DELETE "repos/${GITHUB_REPOSITORY}/releases/$release_id"
+        done < <(
+          jq -r '
+            map(select(
+              .draft == false and
+              .prerelease == true and
+              (.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-alpha\\.[0-9]+$"))
+            ))
+            | sort_by(.published_at)
+            | reverse
+            | .[7:]
+            | .[]
+            | [.id, .tag_name]
+            | @tsv
+          ' <<< "$releases_json"
+        )

--- a/.github/workflows/daily-alpha-release.yml
+++ b/.github/workflows/daily-alpha-release.yml
@@ -1,0 +1,114 @@
+name: Daily Alpha Release
+
+on:
+  schedule:
+    - cron: '0 14 * * *'
+      timezone: America/Los_Angeles
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: write
+
+concurrency:
+  group: daily-alpha-release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Find the previous published release
+        id: previous_release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          previous_tag="$(
+            gh api --paginate "repos/${GITHUB_REPOSITORY}/releases?per_page=100" |
+              jq -sr '
+                add
+                | map(select(.draft == false and .published_at != null))
+                | sort_by(.published_at)
+                | last
+                | .tag_name // empty
+              '
+          )"
+          if [[ -z "$previous_tag" ]]; then
+            echo "::error::No previous published release was found."
+            exit 1
+          fi
+
+          previous_sha="$(git rev-list -n 1 "$previous_tag")"
+          if [[ -z "$previous_sha" ]]; then
+            echo "::error::Could not resolve previous release tag $previous_tag."
+            exit 1
+          fi
+
+          echo "tag=$previous_tag" >> "$GITHUB_OUTPUT"
+          echo "sha=$previous_sha" >> "$GITHUB_OUTPUT"
+          if [[ "$previous_sha" == "$GITHUB_SHA" ]]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No changes since $previous_tag; skipping today's alpha release."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Changes found after $previous_tag ($previous_sha)."
+          fi
+
+      - name: Install GitVersion
+        if: steps.previous_release.outputs.changed == 'true'
+        uses: gittools/actions/gitversion/setup@v4
+        with:
+          versionSpec: '6.8.x'
+
+      - name: Determine alpha version
+        if: steps.previous_release.outputs.changed == 'true'
+        id: gitversion
+        uses: gittools/actions/gitversion/execute@v4
+
+      - name: Create or reuse alpha tag
+        if: steps.previous_release.outputs.changed == 'true'
+        id: alpha_tag
+        shell: bash
+        env:
+          SEMVER: ${{ steps.gitversion.outputs.semVer }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$SEMVER" =~ ^[0-9]+\.[0-9]+\.[0-9]+-alpha\.[0-9]+$ ]]; then
+            echo "::error::GitVersion produced '$SEMVER', not a canonical alpha version."
+            exit 1
+          fi
+
+          tag="v$SEMVER"
+          if git show-ref --verify --quiet "refs/tags/$tag"; then
+            tagged_sha="$(git rev-list -n 1 "$tag")"
+            if [[ "$tagged_sha" != "$GITHUB_SHA" ]]; then
+              echo "::error::Existing tag $tag points to $tagged_sha instead of $GITHUB_SHA."
+              exit 1
+            fi
+            echo "Reusing $tag at $GITHUB_SHA."
+          else
+            git tag "$tag" "$GITHUB_SHA"
+            git push origin "refs/tags/$tag"
+            echo "Created $tag at $GITHUB_SHA."
+          fi
+
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch validated release build
+        if: steps.previous_release.outputs.changed == 'true'
+        shell: bash
+        env:
+          ALPHA_TAG: ${{ steps.alpha_tag.outputs.tag }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh workflow run ci.yml --ref "$ALPHA_TAG"
+          echo "Dispatched the full validation and GitHub Release pipeline for $ALPHA_TAG."

--- a/.github/workflows/daily-alpha-release.yml
+++ b/.github/workflows/daily-alpha-release.yml
@@ -4,7 +4,6 @@ on:
   schedule:
     - cron: '0 14 * * *'
       timezone: America/Los_Angeles
-  workflow_dispatch:
 
 permissions:
   actions: write
@@ -21,6 +20,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          ref: ${{ github.event.repository.default_branch }}
 
       - name: Find the previous published release
         id: previous_release
@@ -51,9 +51,20 @@ jobs:
             exit 1
           fi
 
+          current_sha="$(git rev-parse HEAD)"
+          head_non_alpha_tag="$(
+            git tag --points-at "$current_sha" --list 'v*' |
+              grep -Ev '^v[0-9]+\.[0-9]+\.[0-9]+-alpha\.[0-9]+$' |
+              head -n 1 || true
+          )"
+
           echo "tag=$previous_tag" >> "$GITHUB_OUTPUT"
           echo "sha=$previous_sha" >> "$GITHUB_OUTPUT"
-          if [[ "$previous_sha" == "$GITHUB_SHA" ]]; then
+          echo "current_sha=$current_sha" >> "$GITHUB_OUTPUT"
+          if [[ -n "$head_non_alpha_tag" ]]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Deferring alpha release because main already has unpublished non-alpha tag $head_non_alpha_tag."
+          elif [[ "$previous_sha" == "$current_sha" ]]; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
             echo "No changes since $previous_tag; skipping today's alpha release."
           else
@@ -77,6 +88,7 @@ jobs:
         id: alpha_tag
         shell: bash
         env:
+          CURRENT_SHA: ${{ steps.previous_release.outputs.current_sha }}
           SEMVER: ${{ steps.gitversion.outputs.semVer }}
         run: |
           set -euo pipefail
@@ -89,15 +101,15 @@ jobs:
           tag="v$SEMVER"
           if git show-ref --verify --quiet "refs/tags/$tag"; then
             tagged_sha="$(git rev-list -n 1 "$tag")"
-            if [[ "$tagged_sha" != "$GITHUB_SHA" ]]; then
-              echo "::error::Existing tag $tag points to $tagged_sha instead of $GITHUB_SHA."
+            if [[ "$tagged_sha" != "$CURRENT_SHA" ]]; then
+              echo "::error::Existing tag $tag points to $tagged_sha instead of $CURRENT_SHA."
               exit 1
             fi
-            echo "Reusing $tag at $GITHUB_SHA."
+            echo "Reusing $tag at $CURRENT_SHA."
           else
-            git tag "$tag" "$GITHUB_SHA"
+            git tag "$tag" "$CURRENT_SHA"
             git push origin "refs/tags/$tag"
-            echo "Created $tag at $GITHUB_SHA."
+            echo "Created $tag at $CURRENT_SHA."
           fi
 
           echo "tag=$tag" >> "$GITHUB_OUTPUT"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -86,6 +86,9 @@ Stable, stable-correction, and alpha tags use the same signed CI release pipelin
   numeric-suffix tag, including malformed ones such as `-0` and `-03`, is routed
   through the validator rather than silently classified by GitVersion.
 - `vX.Y.Z-alpha.N` creates a prerelease that stable updater checks do not offer.
+  CI retains the seven newest canonical alpha GitHub Releases so daily builds do
+  not overwhelm the Releases page. Cleanup removes only the older release
+  objects and assets; their Git tags remain as GitVersion history.
 
 The validator has no dependency on another repository's release API. Run it
 offline against an explicit current release to preview a decision:

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -86,9 +86,9 @@ Stable, stable-correction, and alpha tags use the same signed CI release pipelin
   numeric-suffix tag, including malformed ones such as `-0` and `-03`, is routed
   through the validator rather than silently classified by GitVersion.
 - `vX.Y.Z-alpha.N` creates a prerelease that stable updater checks do not offer.
-  CI retains the seven newest canonical alpha GitHub Releases so daily builds do
-  not overwhelm the Releases page. Cleanup removes only the older release
-  objects and assets; their Git tags remain as GitVersion history.
+  CI retains canonical alpha GitHub Releases for 30 days so daily builds do not
+  overwhelm the Releases page. Cleanup removes only older release objects and
+  assets; their Git tags remain as GitVersion history.
 
 The validator has no dependency on another repository's release API. Run it
 offline against an explicit current release to preview a decision:

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -92,8 +92,8 @@ then explicitly dispatches this workflow at that tag. The explicit dispatch is
 required because a tag pushed with the workflow's `GITHUB_TOKEN` does not
 itself start another workflow. The normal test, E2E, build, signing, and release
 jobs remain the publication gate; the alpha GitHub Release is created only when
-all validation succeeds. After publication, CI keeps the seven newest canonical
-alpha GitHub Releases and deletes older alpha release objects and their assets.
+all validation succeeds. After publication, CI keeps canonical alpha GitHub
+Releases for 30 days and deletes older alpha release objects and their assets.
 It intentionally retains every Git tag so GitVersion can continue deriving the
 next monotonic alpha version from complete tag history.
 

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -92,7 +92,10 @@ then explicitly dispatches this workflow at that tag. The explicit dispatch is
 required because a tag pushed with the workflow's `GITHUB_TOKEN` does not
 itself start another workflow. The normal test, E2E, build, signing, and release
 jobs remain the publication gate; the alpha GitHub Release is created only when
-all validation succeeds.
+all validation succeeds. After publication, CI keeps the seven newest canonical
+alpha GitHub Releases and deletes older alpha release objects and their assets.
+It intentionally retains every Git tag so GitVersion can continue deriving the
+next monotonic alpha version from complete tag history.
 
 GitVersion interprets `X.Y.Z-N` as a prerelease, so numeric stable corrections
 use one narrow exception: the release-version step recognizes the correction

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -84,6 +84,16 @@ and artifact naming. It then passes that resolved value to product builds as
 one exact identity. CI must not pass a competing hardcoded version literal that
 could hide drift.
 
+The daily alpha workflow runs at 2:00 PM in `America/Los_Angeles`. It compares
+the default-branch head with the most recently published GitHub Release and
+does nothing when they are the same commit. When changes exist, it uses the
+same GitVersion 6.8.x line to create the next canonical `vX.Y.Z-alpha.N` tag,
+then explicitly dispatches this workflow at that tag. The explicit dispatch is
+required because a tag pushed with the workflow's `GITHUB_TOKEN` does not
+itself start another workflow. The normal test, E2E, build, signing, and release
+jobs remain the publication gate; the alpha GitHub Release is created only when
+all validation succeeds.
+
 GitVersion interprets `X.Y.Z-N` as a prerelease, so numeric stable corrections
 use one narrow exception: the release-version step recognizes the correction
 tag, validates its stable ordering with

--- a/tests/OpenClaw.Tray.Tests/VersioningContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/VersioningContractTests.cs
@@ -87,8 +87,8 @@ public sealed class VersioningContractTests
         Assert.Contains("workflow_dispatch:", releaseWorkflow);
         Assert.Contains("uses: softprops/action-gh-release@v3", releaseWorkflow);
         Assert.Contains("prerelease: ${{ needs.test.outputs.isPrerelease }}", releaseWorkflow);
-        Assert.Contains("Retain the latest seven alpha releases", releaseWorkflow);
-        Assert.Contains("| .[7:]", releaseWorkflow);
+        Assert.Contains("Retain alpha releases for 30 days", releaseWorkflow);
+        Assert.Contains("now - (30 * 24 * 60 * 60)", releaseWorkflow);
         Assert.Contains("retaining its Git tag", releaseWorkflow);
         Assert.Contains("gh api --method DELETE", releaseWorkflow);
     }

--- a/tests/OpenClaw.Tray.Tests/VersioningContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/VersioningContractTests.cs
@@ -56,6 +56,36 @@ public sealed class VersioningContractTests
     }
 
     [Fact]
+    public void DailyAlphaRelease_IsChangeGatedAndDispatchesTheValidatedReleasePipeline()
+    {
+        var repoRoot = TestRepositoryPaths.GetRepositoryRoot();
+        var dailyWorkflow = File.ReadAllText(Path.Combine(
+            repoRoot,
+            ".github",
+            "workflows",
+            "daily-alpha-release.yml"));
+        var releaseWorkflow = File.ReadAllText(Path.Combine(
+            repoRoot,
+            ".github",
+            "workflows",
+            "ci.yml"));
+
+        Assert.Contains("cron: '0 14 * * *'", dailyWorkflow);
+        Assert.Contains("timezone: America/Los_Angeles", dailyWorkflow);
+        Assert.Contains("actions: write", dailyWorkflow);
+        Assert.Contains("contents: write", dailyWorkflow);
+        Assert.Contains("previous_sha\" == \"$GITHUB_SHA", dailyWorkflow);
+        Assert.Contains("steps.previous_release.outputs.changed == 'true'", dailyWorkflow);
+        Assert.Contains("versionSpec: '6.8.x'", dailyWorkflow);
+        Assert.Contains("-alpha\\.[0-9]+", dailyWorkflow);
+        Assert.Contains("git push origin \"refs/tags/$tag\"", dailyWorkflow);
+        Assert.Contains("gh workflow run ci.yml --ref \"$ALPHA_TAG\"", dailyWorkflow);
+        Assert.Contains("workflow_dispatch:", releaseWorkflow);
+        Assert.Contains("uses: softprops/action-gh-release@v3", releaseWorkflow);
+        Assert.Contains("prerelease: ${{ needs.test.outputs.isPrerelease }}", releaseWorkflow);
+    }
+
+    [Fact]
     public void ReleaseWorkflow_TreatsNumericCorrectionsAsStableExactVersions()
     {
         var repoRoot = TestRepositoryPaths.GetRepositoryRoot();

--- a/tests/OpenClaw.Tray.Tests/VersioningContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/VersioningContractTests.cs
@@ -74,7 +74,11 @@ public sealed class VersioningContractTests
         Assert.Contains("timezone: America/Los_Angeles", dailyWorkflow);
         Assert.Contains("actions: write", dailyWorkflow);
         Assert.Contains("contents: write", dailyWorkflow);
-        Assert.Contains("previous_sha\" == \"$GITHUB_SHA", dailyWorkflow);
+        Assert.Contains("ref: ${{ github.event.repository.default_branch }}", dailyWorkflow);
+        Assert.DoesNotContain("workflow_dispatch:", dailyWorkflow);
+        Assert.Contains("head_non_alpha_tag", dailyWorkflow);
+        Assert.Contains("Deferring alpha release because main already has unpublished non-alpha tag", dailyWorkflow);
+        Assert.Contains("previous_sha\" == \"$current_sha", dailyWorkflow);
         Assert.Contains("steps.previous_release.outputs.changed == 'true'", dailyWorkflow);
         Assert.Contains("versionSpec: '6.8.x'", dailyWorkflow);
         Assert.Contains("-alpha\\.[0-9]+", dailyWorkflow);
@@ -83,6 +87,10 @@ public sealed class VersioningContractTests
         Assert.Contains("workflow_dispatch:", releaseWorkflow);
         Assert.Contains("uses: softprops/action-gh-release@v3", releaseWorkflow);
         Assert.Contains("prerelease: ${{ needs.test.outputs.isPrerelease }}", releaseWorkflow);
+        Assert.Contains("Retain the latest seven alpha releases", releaseWorkflow);
+        Assert.Contains("| .[7:]", releaseWorkflow);
+        Assert.Contains("retaining its Git tag", releaseWorkflow);
+        Assert.Contains("gh api --method DELETE", releaseWorkflow);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- run the daily alpha check at 2:00 PM Pacific using supported UTC schedules with a daylight-saving offset gate
- skip publication when any published GitHub Release already represents the default-branch head
- defer when `main` carries an unpublished non-alpha tag instead of misclassifying it as an alpha
- pin every action in the write-capable scheduler to an immutable reviewed SHA
- require each new canonical alpha tag to be newer than the reachable alpha high-water mark
- dispatch the existing full validation, signing, and GitHub Release pipeline at that tag
- clean up canonical alpha Release objects older than 30 days with bounded retries while preserving all Git tags
- add workflow contract coverage and document the release and retention flow

## Required proof pools

- `none`: this change is GitHub Actions release automation and contract coverage; it does not require a custom Windows host class from `docs/PROOF_POOLS.md`.

## Validation

- `./build.ps1`: passed in 38.637s
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore`: 3,905 passed, 32 skipped, 0 failed in 29.413s wall clock
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore`: 2,837 passed, 0 skipped, 0 failed in 39.578s wall clock
- `scripts/test-ci-workflow-contract.ps1`, `scripts/validate-docs.ps1`, YAML parsing, and `git diff --check`: passed in 10.530s
- dual-model adversarial review completed with Claude Opus 5 and GPT-5.3-Codex; all confirmed correctness findings were addressed
- [Build and Test run 33842058064](https://github.com/openclaw/openclaw-windows-node/actions/runs/33842058064): passed in 17m28s; required [CI Gate](https://github.com/openclaw/openclaw-windows-node/actions/runs/33842058064/job/100929430072) passed
- [CodeQL run 33842058039](https://github.com/openclaw/openclaw-windows-node/actions/runs/33842058039): passed in 43s; advanced setup gate passed in 3s and path-gated scans skipped as intended
- key job wall clocks: fast validation 43s, release metadata 32s, core/CLI 3m35s, tray/setup/integration 5m58s, x64 release smoke 4m14s, proof-pool contracts 8m17s, UI/accessibility 8m45s, network recovery 9m31s, revocation recovery 11m15s, setup/connect E2E 16m23s, CI Gate 10s

## Real behavior proof

- both changed workflows parse as YAML
- the Pacific gate maps `-0700` to `21:00 UTC` and `-0800` to `22:00 UTC`; contract tests pin both mappings
- published-HEAD detection tolerates release entries whose Git tags no longer exist
- existing same-SHA alpha tags remain retryable; newly created tags fail closed unless strictly newer than the newest reachable canonical alpha tag
- release cleanup retries each deletion three times, warns on persistent API failure, and leaves the successful publication green for retry on the next alpha
- the scheduler has no manual dispatch path and explicitly checks out the repository default branch
- current `origin/main` (`709767d04f28e708c5c3b5dbf43dc8561082beff`) is not represented by a published release; the latest reachable canonical alpha tag is `v2026.7.2-alpha.19`

## Release behavior

The scheduler runs only from the default branch. It creates or safely reuses the GitVersion-produced alpha tag, then uses `workflow_dispatch` because a tag pushed with `GITHUB_TOKEN` does not recursively trigger the tag workflow. The existing CI Gate remains authoritative before signing and release publication. Successful alpha tags publish as GitHub prereleases and do not replace the latest stable release.

After each successful alpha publication, CI deletes canonical alpha release objects and assets older than 30 days. It deliberately retains their tags for monotonic GitVersion derivation and historical source refs. Cleanup defers to the next alpha publication when the new release is not yet visible through the Releases API.