### PR TITLE
ci: reduce superseded PR work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('{0}-{1}', github.ref, github.sha) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   repo-hygiene:
     runs-on: ubuntu-latest
@@ -33,6 +37,8 @@ jobs:
     needs: repo-hygiene
     if: ${{ !cancelled() }}
     runs-on: windows-latest
+    env:
+      OPENCLAW_CI_COLLECT_COVERAGE: ${{ github.event_name != 'pull_request' }}
     steps:
     - name: Fail if repo hygiene failed
       if: ${{ needs.repo-hygiene.result != 'success' }}
@@ -111,9 +117,31 @@ jobs:
       shell: pwsh
       run: ./scripts/validate-docs.ps1
 
+    - name: Select proof-pool regression scope
+      id: proof_pool_regression
+      continue-on-error: true
+      shell: pwsh
+      env:
+        PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      run: |
+        $decision = ./scripts/Get-CiProofPoolRegressionDecision.ps1 `
+          -EventName $env:GITHUB_EVENT_NAME `
+          -BaseSha $env:PR_BASE_SHA `
+          -HeadSha $env:PR_HEAD_SHA
+        if ($decision -notin @("true", "false")) {
+          throw "Unexpected proof-pool regression decision '$decision'."
+        }
+        "run=$decision" >> $env:GITHUB_OUTPUT
+
     - name: Validate proof-pool regressions
+      if: ${{ steps.proof_pool_regression.outcome != 'success' || steps.proof_pool_regression.outputs.run != 'false' }}
       shell: pwsh
       run: ./scripts/test-proof-pool-validator.ps1
+
+    - name: Validate CI workflow contracts
+      shell: pwsh
+      run: ./scripts/test-ci-workflow-contract.ps1
 
     - name: Validate stable correction release ordering regressions
       shell: pwsh
@@ -122,11 +150,8 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
 
-    # dotnet-coverage replaces coverlet because the integration tests spawn the
-    # tray exe out-of-process; coverlet only instruments the in-proc test
-    # assembly. Installing once at the job level lets every test step wrap its
-    # `dotnet test` invocation in `dotnet-coverage collect`.
     - name: Install dotnet-coverage
+      if: ${{ github.event_name != 'pull_request' }}
       run: dotnet tool install --global dotnet-coverage
 
     - name: Build Shared Library
@@ -150,71 +175,44 @@ jobs:
       env:
         OPENCLAW_RUN_INTEGRATION: 1
       run: >
-        dotnet-coverage collect
-        --output TestResults\Shared\coverage.cobertura.xml
-        --output-format cobertura
-        "dotnet test tests/OpenClaw.Shared.Tests
-        --no-build
-        -c Debug
-        --verbosity normal
-        --results-directory TestResults\Shared
-        --logger trx;LogFileName=OpenClaw.Shared.Tests.trx"
+        ./scripts/Invoke-CiTest.ps1
+        -Project tests/OpenClaw.Shared.Tests
+        -ResultsDirectory TestResults\Shared
+        -TrxFileName OpenClaw.Shared.Tests.trx
 
     - name: Run Tray Tests
       run: >
-        dotnet-coverage collect
-        --output TestResults\Tray\coverage.cobertura.xml
-        --output-format cobertura
-        "dotnet test tests/OpenClaw.Tray.Tests
-        --no-build
-        -c Debug
-        -r win-x64
-        --verbosity normal
-        --results-directory TestResults\Tray
-        --logger trx;LogFileName=OpenClaw.Tray.Tests.trx"
+        ./scripts/Invoke-CiTest.ps1
+        -Project tests/OpenClaw.Tray.Tests
+        -ResultsDirectory TestResults\Tray
+        -TrxFileName OpenClaw.Tray.Tests.trx
+        -Runtime win-x64
 
     - name: Run Connection Tests
       run: >
-        dotnet-coverage collect
-        --output TestResults\Connection\coverage.cobertura.xml
-        --output-format cobertura
-        "dotnet test tests/OpenClaw.Connection.Tests
-        --no-build
-        -c Debug
-        --verbosity normal
-        --results-directory TestResults\Connection
-        --logger trx;LogFileName=OpenClaw.Connection.Tests.trx"
+        ./scripts/Invoke-CiTest.ps1
+        -Project tests/OpenClaw.Connection.Tests
+        -ResultsDirectory TestResults\Connection
+        -TrxFileName OpenClaw.Connection.Tests.trx
 
     - name: Run WinNode CLI Tests
       run: >
-        dotnet-coverage collect
-        --output TestResults\WinNodeCli\coverage.cobertura.xml
-        --output-format cobertura
-        "dotnet test tests/OpenClaw.WinNode.Cli.Tests
-        --no-build
-        -c Debug
-        --verbosity normal
-        --results-directory TestResults\WinNodeCli
-        --logger trx;LogFileName=OpenClaw.WinNode.Cli.Tests.trx"
+        ./scripts/Invoke-CiTest.ps1
+        -Project tests/OpenClaw.WinNode.Cli.Tests
+        -ResultsDirectory TestResults\WinNodeCli
+        -TrxFileName OpenClaw.WinNode.Cli.Tests.trx
 
     # Tray integration tests gate on OPENCLAW_RUN_INTEGRATION; set it so the
-    # MCP-server / capability tests actually run. dotnet-coverage with no
-    # filter captures coverage for both the test host AND the spawned tray
-    # exe (coverlet could not — see tests/Directory.Build.props comment).
+    # MCP-server and capability tests actually run.
     - name: Run Tray Integration Tests
       env:
         OPENCLAW_RUN_INTEGRATION: 1
       run: >
-        dotnet-coverage collect
-        --output TestResults\TrayIntegration\coverage.cobertura.xml
-        --output-format cobertura
-        "dotnet test tests/OpenClaw.Tray.IntegrationTests
-        --no-build
-        -c Debug
-        -r win-x64
-        --verbosity normal
-        --results-directory TestResults\TrayIntegration
-        --logger trx;LogFileName=OpenClaw.Tray.IntegrationTests.trx"
+        ./scripts/Invoke-CiTest.ps1
+        -Project tests/OpenClaw.Tray.IntegrationTests
+        -ResultsDirectory TestResults\TrayIntegration
+        -TrxFileName OpenClaw.Tray.IntegrationTests.trx
+        -Runtime win-x64
 
     # UI tests need a real visual tree AND a system-registered WindowsAppRuntime
     # framework MSIX. The hosted windows-2025 runner image doesn't preinstall it,
@@ -243,43 +241,28 @@ jobs:
 
     - name: Run Functional UI Tests
       run: >
-        dotnet-coverage collect
-        --output TestResults\FunctionalUI\coverage.cobertura.xml
-        --output-format cobertura
-        "dotnet test tests/OpenClawTray.FunctionalUI.Tests
-        --no-build
-        -c Debug
-        -r win-x64
-        --verbosity normal
-        --results-directory TestResults\FunctionalUI
-        --logger trx;LogFileName=OpenClawTray.FunctionalUI.Tests.trx"
+        ./scripts/Invoke-CiTest.ps1
+        -Project tests/OpenClawTray.FunctionalUI.Tests
+        -ResultsDirectory TestResults\FunctionalUI
+        -TrxFileName OpenClawTray.FunctionalUI.Tests.trx
+        -Runtime win-x64
 
     - name: Run SetupEngine Tests
       run: >
-        dotnet-coverage collect
-        --output TestResults\SetupEngine\coverage.cobertura.xml
-        --output-format cobertura
-        "dotnet test tests/OpenClaw.SetupEngine.Tests
-        --no-build
-        -c Debug
-        -r win-x64
-        --verbosity normal
-        --results-directory TestResults\SetupEngine
-        --logger trx;LogFileName=OpenClaw.SetupEngine.Tests.trx"
+        ./scripts/Invoke-CiTest.ps1
+        -Project tests/OpenClaw.SetupEngine.Tests
+        -ResultsDirectory TestResults\SetupEngine
+        -TrxFileName OpenClaw.SetupEngine.Tests.trx
+        -Runtime win-x64
 
     - name: Run Tray UI Tests
       run: >
-        dotnet-coverage collect
-        --output TestResults\TrayUI\coverage.cobertura.xml
-        --output-format cobertura
-        "dotnet test tests/OpenClaw.Tray.UITests
-        --no-build
-        -c Debug
-        -r win-x64
-        --verbosity normal
-        --results-directory TestResults\TrayUI
-        --logger trx;LogFileName=OpenClaw.Tray.UITests.trx
-        --filter Category!=Accessibility"
+        ./scripts/Invoke-CiTest.ps1
+        -Project tests/OpenClaw.Tray.UITests
+        -ResultsDirectory TestResults\TrayUI
+        -TrxFileName OpenClaw.Tray.UITests.trx
+        -Runtime win-x64
+        -Filter Category!=Accessibility
 
     # Accessibility Insights CI pass: scans each page in the real app process.
     - name: Run Accessibility Tests (Axe.Windows)
@@ -514,9 +497,6 @@ jobs:
 
     - name: Restore WinUI Tray App
       run: dotnet restore src/OpenClaw.Tray.WinUI -r ${{ matrix.rid }}
-
-    - name: Build WinUI Tray App (Release)
-      run: dotnet build src/OpenClaw.Tray.WinUI --no-restore -c Release -r ${{ matrix.rid }} -p:Version=$env:OPENCLAW_BUILD_VERSION -p:InformationalVersion=$env:OPENCLAW_BUILD_VERSION
 
     - name: Publish WinUI Tray App
       run: dotnet publish src/OpenClaw.Tray.WinUI -c Release -r ${{ matrix.rid }} --self-contained --no-restore -o publish -p:Version=$env:OPENCLAW_BUILD_VERSION -p:InformationalVersion=$env:OPENCLAW_BUILD_VERSION

--- a/scripts/Get-CiProofPoolRegressionDecision.ps1
+++ b/scripts/Get-CiProofPoolRegressionDecision.ps1
@@ -1,0 +1,81 @@
+<#
+.SYNOPSIS
+    Selects whether CI should run the full proof-pool regression matrix.
+#>
+
+[CmdletBinding()]
+param(
+    [string]$EventName = $env:GITHUB_EVENT_NAME,
+    [string]$BaseSha,
+    [string]$HeadSha = $env:GITHUB_SHA,
+    [string]$RepoRoot
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+if ([string]::IsNullOrWhiteSpace($RepoRoot)) {
+    $RepoRoot = Split-Path -Parent $scriptRoot
+}
+$repoRootPath = [System.IO.Path]::GetFullPath($RepoRoot)
+
+function Complete-Decision([bool]$ShouldRun) {
+    $global:LASTEXITCODE = 0
+    $ShouldRun.ToString().ToLowerInvariant()
+}
+
+if ($EventName -ne "pull_request") {
+    Complete-Decision $true
+    return
+}
+
+if ([string]::IsNullOrWhiteSpace($BaseSha) -or
+    [string]::IsNullOrWhiteSpace($HeadSha)) {
+    Write-Warning "Proof-pool diff inputs are incomplete. Running the regression fail-closed."
+    Complete-Decision $true
+    return
+}
+
+$triggerPaths = [System.Collections.Generic.HashSet[string]]::new(
+    [System.StringComparer]::OrdinalIgnoreCase)
+@(
+    ".github/proof-pools.json",
+    ".github/proof-pools.schema.json",
+    "scripts/validate-proof-pools.ps1",
+    "scripts/test-proof-pool-validator.ps1",
+    "scripts/test-validate-docs-proof-pool-flow.ps1",
+    "scripts/validate-docs.ps1",
+    "scripts/Get-CiProofPoolRegressionDecision.ps1",
+    "scripts/test-ci-workflow-contract.ps1"
+) | ForEach-Object { [void]$triggerPaths.Add($_) }
+
+try {
+    $diffOutput = @(
+        & git -C $repoRootPath diff --name-only --no-renames "$BaseSha...$HeadSha" 2>&1
+    )
+    $gitExitCode = $LASTEXITCODE
+    $global:LASTEXITCODE = 0
+} catch {
+    Write-Warning "Proof-pool diff failed. Running the regression fail-closed: $($_.Exception.Message)"
+    Complete-Decision $true
+    return
+}
+
+if ($gitExitCode -ne 0) {
+    $detail = ($diffOutput | Out-String).Trim()
+    Write-Warning "Proof-pool diff exited with code $gitExitCode. Running the regression fail-closed: $detail"
+    Complete-Decision $true
+    return
+}
+
+$shouldRun = $false
+foreach ($changedPath in $diffOutput) {
+    $normalizedPath = ([string]$changedPath).Trim().Replace("\", "/")
+    if ($triggerPaths.Contains($normalizedPath)) {
+        $shouldRun = $true
+        break
+    }
+}
+
+Complete-Decision $shouldRun

--- a/scripts/Invoke-CiTest.ps1
+++ b/scripts/Invoke-CiTest.ps1
@@ -1,0 +1,59 @@
+<#
+.SYNOPSIS
+    Runs a CI test project with optional push/tag coverage collection.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$Project,
+    [Parameter(Mandatory)][string]$ResultsDirectory,
+    [Parameter(Mandatory)][string]$TrxFileName,
+    [string]$Runtime,
+    [string]$Filter
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$testArguments = [System.Collections.Generic.List[string]]::new()
+@(
+    "test",
+    $Project,
+    "--no-build",
+    "-c",
+    "Debug"
+) | ForEach-Object { $testArguments.Add($_) }
+
+if (-not [string]::IsNullOrWhiteSpace($Runtime)) {
+    $testArguments.Add("-r")
+    $testArguments.Add($Runtime)
+}
+
+@(
+    "--verbosity",
+    "normal",
+    "--results-directory",
+    $ResultsDirectory,
+    "--logger",
+    "trx;LogFileName=$TrxFileName"
+) | ForEach-Object { $testArguments.Add($_) }
+
+if (-not [string]::IsNullOrWhiteSpace($Filter)) {
+    $testArguments.Add("--filter")
+    $testArguments.Add($Filter)
+}
+
+$collectCoverage = $env:OPENCLAW_CI_COLLECT_COVERAGE -eq "true"
+if ($collectCoverage) {
+    $coverageOutput = Join-Path $ResultsDirectory "coverage.cobertura.xml"
+    & dotnet-coverage collect `
+        --output $coverageOutput `
+        --output-format cobertura `
+        dotnet @testArguments
+} else {
+    & dotnet @testArguments
+}
+
+if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+}

