### PR TITLE
ci: add fail-closed docs and skill fast path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,40 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  repo-hygiene:
+  change-classification:
     runs-on: ubuntu-latest
+    outputs:
+      classification: ${{ steps.classify.outputs.classification }}
+      full: ${{ steps.classify.outputs.full }}
     steps:
     - uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+
+    - name: Classify changed paths
+      id: classify
+      shell: pwsh
+      env:
+        PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      run: |
+        $classification = ./scripts/Get-CiChangeClassification.ps1 `
+          -EventName $env:GITHUB_EVENT_NAME `
+          -BaseSha $env:PR_BASE_SHA `
+          -HeadSha $env:PR_HEAD_SHA
+        if ($classification -notin @("docs_only", "full")) {
+          throw "Unexpected CI change classification '$classification'."
+        }
+        "classification=$classification" >> $env:GITHUB_OUTPUT
+        "full=$(($classification -eq 'full').ToString().ToLowerInvariant())" >> $env:GITHUB_OUTPUT
+        "CI change classification: $classification" >> $env:GITHUB_STEP_SUMMARY
+
+  fast-validation:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
 
     - name: Ensure .squad stays untracked
       shell: bash
@@ -33,20 +63,41 @@ jobs:
     - name: Test repository triage automation
       run: node --test .github/scripts/repository-triage.test.cjs
 
+    - name: Validate documentation
+      shell: pwsh
+      run: ./scripts/validate-docs.ps1
+
+    - name: Validate agent skills
+      shell: pwsh
+      run: ./scripts/validate-agent-skills.ps1
+
+    - name: Test agent skill validator
+      shell: pwsh
+      run: ./scripts/test-agent-skills-validator.ps1
+
+    - name: Validate CI change classifier
+      shell: pwsh
+      run: ./scripts/test-ci-change-classifier.ps1
+
+    - name: Validate CI Gate result contracts
+      shell: pwsh
+      run: ./scripts/test-ci-gate-results.ps1
+
+    - name: Validate CI workflow contracts
+      shell: pwsh
+      run: ./scripts/test-ci-workflow-contract.ps1
+
+    - name: Validate stable correction release ordering regressions
+      shell: pwsh
+      run: ./scripts/test-stable-correction-release-validator.ps1
+
   test:
-    needs: repo-hygiene
-    if: ${{ !cancelled() }}
+    needs: [change-classification, fast-validation]
+    if: ${{ !cancelled() && needs.change-classification.result == 'success' && needs.fast-validation.result == 'success' && needs.change-classification.outputs.full == 'true' }}
     runs-on: windows-latest
     env:
       OPENCLAW_CI_COLLECT_COVERAGE: ${{ github.event_name != 'pull_request' }}
     steps:
-    - name: Fail if repo hygiene failed
-      if: ${{ needs.repo-hygiene.result != 'success' }}
-      shell: pwsh
-      run: |
-        Write-Error "repo-hygiene failed; see the repo-hygiene job output."
-        exit 1
-
     - uses: actions/checkout@v7
       with:
         fetch-depth: 0
@@ -113,10 +164,6 @@ jobs:
         "isPrerelease=$($isPrerelease.ToString().ToLowerInvariant())" >> $env:GITHUB_OUTPUT
         "isStableCorrection=$($isStableCorrection.ToString().ToLowerInvariant())" >> $env:GITHUB_OUTPUT
 
-    - name: Validate documentation
-      shell: pwsh
-      run: ./scripts/validate-docs.ps1
-
     - name: Select proof-pool regression scope
       id: proof_pool_regression
       continue-on-error: true
@@ -138,14 +185,6 @@ jobs:
       if: ${{ steps.proof_pool_regression.outcome != 'success' || steps.proof_pool_regression.outputs.run != 'false' }}
       shell: pwsh
       run: ./scripts/test-proof-pool-validator.ps1
-
-    - name: Validate CI workflow contracts
-      shell: pwsh
-      run: ./scripts/test-ci-workflow-contract.ps1
-
-    - name: Validate stable correction release ordering regressions
-      shell: pwsh
-      run: ./scripts/test-stable-correction-release-validator.ps1
 
     - name: Restore dependencies
       run: dotnet restore
@@ -326,8 +365,8 @@ jobs:
       isStableCorrection: ${{ steps.release_version.outputs.isStableCorrection }}
 
   e2etests:
-    needs: repo-hygiene
-    if: ${{ !cancelled() }}
+    needs: [change-classification, fast-validation]
+    if: ${{ !cancelled() && needs.change-classification.result == 'success' && needs.fast-validation.result == 'success' && needs.change-classification.outputs.full == 'true' }}
     runs-on: windows-latest
     timeout-minutes: ${{ matrix.timeout_minutes }}
     strategy:
@@ -344,13 +383,6 @@ jobs:
             timeout_minutes: 25
             filter: FullyQualifiedName~OpenClaw.E2ETests.Setup.NetworkRecoveryTests
     steps:
-    - name: Fail if repo hygiene failed
-      if: ${{ needs.repo-hygiene.result != 'success' }}
-      shell: pwsh
-      run: |
-        Write-Error "repo-hygiene failed; see the repo-hygiene job output."
-        exit 1
-
     - uses: actions/checkout@v7
       with:
         fetch-depth: 0
@@ -469,7 +501,8 @@ jobs:
         if-no-files-found: warn
 
   build:
-    needs: [test, e2etests]
+    needs: [change-classification, test, e2etests]
+    if: ${{ !cancelled() && needs.change-classification.outputs.full == 'true' && needs.test.result == 'success' && needs.e2etests.result == 'success' }}
     runs-on: ${{ matrix.rid == 'win-arm64' && 'windows-11-arm' || 'windows-latest' }}
     env:
       OPENCLAW_BUILD_VERSION: ${{ needs.test.outputs.semVer }}
@@ -630,9 +663,34 @@ jobs:
         name: openclaw-msix-${{ matrix.rid }}
         path: ${{ steps.find-msix.outputs.msix_path }}
 
+  ci-gate:
+    name: CI Gate
+    if: ${{ always() }}
+    needs: [change-classification, fast-validation, test, e2etests, build]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Enforce required CI results
+      shell: pwsh
+      env:
+        CLASSIFICATION_RESULT: ${{ needs.change-classification.result }}
+        CLASSIFICATION: ${{ needs.change-classification.outputs.classification }}
+        FAST_VALIDATION_RESULT: ${{ needs.fast-validation.result }}
+        TEST_RESULT: ${{ needs.test.result }}
+        E2E_RESULT: ${{ needs.e2etests.result }}
+        BUILD_RESULT: ${{ needs.build.result }}
+      run: |
+        $validatedMode = ./scripts/Assert-CiGateResults.ps1 `
+          -ClassificationResult $env:CLASSIFICATION_RESULT `
+          -Classification $env:CLASSIFICATION `
+          -FastValidationResult $env:FAST_VALIDATION_RESULT `
+          -TestResult $env:TEST_RESULT `
+          -E2eResult $env:E2E_RESULT `
+          -BuildResult $env:BUILD_RESULT
+        "CI Gate passed $validatedMode validation." >> $env:GITHUB_STEP_SUMMARY
+
   release:
-    needs: [repo-hygiene, test, e2etests, build]
-    if: startsWith(github.ref, 'refs/tags/v') && needs.repo-hygiene.result == 'success' && needs.test.result == 'success' && needs.e2etests.result == 'success' && needs.build.result == 'success' && !cancelled()
+    needs: [change-classification, fast-validation, test, e2etests, build, ci-gate]
+    if: startsWith(github.ref, 'refs/tags/v') && needs.ci-gate.result == 'success' && needs.change-classification.outputs.full == 'true' && needs.fast-validation.result == 'success' && needs.test.result == 'success' && needs.e2etests.result == 'success' && needs.build.result == 'success' && !cancelled()
     runs-on: windows-latest
     environment: release-signing
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -669,6 +669,8 @@ jobs:
     needs: [change-classification, fast-validation, test, e2etests, build]
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v7
+
     - name: Enforce required CI results
       shell: pwsh
       env:

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -224,10 +224,12 @@ release artifacts are created.
 
 For release tags, the **Build and Test** workflow should run:
 
-- `repo-hygiene`
+- `change-classification` with the `full` result
+- `fast-validation`
 - `test`
 - `e2etests` shards: `setup-connect`, `revocation-recovery`, and `network-recovery`
 - `build` matrix entries shown by GitHub as `build (win-x64)` and `build (win-arm64)`
+- `CI Gate`
 - `release`
 
 The `setup-connect` E2E shard contains the MXC proof tests for the gateway ->
@@ -235,7 +237,9 @@ Windows node -> `system.run` path and validates that the expected proof test
 names appear in the TRX output. GitHub-hosted runners may report those MXC
 proofs as skipped when the host is not MXC-capable; use
 `.\scripts\validate-mxc-e2e.ps1` for required local/self-hosted MXC merge
-validation. The `build-msix` job is disabled with `if: false` while MSIX
+validation. Release tags cannot enter the `release` job until **CI Gate**
+confirms classification, fast validation, tests, E2E, and release builds all
+succeeded. The `build-msix` job is disabled with `if: false` while MSIX
 distribution is paused, so it should not appear in the required run list.
 
 The release job should:

--- a/docs/TEST_COVERAGE.md
+++ b/docs/TEST_COVERAGE.md
@@ -76,7 +76,8 @@ required closeout lane for code changes.
 |---|---|---|
 | Required closeout | `.\build.ps1`, Shared tests, Tray tests | Every code change and every agent closeout |
 | Proof-pool inventory | `.\scripts\validate-proof-pools.ps1`, `.\scripts\test-proof-pool-validator.ps1`, and `.\scripts\test-validate-docs-proof-pool-flow.ps1` | Every inventory or proof scheduling change; the documentation gate runs core schema and parent-flow checks, while CI runs the full malformed-contract matrix |
-| GitHub-hosted PR/main CI | `.github\workflows\ci.yml` | Every pull request and push to `main`; runs normal E2E shards but skips MXC proofs on hosted runners |
+| Agent skills | `.\scripts\validate-agent-skills.ps1` and `.\scripts\test-agent-skills-validator.ps1` | Changes under `.agents\skills`; validates skill metadata, agent-facing prose, and local links |
+| GitHub-hosted PR/main CI | `.github\workflows\ci.yml` | Every pull request and push to `main`; docs-only PRs use the fast path, while all other PRs plus main and tag pushes run the full test, E2E, and release-build lanes |
 | Accessibility scan | `.\scripts\run-proof-tests.ps1 -Project 'tests\OpenClaw.Tray.UITests\OpenClaw.Tray.UITests.csproj' -Filter 'Category=Accessibility' -ResultName 'winui-accessibility' -RuntimeIdentifier win-x64` | UI changes and CI quality gate; runs real-process Axe.Windows scans; see `docs\ACCESSIBILITY.md` |
 | Local E2E | `OPENCLAW_RUN_E2E=1` with `OpenClaw.E2ETests` | Gateway setup/connect, recovery, or pairing changes that need real WSL Gateway coverage |
 | Local MXC E2E | `.\scripts\validate-mxc-e2e.ps1` | MXC sandboxing, `system.run`, exec approvals, Windows node command execution, gateway setup/connect changes that affect MXC |
@@ -88,6 +89,26 @@ Capacity-dependent Windows validation is named in
 [`PROOF_POOLS.md`](./PROOF_POOLS.md). Pull requests declare the exact pool IDs
 they need. A declaration does not claim that the pool ran, and unavailable
 proof must remain reported as blocked.
+
+### CI docs-only fast path
+
+The `change-classification` job selects `docs_only` only for pull requests where
+every changed path is explicitly allowlisted maintained documentation or
+non-executable `.agents\skills` content. Mixed changes, scripts, source, tests,
+workflow or build configuration, package manifests, installer files, unknown
+paths, empty diffs, invalid revisions, and diff failures select `full`.
+Pushes to `main` and release tags always select `full`.
+
+`fast-validation` runs for every workflow invocation. It owns repository
+hygiene, documentation validation, agent-skill validation, classifier
+regressions, and workflow contracts. The heavier malformed proof-contract
+matrix remains in the full Windows `test` lane under its existing conditional
+decision. For a docs-only pull request, the Windows `test`, E2E, and
+release-build matrices are skipped. The always-running **CI Gate** check
+accepts those skips only when the classification is `docs_only`; otherwise it
+requires every full lane to succeed. Classification or fast-validation
+failures always fail **CI Gate**. This stable check avoids required-check names
+disappearing when a pull request uses the fast path.
 
 ## Running tests
 

--- a/scripts/Assert-CiGateResults.ps1
+++ b/scripts/Assert-CiGateResults.ps1
@@ -1,0 +1,50 @@
+<#
+.SYNOPSIS
+    Enforces the stable CI Gate result contract.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$ClassificationResult,
+    [Parameter(Mandatory)][string]$Classification,
+    [Parameter(Mandatory)][string]$FastValidationResult,
+    [Parameter(Mandatory)][string]$TestResult,
+    [Parameter(Mandatory)][string]$E2eResult,
+    [Parameter(Mandatory)][string]$BuildResult
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+if ($ClassificationResult -ne "success") {
+    throw "Change classification did not succeed: $ClassificationResult"
+}
+if ($FastValidationResult -ne "success") {
+    throw "Fast validation did not succeed: $FastValidationResult"
+}
+
+$heavyResults = [ordered]@{
+    test = $TestResult
+    e2e = $E2eResult
+    build = $BuildResult
+}
+
+if ($Classification -eq "docs_only") {
+    foreach ($lane in $heavyResults.GetEnumerator()) {
+        if ($lane.Value -ne "skipped") {
+            throw "Docs-only CI expected $($lane.Key) to be skipped, but it was '$($lane.Value)'."
+        }
+    }
+    "docs_only"
+    return
+}
+
+if ($Classification -ne "full") {
+    throw "Unknown or missing change classification '$Classification'."
+}
+foreach ($lane in $heavyResults.GetEnumerator()) {
+    if ($lane.Value -ne "success") {
+        throw "Full CI requires $($lane.Key) to succeed, but it was '$($lane.Value)'."
+    }
+}
+"full"

--- a/scripts/Get-CiChangeClassification.ps1
+++ b/scripts/Get-CiChangeClassification.ps1
@@ -1,0 +1,149 @@
+<#
+.SYNOPSIS
+    Classifies a workflow change as docs_only or full.
+
+.DESCRIPTION
+    Pull requests use the docs-only fast path only when every changed path is
+    explicitly allowlisted. All non-PR events and every indeterminate diff
+    classify as full.
+#>
+
+[CmdletBinding()]
+param(
+    [string]$EventName = $env:GITHUB_EVENT_NAME,
+    [string]$BaseSha,
+    [string]$HeadSha = $env:GITHUB_SHA,
+    [string]$RepoRoot,
+    [string[]]$ChangedPaths
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+if ([string]::IsNullOrWhiteSpace($RepoRoot)) {
+    $RepoRoot = Split-Path -Parent $scriptRoot
+}
+$repoRootPath = [System.IO.Path]::GetFullPath($RepoRoot)
+
+function Complete-Classification([string]$Classification) {
+    $global:LASTEXITCODE = 0
+    $Classification
+}
+
+function Test-IsSafeDocumentationPath([string]$Path) {
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        return $false
+    }
+
+    $normalizedPath = $Path.Trim().Replace("\", "/")
+    if ($normalizedPath.StartsWith("/", [StringComparison]::Ordinal) -or
+        $normalizedPath.Contains("..", [StringComparison]::Ordinal) -or
+        $normalizedPath.Contains([char]0)) {
+        return $false
+    }
+
+    $rootMarkdown = [System.Collections.Generic.HashSet[string]]::new(
+        [System.StringComparer]::OrdinalIgnoreCase)
+    @(
+        "AGENTS.md",
+        "DEVELOPMENT.md",
+        "README.md",
+        "SECURITY.md",
+        ".github/pull_request_template.md"
+    ) | ForEach-Object { [void]$rootMarkdown.Add($_) }
+    if ($rootMarkdown.Contains($normalizedPath)) {
+        return $true
+    }
+
+    $extension = [System.IO.Path]::GetExtension($normalizedPath)
+    $safeDocumentationExtensions = [System.Collections.Generic.HashSet[string]]::new(
+        [System.StringComparer]::OrdinalIgnoreCase)
+    @(
+        ".md",
+        ".excalidraw",
+        ".svg",
+        ".png",
+        ".jpg",
+        ".jpeg",
+        ".gif",
+        ".webp"
+    ) | ForEach-Object { [void]$safeDocumentationExtensions.Add($_) }
+
+    if (-not $safeDocumentationExtensions.Contains($extension)) {
+        return $false
+    }
+
+    if ($normalizedPath.StartsWith("docs/", [StringComparison]::OrdinalIgnoreCase)) {
+        return $true
+    }
+
+    return $normalizedPath.StartsWith(
+        ".agents/skills/",
+        [StringComparison]::OrdinalIgnoreCase)
+}
+
+if ($EventName -ne "pull_request") {
+    Complete-Classification "full"
+    return
+}
+
+$paths = @()
+if ($PSBoundParameters.ContainsKey("ChangedPaths")) {
+    $paths = @($ChangedPaths)
+} else {
+    $shaPattern = "^[0-9a-fA-F]{40}$"
+    if ([string]::IsNullOrWhiteSpace($BaseSha) -or
+        [string]::IsNullOrWhiteSpace($HeadSha) -or
+        $BaseSha -notmatch $shaPattern -or
+        $HeadSha -notmatch $shaPattern) {
+        Write-Warning "CI diff revisions are missing or invalid. Selecting full validation."
+        Complete-Classification "full"
+        return
+    }
+
+    foreach ($sha in @($BaseSha, $HeadSha)) {
+        & git -C $repoRootPath cat-file -e "$sha^{commit}" 2>$null
+        if ($LASTEXITCODE -ne 0) {
+            $global:LASTEXITCODE = 0
+            Write-Warning "CI diff revision '$sha' is unavailable. Selecting full validation."
+            Complete-Classification "full"
+            return
+        }
+    }
+
+    try {
+        $diffOutput = @(
+            & git -C $repoRootPath diff --name-only --no-renames "$BaseSha...$HeadSha" -- 2>&1
+        )
+        $gitExitCode = $LASTEXITCODE
+        $global:LASTEXITCODE = 0
+    } catch {
+        Write-Warning "CI diff failed. Selecting full validation: $($_.Exception.Message)"
+        Complete-Classification "full"
+        return
+    }
+
+    if ($gitExitCode -ne 0) {
+        $detail = ($diffOutput | Out-String).Trim()
+        Write-Warning "CI diff exited with code $gitExitCode. Selecting full validation: $detail"
+        Complete-Classification "full"
+        return
+    }
+    $paths = @($diffOutput)
+}
+
+if ($paths.Count -eq 0) {
+    Write-Warning "CI diff contained no changed paths. Selecting full validation."
+    Complete-Classification "full"
+    return
+}
+
+foreach ($changedPath in $paths) {
+    if (-not (Test-IsSafeDocumentationPath ([string]$changedPath))) {
+        Complete-Classification "full"
+        return
+    }
+}
+
+Complete-Classification "docs_only"

--- a/scripts/Get-CiProofPoolRegressionDecision.ps1
+++ b/scripts/Get-CiProofPoolRegressionDecision.ps1
@@ -47,6 +47,12 @@ $triggerPaths = [System.Collections.Generic.HashSet[string]]::new(
     "scripts/test-validate-docs-proof-pool-flow.ps1",
     "scripts/validate-docs.ps1",
     "scripts/Get-CiProofPoolRegressionDecision.ps1",
+    "scripts/Get-CiChangeClassification.ps1",
+    "scripts/test-ci-change-classifier.ps1",
+    "scripts/Assert-CiGateResults.ps1",
+    "scripts/test-ci-gate-results.ps1",
+    "scripts/validate-agent-skills.ps1",
+    "scripts/test-agent-skills-validator.ps1",
     "scripts/test-ci-workflow-contract.ps1"
 ) | ForEach-Object { [void]$triggerPaths.Add($_) }
 

--- a/scripts/test-agent-skills-validator.ps1
+++ b/scripts/test-agent-skills-validator.ps1
@@ -89,3 +89,5 @@ See [reference](reference.md).
 }
 
 Write-Host "Agent skill validator regressions passed: valid metadata and broken name/link cases." -ForegroundColor Green
+$global:LASTEXITCODE = 0
+exit 0

--- a/scripts/test-agent-skills-validator.ps1
+++ b/scripts/test-agent-skills-validator.ps1
@@ -1,0 +1,91 @@
+<#
+.SYNOPSIS
+    Exercises agent skill validator regressions.
+#>
+
+[CmdletBinding()]
+param(
+    [string]$RepoRoot
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+if ([string]::IsNullOrWhiteSpace($RepoRoot)) {
+    $RepoRoot = Split-Path -Parent $scriptRoot
+}
+$repoRootPath = [System.IO.Path]::GetFullPath($RepoRoot)
+$validatorPath = Join-Path $repoRootPath "scripts\validate-agent-skills.ps1"
+$childPowerShell = (Get-Command pwsh -ErrorAction SilentlyContinue)
+if ($null -eq $childPowerShell) {
+    $childPowerShell = Get-Command powershell.exe -ErrorAction Stop
+}
+
+function Invoke-Validator([string]$Root) {
+    $previousErrorActionPreference = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = "Continue"
+        $output = (& $childPowerShell.Source `
+            -NoProfile `
+            -ExecutionPolicy Bypass `
+            -File $validatorPath `
+            -RepoRoot $Root 2>&1 | Out-String)
+        return @{
+            ExitCode = $LASTEXITCODE
+            Output = $output
+        }
+    } finally {
+        $ErrorActionPreference = $previousErrorActionPreference
+    }
+}
+
+$tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) (
+    "openclaw-skill-validator-" + [guid]::NewGuid().ToString("N"))
+try {
+    $skillRoot = Join-Path $tempRoot ".agents\skills\example"
+    New-Item -ItemType Directory -Path $skillRoot -Force | Out-Null
+    Set-Content -LiteralPath (Join-Path $skillRoot "reference.md") -Value "# Reference"
+    $skillPath = Join-Path $skillRoot "SKILL.md"
+    Set-Content -LiteralPath $skillPath -Value @"
+---
+name: example
+description: Example validator fixture.
+---
+
+# Example
+
+See [reference](reference.md).
+"@
+
+    $validResult = Invoke-Validator $tempRoot
+    if ($validResult.ExitCode -ne 0) {
+        throw "Valid skill fixture failed validation: $($validResult.Output)"
+    }
+
+    (Get-Content -LiteralPath $skillPath -Raw).Replace(
+        "name: example",
+        "name: wrong") | Set-Content -LiteralPath $skillPath
+    $nameResult = Invoke-Validator $tempRoot
+    if ($nameResult.ExitCode -eq 0 -or
+        $nameResult.Output -notmatch "must match the directory name") {
+        throw "Skill name mismatch was not rejected: $($nameResult.Output)"
+    }
+
+    (Get-Content -LiteralPath $skillPath -Raw).Replace(
+        "name: wrong",
+        "name: example").Replace(
+        "reference.md",
+        "missing.md") | Set-Content -LiteralPath $skillPath
+    $linkResult = Invoke-Validator $tempRoot
+    if ($linkResult.ExitCode -eq 0 -or
+        $linkResult.Output -notmatch "local link target does not exist") {
+        throw "Missing skill link was not rejected: $($linkResult.Output)"
+    }
+} finally {
+    if (Test-Path -LiteralPath $tempRoot) {
+        Remove-Item -LiteralPath $tempRoot -Recurse -Force
+    }
+}
+
+Write-Host "Agent skill validator regressions passed: valid metadata and broken name/link cases." -ForegroundColor Green

--- a/scripts/test-ci-change-classifier.ps1
+++ b/scripts/test-ci-change-classifier.ps1
@@ -1,0 +1,145 @@
+<#
+.SYNOPSIS
+    Exercises the fail-closed CI change classifier.
+#>
+
+[CmdletBinding()]
+param(
+    [string]$RepoRoot
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+if ([string]::IsNullOrWhiteSpace($RepoRoot)) {
+    $RepoRoot = Split-Path -Parent $scriptRoot
+}
+$repoRootPath = [System.IO.Path]::GetFullPath($RepoRoot)
+$classifierPath = Join-Path $repoRootPath "scripts\Get-CiChangeClassification.ps1"
+
+function Assert-Classification {
+    param(
+        [Parameter(Mandatory)][string]$Expected,
+        [Parameter(Mandatory)][string[]]$Paths,
+        [Parameter(Mandatory)][string]$Scenario
+    )
+
+    $actual = & $classifierPath `
+        -EventName pull_request `
+        -RepoRoot $repoRootPath `
+        -ChangedPaths $Paths
+    if ($actual -ne $Expected) {
+        throw "$Scenario classified as '$actual' instead of '$Expected'."
+    }
+}
+
+Assert-Classification `
+    -Expected docs_only `
+    -Paths @(".agents/skills/example/SKILL.md") `
+    -Scenario "Skill-only documentation"
+Assert-Classification `
+    -Expected docs_only `
+    -Paths @("README.md", "docs/TEST_COVERAGE.md", "docs/diagrams/ci.svg") `
+    -Scenario "Maintained documentation"
+Assert-Classification `
+    -Expected full `
+    -Paths @(".agents/skills/example/SKILL.md", "src/OpenClaw.Shared/Example.cs") `
+    -Scenario "Mixed skill and source change"
+
+$unsafePaths = @(
+    ".github/workflows/ci.yml",
+    ".github/dependabot.yml",
+    "scripts/validate-docs.ps1",
+    "Directory.Build.props",
+    "Directory.Build.targets",
+    "Directory.Packages.props",
+    "package.json",
+    "src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj",
+    "installer/OpenClaw.iss",
+    "src/OpenClaw.Shared/Example.cs",
+    "tests/OpenClaw.Shared.Tests/ExampleTests.cs",
+    ".agents/skills/example/scripts/run.ps1",
+    ".agents/skills/example/scripts/run",
+    "unknown/location/file.txt"
+)
+foreach ($unsafePath in $unsafePaths) {
+    Assert-Classification `
+        -Expected full `
+        -Paths @($unsafePath) `
+        -Scenario "Unsafe path '$unsafePath'"
+}
+
+$emptyDecision = & $classifierPath `
+    -EventName pull_request `
+    -RepoRoot $repoRootPath `
+    -ChangedPaths @()
+if ($emptyDecision -ne "full") {
+    throw "An empty explicit path list must classify as full."
+}
+
+$pushDecision = & $classifierPath `
+    -EventName push `
+    -RepoRoot $repoRootPath `
+    -ChangedPaths @(".agents/skills/example/SKILL.md")
+if ($pushDecision -ne "full") {
+    throw "Push and tag workflow invocations must classify as full."
+}
+
+$tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) (
+    "openclaw-change-classifier-" + [guid]::NewGuid().ToString("N"))
+try {
+    New-Item -ItemType Directory -Path $tempRoot | Out-Null
+    & git -C $tempRoot init --quiet
+    & git -C $tempRoot config user.email "ci-classifier@example.invalid"
+    & git -C $tempRoot config user.name "CI Classifier"
+
+    $skillPath = Join-Path $tempRoot ".agents\skills\example\SKILL.md"
+    New-Item -ItemType Directory -Path (Split-Path -Parent $skillPath) -Force | Out-Null
+    Set-Content -LiteralPath $skillPath -Value "baseline"
+    & git -C $tempRoot add .
+    & git -C $tempRoot commit --quiet -m "baseline"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Could not commit classifier test baseline."
+    }
+    $baseSha = (& git -C $tempRoot rev-parse HEAD).Trim()
+
+    Add-Content -LiteralPath $skillPath -Value "changed"
+    & git -C $tempRoot add .
+    & git -C $tempRoot commit --quiet -m "skill docs"
+    $headSha = (& git -C $tempRoot rev-parse HEAD).Trim()
+    $gitDecision = & $classifierPath `
+        -EventName pull_request `
+        -BaseSha $baseSha `
+        -HeadSha $headSha `
+        -RepoRoot $tempRoot
+    if ($gitDecision -ne "docs_only") {
+        throw "A real skill-only git diff classified as '$gitDecision'."
+    }
+
+    $emptyGitDecision = & $classifierPath `
+        -EventName pull_request `
+        -BaseSha $headSha `
+        -HeadSha $headSha `
+        -RepoRoot $tempRoot
+    if ($emptyGitDecision -ne "full") {
+        throw "An empty git diff must classify as full."
+    }
+
+    foreach ($invalidBase in @("", "missing-base", ("f" * 40))) {
+        $invalidDecision = & $classifierPath `
+            -EventName pull_request `
+            -BaseSha $invalidBase `
+            -HeadSha $headSha `
+            -RepoRoot $tempRoot
+        if ($invalidDecision -ne "full") {
+            throw "Invalid revision '$invalidBase' classified as '$invalidDecision'."
+        }
+    }
+} finally {
+    if (Test-Path -LiteralPath $tempRoot) {
+        Remove-Item -LiteralPath $tempRoot -Recurse -Force
+    }
+}
+
+Write-Host "CI change classifier regressions passed: safe docs fast-path and fail-closed full validation cases." -ForegroundColor Green