--- a/scripts/test-ci-workflow-contract.ps1
+++ b/scripts/test-ci-workflow-contract.ps1
@@ -1,0 +1,194 @@
+<#
+.SYNOPSIS
+    Validates CI quick-win workflow and proof-regression routing contracts.
+#>
+
+[CmdletBinding()]
+param(
+    [string]$RepoRoot
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+if ([string]::IsNullOrWhiteSpace($RepoRoot)) {
+    $RepoRoot = Split-Path -Parent $scriptRoot
+}
+$repoRootPath = [System.IO.Path]::GetFullPath($RepoRoot)
+$workflowPath = Join-Path $repoRootPath ".github\workflows\ci.yml"
+$selectorPath = Join-Path $repoRootPath "scripts\Get-CiProofPoolRegressionDecision.ps1"
+$runnerPath = Join-Path $repoRootPath "scripts\Invoke-CiTest.ps1"
+$workflow = Get-Content -LiteralPath $workflowPath -Raw
+$runner = Get-Content -LiteralPath $runnerPath -Raw
+
+function Assert-Contains {
+    param(
+        [Parameter(Mandatory)][string]$Text,
+        [Parameter(Mandatory)][string]$Expected,
+        [Parameter(Mandatory)][string]$Message
+    )
+
+    if (-not $Text.Contains($Expected, [StringComparison]::Ordinal)) {
+        throw $Message
+    }
+}
+
+Assert-Contains `
+    -Text $workflow `
+    -Expected "group: `${{ github.workflow }}-`${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('{0}-{1}', github.ref, github.sha) }}" `
+    -Message "CI concurrency must group PR runs by PR number and push/tag runs by ref and SHA."
+Assert-Contains `
+    -Text $workflow `
+    -Expected "cancel-in-progress: `${{ github.event_name == 'pull_request' }}" `
+    -Message "CI cancellation must apply only to pull_request runs."
+Assert-Contains `
+    -Text $workflow `
+    -Expected "steps.proof_pool_regression.outcome != 'success' || steps.proof_pool_regression.outputs.run != 'false'" `
+    -Message "Proof-pool regression routing must run when diff selection fails or does not explicitly return false."
+Assert-Contains `
+    -Text $workflow `
+    -Expected "if: `${{ github.event_name != 'pull_request' }}" `
+    -Message "dotnet-coverage installation must be limited to push and tag runs."
+Assert-Contains `
+    -Text $workflow `
+    -Expected "OPENCLAW_CI_COLLECT_COVERAGE: `${{ github.event_name != 'pull_request' }}" `
+    -Message "Test coverage must be disabled only for pull_request runs."
+
+$runnerUses = [regex]::Matches(
+    $workflow,
+    "(?m)^\s+\./scripts/Invoke-CiTest\.ps1\s*$").Count
+if ($runnerUses -ne 8) {
+    throw "Expected 8 CI test steps to use Invoke-CiTest.ps1, found $runnerUses."
+}
+if ($workflow -match "(?m)^\s+dotnet-coverage collect\s*$") {
+    throw "Workflow test steps must not invoke dotnet-coverage directly."
+}
+
+foreach ($requiredRunnerToken in @(
+    '"--logger"',
+    '"trx;LogFileName=$TrxFileName"',
+    'dotnet-coverage collect',
+    '--output-format cobertura',
+    '& dotnet @testArguments'
+)) {
+    Assert-Contains `
+        -Text $runner `
+        -Expected $requiredRunnerToken `
+        -Message "CI test runner is missing required token '$requiredRunnerToken'."
+}
+
+$buildJobStart = $workflow.IndexOf("  build:", [StringComparison]::Ordinal)
+$buildMsixStart = $workflow.IndexOf("  build-msix:", [StringComparison]::Ordinal)
+if ($buildJobStart -lt 0 -or $buildMsixStart -le $buildJobStart) {
+    throw "Could not isolate the Release build job."
+}
+$buildJob = $workflow.Substring($buildJobStart, $buildMsixStart - $buildJobStart)
+if ($buildJob.Contains("Build WinUI Tray App (Release)", [StringComparison]::Ordinal)) {
+    throw "Release packaging must not compile once before dotnet publish compiles the payload."
+}
+foreach ($publishToken in @(
+    "dotnet publish src/OpenClaw.Tray.WinUI",
+    "--self-contained",
+    "--no-restore",
+    "-p:Version=`$env:OPENCLAW_BUILD_VERSION",
+    "-p:InformationalVersion=`$env:OPENCLAW_BUILD_VERSION",
+    "Test-ReleaseNativeDependencies.ps1 -PayloadPath publish"
+)) {
+    Assert-Contains `
+        -Text $buildJob `
+        -Expected $publishToken `
+        -Message "Release publish contract is missing '$publishToken'."
+}
+
+$triggerPaths = @(
+    ".github/proof-pools.json",
+    ".github/proof-pools.schema.json",
+    "scripts/validate-proof-pools.ps1",
+    "scripts/test-proof-pool-validator.ps1",
+    "scripts/test-validate-docs-proof-pool-flow.ps1",
+    "scripts/validate-docs.ps1",
+    "scripts/Get-CiProofPoolRegressionDecision.ps1",
+    "scripts/test-ci-workflow-contract.ps1"
+)
+
+$tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) (
+    "openclaw-ci-contract-" + [guid]::NewGuid().ToString("N"))
+try {
+    New-Item -ItemType Directory -Path $tempRoot | Out-Null
+    & git -C $tempRoot init --quiet
+    if ($LASTEXITCODE -ne 0) {
+        throw "Could not initialize temporary git repository."
+    }
+    & git -C $tempRoot config user.email "ci-contract@example.invalid"
+    & git -C $tempRoot config user.name "CI Contract"
+
+    foreach ($triggerPath in $triggerPaths) {
+        $fullPath = Join-Path $tempRoot ($triggerPath.Replace("/", "\"))
+        New-Item -ItemType Directory -Path (Split-Path -Parent $fullPath) -Force | Out-Null
+        Set-Content -LiteralPath $fullPath -Value "baseline"
+    }
+    $unrelatedPath = Join-Path $tempRoot "docs\unrelated.md"
+    New-Item -ItemType Directory -Path (Split-Path -Parent $unrelatedPath) -Force | Out-Null
+    Set-Content -LiteralPath $unrelatedPath -Value "baseline"
+
+    & git -C $tempRoot add .
+    & git -C $tempRoot commit --quiet -m "baseline"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Could not commit temporary baseline."
+    }
+
+    foreach ($triggerPath in $triggerPaths) {
+        $baseSha = (& git -C $tempRoot rev-parse HEAD).Trim()
+        Add-Content `
+            -LiteralPath (Join-Path $tempRoot ($triggerPath.Replace("/", "\"))) `
+            -Value "changed"
+        & git -C $tempRoot add .
+        & git -C $tempRoot commit --quiet -m "change $triggerPath"
+        $headSha = (& git -C $tempRoot rev-parse HEAD).Trim()
+        $decision = & $selectorPath `
+            -EventName pull_request `
+            -BaseSha $baseSha `
+            -HeadSha $headSha `
+            -RepoRoot $tempRoot
+        if ($decision -ne "true") {
+            throw "Proof-pool trigger '$triggerPath' produced decision '$decision'."
+        }
+    }
+
+    $baseSha = (& git -C $tempRoot rev-parse HEAD).Trim()
+    Add-Content -LiteralPath $unrelatedPath -Value "changed"
+    & git -C $tempRoot add .
+    & git -C $tempRoot commit --quiet -m "unrelated change"
+    $headSha = (& git -C $tempRoot rev-parse HEAD).Trim()
+    $unrelatedDecision = & $selectorPath `
+        -EventName pull_request `
+        -BaseSha $baseSha `
+        -HeadSha $headSha `
+        -RepoRoot $tempRoot
+    if ($unrelatedDecision -ne "false") {
+        throw "Unrelated PR change produced decision '$unrelatedDecision'."
+    }
+
+    $missingDiffDecision = & $selectorPath `
+        -EventName pull_request `
+        -BaseSha "missing-base" `
+        -HeadSha $headSha `
+        -RepoRoot $tempRoot
+    if ($missingDiffDecision -ne "true") {
+        throw "Undetermined PR diff must run the regression fail-closed."
+    }
+
+    $pushDecision = & $selectorPath `
+        -EventName push `
+        -RepoRoot $tempRoot
+    if ($pushDecision -ne "true") {
+        throw "Push and tag workflow runs must run the proof-pool regression."
+    }
+} finally {
+    if (Test-Path -LiteralPath $tempRoot) {
+        Remove-Item -LiteralPath $tempRoot -Recurse -Force
+    }
+}
+
+Write-Host "CI workflow contracts passed: PR cancellation, fail-closed proof routing, conditional coverage, TRX logging, and single-pass Release publish." -ForegroundColor Green


### PR DESCRIPTION
## Summary

- Cancel superseded `pull_request` workflow runs while keeping main and tag runs non-cancelling with ref/SHA-specific groups.
- Run the 75-case proof-pool validator regression on main/tags and only on PRs that touch proof-pool contracts or validator implementation. Diff failures run the regression fail-closed.
- Run PR tests directly while retaining `dotnet-coverage` and Cobertura output on pushes/tags. All test paths continue to emit TRX.
- Remove the redundant Release `dotnet build`; the self-contained, versioned `dotnet publish` remains the single packaging compilation and retains native-payload validation.

## Required proof pools

`none`: this changes CI orchestration only. It does not change installer behavior, Windows node behavior, MXC, gateway flows, ARM64 runtime behavior, or WinUI UX.

## Validation

- `$env:OPENCLAW_REPO_ROOT=(Get-Location).Path; .\build.ps1` passed: Shared, CLI, WinNode CLI, SetupEngine, and WinUI built; documentation validation checked 48 Markdown files.
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore` passed: 3,905 passed, 32 skipped, 0 failed.
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore` passed: 2,833 passed, 0 skipped, 0 failed.
- `.\scripts\test-ci-workflow-contract.ps1` passed: required trigger paths, unrelated PR skip, invalid-revision fail-closed behavior, push behavior, PR-only cancellation, coverage routing, TRX retention, and single-pass Release publish.
- `actionlint -ignore 'constant expression "false"' .github\workflows\ci.yml` passed. The ignored diagnostic is the pre-existing intentional paused MSIX job.
- Rubber-duck review completed with no required findings.

The fresh worktree initially required restoring test assets before `--no-restore` could execute. One Tray lifecycle timing test failed once during an intermediate run, passed immediately in isolation, and the full required build plus both suites then passed cleanly as reported above.

## Real behavior proof

- PR-mode `Invoke-CiTest.ps1` ran one real Shared test and produced `pr.trx` with no coverage file.
- Push/tag-mode `Invoke-CiTest.ps1` ran the same real test and produced both `coverage.trx` and `coverage.cobertura.xml`.
- The proof-pool regression completed all 75 invalid-contract cases across 3 validation modes and took 317.16 seconds locally. Unrelated PRs now avoid that measured 5 minute 17 second cost.
- The Release matrix removes 2 redundant standalone compile invocations, one each for `win-x64` and `win-arm64`; publish output checks remain unchanged.
- PRs avoid 8 `dotnet-coverage` wrappers plus the tool installation. Main and tag runs retain all 8 coverage outputs.

## Expected effect

Unrelated PRs should save approximately 5 minutes 17 seconds from proof-regression execution on a comparable host, plus coverage instrumentation overhead across 8 test suites. Superseded commits stop consuming the full workflow. Release packaging performs one compilation per RID instead of two.

## Rollback boundary

Reverting this commit restores the previous workflow behavior in one change. The selector and test runner are CI-only scripts with no product runtime dependency or persisted data migration.