--- a/scripts/test-ci-gate-results.ps1
+++ b/scripts/test-ci-gate-results.ps1
@@ -1,0 +1,97 @@
+<#
+.SYNOPSIS
+    Exercises stable CI Gate pass, failure, cancellation, and skip contracts.
+#>
+
+[CmdletBinding()]
+param(
+    [string]$RepoRoot
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+if ([string]::IsNullOrWhiteSpace($RepoRoot)) {
+    $RepoRoot = Split-Path -Parent $scriptRoot
+}
+$gatePath = Join-Path $RepoRoot "scripts\Assert-CiGateResults.ps1"
+
+function Invoke-Gate {
+    param(
+        [string]$ClassificationResult = "success",
+        [string]$Classification = "full",
+        [string]$FastValidationResult = "success",
+        [string]$TestResult = "success",
+        [string]$E2eResult = "success",
+        [string]$BuildResult = "success"
+    )
+
+    & $gatePath `
+        -ClassificationResult $ClassificationResult `
+        -Classification $Classification `
+        -FastValidationResult $FastValidationResult `
+        -TestResult $TestResult `
+        -E2eResult $E2eResult `
+        -BuildResult $BuildResult
+}
+
+function Assert-GateFails {
+    param(
+        [Parameter(Mandatory)][hashtable]$Arguments,
+        [Parameter(Mandatory)][string]$Scenario
+    )
+
+    try {
+        $result = Invoke-Gate @Arguments
+        throw "$Scenario unexpectedly passed with result '$result'."
+    } catch {
+        if ($_.Exception.Message.StartsWith(
+                "$Scenario unexpectedly passed",
+                [StringComparison]::Ordinal)) {
+            throw
+        }
+    }
+}
+
+$docsOnly = Invoke-Gate `
+    -Classification docs_only `
+    -TestResult skipped `
+    -E2eResult skipped `
+    -BuildResult skipped
+if ($docsOnly -ne "docs_only") {
+    throw "Expected the docs-only gate to pass."
+}
+
+$full = Invoke-Gate
+if ($full -ne "full") {
+    throw "Expected the full gate to pass."
+}
+
+Assert-GateFails `
+    -Arguments @{ ClassificationResult = "failure" } `
+    -Scenario "Failed classification"
+Assert-GateFails `
+    -Arguments @{ FastValidationResult = "cancelled" } `
+    -Scenario "Cancelled fast validation"
+Assert-GateFails `
+    -Arguments @{
+        Classification = "docs_only"
+        TestResult = "success"
+        E2eResult = "skipped"
+        BuildResult = "skipped"
+    } `
+    -Scenario "Unskipped docs-only test lane"
+Assert-GateFails `
+    -Arguments @{ Classification = "unexpected" } `
+    -Scenario "Unknown classification"
+
+foreach ($lane in @("TestResult", "E2eResult", "BuildResult")) {
+    foreach ($result in @("failure", "cancelled", "skipped")) {
+        Assert-GateFails `
+            -Arguments @{ $lane = $result } `
+            -Scenario "Full $lane result '$result'"
+    }
+}
+
+Write-Host "CI Gate regressions passed: docs-only skips accepted, full successes accepted, and failures/cancellations/unexpected skips rejected." -ForegroundColor Green

--- a/scripts/test-ci-workflow-contract.ps1
+++ b/scripts/test-ci-workflow-contract.ps1
@@ -120,6 +120,7 @@ foreach ($token in @(
     "name: CI Gate",
     "if: `${{ always() }}",
     "needs: [change-classification, fast-validation, test, e2etests, build]",
+    "uses: actions/checkout@v7",
     "./scripts/Assert-CiGateResults.ps1",
     "-ClassificationResult `$env:CLASSIFICATION_RESULT",
     "-FastValidationResult `$env:FAST_VALIDATION_RESULT",

--- a/scripts/test-ci-workflow-contract.ps1
+++ b/scripts/test-ci-workflow-contract.ps1
@@ -34,6 +34,28 @@ function Assert-Contains {
     }
 }
 
+function Get-JobBlock {
+    param(
+        [Parameter(Mandatory)][string]$Name
+    )
+
+    $escapedName = [regex]::Escape($Name)
+    $startMatch = [regex]::Match($workflow, "(?m)^  ${escapedName}:\r?$")
+    if (-not $startMatch.Success) {
+        throw "Could not find CI job '$Name'."
+    }
+    $jobHeadingPattern = [regex]::new("(?m)^  [a-zA-Z0-9_-]+:\r?$")
+    $nextMatch = $jobHeadingPattern.Match(
+        $workflow,
+        $startMatch.Index + $startMatch.Length)
+    if (-not $nextMatch.Success) {
+        return $workflow.Substring($startMatch.Index)
+    }
+    return $workflow.Substring(
+        $startMatch.Index,
+        $nextMatch.Index - $startMatch.Index)
+}
+
 Assert-Contains `
     -Text $workflow `
     -Expected "group: `${{ github.workflow }}-`${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('{0}-{1}', github.ref, github.sha) }}" `
@@ -54,6 +76,84 @@ Assert-Contains `
     -Text $workflow `
     -Expected "OPENCLAW_CI_COLLECT_COVERAGE: `${{ github.event_name != 'pull_request' }}" `
     -Message "Test coverage must be disabled only for pull_request runs."
+
+$classificationJob = Get-JobBlock "change-classification"
+foreach ($token in @(
+    "fetch-depth: 0",
+    "./scripts/Get-CiChangeClassification.ps1",
+    "classification: `${{ steps.classify.outputs.classification }}",
+    "full: `${{ steps.classify.outputs.full }}"
+)) {
+    Assert-Contains `
+        -Text $classificationJob `
+        -Expected $token `
+        -Message "Change classification job is missing '$token'."
+}
+
+$fastValidationJob = Get-JobBlock "fast-validation"
+foreach ($token in @(
+    "Ensure .squad stays untracked",
+    "node --test .github/scripts/repository-triage.test.cjs",
+    "./scripts/validate-docs.ps1",
+    "./scripts/validate-agent-skills.ps1",
+    "./scripts/test-agent-skills-validator.ps1",
+    "./scripts/test-ci-change-classifier.ps1",
+    "./scripts/test-ci-gate-results.ps1",
+    "./scripts/test-ci-workflow-contract.ps1"
+)) {
+    Assert-Contains `
+        -Text $fastValidationJob `
+        -Expected $token `
+        -Message "Always-running fast validation job is missing '$token'."
+}
+
+foreach ($heavyJobName in @("test", "e2etests", "build")) {
+    $heavyJob = Get-JobBlock $heavyJobName
+    Assert-Contains `
+        -Text $heavyJob `
+        -Expected "needs.change-classification.outputs.full == 'true'" `
+        -Message "Heavy job '$heavyJobName' must run only for full validation."
+}
+
+$ciGateJob = Get-JobBlock "ci-gate"
+foreach ($token in @(
+    "name: CI Gate",
+    "if: `${{ always() }}",
+    "needs: [change-classification, fast-validation, test, e2etests, build]",
+    "./scripts/Assert-CiGateResults.ps1",
+    "-ClassificationResult `$env:CLASSIFICATION_RESULT",
+    "-FastValidationResult `$env:FAST_VALIDATION_RESULT",
+    "-TestResult `$env:TEST_RESULT",
+    "-E2eResult `$env:E2E_RESULT",
+    "-BuildResult `$env:BUILD_RESULT"
+)) {
+    Assert-Contains `
+        -Text $ciGateJob `
+        -Expected $token `
+        -Message "Stable CI Gate is missing '$token'."
+}
+
+$releaseJob = Get-JobBlock "release"
+Assert-Contains `
+    -Text $releaseJob `
+    -Expected "needs: [change-classification, fast-validation, test, e2etests, build, ci-gate]" `
+    -Message "Tag release must depend on the stable CI Gate."
+Assert-Contains `
+    -Text $releaseJob `
+    -Expected "needs.ci-gate.result == 'success'" `
+    -Message "Tag release must require the stable CI Gate to succeed."
+
+$testJob = Get-JobBlock "test"
+foreach ($token in @(
+    "./scripts/Get-CiProofPoolRegressionDecision.ps1",
+    "steps.proof_pool_regression.outcome != 'success' || steps.proof_pool_regression.outputs.run != 'false'",
+    "./scripts/test-proof-pool-validator.ps1"
+)) {
+    Assert-Contains `
+        -Text $testJob `
+        -Expected $token `
+        -Message "Full Windows test lane is missing conditional proof-pool regression token '$token'."
+}
 
 $runnerUses = [regex]::Matches(
     $workflow,
@@ -109,6 +209,12 @@ $triggerPaths = @(
     "scripts/test-validate-docs-proof-pool-flow.ps1",
     "scripts/validate-docs.ps1",
     "scripts/Get-CiProofPoolRegressionDecision.ps1",
+    "scripts/Get-CiChangeClassification.ps1",
+    "scripts/test-ci-change-classifier.ps1",
+    "scripts/Assert-CiGateResults.ps1",
+    "scripts/test-ci-gate-results.ps1",
+    "scripts/validate-agent-skills.ps1",
+    "scripts/test-agent-skills-validator.ps1",
     "scripts/test-ci-workflow-contract.ps1"
 )
 
@@ -191,4 +297,4 @@ try {
     }
 }
 
-Write-Host "CI workflow contracts passed: PR cancellation, fail-closed proof routing, conditional coverage, TRX logging, and single-pass Release publish." -ForegroundColor Green
+Write-Host "CI workflow contracts passed: PR cancellation, docs-only routing, stable gate enforcement, fail-closed proof routing, conditional coverage, TRX logging, and single-pass Release publish." -ForegroundColor Green

--- a/scripts/validate-agent-skills.ps1
+++ b/scripts/validate-agent-skills.ps1
@@ -1,0 +1,104 @@
+<#
+.SYNOPSIS
+    Validates repository-owned agent skill documentation.
+#>
+
+[CmdletBinding()]
+param(
+    [string]$RepoRoot
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+if ([string]::IsNullOrWhiteSpace($RepoRoot)) {
+    $RepoRoot = Split-Path -Parent $scriptRoot
+}
+$repoRootPath = [System.IO.Path]::GetFullPath($RepoRoot)
+$skillsRoot = Join-Path $repoRootPath ".agents\skills"
+$errors = [System.Collections.Generic.List[string]]::new()
+
+if (-not (Test-Path -LiteralPath $skillsRoot -PathType Container)) {
+    throw "Agent skills directory is missing: $skillsRoot"
+}
+
+$skillsRootPrefix = $skillsRoot.TrimEnd("\") + "\"
+$skillDirectories = @(Get-ChildItem -LiteralPath $skillsRoot -Directory)
+if ($skillDirectories.Count -eq 0) {
+    throw "Agent skills directory contains no skills."
+}
+
+foreach ($skillDirectory in $skillDirectories) {
+    $skillFile = Join-Path $skillDirectory.FullName "SKILL.md"
+    if (-not (Test-Path -LiteralPath $skillFile -PathType Leaf)) {
+        $errors.Add(".agents/skills/$($skillDirectory.Name): SKILL.md is required")
+        continue
+    }
+
+    $content = [System.IO.File]::ReadAllText($skillFile)
+    $frontMatter = [regex]::Match(
+        $content,
+        '\A---\r?\nname:\s*(?<name>[^\r\n]+)\r?\ndescription:\s*(?<description>[^\r\n]+)\r?\n---(?:\r?\n|\z)')
+    if (-not $frontMatter.Success) {
+        $errors.Add(".agents/skills/$($skillDirectory.Name)/SKILL.md: expected name and description YAML front matter")
+        continue
+    }
+
+    $name = $frontMatter.Groups["name"].Value.Trim().Trim('"', "'")
+    if ($name -cne $skillDirectory.Name) {
+        $errors.Add(".agents/skills/$($skillDirectory.Name)/SKILL.md: name '$name' must match the directory name")
+    }
+    $description = $frontMatter.Groups["description"].Value.Trim().Trim('"', "'")
+    if ([string]::IsNullOrWhiteSpace($description)) {
+        $errors.Add(".agents/skills/$($skillDirectory.Name)/SKILL.md: description must not be empty")
+    }
+}
+
+$linkPattern = [regex]'!?\[[^\]]*\]\((?<target><[^>]+>|[^)\s]+)(?:\s+["''][^)]*["''])?\)'
+$markdownFiles = @(Get-ChildItem -LiteralPath $skillsRoot -Filter "*.md" -Recurse -File)
+foreach ($markdownFile in $markdownFiles) {
+    $relativePath = $markdownFile.FullName.Substring($skillsRootPrefix.Length).Replace("\", "/")
+    $content = [System.IO.File]::ReadAllText($markdownFile.FullName)
+    if ($content.Contains([string][char]0x2014)) {
+        $errors.Add(".agents/skills/${relativePath}: agent-facing content must not use em dashes")
+    }
+
+    foreach ($match in $linkPattern.Matches($content)) {
+        $target = $match.Groups["target"].Value.Trim().Trim("<", ">")
+        if ([string]::IsNullOrWhiteSpace($target) -or
+            $target.StartsWith("#") -or
+            $target.StartsWith("/") -or
+            $target -match "^[a-z][a-z0-9+.-]*:" -or
+            $target.Contains("{") -or
+            $target.Contains("}")) {
+            continue
+        }
+
+        $targetWithoutFragment = $target.Split("#", 2)[0].Split("?", 2)[0]
+        if ([string]::IsNullOrWhiteSpace($targetWithoutFragment)) {
+            continue
+        }
+        $resolvedPath = [System.IO.Path]::GetFullPath(
+            (Join-Path $markdownFile.DirectoryName (
+                [System.Uri]::UnescapeDataString($targetWithoutFragment) -replace "/", "\")))
+        if (-not $resolvedPath.StartsWith(
+                $skillsRootPrefix,
+                [StringComparison]::OrdinalIgnoreCase)) {
+            $errors.Add(".agents/skills/${relativePath}: local link leaves the skills directory: $target")
+        } elseif (-not (Test-Path -LiteralPath $resolvedPath)) {
+            $errors.Add(".agents/skills/${relativePath}: local link target does not exist: $target")
+        }
+    }
+}
+
+if ($errors.Count -gt 0) {
+    Write-Host "`nAgent skill validation failed:" -ForegroundColor Red
+    foreach ($validationError in $errors) {
+        Write-Host "  - $validationError" -ForegroundColor Red
+    }
+    exit 1
+}
+
+Write-Host "Agent skill validation passed: $($skillDirectories.Count) skills and $($markdownFiles.Count) Markdown files checked." -ForegroundColor Green
+exit 0

--- a/tests/OpenClaw.Tray.Tests/ReleaseSigningWorkflowTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ReleaseSigningWorkflowTests.cs
@@ -120,7 +120,7 @@ public sealed class ReleaseSigningWorkflowTests
         var workflow = File.ReadAllText(Path.Combine(TestRepositoryPaths.GetRepositoryRoot(), ".github", "workflows", "ci.yml"));
 
         Assert.Contains("if: false # MSIX distribution is paused; ship Inno setup and portable ZIP artifacts only.", workflow);
-        Assert.Contains("needs: [repo-hygiene, test, e2etests, build]", workflow);
+        Assert.Contains("needs: [change-classification, fast-validation, test, e2etests, build, ci-gate]", workflow);
         Assert.DoesNotContain("Download win-x64 MSIX artifact", workflow);
         Assert.DoesNotContain("Download win-arm64 MSIX artifact", workflow);
         Assert.DoesNotContain("Sign Release MSIX Packages", workflow);


### PR DESCRIPTION
## Summary

- classify pull requests as `docs_only` only when every changed path is explicitly allowlisted maintained documentation or non-executable `.agents/skills` content
- run repository hygiene, documentation, agent-skill, classifier, gate, and workflow contract validation in a lightweight always-running lane
- skip Windows test, E2E, and release-build matrices only for docs-only PRs while preserving full validation for mixed/unknown changes, main pushes, and tags
- add the stable `CI Gate` check, which rejects classification/fast-validation failures and unexpected failed, cancelled, or skipped full lanes
- require tag releases to pass `CI Gate`

## Required proof pools

`none`: this changes CI orchestration and repository validation scripts only. It does not change product, Windows node, MCP, gateway, installer runtime, or UI behavior.

## Validation

- `$env:OPENCLAW_REPO_ROOT=(Get-Location).Path; .\build.ps1` - passed
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore` - passed: 3,905 passed, 32 skipped, 0 failed
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore` with isolated `OPENCLAW_TRAY_DATA_DIR` - passed: 2,833 passed, 0 skipped, 0 failed
- `.\scripts\test-ci-change-classifier.ps1` - passed
- `.\scripts\test-ci-gate-results.ps1` - passed
- `.\scripts\test-ci-workflow-contract.ps1` - passed
- `.\scripts\validate-agent-skills.ps1` - passed: 5 skills and 12 Markdown files
- `.\scripts\test-agent-skills-validator.ps1` - passed
- `.\scripts\test-proof-pool-validator.ps1` - passed: 75 invalid contracts rejected in 3 validation modes
- `actionlint .github/workflows/ci.yml` - no new findings; only the pre-existing intentional `build-msix` `if: false` diagnostic remains
- rubber-duck review - completed; moved `fast-validation` to Windows after identifying reused validators' Windows path assumptions, and added executable gate-result matrix tests

## Real behavior proof

- synthetic `.agents/skills/example/SKILL.md`-only input returns `docs_only`
- skill docs plus `src/OpenClaw.Shared/Example.cs` returns `full`
- workflow/build configuration, scripts, props/targets, package manifests, installer, source, test, extensionless skill script, and unknown paths return `full`
- empty diffs and invalid/missing revisions return `full`
- gate matrix accepts only intentional docs-only skips or all-success full lanes; it rejects classification/fast-validation failure, cancellation, full-lane failure, and unexpected skips
- this PR's own workflow/script change set returns `full`

## Expected docs-only target

The motivating target is a PR whose complete diff is non-executable content under `.agents/skills/**`, such as a global skill `SKILL.md` update. Maintained root/docs Markdown and documentation diagram assets are also allowlisted. Any mixed or unknown path falls back to full CI.

## Rollback boundary

Revert this PR to restore the previous always-full workflow. The classifier, fast-validation lane, and `CI Gate` are self-contained CI orchestration changes and do not alter product binaries or release artifacts.