### PR TITLE
ci: add code impact fast paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,14 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       classification: ${{ steps.classify.outputs.classification }}
+      core_tests: ${{ steps.classify.outputs.core_tests }}
+      tray_tests: ${{ steps.classify.outputs.tray_tests }}
+      ui_tests: ${{ steps.classify.outputs.ui_tests }}
+      setup_e2e: ${{ steps.classify.outputs.setup_e2e }}
+      revocation_e2e: ${{ steps.classify.outputs.revocation_e2e }}
+      network_e2e: ${{ steps.classify.outputs.network_e2e }}
+      x64_release: ${{ steps.classify.outputs.x64_release }}
+      arm64_release: ${{ steps.classify.outputs.arm64_release }}
       full: ${{ steps.classify.outputs.full }}
     steps:
     - uses: actions/checkout@v7
@@ -32,16 +40,30 @@ jobs:
         PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       run: |
-        $classification = ./scripts/Get-CiChangeClassification.ps1 `
+        $impactJson = ./scripts/Get-CiChangeClassification.ps1 `
           -EventName $env:GITHUB_EVENT_NAME `
           -BaseSha $env:PR_BASE_SHA `
           -HeadSha $env:PR_HEAD_SHA
-        if ($classification -notin @("docs_only", "full")) {
-          throw "Unexpected CI change classification '$classification'."
+        $impact = $impactJson | ConvertFrom-Json
+        if ($impact.classification -notin @("docs_only", "targeted", "full")) {
+          throw "Unexpected CI change classification '$($impact.classification)'."
         }
-        "classification=$classification" >> $env:GITHUB_OUTPUT
-        "full=$(($classification -eq 'full').ToString().ToLowerInvariant())" >> $env:GITHUB_OUTPUT
-        "CI change classification: $classification" >> $env:GITHUB_STEP_SUMMARY
+        "classification=$($impact.classification)" >> $env:GITHUB_OUTPUT
+        foreach ($lane in @(
+            "core_tests",
+            "tray_tests",
+            "ui_tests",
+            "setup_e2e",
+            "revocation_e2e",
+            "network_e2e",
+            "x64_release",
+            "arm64_release",
+            "full")) {
+          $value = ([bool]$impact.$lane).ToString().ToLowerInvariant()
+          "$lane=$value" >> $env:GITHUB_OUTPUT
+          "CI lane $lane`: $value" >> $env:GITHUB_STEP_SUMMARY
+        }
+        "CI change classification: $($impact.classification)" >> $env:GITHUB_STEP_SUMMARY
 
   fast-validation:
     runs-on: windows-latest
@@ -91,12 +113,46 @@ jobs:
       shell: pwsh
       run: ./scripts/test-stable-correction-release-validator.ps1
 
-  test:
-    needs: [change-classification, fast-validation]
-    if: ${{ !cancelled() && needs.change-classification.result == 'success' && needs.fast-validation.result == 'success' && needs.change-classification.outputs.full == 'true' }}
+  proof-pool-contracts:
+    name: Proof-pool contracts
     runs-on: windows-latest
-    env:
-      OPENCLAW_CI_COLLECT_COVERAGE: ${{ github.event_name != 'pull_request' }}
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+
+    - name: Select proof-pool regression scope
+      id: proof_pool_regression
+      continue-on-error: true
+      shell: pwsh
+      env:
+        PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      run: |
+        $decision = ./scripts/Get-CiProofPoolRegressionDecision.ps1 `
+          -EventName $env:GITHUB_EVENT_NAME `
+          -BaseSha $env:PR_BASE_SHA `
+          -HeadSha $env:PR_HEAD_SHA
+        if ($decision -notin @("true", "false")) {
+          throw "Unexpected proof-pool regression decision '$decision'."
+        }
+        "run=$decision" >> $env:GITHUB_OUTPUT
+
+    - name: Validate proof-pool regressions
+      if: ${{ steps.proof_pool_regression.outcome != 'success' || steps.proof_pool_regression.outputs.run != 'false' }}
+      shell: pwsh
+      run: ./scripts/test-proof-pool-validator.ps1
+
+  metadata:
+    name: Release metadata
+    needs: change-classification
+    if: ${{ !cancelled() && needs.change-classification.result == 'success' && (needs.change-classification.outputs.x64_release == 'true' || needs.change-classification.outputs.arm64_release == 'true') }}
+    runs-on: windows-latest
+    outputs:
+      semVer: ${{ steps.release_version.outputs.semVer }}
+      majorMinorPatch: ${{ steps.release_version.outputs.majorMinorPatch }}
+      isPrerelease: ${{ steps.release_version.outputs.isPrerelease }}
+      isStableCorrection: ${{ steps.release_version.outputs.isStableCorrection }}
     steps:
     - uses: actions/checkout@v7
       with:
@@ -106,14 +162,6 @@ jobs:
       uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 10.0.x
-
-    - name: Cache NuGet packages
-      continue-on-error: true
-      uses: actions/cache@v6
-      with:
-        path: ~/.nuget/packages
-        key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props') }}
-        restore-keys: nuget-${{ runner.os }}-
 
     - name: Install GitVersion
       uses: gittools/actions/gitversion/setup@v4
@@ -164,51 +212,47 @@ jobs:
         "isPrerelease=$($isPrerelease.ToString().ToLowerInvariant())" >> $env:GITHUB_OUTPUT
         "isStableCorrection=$($isStableCorrection.ToString().ToLowerInvariant())" >> $env:GITHUB_OUTPUT
 
-    - name: Select proof-pool regression scope
-      id: proof_pool_regression
+  core-tests:
+    name: Core and CLI tests
+    needs: [change-classification, fast-validation]
+    if: ${{ !cancelled() && needs.change-classification.result == 'success' && needs.fast-validation.result == 'success' && needs.change-classification.outputs.core_tests == 'true' }}
+    runs-on: windows-latest
+    env:
+      OPENCLAW_CI_COLLECT_COVERAGE: ${{ github.event_name != 'pull_request' }}
+      OPENCLAW_REPO_ROOT: ${{ github.workspace }}
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+
+    - name: Setup .NET 10
+      uses: actions/setup-dotnet@v6
+      with:
+        dotnet-version: 10.0.x
+
+    - name: Cache NuGet packages
       continue-on-error: true
-      shell: pwsh
-      env:
-        PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      uses: actions/cache@v6
+      with:
+        path: ~/.nuget/packages
+        key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props') }}
+        restore-keys: nuget-${{ runner.os }}-
+
+    - name: Restore core test projects
       run: |
-        $decision = ./scripts/Get-CiProofPoolRegressionDecision.ps1 `
-          -EventName $env:GITHUB_EVENT_NAME `
-          -BaseSha $env:PR_BASE_SHA `
-          -HeadSha $env:PR_HEAD_SHA
-        if ($decision -notin @("true", "false")) {
-          throw "Unexpected proof-pool regression decision '$decision'."
-        }
-        "run=$decision" >> $env:GITHUB_OUTPUT
-
-    - name: Validate proof-pool regressions
-      if: ${{ steps.proof_pool_regression.outcome != 'success' || steps.proof_pool_regression.outputs.run != 'false' }}
-      shell: pwsh
-      run: ./scripts/test-proof-pool-validator.ps1
-
-    - name: Restore dependencies
-      run: dotnet restore
+        dotnet restore tests/OpenClaw.Shared.Tests
+        dotnet restore tests/OpenClaw.Connection.Tests
+        dotnet restore tests/OpenClaw.WinNode.Cli.Tests
 
     - name: Install dotnet-coverage
       if: ${{ github.event_name != 'pull_request' }}
       run: dotnet tool install --global dotnet-coverage
 
-    - name: Build Shared Library
-      run: dotnet build src/OpenClaw.Shared -c Debug --no-restore
-
-    - name: Build Tray App (WinUI)
-      run: dotnet build src/OpenClaw.Tray.WinUI -c Debug -r win-x64
-
-    - name: Build Tests
+    - name: Build core test projects
       run: |
         dotnet build tests/OpenClaw.Shared.Tests -c Debug --no-restore
-        dotnet build tests/OpenClaw.Tray.Tests -c Debug -r win-x64 --no-restore
         dotnet build tests/OpenClaw.Connection.Tests -c Debug --no-restore
         dotnet build tests/OpenClaw.WinNode.Cli.Tests -c Debug --no-restore
-        dotnet build tests/OpenClaw.Tray.IntegrationTests -c Debug -r win-x64 --no-restore
-        dotnet build tests/OpenClaw.Tray.UITests -c Debug -r win-x64 --no-restore
-        dotnet build tests/OpenClawTray.FunctionalUI.Tests -c Debug -r win-x64 --no-restore
-        dotnet build tests/OpenClaw.SetupEngine.Tests -c Debug -r win-x64
 
     - name: Run Shared Tests
       env:
@@ -218,14 +262,6 @@ jobs:
         -Project tests/OpenClaw.Shared.Tests
         -ResultsDirectory TestResults\Shared
         -TrxFileName OpenClaw.Shared.Tests.trx
-
-    - name: Run Tray Tests
-      run: >
-        ./scripts/Invoke-CiTest.ps1
-        -Project tests/OpenClaw.Tray.Tests
-        -ResultsDirectory TestResults\Tray
-        -TrxFileName OpenClaw.Tray.Tests.trx
-        -Runtime win-x64
 
     - name: Run Connection Tests
       run: >
@@ -241,6 +277,65 @@ jobs:
         -ResultsDirectory TestResults\WinNodeCli
         -TrxFileName OpenClaw.WinNode.Cli.Tests.trx
 
+    - name: Upload Test Results
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: test-results-core
+        path: TestResults/
+        if-no-files-found: warn
+
+  tray-tests:
+    name: Tray, setup, and integration tests
+    needs: [change-classification, fast-validation]
+    if: ${{ !cancelled() && needs.change-classification.result == 'success' && needs.fast-validation.result == 'success' && needs.change-classification.outputs.tray_tests == 'true' }}
+    runs-on: windows-latest
+    env:
+      OPENCLAW_CI_COLLECT_COVERAGE: ${{ github.event_name != 'pull_request' }}
+      OPENCLAW_REPO_ROOT: ${{ github.workspace }}
+      OPENCLAW_TRAY_DATA_DIR: ${{ github.workspace }}\TestData\OpenClawTrayTests
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Setup .NET 10
+      uses: actions/setup-dotnet@v6
+      with:
+        dotnet-version: 10.0.x
+
+    - name: Cache NuGet packages
+      continue-on-error: true
+      uses: actions/cache@v6
+      with:
+        path: ~/.nuget/packages
+        key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props') }}
+        restore-keys: nuget-${{ runner.os }}-
+
+    - name: Restore tray test projects
+      run: |
+        dotnet restore src/OpenClaw.Tray.WinUI -r win-x64
+        dotnet restore tests/OpenClaw.Tray.Tests -r win-x64
+        dotnet restore tests/OpenClaw.SetupEngine.Tests -r win-x64
+        dotnet restore tests/OpenClaw.Tray.IntegrationTests -r win-x64
+
+    - name: Install dotnet-coverage
+      if: ${{ github.event_name != 'pull_request' }}
+      run: dotnet tool install --global dotnet-coverage
+
+    - name: Build tray test projects
+      run: |
+        dotnet build src/OpenClaw.Tray.WinUI -c Debug -r win-x64 --no-restore
+        dotnet build tests/OpenClaw.Tray.Tests -c Debug -r win-x64 --no-restore
+        dotnet build tests/OpenClaw.SetupEngine.Tests -c Debug -r win-x64 --no-restore
+        dotnet build tests/OpenClaw.Tray.IntegrationTests -c Debug -r win-x64 --no-restore
+
+    - name: Run Tray Tests
+      run: >
+        ./scripts/Invoke-CiTest.ps1
+        -Project tests/OpenClaw.Tray.Tests
+        -ResultsDirectory TestResults\Tray
+        -TrxFileName OpenClaw.Tray.Tests.trx
+        -Runtime win-x64
+
     # Tray integration tests gate on OPENCLAW_RUN_INTEGRATION; set it so the
     # MCP-server and capability tests actually run.
     - name: Run Tray Integration Tests
@@ -253,9 +348,64 @@ jobs:
         -TrxFileName OpenClaw.Tray.IntegrationTests.trx
         -Runtime win-x64
 
+    - name: Run SetupEngine Tests
+      run: >
+        ./scripts/Invoke-CiTest.ps1
+        -Project tests/OpenClaw.SetupEngine.Tests
+        -ResultsDirectory TestResults\SetupEngine
+        -TrxFileName OpenClaw.SetupEngine.Tests.trx
+        -Runtime win-x64
+
+    - name: Upload Test Results
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: test-results-tray
+        path: TestResults/
+        if-no-files-found: warn
+
+  ui-tests:
+    name: UI, functional, and accessibility tests
+    needs: [change-classification, fast-validation]
+    if: ${{ !cancelled() && needs.change-classification.result == 'success' && needs.fast-validation.result == 'success' && needs.change-classification.outputs.ui_tests == 'true' }}
+    runs-on: windows-latest
+    env:
+      OPENCLAW_CI_COLLECT_COVERAGE: ${{ github.event_name != 'pull_request' }}
+      OPENCLAW_REPO_ROOT: ${{ github.workspace }}
+      OPENCLAW_TRAY_DATA_DIR: ${{ github.workspace }}\TestData\OpenClawTrayUITests
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Setup .NET 10
+      uses: actions/setup-dotnet@v6
+      with:
+        dotnet-version: 10.0.x
+
+    - name: Cache NuGet packages
+      continue-on-error: true
+      uses: actions/cache@v6
+      with:
+        path: ~/.nuget/packages
+        key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props') }}
+        restore-keys: nuget-${{ runner.os }}-
+
+    - name: Restore UI test projects
+      run: |
+        dotnet restore tests/OpenClaw.Tray.UITests -r win-x64
+        dotnet restore tests/OpenClawTray.FunctionalUI.Tests -r win-x64
+
+    - name: Install dotnet-coverage
+      if: ${{ github.event_name != 'pull_request' }}
+      run: dotnet tool install --global dotnet-coverage
+
+    - name: Build UI test projects
+      run: |
+        dotnet build tests/OpenClaw.Tray.UITests -c Debug -r win-x64 --no-restore
+        dotnet build tests/OpenClawTray.FunctionalUI.Tests -c Debug -r win-x64 --no-restore
+
     # UI tests need a real visual tree AND a system-registered WindowsAppRuntime
-    # framework MSIX. The hosted windows-2025 runner image doesn't preinstall it,
-    # so install the runtime that matches the repo-level WindowsAppSDK version.
+    # framework MSIX. The hosted runner image does not preinstall it, so install
+    # the runtime matching the repo-level WindowsAppSDK version.
     - name: Install WindowsAppRuntime
       shell: pwsh
       run: |
@@ -284,14 +434,6 @@ jobs:
         -Project tests/OpenClawTray.FunctionalUI.Tests
         -ResultsDirectory TestResults\FunctionalUI
         -TrxFileName OpenClawTray.FunctionalUI.Tests.trx
-        -Runtime win-x64
-
-    - name: Run SetupEngine Tests
-      run: >
-        ./scripts/Invoke-CiTest.ps1
-        -Project tests/OpenClaw.SetupEngine.Tests
-        -ResultsDirectory TestResults\SetupEngine
-        -TrxFileName OpenClaw.SetupEngine.Tests.trx
         -Runtime win-x64
 
     - name: Run Tray UI Tests
@@ -354,34 +496,18 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v7
       with:
-        name: test-results
+        name: test-results-ui
         path: TestResults/
         if-no-files-found: warn
 
-    outputs:
-      semVer: ${{ steps.release_version.outputs.semVer }}
-      majorMinorPatch: ${{ steps.release_version.outputs.majorMinorPatch }}
-      isPrerelease: ${{ steps.release_version.outputs.isPrerelease }}
-      isStableCorrection: ${{ steps.release_version.outputs.isStableCorrection }}
-
-  e2etests:
+  setup-e2e:
+    name: Setup and connect E2E
     needs: [change-classification, fast-validation]
-    if: ${{ !cancelled() && needs.change-classification.result == 'success' && needs.fast-validation.result == 'success' && needs.change-classification.outputs.full == 'true' }}
+    if: ${{ !cancelled() && needs.change-classification.result == 'success' && needs.fast-validation.result == 'success' && needs.change-classification.outputs.setup_e2e == 'true' }}
     runs-on: windows-latest
-    timeout-minutes: ${{ matrix.timeout_minutes }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: setup-connect
-            timeout_minutes: 45
-            filter: "FullyQualifiedName~OpenClaw.E2ETests.Setup.SetupAndConnectTests|FullyQualifiedName~OpenClaw.E2ETests.Setup.MxcSetupAndConnectTests|FullyQualifiedName~OpenClaw.E2ETests.Setup.MirroredWslPortLeaseTests|FullyQualifiedName~OpenClaw.E2ETests.Setup.SshOwnershipAdversarialProofTests|FullyQualifiedName~OpenClaw.E2ETests.Setup.TrayExecutableResolutionTests"
-          - name: revocation-recovery
-            timeout_minutes: 25
-            filter: FullyQualifiedName~OpenClaw.E2ETests.Setup.RevocationAndRecoveryTests
-          - name: network-recovery
-            timeout_minutes: 25
-            filter: FullyQualifiedName~OpenClaw.E2ETests.Setup.NetworkRecoveryTests
+    timeout-minutes: 45
+    env:
+      OPENCLAW_REPO_ROOT: ${{ github.workspace }}
     steps:
     - uses: actions/checkout@v7
       with:
@@ -400,115 +526,149 @@ jobs:
         key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props') }}
         restore-keys: nuget-${{ runner.os }}-
 
-    - name: Restore dependencies
-      run: dotnet restore
+    - name: Restore E2E project graph
+      run: |
+        dotnet restore src/OpenClaw.Tray.WinUI -r win-x64
+        dotnet restore tests/OpenClaw.E2ETests -r win-x64
 
-    - name: Build Shared Library
-      run: dotnet build src/OpenClaw.Shared -c Debug --no-restore
+    - name: Build E2E project graph
+      run: |
+        dotnet build src/OpenClaw.Tray.WinUI -c Debug -r win-x64 --no-restore
+        dotnet build tests/OpenClaw.E2ETests -c Debug -r win-x64 --no-restore
 
-    - name: Build SetupEngine
-      run: dotnet build src/OpenClaw.SetupEngine -c Debug --no-restore
-
-    - name: Build Tray App (WinUI)
-      run: dotnet build src/OpenClaw.Tray.WinUI -c Debug -r win-x64
-
-    - name: Build E2E Tests
-      run: dotnet build tests/OpenClaw.E2ETests -c Debug -r win-x64
-
-    - name: Run E2E Tests (${{ matrix.name }})
+    - name: Run setup and connect E2E tests
       env:
         OPENCLAW_RUN_E2E: 1
       shell: pwsh
-      run: |
-        dotnet test tests/OpenClaw.E2ETests `
-          --no-build `
-          -c Debug `
-          -r win-x64 `
-          --verbosity normal `
-          --results-directory TestResults/E2E `
-          --logger "trx;LogFileName=OpenClaw.E2ETests.${{ matrix.name }}.trx" `
-          --logger "console;verbosity=detailed" `
-          --filter "${{ matrix.filter }}"
-        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
-        [xml]$trx = Get-Content "TestResults\E2E\OpenClaw.E2ETests.${{ matrix.name }}.trx"
-        $executed = [int]$trx.TestRun.ResultSummary.Counters.executed
-        if ($executed -lt 1) {
-          Write-Error "E2E shard '${{ matrix.name }}' executed zero tests. Check OPENCLAW_RUN_E2E gating/filter before merging."
-          exit 1
-        }
-        if ("${{ matrix.name }}" -eq "setup-connect") {
-          $mxcProofNames = @(
-            "RealGateway_SystemRun_ExecutesThroughWindowsNodeMxcSandbox",
-            "RealGateway_SystemRun_BlocksWritesToTrayDataDirectoryInMxcSandbox"
-          )
-
-          foreach ($mxcProofName in $mxcProofNames) {
-            $mxcProof = @($trx.TestRun.Results.UnitTestResult | Where-Object { $_.testName -like "*$mxcProofName*" }) | Select-Object -First 1
-            if ($null -eq $mxcProof) {
-              Write-Error "E2E shard '${{ matrix.name }}' did not report the MXC proof test '$mxcProofName'. Check the setup-connect filter before merging."
-              exit 1
-            }
-
-            $mxcOutcome = [string]$mxcProof.outcome
-            if ($mxcOutcome -eq "Passed") {
-              Write-Host "MXC E2E proof passed: $mxcProofName"
-            } elseif ($mxcOutcome -eq "NotExecuted" -or $mxcOutcome -eq "Skipped") {
-              $mxcSkipReason = @($mxcProof.Output.ErrorInfo.Message, $mxcProof.Output.StdOut) |
-                Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
-                Select-Object -First 1
-              if ([string]::IsNullOrWhiteSpace($mxcSkipReason)) {
-                $mxcSkipReason = "skip reason was not present in the trx output"
-              }
-              Write-Warning "MXC E2E proof skipped: $mxcProofName; $mxcSkipReason"
-            } else {
-              Write-Error "MXC E2E proof '$mxcProofName' had unexpected outcome '$mxcOutcome'."
-              exit 1
-            }
-          }
-
-          $sshOwnershipProofNames = @(
-            "UnownedListenerIsRejectedThenOwnedTunnelRecoversWithoutRepairing",
-            "InitialHandshakeListenerReplacementWithholdsCredentialFrame",
-            "InitialNodeHandshakeListenerReplacementWithholdsCredentialFrame"
-          )
-          foreach ($sshOwnershipProofName in $sshOwnershipProofNames) {
-            $sshOwnershipProof = @(
-              $trx.TestRun.Results.UnitTestResult |
-                Where-Object { $_.testName -like "*$sshOwnershipProofName*" }
-            ) | Select-Object -First 1
-            if ($null -eq $sshOwnershipProof) {
-              Write-Error "E2E shard '${{ matrix.name }}' did not report the SSH ownership proof test '$sshOwnershipProofName'. Check the setup-connect filter before merging."
-              exit 1
-            }
-
-            $sshOwnershipOutcome = [string]$sshOwnershipProof.outcome
-            if ($sshOwnershipOutcome -ne "Passed") {
-              Write-Error "SSH ownership E2E proof '$sshOwnershipProofName' had outcome '$sshOwnershipOutcome'; this proof must pass and may not skip."
-              exit 1
-            }
-            Write-Host "SSH ownership E2E proof passed: $sshOwnershipProofName"
-          }
-        }
+      run: >
+        ./scripts/Invoke-CiE2e.ps1
+        -Name setup-connect
+        -Filter "FullyQualifiedName~OpenClaw.E2ETests.Setup.SetupAndConnectTests|FullyQualifiedName~OpenClaw.E2ETests.Setup.MxcSetupAndConnectTests|FullyQualifiedName~OpenClaw.E2ETests.Setup.MirroredWslPortLeaseTests|FullyQualifiedName~OpenClaw.E2ETests.Setup.SshOwnershipAdversarialProofTests|FullyQualifiedName~OpenClaw.E2ETests.Setup.TrayExecutableResolutionTests"
 
     - name: Upload E2E Test Results & Logs
       if: always()
       uses: actions/upload-artifact@v7
       with:
-        name: e2e-test-results-${{ matrix.name }}
+        name: e2e-test-results-setup-connect
         path: |
           TestResults/E2E/
         if-no-files-found: warn
 
-  build:
-    needs: [change-classification, test, e2etests]
-    if: ${{ !cancelled() && needs.change-classification.outputs.full == 'true' && needs.test.result == 'success' && needs.e2etests.result == 'success' }}
-    runs-on: ${{ matrix.rid == 'win-arm64' && 'windows-11-arm' || 'windows-latest' }}
+  revocation-e2e:
+    name: Revocation recovery E2E
+    needs: [change-classification, fast-validation]
+    if: ${{ !cancelled() && needs.change-classification.result == 'success' && needs.fast-validation.result == 'success' && needs.change-classification.outputs.revocation_e2e == 'true' }}
+    runs-on: windows-latest
+    timeout-minutes: 25
     env:
-      OPENCLAW_BUILD_VERSION: ${{ needs.test.outputs.semVer }}
-    strategy:
-      matrix:
-        rid: [win-x64, win-arm64]
+      OPENCLAW_REPO_ROOT: ${{ github.workspace }}
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+
+    - name: Setup .NET 10
+      uses: actions/setup-dotnet@v6
+      with:
+        dotnet-version: 10.0.x
+
+    - name: Cache NuGet packages
+      continue-on-error: true
+      uses: actions/cache@v6
+      with:
+        path: ~/.nuget/packages
+        key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props') }}
+        restore-keys: nuget-${{ runner.os }}-
+
+    - name: Restore E2E project graph
+      run: |
+        dotnet restore src/OpenClaw.Tray.WinUI -r win-x64
+        dotnet restore tests/OpenClaw.E2ETests -r win-x64
+
+    - name: Build E2E project graph
+      run: |
+        dotnet build src/OpenClaw.Tray.WinUI -c Debug -r win-x64 --no-restore
+        dotnet build tests/OpenClaw.E2ETests -c Debug -r win-x64 --no-restore
+
+    - name: Run revocation recovery E2E tests
+      env:
+        OPENCLAW_RUN_E2E: 1
+      shell: pwsh
+      run: >
+        ./scripts/Invoke-CiE2e.ps1
+        -Name revocation-recovery
+        -Filter FullyQualifiedName~OpenClaw.E2ETests.Setup.RevocationAndRecoveryTests
+
+    - name: Upload E2E Test Results & Logs
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: e2e-test-results-revocation-recovery
+        path: |
+          TestResults/E2E/
+        if-no-files-found: warn
+
+  network-e2e:
+    name: Network recovery E2E
+    needs: [change-classification, fast-validation]
+    if: ${{ !cancelled() && needs.change-classification.result == 'success' && needs.fast-validation.result == 'success' && needs.change-classification.outputs.network_e2e == 'true' }}
+    runs-on: windows-latest
+    timeout-minutes: 25
+    env:
+      OPENCLAW_REPO_ROOT: ${{ github.workspace }}
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+
+    - name: Setup .NET 10
+      uses: actions/setup-dotnet@v6
+      with:
+        dotnet-version: 10.0.x
+
+    - name: Cache NuGet packages
+      continue-on-error: true
+      uses: actions/cache@v6
+      with:
+        path: ~/.nuget/packages
+        key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props') }}
+        restore-keys: nuget-${{ runner.os }}-
+
+    - name: Restore E2E project graph
+      run: |
+        dotnet restore src/OpenClaw.Tray.WinUI -r win-x64
+        dotnet restore tests/OpenClaw.E2ETests -r win-x64
+
+    - name: Build E2E project graph
+      run: |
+        dotnet build src/OpenClaw.Tray.WinUI -c Debug -r win-x64 --no-restore
+        dotnet build tests/OpenClaw.E2ETests -c Debug -r win-x64 --no-restore
+
+    - name: Run network recovery E2E tests
+      env:
+        OPENCLAW_RUN_E2E: 1
+      shell: pwsh
+      run: >
+        ./scripts/Invoke-CiE2e.ps1
+        -Name network-recovery
+        -Filter FullyQualifiedName~OpenClaw.E2ETests.Setup.NetworkRecoveryTests
+
+    - name: Upload E2E Test Results & Logs
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: e2e-test-results-network-recovery
+        path: |
+          TestResults/E2E/
+        if-no-files-found: warn
+
+  build-x64:
+    name: x64 release publish smoke
+    needs: [change-classification, metadata]
+    if: ${{ !cancelled() && needs.change-classification.result == 'success' && needs.metadata.result == 'success' && needs.change-classification.outputs.x64_release == 'true' }}
+    runs-on: windows-latest
+    env:
+      OPENCLAW_BUILD_VERSION: ${{ needs.metadata.outputs.semVer }}
 
     steps:
     - uses: actions/checkout@v7
@@ -529,29 +689,19 @@ jobs:
         restore-keys: nuget-${{ runner.os }}-
 
     - name: Restore WinUI Tray App
-      run: dotnet restore src/OpenClaw.Tray.WinUI -r ${{ matrix.rid }}
+      run: dotnet restore src/OpenClaw.Tray.WinUI -r win-x64
 
     - name: Publish WinUI Tray App
-      run: dotnet publish src/OpenClaw.Tray.WinUI -c Release -r ${{ matrix.rid }} --self-contained --no-restore -o publish -p:Version=$env:OPENCLAW_BUILD_VERSION -p:InformationalVersion=$env:OPENCLAW_BUILD_VERSION
+      run: dotnet publish src/OpenClaw.Tray.WinUI -c Release -r win-x64 --self-contained --no-restore -o publish -p:Version=$env:OPENCLAW_BUILD_VERSION -p:InformationalVersion=$env:OPENCLAW_BUILD_VERSION
 
     - name: Verify x64 Native Runtime Payload
-      if: matrix.rid == 'win-x64'
       shell: pwsh
       run: .\scripts\Test-ReleaseNativeDependencies.ps1 -PayloadPath publish -RequireAppLocalVCRuntime
-
-    - name: Verify ARM64 Native Runtime Payload
-      if: matrix.rid == 'win-arm64'
-      shell: pwsh
-      # -SkipNativeLoadProbe: an ARM64 runner CAN LoadLibrary ARM64 DLLs, but
-      # the full tray native dependency chain may include components that are
-      # not in this payload here (WindowsAppSDK pieces, etc.). The probe is for
-      # x64 parity; signature + presence is what we actually care about.
-      run: .\scripts\Test-ReleaseNativeDependencies.ps1 -PayloadPath publish -RequireAppLocalVCRuntime -SkipNativeLoadProbe
 
     - name: Verify GitVersion assembly metadata
       shell: pwsh
       run: |
-        $expected = "${{ needs.test.outputs.semVer }}"
+        $expected = "${{ needs.metadata.outputs.semVer }}"
         $assemblyPath = Resolve-Path "publish\OpenClaw.Tray.WinUI.dll"
         $metadata = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($assemblyPath)
         if ([string]::IsNullOrWhiteSpace($metadata.ProductVersion)) {
@@ -565,11 +715,69 @@ jobs:
     - name: Upload Tray Artifact
       uses: actions/upload-artifact@v7
       with:
-        name: openclaw-tray-${{ matrix.rid }}
+        name: openclaw-tray-win-x64
+        path: publish/
+
+  build-arm64:
+    name: ARM64 release publish
+    needs: [change-classification, metadata]
+    if: ${{ !cancelled() && needs.change-classification.result == 'success' && needs.metadata.result == 'success' && needs.change-classification.outputs.arm64_release == 'true' }}
+    runs-on: windows-11-arm
+    env:
+      OPENCLAW_BUILD_VERSION: ${{ needs.metadata.outputs.semVer }}
+
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+
+    - name: Setup .NET 10
+      uses: actions/setup-dotnet@v6
+      with:
+        dotnet-version: 10.0.x
+
+    - name: Cache NuGet packages
+      continue-on-error: true
+      uses: actions/cache@v6
+      with:
+        path: ~/.nuget/packages
+        key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props') }}
+        restore-keys: nuget-${{ runner.os }}-
+
+    - name: Restore WinUI Tray App
+      run: dotnet restore src/OpenClaw.Tray.WinUI -r win-arm64
+
+    - name: Publish WinUI Tray App
+      run: dotnet publish src/OpenClaw.Tray.WinUI -c Release -r win-arm64 --self-contained --no-restore -o publish -p:Version=$env:OPENCLAW_BUILD_VERSION -p:InformationalVersion=$env:OPENCLAW_BUILD_VERSION
+
+    - name: Verify ARM64 Native Runtime Payload
+      shell: pwsh
+      # -SkipNativeLoadProbe keeps parity with the prior release matrix. Presence
+      # and signature checks remain authoritative for this payload.
+      run: .\scripts\Test-ReleaseNativeDependencies.ps1 -PayloadPath publish -RequireAppLocalVCRuntime -SkipNativeLoadProbe
+
+    - name: Verify GitVersion assembly metadata
+      shell: pwsh
+      run: |
+        $expected = "${{ needs.metadata.outputs.semVer }}"
+        $assemblyPath = Resolve-Path "publish\OpenClaw.Tray.WinUI.dll"
+        $metadata = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($assemblyPath)
+        if ([string]::IsNullOrWhiteSpace($metadata.ProductVersion)) {
+          throw "OpenClaw.Tray.WinUI.dll is missing ProductVersion metadata."
+        }
+        $actual = $metadata.ProductVersion -replace '\+.*$', ''
+        if ($actual -ne $expected) {
+          throw "ProductVersion '$actual' did not match GitVersion SemVer '$expected'."
+        }
+
+    - name: Upload Tray Artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: openclaw-tray-win-arm64
         path: publish/
 
   build-msix:
-    needs: [test, e2etests]
+    needs: [metadata]
     if: false # MSIX distribution is paused; ship Inno setup and portable ZIP artifacts only.
     runs-on: ${{ matrix.rid == 'win-arm64' && 'windows-11-arm' || 'windows-latest' }}
     continue-on-error: true
@@ -618,7 +826,7 @@ jobs:
     - name: Patch MSIX manifest metadata
       shell: pwsh
       run: |
-        $version = "${{ needs.test.outputs.majorMinorPatch }}.0"
+        $version = "${{ needs.metadata.outputs.majorMinorPatch }}.0"
         $isAlpha = "${{ startsWith(github.ref, 'refs/tags/v') && contains(github.ref_name, '-') }}" -eq "true"
         $identityName = if ($isAlpha) { "OpenClaw.Companion.Alpha" } else { "OpenClaw.Companion" }
         $displayName = if ($isAlpha) { "OpenClaw Companion Alpha" } else { "OpenClaw Companion" }
@@ -666,7 +874,7 @@ jobs:
   ci-gate:
     name: CI Gate
     if: ${{ always() }}
-    needs: [change-classification, fast-validation, test, e2etests, build]
+    needs: [change-classification, fast-validation, proof-pool-contracts, metadata, core-tests, tray-tests, ui-tests, setup-e2e, revocation-e2e, network-e2e, build-x64, build-arm64]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
@@ -676,23 +884,55 @@ jobs:
       env:
         CLASSIFICATION_RESULT: ${{ needs.change-classification.result }}
         CLASSIFICATION: ${{ needs.change-classification.outputs.classification }}
+        FULL_REQUIRED: ${{ needs.change-classification.outputs.full }}
         FAST_VALIDATION_RESULT: ${{ needs.fast-validation.result }}
-        TEST_RESULT: ${{ needs.test.result }}
-        E2E_RESULT: ${{ needs.e2etests.result }}
-        BUILD_RESULT: ${{ needs.build.result }}
+        PROOF_POOL_CONTRACTS_RESULT: ${{ needs.proof-pool-contracts.result }}
+        CORE_REQUIRED: ${{ needs.change-classification.outputs.core_tests }}
+        CORE_RESULT: ${{ needs.core-tests.result }}
+        TRAY_REQUIRED: ${{ needs.change-classification.outputs.tray_tests }}
+        TRAY_RESULT: ${{ needs.tray-tests.result }}
+        UI_REQUIRED: ${{ needs.change-classification.outputs.ui_tests }}
+        UI_RESULT: ${{ needs.ui-tests.result }}
+        SETUP_E2E_REQUIRED: ${{ needs.change-classification.outputs.setup_e2e }}
+        SETUP_E2E_RESULT: ${{ needs.setup-e2e.result }}
+        REVOCATION_E2E_REQUIRED: ${{ needs.change-classification.outputs.revocation_e2e }}
+        REVOCATION_E2E_RESULT: ${{ needs.revocation-e2e.result }}
+        NETWORK_E2E_REQUIRED: ${{ needs.change-classification.outputs.network_e2e }}
+        NETWORK_E2E_RESULT: ${{ needs.network-e2e.result }}
+        X64_RELEASE_REQUIRED: ${{ needs.change-classification.outputs.x64_release }}
+        X64_RELEASE_RESULT: ${{ needs.build-x64.result }}
+        ARM64_RELEASE_REQUIRED: ${{ needs.change-classification.outputs.arm64_release }}
+        ARM64_RELEASE_RESULT: ${{ needs.build-arm64.result }}
+        METADATA_RESULT: ${{ needs.metadata.result }}
       run: |
         $validatedMode = ./scripts/Assert-CiGateResults.ps1 `
           -ClassificationResult $env:CLASSIFICATION_RESULT `
           -Classification $env:CLASSIFICATION `
+          -FullRequired $env:FULL_REQUIRED `
           -FastValidationResult $env:FAST_VALIDATION_RESULT `
-          -TestResult $env:TEST_RESULT `
-          -E2eResult $env:E2E_RESULT `
-          -BuildResult $env:BUILD_RESULT
+          -ProofPoolContractsResult $env:PROOF_POOL_CONTRACTS_RESULT `
+          -CoreRequired $env:CORE_REQUIRED `
+          -CoreResult $env:CORE_RESULT `
+          -TrayRequired $env:TRAY_REQUIRED `
+          -TrayResult $env:TRAY_RESULT `
+          -UiRequired $env:UI_REQUIRED `
+          -UiResult $env:UI_RESULT `
+          -SetupE2eRequired $env:SETUP_E2E_REQUIRED `
+          -SetupE2eResult $env:SETUP_E2E_RESULT `
+          -RevocationE2eRequired $env:REVOCATION_E2E_REQUIRED `
+          -RevocationE2eResult $env:REVOCATION_E2E_RESULT `
+          -NetworkE2eRequired $env:NETWORK_E2E_REQUIRED `
+          -NetworkE2eResult $env:NETWORK_E2E_RESULT `
+          -X64ReleaseRequired $env:X64_RELEASE_REQUIRED `
+          -X64ReleaseResult $env:X64_RELEASE_RESULT `
+          -Arm64ReleaseRequired $env:ARM64_RELEASE_REQUIRED `
+          -Arm64ReleaseResult $env:ARM64_RELEASE_RESULT `
+          -MetadataResult $env:METADATA_RESULT
         "CI Gate passed $validatedMode validation." >> $env:GITHUB_STEP_SUMMARY
 
   release:
-    needs: [change-classification, fast-validation, test, e2etests, build, ci-gate]
-    if: startsWith(github.ref, 'refs/tags/v') && needs.ci-gate.result == 'success' && needs.change-classification.outputs.full == 'true' && needs.fast-validation.result == 'success' && needs.test.result == 'success' && needs.e2etests.result == 'success' && needs.build.result == 'success' && !cancelled()
+    needs: [change-classification, metadata, build-x64, build-arm64, ci-gate]
+    if: startsWith(github.ref, 'refs/tags/v') && needs.ci-gate.result == 'success' && needs.change-classification.outputs.full == 'true' && needs.metadata.result == 'success' && needs.build-x64.result == 'success' && needs.build-arm64.result == 'success' && !cancelled()
     runs-on: windows-latest
     environment: release-signing
     permissions:
@@ -841,11 +1081,11 @@ jobs:
     # on the windows-11-arm runner; see src/Directory.Build.targets).
     - name: Create x64 Release ZIP
       run: |
-        Compress-Archive -Path artifacts/tray-win-x64/* -DestinationPath OpenClawTray-${{ needs.test.outputs.semVer }}-win-x64.zip
+        Compress-Archive -Path artifacts/tray-win-x64/* -DestinationPath OpenClawTray-${{ needs.metadata.outputs.semVer }}-win-x64.zip
 
     - name: Create arm64 Release ZIP
       run: |
-        Compress-Archive -Path artifacts/tray-win-arm64/* -DestinationPath OpenClawTray-${{ needs.test.outputs.semVer }}-win-arm64.zip
+        Compress-Archive -Path artifacts/tray-win-arm64/* -DestinationPath OpenClawTray-${{ needs.metadata.outputs.semVer }}-win-arm64.zip
 
     # Inno Setup installer for x64
     - name: Install Inno Setup
@@ -858,7 +1098,7 @@ jobs:
         copy artifacts/tray-win-x64/* publish-x64/ -Recurse
         .\scripts\Test-ReleaseNativeDependencies.ps1 -PayloadPath publish-x64 -RequireAppLocalVCRuntime -RequireInstallerVCRedist -InstallerVCRedistPath vc_redist.x64.exe
         # Build installer
-        & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /DMyAppVersion=${{ needs.test.outputs.semVer }} /DMyAppArch=x64 /Dpublish=publish-x64 /DvcRedist=vc_redist.x64.exe installer.iss
+        & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /DMyAppVersion=${{ needs.metadata.outputs.semVer }} /DMyAppArch=x64 /Dpublish=publish-x64 /DvcRedist=vc_redist.x64.exe installer.iss
 
     - name: Build arm64 Installer
       run: |
@@ -870,7 +1110,7 @@ jobs:
         #                             LoadLibrary an arm64 DLL.
         .\scripts\Test-ReleaseNativeDependencies.ps1 -PayloadPath publish-arm64 -RequireAppLocalVCRuntime -RequireInstallerVCRedist -InstallerVCRedistPath vc_redist.arm64.exe -SkipNativeLoadProbe
         # Build installer
-        & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /DMyAppVersion=${{ needs.test.outputs.semVer }} /DMyAppArch=arm64 /Dpublish=publish-arm64 /DvcRedist=vc_redist.arm64.exe installer.iss
+        & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /DMyAppVersion=${{ needs.metadata.outputs.semVer }} /DMyAppArch=arm64 /Dpublish=publish-arm64 /DvcRedist=vc_redist.arm64.exe installer.iss
 
     - name: Sign Installers
       uses: azure/artifact-signing-action@v2
@@ -885,7 +1125,7 @@ jobs:
         timestamp-digest: SHA256
 
     - name: Revalidate stable correction release ordering
-      if: needs.test.outputs.isStableCorrection == 'true'
+      if: needs.metadata.outputs.isStableCorrection == 'true'
       shell: pwsh
       env:
         GH_TOKEN: ${{ github.token }}
@@ -902,18 +1142,18 @@ jobs:
         files: |
           Output/OpenClawCompanion-Setup-x64.exe
           Output/OpenClawCompanion-Setup-arm64.exe
-          OpenClawTray-${{ needs.test.outputs.semVer }}-win-x64.zip
-          OpenClawTray-${{ needs.test.outputs.semVer }}-win-arm64.zip
-        prerelease: ${{ needs.test.outputs.isPrerelease }}
-        make_latest: ${{ needs.test.outputs.isPrerelease == 'true' && 'false' || 'true' }}
+          OpenClawTray-${{ needs.metadata.outputs.semVer }}-win-x64.zip
+          OpenClawTray-${{ needs.metadata.outputs.semVer }}-win-arm64.zip
+        prerelease: ${{ needs.metadata.outputs.isPrerelease }}
+        make_latest: ${{ needs.metadata.outputs.isPrerelease == 'true' && 'false' || 'true' }}
         body: |
           ## OpenClaw Windows Hub ${{ github.ref_name }}
 
           ### Downloads
           - **Installer (x64)**: `OpenClawCompanion-Setup-x64.exe` - Intel/AMD 64-bit
           - **Installer (ARM64)**: `OpenClawCompanion-Setup-arm64.exe` - Windows on ARM (Surface, etc.)
-          - **Portable x64**: `OpenClawTray-${{ needs.test.outputs.semVer }}-win-x64.zip`
-          - **Portable ARM64**: `OpenClawTray-${{ needs.test.outputs.semVer }}-win-arm64.zip`
+          - **Portable x64**: `OpenClawTray-${{ needs.metadata.outputs.semVer }}-win-x64.zip`
+          - **Portable ARM64**: `OpenClawTray-${{ needs.metadata.outputs.semVer }}-win-arm64.zip`
 
           ### Features
           - 🦞 System tray integration with gateway status

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,6 +296,8 @@ jobs:
       OPENCLAW_TRAY_DATA_DIR: ${{ github.workspace }}\TestData\OpenClawTrayTests
     steps:
     - uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
 
     - name: Setup .NET 10
       uses: actions/setup-dotnet@v6
@@ -375,6 +377,8 @@ jobs:
       OPENCLAW_TRAY_DATA_DIR: ${{ github.workspace }}\TestData\OpenClawTrayUITests
     steps:
     - uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
 
     - name: Setup .NET 10
       uses: actions/setup-dotnet@v6

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -4,6 +4,14 @@ This repo uses **GitVersion + CI** for release versioning. The canonical release
 flow is **tag-driven**: merge to `main`, tag `main`, and let GitHub Actions
 build/sign/publish release artifacts.
 
+CI computes GitVersion and stable-correction metadata in the independent
+`metadata` job. On `main` and tags, x64 and ARM64 publish jobs start from that
+metadata in parallel with tests and E2E, and the stable **CI Gate** requires all
+selected lanes before a tag can publish. Pull requests do not produce release
+artifacts unless packaging, build, installer, release, workflow, or classifier
+infrastructure changes. Those fail-closed pull requests run the x64 publish
+smoke only; ARM64 publish remains required on `main` and tags.
+
 ## Release checklist
 
 1. Start clean on current `main`.

--- a/docs/TEST_COVERAGE.md
+++ b/docs/TEST_COVERAGE.md
@@ -77,7 +77,7 @@ required closeout lane for code changes.
 | Required closeout | `.\build.ps1`, Shared tests, Tray tests | Every code change and every agent closeout |
 | Proof-pool inventory | `.\scripts\validate-proof-pools.ps1`, `.\scripts\test-proof-pool-validator.ps1`, and `.\scripts\test-validate-docs-proof-pool-flow.ps1` | Every inventory or proof scheduling change; the documentation gate runs core schema and parent-flow checks, while CI runs the full malformed-contract matrix |
 | Agent skills | `.\scripts\validate-agent-skills.ps1` and `.\scripts\test-agent-skills-validator.ps1` | Changes under `.agents\skills`; validates skill metadata, agent-facing prose, and local links |
-| GitHub-hosted PR/main CI | `.github\workflows\ci.yml` | Every pull request and push to `main`; docs-only PRs use the fast path, while all other PRs plus main and tag pushes run the full test, E2E, and release-build lanes |
+| GitHub-hosted PR/main CI | `.github\workflows\ci.yml` | Every pull request and push to `main`; explicit conservative impact outputs select the required test, E2E, and release-publish lanes |
 | Accessibility scan | `.\scripts\run-proof-tests.ps1 -Project 'tests\OpenClaw.Tray.UITests\OpenClaw.Tray.UITests.csproj' -Filter 'Category=Accessibility' -ResultName 'winui-accessibility' -RuntimeIdentifier win-x64` | UI changes and CI quality gate; runs real-process Axe.Windows scans; see `docs\ACCESSIBILITY.md` |
 | Local E2E | `OPENCLAW_RUN_E2E=1` with `OpenClaw.E2ETests` | Gateway setup/connect, recovery, or pairing changes that need real WSL Gateway coverage |
 | Local MXC E2E | `.\scripts\validate-mxc-e2e.ps1` | MXC sandboxing, `system.run`, exec approvals, Windows node command execution, gateway setup/connect changes that affect MXC |
@@ -90,25 +90,98 @@ Capacity-dependent Windows validation is named in
 they need. A declaration does not claim that the pool ran, and unavailable
 proof must remain reported as blocked.
 
-### CI docs-only fast path
+### CI impact fast paths
 
-The `change-classification` job selects `docs_only` only for pull requests where
-every changed path is explicitly allowlisted maintained documentation or
-non-executable `.agents\skills` content. Mixed changes, scripts, source, tests,
-workflow or build configuration, package manifests, installer files, unknown
-paths, empty diffs, invalid revisions, and diff failures select `full`.
-Pushes to `main` and release tags always select `full`.
+The `change-classification` job emits explicit booleans for `core_tests`,
+`tray_tests`, `ui_tests`, `setup_e2e`, `revocation_e2e`, `network_e2e`,
+`x64_release`, `arm64_release`, and `full`. Jobs consume those outputs directly.
+The summary classification is `docs_only`, `targeted`, or `full`; it is not the
+authority for individual job conditions.
 
-`fast-validation` runs for every workflow invocation. It owns repository
-hygiene, documentation validation, agent-skill validation, classifier
-regressions, and workflow contracts. The heavier malformed proof-contract
-matrix remains in the full Windows `test` lane under its existing conditional
-decision. For a docs-only pull request, the Windows `test`, E2E, and
-release-build matrices are skipped. The always-running **CI Gate** check
-accepts those skips only when the classification is `docs_only`; otherwise it
-requires every full lane to succeed. Classification or fast-validation
-failures always fail **CI Gate**. This stable check avoids required-check names
-disappearing when a pull request uses the fast path.
+The classifier uses conservative project boundaries:
+
+| Change surface | Core / CLI | Tray / setup / integration | UI / accessibility | Setup E2E | Recovery E2E | Release publish |
+|---|---:|---:|---:|---:|---:|---:|
+| Maintained docs or non-executable agent-skill content |  |  |  |  |  |  |
+| `OpenClaw.Cli`, `OpenClaw.WinNode.Cli` | Yes |  |  |  |  |  |
+| Tray WinUI, including pure service logic |  | Yes | Yes |  |  |  |
+| Chat, FunctionalUI, XAML, resources, pages, controls |  | Yes | Yes |  |  |  |
+| SetupEngine, onboarding, setup, pairing |  | Yes | When UI-bound | Yes |  |  |
+| Connection, gateway, node, MCP, WSL paths | As applicable | Yes | When UI-bound | Yes | Yes |  |
+| Broad Shared or protocol changes | Yes | Yes | Yes | Yes | Yes |  |
+| Test-only change | Corresponding lane | Corresponding lane | Corresponding lane | Corresponding shard | Corresponding shard |  |
+| Packaging, project/build files, installer, workflow or classifier contracts | Yes | Yes | Yes | Yes | Yes | x64 |
+| Push to `main` or a tag | Yes | Yes | Yes | Yes | Yes | x64 and ARM64 |
+
+Known mixed changes take the union of their lanes. Any unknown path, a mixed
+change containing an unrecognized path, invalid or unavailable revisions, an
+empty diff, workflow/build infrastructure, project/package metadata, installer
+input, or classifier/contract change selects `full` fail-closed. A full pull
+request runs all test and E2E lanes plus the x64 publish smoke. Pushes to `main`
+and tags also run ARM64 publish.
+
+The former serialized Windows `test` job is split into three clean-runner lanes.
+Each lane restores and builds its own minimal project graph and publishes a
+separate TRX artifact:
+
+| Lane | Projects |
+|---|---|
+| `core-tests` | Shared, Connection, WinNode CLI |
+| `tray-tests` | Tray, SetupEngine, Tray Integration |
+| `ui-tests` | FunctionalUI, Tray UI, Axe.Windows accessibility |
+
+All three use the same repository-wide NuGet cache key. This change does not
+introduce per-lane cache keys or cross-job build artifact sharing. Tray settings
+remain isolated through `OPENCLAW_TRAY_DATA_DIR`, integration tests retain
+`OPENCLAW_RUN_INTEGRATION=1`, UI tests install WindowsAppRuntime, and every test
+project continues to publish TRX output.
+
+`fast-validation` still runs for every invocation and owns repository hygiene,
+documentation, agent-skill, classifier, gate, workflow, and release-ordering
+contracts. The heavyweight malformed proof-pool matrix moved to the independent
+`proof-pool-contracts` job. Its existing decision helper still fails closed,
+but ordinary product code no longer waits for the matrix. The three existing
+E2E shards are unchanged in scope and have separate job conditions; no E2E
+shards were added.
+
+Release metadata is produced by the small `metadata` job only when release
+publish validation is required. It preserves GitVersion `semVer`,
+`majorMinorPatch`, `isPrerelease`, `isStableCorrection`, and stable-correction
+tag validation. The x64 and ARM64 publish jobs depend only on classification
+and metadata, so they can run in parallel with tests and E2E. Ordinary product
+pull requests produce no release artifact. Packaging/build/release-sensitive
+pull requests run only x64 publish smoke; main and tags run x64 plus ARM64.
+
+The always-running **CI Gate** validates every classifier output against the
+corresponding job result. A required lane must succeed, an unrequired lane must
+be skipped, and classification, fast validation, proof-contract selection,
+missing outputs, cancellation, or unexpected results fail closed.
+
+#### Timing and runner-minute model
+
+The pre-split full PR baseline is run `33815204229`: the serialized `test` job
+took 22 minutes 11 seconds, including 6 minutes 48 seconds for the malformed
+proof-contract matrix and 3 minutes 28 seconds for accessibility. Existing E2E
+shards took 14 minutes 43 seconds, 9 minutes 33 seconds, and 11 minutes 7
+seconds. x64 and ARM64 publishes took 5 minutes 13 seconds and 6 minutes 17
+seconds. The merged docs/skill fast path is run `33819700640` at 51 seconds.
+
+Using those step baselines, expected pull request critical paths are:
+
+| Change class | Expected wall-clock | Expected runner cost relative to old full PR |
+|---|---:|---:|
+| Docs / agent-skill prose | About 1 minute | About 2% |
+| CLI-only | 5 to 7 minutes | About 10% |
+| Tray logic | 8 to 12 minutes | About 25% |
+| UI / XAML | 8 to 12 minutes | About 25% |
+| Setup / connection / Shared | 10 to 16 minutes, governed by required E2E | About 55% to 85% |
+| Build or workflow infrastructure | 10 to 16 minutes | Within 15% of the old full runner total |
+
+The full test split duplicates checkout, SDK setup, and cache restore, but removes
+the serialized proof matrix from product paths. Estimated full-infrastructure
+runner minutes remain below the 30% rejection threshold, while ordinary code
+latency falls to the longest required lane instead of the sum of every lane and
+release publish.
 
 ## Running tests
 

--- a/scripts/Assert-CiGateResults.ps1
+++ b/scripts/Assert-CiGateResults.ps1
@@ -1,20 +1,60 @@
 <#
 .SYNOPSIS
-    Enforces the stable CI Gate result contract.
+    Enforces the stable CI Gate result contract for classifier-selected lanes.
 #>
 
 [CmdletBinding()]
 param(
     [Parameter(Mandatory)][string]$ClassificationResult,
     [Parameter(Mandatory)][string]$Classification,
+    [Parameter(Mandatory)][string]$FullRequired,
     [Parameter(Mandatory)][string]$FastValidationResult,
-    [Parameter(Mandatory)][string]$TestResult,
-    [Parameter(Mandatory)][string]$E2eResult,
-    [Parameter(Mandatory)][string]$BuildResult
+    [Parameter(Mandatory)][string]$ProofPoolContractsResult,
+    [Parameter(Mandatory)][string]$CoreRequired,
+    [Parameter(Mandatory)][string]$CoreResult,
+    [Parameter(Mandatory)][string]$TrayRequired,
+    [Parameter(Mandatory)][string]$TrayResult,
+    [Parameter(Mandatory)][string]$UiRequired,
+    [Parameter(Mandatory)][string]$UiResult,
+    [Parameter(Mandatory)][string]$SetupE2eRequired,
+    [Parameter(Mandatory)][string]$SetupE2eResult,
+    [Parameter(Mandatory)][string]$RevocationE2eRequired,
+    [Parameter(Mandatory)][string]$RevocationE2eResult,
+    [Parameter(Mandatory)][string]$NetworkE2eRequired,
+    [Parameter(Mandatory)][string]$NetworkE2eResult,
+    [Parameter(Mandatory)][string]$X64ReleaseRequired,
+    [Parameter(Mandatory)][string]$X64ReleaseResult,
+    [Parameter(Mandatory)][string]$Arm64ReleaseRequired,
+    [Parameter(Mandatory)][string]$Arm64ReleaseResult,
+    [Parameter(Mandatory)][string]$MetadataResult
 )
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
+
+function ConvertTo-RequiredBoolean {
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][string]$Value
+    )
+
+    if ($Value -eq "true") { return $true }
+    if ($Value -eq "false") { return $false }
+    throw "Classifier output '$Name' must be 'true' or 'false', but it was '$Value'."
+}
+
+function Assert-LaneResult {
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][bool]$Required,
+        [Parameter(Mandatory)][string]$Result
+    )
+
+    $expected = if ($Required) { "success" } else { "skipped" }
+    if ($Result -ne $expected) {
+        throw "CI lane '$Name' required=$Required expected '$expected', but it was '$Result'."
+    }
+}
 
 if ($ClassificationResult -ne "success") {
     throw "Change classification did not succeed: $ClassificationResult"
@@ -22,29 +62,68 @@ if ($ClassificationResult -ne "success") {
 if ($FastValidationResult -ne "success") {
     throw "Fast validation did not succeed: $FastValidationResult"
 }
-
-$heavyResults = [ordered]@{
-    test = $TestResult
-    e2e = $E2eResult
-    build = $BuildResult
+if ($ProofPoolContractsResult -ne "success") {
+    throw "Proof-pool contract selection or validation did not succeed: $ProofPoolContractsResult"
 }
 
-if ($Classification -eq "docs_only") {
-    foreach ($lane in $heavyResults.GetEnumerator()) {
-        if ($lane.Value -ne "skipped") {
-            throw "Docs-only CI expected $($lane.Key) to be skipped, but it was '$($lane.Value)'."
+$required = [ordered]@{
+    core = ConvertTo-RequiredBoolean "core_tests" $CoreRequired
+    tray = ConvertTo-RequiredBoolean "tray_tests" $TrayRequired
+    ui = ConvertTo-RequiredBoolean "ui_tests" $UiRequired
+    setup_e2e = ConvertTo-RequiredBoolean "setup_e2e" $SetupE2eRequired
+    revocation_e2e = ConvertTo-RequiredBoolean "revocation_e2e" $RevocationE2eRequired
+    network_e2e = ConvertTo-RequiredBoolean "network_e2e" $NetworkE2eRequired
+    x64_release = ConvertTo-RequiredBoolean "x64_release" $X64ReleaseRequired
+    arm64_release = ConvertTo-RequiredBoolean "arm64_release" $Arm64ReleaseRequired
+}
+$full = ConvertTo-RequiredBoolean "full" $FullRequired
+
+switch ($Classification) {
+    "docs_only" {
+        if ($full -or @($required.Values | Where-Object { $_ }).Count -ne 0) {
+            throw "Docs-only classification may not require product lanes."
         }
     }
-    "docs_only"
-    return
-}
-
-if ($Classification -ne "full") {
-    throw "Unknown or missing change classification '$Classification'."
-}
-foreach ($lane in $heavyResults.GetEnumerator()) {
-    if ($lane.Value -ne "success") {
-        throw "Full CI requires $($lane.Key) to succeed, but it was '$($lane.Value)'."
+    "targeted" {
+        if ($full) {
+            throw "Targeted classification may not set full=true."
+        }
+        if (@($required.Values | Where-Object { $_ }).Count -eq 0) {
+            throw "Targeted classification must require at least one lane."
+        }
+    }
+    "full" {
+        if (-not $full) {
+            throw "Full classification must set full=true."
+        }
+        foreach ($laneName in @(
+                "core",
+                "tray",
+                "ui",
+                "setup_e2e",
+                "revocation_e2e",
+                "network_e2e",
+                "x64_release")) {
+            if (-not $required[$laneName]) {
+                throw "Full classification must require lane '$laneName'."
+            }
+        }
+    }
+    default {
+        throw "Unknown or missing change classification '$Classification'."
     }
 }
-"full"
+
+Assert-LaneResult "core tests" $required.core $CoreResult
+Assert-LaneResult "tray tests" $required.tray $TrayResult
+Assert-LaneResult "UI tests" $required.ui $UiResult
+Assert-LaneResult "setup E2E" $required.setup_e2e $SetupE2eResult
+Assert-LaneResult "revocation E2E" $required.revocation_e2e $RevocationE2eResult
+Assert-LaneResult "network E2E" $required.network_e2e $NetworkE2eResult
+Assert-LaneResult "x64 release publish" $required.x64_release $X64ReleaseResult
+Assert-LaneResult "ARM64 release publish" $required.arm64_release $Arm64ReleaseResult
+
+$metadataRequired = $required.x64_release -or $required.arm64_release
+Assert-LaneResult "release metadata" $metadataRequired $MetadataResult
+
+$Classification

--- a/scripts/Get-CiChangeClassification.ps1
+++ b/scripts/Get-CiChangeClassification.ps1
@@ -1,11 +1,12 @@
 <#
 .SYNOPSIS
-    Classifies a workflow change as docs_only or full.
+    Classifies changed paths into conservative CI validation lanes.
 
 .DESCRIPTION
-    Pull requests use the docs-only fast path only when every changed path is
-    explicitly allowlisted. All non-PR events and every indeterminate diff
-    classify as full.
+    Pull requests receive explicit lane decisions from recognized project
+    boundaries. Unknown paths, build or workflow infrastructure, project files,
+    classifier contracts, invalid revisions, empty diffs, and non-PR events
+    select every lane fail-closed.
 #>
 
 [CmdletBinding()]
@@ -26,24 +27,84 @@ if ([string]::IsNullOrWhiteSpace($RepoRoot)) {
 }
 $repoRootPath = [System.IO.Path]::GetFullPath($RepoRoot)
 
-function Complete-Classification([string]$Classification) {
-    $global:LASTEXITCODE = 0
-    $Classification
+function New-Impact([string]$Classification) {
+    [ordered]@{
+        classification = $Classification
+        core_tests = $false
+        tray_tests = $false
+        ui_tests = $false
+        setup_e2e = $false
+        revocation_e2e = $false
+        network_e2e = $false
+        x64_release = $false
+        arm64_release = $false
+        full = $false
+    }
 }
 
-function Test-IsSafeDocumentationPath([string]$Path) {
+function New-FullImpact {
+    param(
+        [switch]$IncludeArm64
+    )
+
+    $impact = New-Impact "full"
+    foreach ($lane in @(
+            "core_tests",
+            "tray_tests",
+            "ui_tests",
+            "setup_e2e",
+            "revocation_e2e",
+            "network_e2e",
+            "x64_release",
+            "full")) {
+        $impact[$lane] = $true
+    }
+    if ($IncludeArm64) {
+        $impact.arm64_release = $true
+    }
+    $impact
+}
+
+function Complete-Impact([System.Collections.IDictionary]$Impact) {
+    $global:LASTEXITCODE = 0
+    $Impact | ConvertTo-Json -Compress
+}
+
+function Add-Lanes {
+    param(
+        [Parameter(Mandatory)][System.Collections.IDictionary]$Impact,
+        [switch]$Core,
+        [switch]$Tray,
+        [switch]$Ui,
+        [switch]$SetupE2e,
+        [switch]$RevocationE2e,
+        [switch]$NetworkE2e
+    )
+
+    if ($Core) { $Impact.core_tests = $true }
+    if ($Tray) { $Impact.tray_tests = $true }
+    if ($Ui) { $Impact.ui_tests = $true }
+    if ($SetupE2e) { $Impact.setup_e2e = $true }
+    if ($RevocationE2e) { $Impact.revocation_e2e = $true }
+    if ($NetworkE2e) { $Impact.network_e2e = $true }
+}
+
+function ConvertTo-NormalizedPath([string]$Path) {
     if ([string]::IsNullOrWhiteSpace($Path)) {
-        return $false
+        return $null
     }
 
     $normalizedPath = $Path.Trim().Replace("\", "/")
     if ($normalizedPath.StartsWith("/", [StringComparison]::Ordinal) -or
         $normalizedPath.Contains("..", [StringComparison]::Ordinal) -or
         $normalizedPath.Contains([char]0)) {
-        return $false
+        return $null
     }
+    $normalizedPath
+}
 
-    $rootMarkdown = [System.Collections.Generic.HashSet[string]]::new(
+function Test-IsSafeDocumentationPath([string]$Path) {
+    $rootDocumentation = [System.Collections.Generic.HashSet[string]]::new(
         [System.StringComparer]::OrdinalIgnoreCase)
     @(
         "AGENTS.md",
@@ -51,13 +112,13 @@ function Test-IsSafeDocumentationPath([string]$Path) {
         "README.md",
         "SECURITY.md",
         ".github/pull_request_template.md"
-    ) | ForEach-Object { [void]$rootMarkdown.Add($_) }
-    if ($rootMarkdown.Contains($normalizedPath)) {
+    ) | ForEach-Object { [void]$rootDocumentation.Add($_) }
+    if ($rootDocumentation.Contains($Path)) {
         return $true
     }
 
-    $extension = [System.IO.Path]::GetExtension($normalizedPath)
-    $safeDocumentationExtensions = [System.Collections.Generic.HashSet[string]]::new(
+    $extension = [System.IO.Path]::GetExtension($Path)
+    $safeExtensions = [System.Collections.Generic.HashSet[string]]::new(
         [System.StringComparer]::OrdinalIgnoreCase)
     @(
         ".md",
@@ -68,23 +129,117 @@ function Test-IsSafeDocumentationPath([string]$Path) {
         ".jpeg",
         ".gif",
         ".webp"
-    ) | ForEach-Object { [void]$safeDocumentationExtensions.Add($_) }
-
-    if (-not $safeDocumentationExtensions.Contains($extension)) {
+    ) | ForEach-Object { [void]$safeExtensions.Add($_) }
+    if (-not $safeExtensions.Contains($extension)) {
         return $false
     }
 
-    if ($normalizedPath.StartsWith("docs/", [StringComparison]::OrdinalIgnoreCase)) {
+    return $Path.StartsWith("docs/", [StringComparison]::OrdinalIgnoreCase) -or
+        $Path.StartsWith(".agents/skills/", [StringComparison]::OrdinalIgnoreCase)
+}
+
+function Test-IsBuildInfrastructurePath([string]$Path) {
+    if ($Path -match '^(?i:\.github/(?:workflows|actions)/|scripts/|installer/|packaging/)' -or
+        $Path -match '^(?i:build\.(?:ps1|cmd|bat)|global\.json|NuGet\.Config|Directory\.(?:Build|Packages)\.(?:props|targets)|installer\.iss)$') {
         return $true
     }
 
-    return $normalizedPath.StartsWith(
-        ".agents/skills/",
-        [StringComparison]::OrdinalIgnoreCase)
+    return $Path -match '(?i)(?:^|/)(?:Directory\.(?:Build|Packages)\.(?:props|targets)|[^/]+\.(?:csproj|sln|slnx|wapproj|props|targets|appxmanifest|wxs|iss)|packages\.lock\.json|package(?:-lock)?\.json)$'
+}
+
+function Add-PathImpact {
+    param(
+        [Parameter(Mandatory)][System.Collections.IDictionary]$Impact,
+        [Parameter(Mandatory)][string]$Path
+    )
+
+    if ($Path.StartsWith("src/OpenClaw.Cli/", [StringComparison]::OrdinalIgnoreCase) -or
+        $Path.StartsWith("src/OpenClaw.WinNode.Cli/", [StringComparison]::OrdinalIgnoreCase)) {
+        Add-Lanes -Impact $Impact -Core
+        return $true
+    }
+
+    if ($Path.StartsWith("src/OpenClaw.Chat/", [StringComparison]::OrdinalIgnoreCase) -or
+        $Path.StartsWith("src/OpenClawTray.FunctionalUI/", [StringComparison]::OrdinalIgnoreCase)) {
+        Add-Lanes -Impact $Impact -Tray -Ui
+        return $true
+    }
+
+    if ($Path.StartsWith("src/OpenClaw.SetupEngine.UI/", [StringComparison]::OrdinalIgnoreCase)) {
+        Add-Lanes -Impact $Impact -Tray -Ui -SetupE2e
+        return $true
+    }
+
+    if ($Path.StartsWith("src/OpenClaw.SetupEngine/", [StringComparison]::OrdinalIgnoreCase)) {
+        Add-Lanes -Impact $Impact -Tray -SetupE2e
+        return $true
+    }
+
+    if ($Path.StartsWith("src/OpenClaw.Connection/", [StringComparison]::OrdinalIgnoreCase)) {
+        Add-Lanes -Impact $Impact -Core -Tray -SetupE2e -RevocationE2e -NetworkE2e
+        return $true
+    }
+
+    if ($Path.StartsWith("src/OpenClaw.Shared/", [StringComparison]::OrdinalIgnoreCase)) {
+        Add-Lanes -Impact $Impact -Core -Tray -Ui -SetupE2e -RevocationE2e -NetworkE2e
+        return $true
+    }
+
+    if ($Path.StartsWith("src/OpenClaw.Tray.WinUI/", [StringComparison]::OrdinalIgnoreCase)) {
+        Add-Lanes -Impact $Impact -Tray -Ui
+        if ($Path -match '(?i)(?:setup|onboarding|pairing)') {
+            Add-Lanes -Impact $Impact -SetupE2e
+        }
+        if ($Path -match '(?i)(?:connection|gateway|mcp|node|wsl)') {
+            Add-Lanes -Impact $Impact -SetupE2e -RevocationE2e -NetworkE2e
+        }
+        return $true
+    }
+
+    if ($Path.StartsWith("tests/OpenClaw.Shared.Tests/", [StringComparison]::OrdinalIgnoreCase) -or
+        $Path.StartsWith("tests/OpenClaw.Connection.Tests/", [StringComparison]::OrdinalIgnoreCase) -or
+        $Path.StartsWith("tests/OpenClaw.WinNode.Cli.Tests/", [StringComparison]::OrdinalIgnoreCase) -or
+        $Path.StartsWith("tests/OpenClaw.Shared.TestHost/", [StringComparison]::OrdinalIgnoreCase)) {
+        Add-Lanes -Impact $Impact -Core
+        return $true
+    }
+
+    if ($Path.StartsWith("tests/OpenClaw.Tray.Tests/", [StringComparison]::OrdinalIgnoreCase) -or
+        $Path.StartsWith("tests/OpenClaw.SetupEngine.Tests/", [StringComparison]::OrdinalIgnoreCase) -or
+        $Path.StartsWith("tests/OpenClaw.Tray.IntegrationTests/", [StringComparison]::OrdinalIgnoreCase)) {
+        Add-Lanes -Impact $Impact -Tray
+        return $true
+    }
+
+    if ($Path.StartsWith("tests/OpenClaw.Tray.UITests/", [StringComparison]::OrdinalIgnoreCase) -or
+        $Path.StartsWith("tests/OpenClawTray.FunctionalUI.Tests/", [StringComparison]::OrdinalIgnoreCase)) {
+        Add-Lanes -Impact $Impact -Ui
+        return $true
+    }
+
+    if ($Path.StartsWith("tests/OpenClaw.TestSupport/", [StringComparison]::OrdinalIgnoreCase)) {
+        Add-Lanes -Impact $Impact -Core -Tray
+        return $true
+    }
+
+    if ($Path.StartsWith("tests/OpenClaw.E2ETests/", [StringComparison]::OrdinalIgnoreCase)) {
+        if ($Path -match '(?i)RevocationAndRecovery') {
+            Add-Lanes -Impact $Impact -RevocationE2e
+        } elseif ($Path -match '(?i)NetworkRecovery') {
+            Add-Lanes -Impact $Impact -NetworkE2e
+        } elseif ($Path -match '(?i)(?:SetupAndConnect|MxcSetupAndConnect|MirroredWslPortLease|SshOwnershipAdversarialProof|TrayExecutableResolution)') {
+            Add-Lanes -Impact $Impact -SetupE2e
+        } else {
+            Add-Lanes -Impact $Impact -SetupE2e -RevocationE2e -NetworkE2e
+        }
+        return $true
+    }
+
+    return $false
 }
 
 if ($EventName -ne "pull_request") {
-    Complete-Classification "full"
+    Complete-Impact (New-FullImpact -IncludeArm64)
     return
 }
 
@@ -98,7 +253,7 @@ if ($PSBoundParameters.ContainsKey("ChangedPaths")) {
         $BaseSha -notmatch $shaPattern -or
         $HeadSha -notmatch $shaPattern) {
         Write-Warning "CI diff revisions are missing or invalid. Selecting full validation."
-        Complete-Classification "full"
+        Complete-Impact (New-FullImpact)
         return
     }
 
@@ -107,7 +262,7 @@ if ($PSBoundParameters.ContainsKey("ChangedPaths")) {
         if ($LASTEXITCODE -ne 0) {
             $global:LASTEXITCODE = 0
             Write-Warning "CI diff revision '$sha' is unavailable. Selecting full validation."
-            Complete-Classification "full"
+            Complete-Impact (New-FullImpact)
             return
         }
     }
@@ -120,14 +275,14 @@ if ($PSBoundParameters.ContainsKey("ChangedPaths")) {
         $global:LASTEXITCODE = 0
     } catch {
         Write-Warning "CI diff failed. Selecting full validation: $($_.Exception.Message)"
-        Complete-Classification "full"
+        Complete-Impact (New-FullImpact)
         return
     }
 
     if ($gitExitCode -ne 0) {
         $detail = ($diffOutput | Out-String).Trim()
         Write-Warning "CI diff exited with code $gitExitCode. Selecting full validation: $detail"
-        Complete-Classification "full"
+        Complete-Impact (New-FullImpact)
         return
     }
     $paths = @($diffOutput)
@@ -135,15 +290,36 @@ if ($PSBoundParameters.ContainsKey("ChangedPaths")) {
 
 if ($paths.Count -eq 0) {
     Write-Warning "CI diff contained no changed paths. Selecting full validation."
-    Complete-Classification "full"
+    Complete-Impact (New-FullImpact)
     return
 }
 
+$impact = New-Impact "targeted"
+$hasProductChange = $false
 foreach ($changedPath in $paths) {
-    if (-not (Test-IsSafeDocumentationPath ([string]$changedPath))) {
-        Complete-Classification "full"
+    $normalizedPath = ConvertTo-NormalizedPath ([string]$changedPath)
+    if ($null -eq $normalizedPath) {
+        Complete-Impact (New-FullImpact)
+        return
+    }
+    if (Test-IsSafeDocumentationPath $normalizedPath) {
+        continue
+    }
+
+    $hasProductChange = $true
+    if (Test-IsBuildInfrastructurePath $normalizedPath) {
+        Complete-Impact (New-FullImpact)
+        return
+    }
+    if (-not (Add-PathImpact -Impact $impact -Path $normalizedPath)) {
+        Complete-Impact (New-FullImpact)
         return
     }
 }
 
-Complete-Classification "docs_only"
+if (-not $hasProductChange) {
+    Complete-Impact (New-Impact "docs_only")
+    return
+}
+
+Complete-Impact $impact

--- a/scripts/Get-CiProofPoolRegressionDecision.ps1
+++ b/scripts/Get-CiProofPoolRegressionDecision.ps1
@@ -40,6 +40,7 @@ if ([string]::IsNullOrWhiteSpace($BaseSha) -or
 $triggerPaths = [System.Collections.Generic.HashSet[string]]::new(
     [System.StringComparer]::OrdinalIgnoreCase)
 @(
+    ".github/workflows/ci.yml",
     ".github/proof-pools.json",
     ".github/proof-pools.schema.json",
     "scripts/validate-proof-pools.ps1",

--- a/scripts/Invoke-CiE2e.ps1
+++ b/scripts/Invoke-CiE2e.ps1
@@ -1,0 +1,93 @@
+<#
+.SYNOPSIS
+    Runs one existing CI E2E shard and enforces its TRX proof contract.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][ValidateSet("setup-connect", "revocation-recovery", "network-recovery")]
+    [string]$Name,
+    [Parameter(Mandatory)][string]$Filter
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$resultsDirectory = "TestResults\E2E"
+$trxPath = Join-Path $resultsDirectory "OpenClaw.E2ETests.$Name.trx"
+dotnet test tests/OpenClaw.E2ETests `
+    --no-build `
+    -c Debug `
+    -r win-x64 `
+    --verbosity normal `
+    --results-directory $resultsDirectory `
+    --logger "trx;LogFileName=OpenClaw.E2ETests.$Name.trx" `
+    --logger "console;verbosity=detailed" `
+    --filter $Filter
+if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+}
+
+[xml]$trx = Get-Content $trxPath
+$executed = [int]$trx.TestRun.ResultSummary.Counters.executed
+if ($executed -lt 1) {
+    throw "E2E shard '$Name' executed zero tests. Check OPENCLAW_RUN_E2E gating/filter before merging."
+}
+
+if ($Name -ne "setup-connect") {
+    return
+}
+
+$mxcProofNames = @(
+    "RealGateway_SystemRun_ExecutesThroughWindowsNodeMxcSandbox",
+    "RealGateway_SystemRun_BlocksWritesToTrayDataDirectoryInMxcSandbox"
+)
+foreach ($mxcProofName in $mxcProofNames) {
+    $mxcProof = @(
+        $trx.TestRun.Results.UnitTestResult |
+            Where-Object { $_.testName -like "*$mxcProofName*" }
+    ) | Select-Object -First 1
+    if ($null -eq $mxcProof) {
+        throw "E2E shard '$Name' did not report the MXC proof test '$mxcProofName'. Check the setup-connect filter before merging."
+    }
+
+    $mxcOutcome = [string]$mxcProof.outcome
+    if ($mxcOutcome -eq "Passed") {
+        Write-Host "MXC E2E proof passed: $mxcProofName"
+    } elseif ($mxcOutcome -eq "NotExecuted" -or $mxcOutcome -eq "Skipped") {
+        $mxcSkipReason = @(
+            $mxcProof.SelectSingleNode("Output/ErrorInfo/Message")
+            $mxcProof.SelectSingleNode("Output/StdOut")
+        ) |
+            Where-Object { $null -ne $_ -and -not [string]::IsNullOrWhiteSpace($_.InnerText) } |
+            ForEach-Object { $_.InnerText.Trim() } |
+            Select-Object -First 1
+        if ([string]::IsNullOrWhiteSpace($mxcSkipReason)) {
+            $mxcSkipReason = "skip reason was not present in the trx output"
+        }
+        Write-Warning "MXC E2E proof skipped: $mxcProofName; $mxcSkipReason"
+    } else {
+        throw "MXC E2E proof '$mxcProofName' had unexpected outcome '$mxcOutcome'."
+    }
+}
+
+$sshOwnershipProofNames = @(
+    "UnownedListenerIsRejectedThenOwnedTunnelRecoversWithoutRepairing",
+    "InitialHandshakeListenerReplacementWithholdsCredentialFrame",
+    "InitialNodeHandshakeListenerReplacementWithholdsCredentialFrame"
+)
+foreach ($sshOwnershipProofName in $sshOwnershipProofNames) {
+    $sshOwnershipProof = @(
+        $trx.TestRun.Results.UnitTestResult |
+            Where-Object { $_.testName -like "*$sshOwnershipProofName*" }
+    ) | Select-Object -First 1
+    if ($null -eq $sshOwnershipProof) {
+        throw "E2E shard '$Name' did not report the SSH ownership proof test '$sshOwnershipProofName'. Check the setup-connect filter before merging."
+    }
+
+    $sshOwnershipOutcome = [string]$sshOwnershipProof.outcome
+    if ($sshOwnershipOutcome -ne "Passed") {
+        throw "SSH ownership E2E proof '$sshOwnershipProofName' had outcome '$sshOwnershipOutcome'; this proof must pass and may not skip."
+    }
+    Write-Host "SSH ownership E2E proof passed: $sshOwnershipProofName"
+}

--- a/scripts/test-ci-change-classifier.ps1
+++ b/scripts/test-ci-change-classifier.ps1
@@ -1,6 +1,6 @@
 <#
 .SYNOPSIS
-    Exercises the fail-closed CI change classifier.
+    Exercises the fail-closed CI impact classifier.
 #>
 
 [CmdletBinding()]
@@ -17,73 +17,222 @@ if ([string]::IsNullOrWhiteSpace($RepoRoot)) {
 }
 $repoRootPath = [System.IO.Path]::GetFullPath($RepoRoot)
 $classifierPath = Join-Path $repoRootPath "scripts\Get-CiChangeClassification.ps1"
+$laneNames = @(
+    "core_tests",
+    "tray_tests",
+    "ui_tests",
+    "setup_e2e",
+    "revocation_e2e",
+    "network_e2e",
+    "x64_release",
+    "arm64_release",
+    "full"
+)
 
-function Assert-Classification {
+function Get-Impact {
     param(
-        [Parameter(Mandatory)][string]$Expected,
-        [Parameter(Mandatory)][string[]]$Paths,
-        [Parameter(Mandatory)][string]$Scenario
+        [string]$EventName = "pull_request",
+        [string[]]$Paths
     )
 
-    $actual = & $classifierPath `
-        -EventName pull_request `
+    $json = & $classifierPath `
+        -EventName $EventName `
         -RepoRoot $repoRootPath `
         -ChangedPaths $Paths
-    if ($actual -ne $Expected) {
-        throw "$Scenario classified as '$actual' instead of '$Expected'."
+    $json | ConvertFrom-Json
+}
+
+function Assert-Impact {
+    param(
+        [Parameter(Mandatory)][string]$Scenario,
+        [Parameter(Mandatory)][string[]]$Paths,
+        [Parameter(Mandatory)][string]$Classification,
+        [string[]]$Required = @(),
+        [string]$EventName = "pull_request"
+    )
+
+    $actual = Get-Impact -EventName $EventName -Paths $Paths
+    if ($actual.classification -ne $Classification) {
+        throw "$Scenario classified as '$($actual.classification)' instead of '$Classification'."
+    }
+
+    foreach ($lane in $laneNames) {
+        $expected = $Required -contains $lane
+        if ([bool]$actual.$lane -ne $expected) {
+            throw "$Scenario expected $lane=$expected but received $($actual.$lane)."
+        }
     }
 }
 
-Assert-Classification `
-    -Expected docs_only `
-    -Paths @(".agents/skills/example/SKILL.md") `
-    -Scenario "Skill-only documentation"
-Assert-Classification `
-    -Expected docs_only `
-    -Paths @("README.md", "docs/TEST_COVERAGE.md", "docs/diagrams/ci.svg") `
-    -Scenario "Maintained documentation"
-Assert-Classification `
-    -Expected full `
-    -Paths @(".agents/skills/example/SKILL.md", "src/OpenClaw.Shared/Example.cs") `
-    -Scenario "Mixed skill and source change"
-
-$unsafePaths = @(
-    ".github/workflows/ci.yml",
-    ".github/dependabot.yml",
-    "scripts/validate-docs.ps1",
-    "Directory.Build.props",
-    "Directory.Build.targets",
-    "Directory.Packages.props",
-    "package.json",
-    "src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj",
-    "installer/OpenClaw.iss",
-    "src/OpenClaw.Shared/Example.cs",
-    "tests/OpenClaw.Shared.Tests/ExampleTests.cs",
-    ".agents/skills/example/scripts/run.ps1",
-    ".agents/skills/example/scripts/run",
-    "unknown/location/file.txt"
+$allLanes = @($laneNames)
+$fullPrLanes = @($laneNames | Where-Object { $_ -ne "arm64_release" })
+$allProductLanes = @(
+    "core_tests",
+    "tray_tests",
+    "ui_tests",
+    "setup_e2e",
+    "revocation_e2e",
+    "network_e2e"
 )
-foreach ($unsafePath in $unsafePaths) {
-    Assert-Classification `
-        -Expected full `
-        -Paths @($unsafePath) `
-        -Scenario "Unsafe path '$unsafePath'"
+$cases = @(
+    @{
+        Scenario = "Maintained documentation"
+        Paths = @("README.md", "docs/TEST_COVERAGE.md", "docs/diagrams/ci.svg")
+        Classification = "docs_only"
+    },
+    @{
+        Scenario = "Skill-only documentation"
+        Paths = @(".agents/skills/example/SKILL.md")
+        Classification = "docs_only"
+    },
+    @{
+        Scenario = "CLI-only product change"
+        Paths = @("src/OpenClaw.Cli/Program.cs")
+        Classification = "targeted"
+        Required = @("core_tests")
+    },
+    @{
+        Scenario = "WinNode CLI-only product change"
+        Paths = @("src/OpenClaw.WinNode.Cli/Program.cs")
+        Classification = "targeted"
+        Required = @("core_tests")
+    },
+    @{
+        Scenario = "Chat UI change"
+        Paths = @("src/OpenClaw.Chat/ChatModels.cs")
+        Classification = "targeted"
+        Required = @("tray_tests", "ui_tests")
+    },
+    @{
+        Scenario = "Pure XAML change"
+        Paths = @("src/OpenClaw.Tray.WinUI/Pages/SettingsPage.xaml")
+        Classification = "targeted"
+        Required = @("tray_tests", "ui_tests")
+    },
+    @{
+        Scenario = "Tray logic change"
+        Paths = @("src/OpenClaw.Tray.WinUI/Services/TrayTooltipBuilder.cs")
+        Classification = "targeted"
+        Required = @("tray_tests", "ui_tests")
+    },
+    @{
+        Scenario = "Setup engine change"
+        Paths = @("src/OpenClaw.SetupEngine/SetupOrchestrator.cs")
+        Classification = "targeted"
+        Required = @("tray_tests", "setup_e2e")
+    },
+    @{
+        Scenario = "Connection change"
+        Paths = @("src/OpenClaw.Connection/GatewayConnectionManager.cs")
+        Classification = "targeted"
+        Required = @("core_tests", "tray_tests", "setup_e2e", "revocation_e2e", "network_e2e")
+    },
+    @{
+        Scenario = "Broad Shared protocol change"
+        Paths = @("src/OpenClaw.Shared/Gateway/GatewayClient.cs")
+        Classification = "targeted"
+        Required = $allProductLanes
+    },
+    @{
+        Scenario = "Tray MCP change"
+        Paths = @("src/OpenClaw.Tray.WinUI/Services/McpRuntimeStatePolicy.cs")
+        Classification = "targeted"
+        Required = @("tray_tests", "ui_tests", "setup_e2e", "revocation_e2e", "network_e2e")
+    },
+    @{
+        Scenario = "Core test-only change"
+        Paths = @("tests/OpenClaw.WinNode.Cli.Tests/ProgramTests.cs")
+        Classification = "targeted"
+        Required = @("core_tests")
+    },
+    @{
+        Scenario = "UI test-only change"
+        Paths = @("tests/OpenClaw.Tray.UITests/ReactorTests.cs")
+        Classification = "targeted"
+        Required = @("ui_tests")
+    },
+    @{
+        Scenario = "Setup E2E test-only change"
+        Paths = @("tests/OpenClaw.E2ETests/Setup/SetupAndConnectTests.cs")
+        Classification = "targeted"
+        Required = @("setup_e2e")
+    },
+    @{
+        Scenario = "Recognized mixed product change"
+        Paths = @("src/OpenClaw.Cli/Program.cs", "src/OpenClaw.Tray.WinUI/Pages/SettingsPage.xaml")
+        Classification = "targeted"
+        Required = @("core_tests", "tray_tests", "ui_tests")
+    },
+    @{
+        Scenario = "Workflow infrastructure"
+        Paths = @(".github/workflows/ci.yml")
+        Classification = "full"
+        Required = $fullPrLanes
+    },
+    @{
+        Scenario = "Package and build infrastructure"
+        Paths = @("Directory.Packages.props")
+        Classification = "full"
+        Required = $fullPrLanes
+    },
+    @{
+        Scenario = "Installer infrastructure"
+        Paths = @("installer.iss")
+        Classification = "full"
+        Required = $fullPrLanes
+    },
+    @{
+        Scenario = "Classifier contract change"
+        Paths = @("scripts/test-ci-change-classifier.ps1")
+        Classification = "full"
+        Required = $fullPrLanes
+    },
+    @{
+        Scenario = "Unknown path"
+        Paths = @("unknown/location/file.txt")
+        Classification = "full"
+        Required = $fullPrLanes
+    },
+    @{
+        Scenario = "Mixed recognized and unknown paths"
+        Paths = @("src/OpenClaw.Cli/Program.cs", "unknown/location/file.txt")
+        Classification = "full"
+        Required = $fullPrLanes
+    },
+    @{
+        Scenario = "Main push"
+        EventName = "push"
+        Paths = @("src/OpenClaw.Cli/Program.cs")
+        Classification = "full"
+        Required = $allLanes
+    },
+    @{
+        Scenario = "Tag push"
+        EventName = "push"
+        Paths = @("docs/TEST_COVERAGE.md")
+        Classification = "full"
+        Required = $allLanes
+    }
+)
+
+foreach ($case in $cases) {
+    $arguments = @{
+        Scenario = $case.Scenario
+        Paths = $case.Paths
+        Classification = $case.Classification
+    }
+    if ($case.ContainsKey("Required")) {
+        $arguments.Required = $case.Required
+    }
+    if ($case.ContainsKey("EventName")) {
+        $arguments.EventName = $case.EventName
+    }
+    Assert-Impact @arguments
 }
 
-$emptyDecision = & $classifierPath `
-    -EventName pull_request `
-    -RepoRoot $repoRootPath `
-    -ChangedPaths @()
-if ($emptyDecision -ne "full") {
-    throw "An empty explicit path list must classify as full."
-}
-
-$pushDecision = & $classifierPath `
-    -EventName push `
-    -RepoRoot $repoRootPath `
-    -ChangedPaths @(".agents/skills/example/SKILL.md")
-if ($pushDecision -ne "full") {
-    throw "Push and tag workflow invocations must classify as full."
+$emptyImpact = Get-Impact -Paths @()
+if ($emptyImpact.classification -ne "full" -or -not $emptyImpact.full) {
+    throw "An empty explicit path list must select full validation."
 }
 
 $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) (
@@ -108,32 +257,32 @@ try {
     & git -C $tempRoot add .
     & git -C $tempRoot commit --quiet -m "skill docs"
     $headSha = (& git -C $tempRoot rev-parse HEAD).Trim()
-    $gitDecision = & $classifierPath `
+    $gitImpact = (& $classifierPath `
         -EventName pull_request `
         -BaseSha $baseSha `
         -HeadSha $headSha `
-        -RepoRoot $tempRoot
-    if ($gitDecision -ne "docs_only") {
-        throw "A real skill-only git diff classified as '$gitDecision'."
+        -RepoRoot $tempRoot) | ConvertFrom-Json
+    if ($gitImpact.classification -ne "docs_only") {
+        throw "A real skill-only git diff classified as '$($gitImpact.classification)'."
     }
 
-    $emptyGitDecision = & $classifierPath `
+    $emptyGitImpact = (& $classifierPath `
         -EventName pull_request `
         -BaseSha $headSha `
         -HeadSha $headSha `
-        -RepoRoot $tempRoot
-    if ($emptyGitDecision -ne "full") {
-        throw "An empty git diff must classify as full."
+        -RepoRoot $tempRoot) | ConvertFrom-Json
+    if ($emptyGitImpact.classification -ne "full" -or -not $emptyGitImpact.full) {
+        throw "An empty git diff must select full validation."
     }
 
     foreach ($invalidBase in @("", "missing-base", ("f" * 40))) {
-        $invalidDecision = & $classifierPath `
+        $invalidImpact = (& $classifierPath `
             -EventName pull_request `
             -BaseSha $invalidBase `
             -HeadSha $headSha `
-            -RepoRoot $tempRoot
-        if ($invalidDecision -ne "full") {
-            throw "Invalid revision '$invalidBase' classified as '$invalidDecision'."
+            -RepoRoot $tempRoot) | ConvertFrom-Json
+        if ($invalidImpact.classification -ne "full" -or -not $invalidImpact.full) {
+            throw "Invalid revision '$invalidBase' did not select full validation."
         }
     }
 } finally {
@@ -142,4 +291,4 @@ try {
     }
 }
 
-Write-Host "CI change classifier regressions passed: safe docs fast-path and fail-closed full validation cases." -ForegroundColor Green
+Write-Host "CI impact classifier regressions passed: targeted project lanes and fail-closed full validation cases." -ForegroundColor Green

--- a/scripts/test-ci-gate-results.ps1
+++ b/scripts/test-ci-gate-results.ps1
@@ -17,33 +17,49 @@ if ([string]::IsNullOrWhiteSpace($RepoRoot)) {
 }
 $gatePath = Join-Path $RepoRoot "scripts\Assert-CiGateResults.ps1"
 
-function Invoke-Gate {
-    param(
-        [string]$ClassificationResult = "success",
-        [string]$Classification = "full",
-        [string]$FastValidationResult = "success",
-        [string]$TestResult = "success",
-        [string]$E2eResult = "success",
-        [string]$BuildResult = "success"
-    )
+function New-GateArguments {
+    @{
+        ClassificationResult = "success"
+        Classification = "targeted"
+        FullRequired = "false"
+        FastValidationResult = "success"
+        ProofPoolContractsResult = "success"
+        CoreRequired = "true"
+        CoreResult = "success"
+        TrayRequired = "false"
+        TrayResult = "skipped"
+        UiRequired = "false"
+        UiResult = "skipped"
+        SetupE2eRequired = "false"
+        SetupE2eResult = "skipped"
+        RevocationE2eRequired = "false"
+        RevocationE2eResult = "skipped"
+        NetworkE2eRequired = "false"
+        NetworkE2eResult = "skipped"
+        X64ReleaseRequired = "false"
+        X64ReleaseResult = "skipped"
+        Arm64ReleaseRequired = "false"
+        Arm64ReleaseResult = "skipped"
+        MetadataResult = "skipped"
+    }
+}
 
-    & $gatePath `
-        -ClassificationResult $ClassificationResult `
-        -Classification $Classification `
-        -FastValidationResult $FastValidationResult `
-        -TestResult $TestResult `
-        -E2eResult $E2eResult `
-        -BuildResult $BuildResult
+function Invoke-Gate([hashtable]$Arguments) {
+    & $gatePath @Arguments
 }
 
 function Assert-GateFails {
     param(
-        [Parameter(Mandatory)][hashtable]$Arguments,
+        [Parameter(Mandatory)][hashtable]$Overrides,
         [Parameter(Mandatory)][string]$Scenario
     )
 
+    $arguments = New-GateArguments
+    foreach ($entry in $Overrides.GetEnumerator()) {
+        $arguments[$entry.Key] = $entry.Value
+    }
     try {
-        $result = Invoke-Gate @Arguments
+        $result = Invoke-Gate $arguments
         throw "$Scenario unexpectedly passed with result '$result'."
     } catch {
         if ($_.Exception.Message.StartsWith(
@@ -54,44 +70,96 @@ function Assert-GateFails {
     }
 }
 
-$docsOnly = Invoke-Gate `
-    -Classification docs_only `
-    -TestResult skipped `
-    -E2eResult skipped `
-    -BuildResult skipped
+$targeted = Invoke-Gate (New-GateArguments)
+if ($targeted -ne "targeted") {
+    throw "Expected a core-only targeted gate to pass."
+}
+
+$docsArguments = New-GateArguments
+$docsArguments.Classification = "docs_only"
+$docsArguments.CoreRequired = "false"
+$docsArguments.CoreResult = "skipped"
+$docsOnly = Invoke-Gate $docsArguments
 if ($docsOnly -ne "docs_only") {
     throw "Expected the docs-only gate to pass."
 }
 
-$full = Invoke-Gate
+$uiArguments = New-GateArguments
+$uiArguments.CoreRequired = "false"
+$uiArguments.CoreResult = "skipped"
+$uiArguments.TrayRequired = "true"
+$uiArguments.TrayResult = "success"
+$uiArguments.UiRequired = "true"
+$uiArguments.UiResult = "success"
+$uiTargeted = Invoke-Gate $uiArguments
+if ($uiTargeted -ne "targeted") {
+    throw "Expected the UI-targeted gate to pass."
+}
+
+$fullArguments = New-GateArguments
+$fullArguments.Classification = "full"
+$fullArguments.FullRequired = "true"
+foreach ($prefix in @(
+        "Core",
+        "Tray",
+        "Ui",
+        "SetupE2e",
+        "RevocationE2e",
+        "NetworkE2e",
+        "X64Release",
+        "Arm64Release")) {
+    $fullArguments["${prefix}Required"] = "true"
+    $fullArguments["${prefix}Result"] = "success"
+}
+$fullArguments.MetadataResult = "success"
+$full = Invoke-Gate $fullArguments
 if ($full -ne "full") {
     throw "Expected the full gate to pass."
 }
 
-Assert-GateFails `
-    -Arguments @{ ClassificationResult = "failure" } `
-    -Scenario "Failed classification"
-Assert-GateFails `
-    -Arguments @{ FastValidationResult = "cancelled" } `
-    -Scenario "Cancelled fast validation"
-Assert-GateFails `
-    -Arguments @{
-        Classification = "docs_only"
-        TestResult = "success"
-        E2eResult = "skipped"
-        BuildResult = "skipped"
-    } `
-    -Scenario "Unskipped docs-only test lane"
-Assert-GateFails `
-    -Arguments @{ Classification = "unexpected" } `
-    -Scenario "Unknown classification"
-
-foreach ($lane in @("TestResult", "E2eResult", "BuildResult")) {
-    foreach ($result in @("failure", "cancelled", "skipped")) {
-        Assert-GateFails `
-            -Arguments @{ $lane = $result } `
-            -Scenario "Full $lane result '$result'"
-    }
+$fullPrArguments = New-GateArguments
+$fullPrArguments.Classification = "full"
+$fullPrArguments.FullRequired = "true"
+foreach ($prefix in @(
+        "Core",
+        "Tray",
+        "Ui",
+        "SetupE2e",
+        "RevocationE2e",
+        "NetworkE2e",
+        "X64Release")) {
+    $fullPrArguments["${prefix}Required"] = "true"
+    $fullPrArguments["${prefix}Result"] = "success"
+}
+$fullPrArguments.MetadataResult = "success"
+$fullPr = Invoke-Gate $fullPrArguments
+if ($fullPr -ne "full") {
+    throw "Expected full pull request validation without ARM64 publish to pass."
 }
 
-Write-Host "CI Gate regressions passed: docs-only skips accepted, full successes accepted, and failures/cancellations/unexpected skips rejected." -ForegroundColor Green
+Assert-GateFails -Overrides @{ ClassificationResult = "failure" } -Scenario "Failed classification"
+Assert-GateFails -Overrides @{ FastValidationResult = "cancelled" } -Scenario "Cancelled fast validation"
+Assert-GateFails -Overrides @{ ProofPoolContractsResult = "failure" } -Scenario "Failed proof contracts"
+Assert-GateFails -Overrides @{ CoreRequired = "" } -Scenario "Missing classifier output"
+Assert-GateFails -Overrides @{ CoreResult = "skipped" } -Scenario "Required lane skipped"
+Assert-GateFails -Overrides @{ CoreResult = "cancelled" } -Scenario "Required lane cancelled"
+Assert-GateFails -Overrides @{ CoreResult = "failure" } -Scenario "Required lane failed"
+Assert-GateFails `
+    -Overrides @{ CoreRequired = "false"; CoreResult = "success" } `
+    -Scenario "Unrequired lane ran"
+Assert-GateFails -Overrides @{ Classification = "unexpected" } -Scenario "Unknown classification"
+Assert-GateFails `
+    -Overrides @{ Classification = "docs_only"; CoreRequired = "false" } `
+    -Scenario "Docs lane unexpectedly succeeded"
+Assert-GateFails `
+    -Overrides @{ Classification = "full"; FullRequired = "true" } `
+    -Scenario "Full classification omitted lanes"
+Assert-GateFails `
+    -Overrides @{
+        X64ReleaseRequired = "true"
+        X64ReleaseResult = "success"
+        MetadataResult = "skipped"
+    } `
+    -Scenario "Release omitted metadata"
+
+Write-Host "CI Gate regressions passed: selected lanes require success, intentional skips pass, and malformed or unexpected results fail closed." -ForegroundColor Green

--- a/scripts/test-ci-workflow-contract.ps1
+++ b/scripts/test-ci-workflow-contract.ps1
@@ -1,6 +1,6 @@
 <#
 .SYNOPSIS
-    Validates CI quick-win workflow and proof-regression routing contracts.
+    Validates CI lane routing, stable gate, release, and proof contracts.
 #>
 
 [CmdletBinding()]
@@ -19,8 +19,10 @@ $repoRootPath = [System.IO.Path]::GetFullPath($RepoRoot)
 $workflowPath = Join-Path $repoRootPath ".github\workflows\ci.yml"
 $selectorPath = Join-Path $repoRootPath "scripts\Get-CiProofPoolRegressionDecision.ps1"
 $runnerPath = Join-Path $repoRootPath "scripts\Invoke-CiTest.ps1"
+$e2eRunnerPath = Join-Path $repoRootPath "scripts\Invoke-CiE2e.ps1"
 $workflow = Get-Content -LiteralPath $workflowPath -Raw
 $runner = Get-Content -LiteralPath $runnerPath -Raw
+$e2eRunner = Get-Content -LiteralPath $e2eRunnerPath -Raw
 
 function Assert-Contains {
     param(
@@ -30,6 +32,18 @@ function Assert-Contains {
     )
 
     if (-not $Text.Contains($Expected, [StringComparison]::Ordinal)) {
+        throw $Message
+    }
+}
+
+function Assert-NotContains {
+    param(
+        [Parameter(Mandatory)][string]$Text,
+        [Parameter(Mandatory)][string]$Unexpected,
+        [Parameter(Mandatory)][string]$Message
+    )
+
+    if ($Text.Contains($Unexpected, [StringComparison]::Ordinal)) {
         throw $Message
     }
 }
@@ -64,26 +78,22 @@ Assert-Contains `
     -Text $workflow `
     -Expected "cancel-in-progress: `${{ github.event_name == 'pull_request' }}" `
     -Message "CI cancellation must apply only to pull_request runs."
-Assert-Contains `
-    -Text $workflow `
-    -Expected "steps.proof_pool_regression.outcome != 'success' || steps.proof_pool_regression.outputs.run != 'false'" `
-    -Message "Proof-pool regression routing must run when diff selection fails or does not explicitly return false."
-Assert-Contains `
-    -Text $workflow `
-    -Expected "if: `${{ github.event_name != 'pull_request' }}" `
-    -Message "dotnet-coverage installation must be limited to push and tag runs."
-Assert-Contains `
-    -Text $workflow `
-    -Expected "OPENCLAW_CI_COLLECT_COVERAGE: `${{ github.event_name != 'pull_request' }}" `
-    -Message "Test coverage must be disabled only for pull_request runs."
 
 $classificationJob = Get-JobBlock "change-classification"
 foreach ($token in @(
-    "fetch-depth: 0",
-    "./scripts/Get-CiChangeClassification.ps1",
-    "classification: `${{ steps.classify.outputs.classification }}",
-    "full: `${{ steps.classify.outputs.full }}"
-)) {
+        "fetch-depth: 0",
+        "./scripts/Get-CiChangeClassification.ps1",
+        "classification: `${{ steps.classify.outputs.classification }}",
+        "core_tests: `${{ steps.classify.outputs.core_tests }}",
+        "tray_tests: `${{ steps.classify.outputs.tray_tests }}",
+        "ui_tests: `${{ steps.classify.outputs.ui_tests }}",
+        "setup_e2e: `${{ steps.classify.outputs.setup_e2e }}",
+        "revocation_e2e: `${{ steps.classify.outputs.revocation_e2e }}",
+        "network_e2e: `${{ steps.classify.outputs.network_e2e }}",
+        "x64_release: `${{ steps.classify.outputs.x64_release }}",
+        "arm64_release: `${{ steps.classify.outputs.arm64_release }}",
+        "full: `${{ steps.classify.outputs.full }}"
+    )) {
     Assert-Contains `
         -Text $classificationJob `
         -Expected $token `
@@ -92,117 +102,276 @@ foreach ($token in @(
 
 $fastValidationJob = Get-JobBlock "fast-validation"
 foreach ($token in @(
-    "Ensure .squad stays untracked",
-    "node --test .github/scripts/repository-triage.test.cjs",
-    "./scripts/validate-docs.ps1",
-    "./scripts/validate-agent-skills.ps1",
-    "./scripts/test-agent-skills-validator.ps1",
-    "./scripts/test-ci-change-classifier.ps1",
-    "./scripts/test-ci-gate-results.ps1",
-    "./scripts/test-ci-workflow-contract.ps1"
-)) {
+        "Ensure .squad stays untracked",
+        "node --test .github/scripts/repository-triage.test.cjs",
+        "./scripts/validate-docs.ps1",
+        "./scripts/validate-agent-skills.ps1",
+        "./scripts/test-agent-skills-validator.ps1",
+        "./scripts/test-ci-change-classifier.ps1",
+        "./scripts/test-ci-gate-results.ps1",
+        "./scripts/test-ci-workflow-contract.ps1",
+        "./scripts/test-stable-correction-release-validator.ps1"
+    )) {
     Assert-Contains `
         -Text $fastValidationJob `
         -Expected $token `
         -Message "Always-running fast validation job is missing '$token'."
 }
 
-foreach ($heavyJobName in @("test", "e2etests", "build")) {
-    $heavyJob = Get-JobBlock $heavyJobName
+$proofJob = Get-JobBlock "proof-pool-contracts"
+foreach ($token in @(
+        "./scripts/Get-CiProofPoolRegressionDecision.ps1",
+        "steps.proof_pool_regression.outcome != 'success' || steps.proof_pool_regression.outputs.run != 'false'",
+        "./scripts/test-proof-pool-validator.ps1"
+    )) {
     Assert-Contains `
-        -Text $heavyJob `
-        -Expected "needs.change-classification.outputs.full == 'true'" `
-        -Message "Heavy job '$heavyJobName' must run only for full validation."
+        -Text $proofJob `
+        -Expected $token `
+        -Message "Dedicated proof-pool contract job is missing '$token'."
+}
+Assert-NotContains `
+    -Text $fastValidationJob `
+    -Unexpected "./scripts/test-proof-pool-validator.ps1" `
+    -Message "The heavyweight malformed proof-contract matrix must not block fast validation."
+
+$testLanes = [ordered]@{
+    "core-tests" = @{
+        Output = "core_tests"
+        Projects = @(
+            "tests/OpenClaw.Shared.Tests",
+            "tests/OpenClaw.Connection.Tests",
+            "tests/OpenClaw.WinNode.Cli.Tests"
+        )
+        Artifact = "test-results-core"
+    }
+    "tray-tests" = @{
+        Output = "tray_tests"
+        Projects = @(
+            "tests/OpenClaw.Tray.Tests",
+            "tests/OpenClaw.SetupEngine.Tests",
+            "tests/OpenClaw.Tray.IntegrationTests"
+        )
+        Artifact = "test-results-tray"
+    }
+    "ui-tests" = @{
+        Output = "ui_tests"
+        Projects = @(
+            "tests/OpenClaw.Tray.UITests",
+            "tests/OpenClawTray.FunctionalUI.Tests"
+        )
+        Artifact = "test-results-ui"
+    }
+}
+foreach ($lane in $testLanes.GetEnumerator()) {
+    $job = Get-JobBlock $lane.Key
+    Assert-Contains `
+        -Text $job `
+        -Expected "needs.change-classification.outputs.$($lane.Value.Output) == 'true'" `
+        -Message "Test lane '$($lane.Key)' does not consume its classifier output."
+    Assert-Contains `
+        -Text $job `
+        -Expected "OPENCLAW_CI_COLLECT_COVERAGE: `${{ github.event_name != 'pull_request' }}" `
+        -Message "Test lane '$($lane.Key)' does not preserve push/tag coverage."
+    Assert-Contains `
+        -Text $job `
+        -Expected "key: nuget-`${{ runner.os }}-`${{ hashFiles('**/*.csproj', '**/Directory.Packages.props') }}" `
+        -Message "Test lane '$($lane.Key)' must retain the shared NuGet cache key."
+    Assert-Contains `
+        -Text $job `
+        -Expected "name: $($lane.Value.Artifact)" `
+        -Message "Test lane '$($lane.Key)' is missing its TRX artifact."
+    foreach ($project in $lane.Value.Projects) {
+        Assert-Contains `
+            -Text $job `
+            -Expected $project `
+            -Message "Test lane '$($lane.Key)' lost project '$project'."
+    }
 }
 
-$ciGateJob = Get-JobBlock "ci-gate"
+$trayJob = Get-JobBlock "tray-tests"
 foreach ($token in @(
-    "name: CI Gate",
-    "if: `${{ always() }}",
-    "needs: [change-classification, fast-validation, test, e2etests, build]",
-    "uses: actions/checkout@v7",
-    "./scripts/Assert-CiGateResults.ps1",
-    "-ClassificationResult `$env:CLASSIFICATION_RESULT",
-    "-FastValidationResult `$env:FAST_VALIDATION_RESULT",
-    "-TestResult `$env:TEST_RESULT",
-    "-E2eResult `$env:E2E_RESULT",
-    "-BuildResult `$env:BUILD_RESULT"
-)) {
-    Assert-Contains `
-        -Text $ciGateJob `
-        -Expected $token `
-        -Message "Stable CI Gate is missing '$token'."
+        "OPENCLAW_TRAY_DATA_DIR:",
+        "OPENCLAW_RUN_INTEGRATION: 1",
+        "-Project tests/OpenClaw.Tray.IntegrationTests",
+        "dotnet restore src/OpenClaw.Tray.WinUI -r win-x64",
+        "dotnet build src/OpenClaw.Tray.WinUI -c Debug -r win-x64 --no-restore"
+    )) {
+    Assert-Contains -Text $trayJob -Expected $token -Message "Tray lane is missing '$token'."
 }
 
-$releaseJob = Get-JobBlock "release"
-Assert-Contains `
-    -Text $releaseJob `
-    -Expected "needs: [change-classification, fast-validation, test, e2etests, build, ci-gate]" `
-    -Message "Tag release must depend on the stable CI Gate."
-Assert-Contains `
-    -Text $releaseJob `
-    -Expected "needs.ci-gate.result == 'success'" `
-    -Message "Tag release must require the stable CI Gate to succeed."
-
-$testJob = Get-JobBlock "test"
+$uiJob = Get-JobBlock "ui-tests"
 foreach ($token in @(
-    "./scripts/Get-CiProofPoolRegressionDecision.ps1",
-    "steps.proof_pool_regression.outcome != 'success' || steps.proof_pool_regression.outputs.run != 'false'",
-    "./scripts/test-proof-pool-validator.ps1"
-)) {
-    Assert-Contains `
-        -Text $testJob `
-        -Expected $token `
-        -Message "Full Windows test lane is missing conditional proof-pool regression token '$token'."
+        "Install WindowsAppRuntime",
+        "-Filter Category!=Accessibility",
+        "--filter Category=Accessibility",
+        "Verify DevBuild identity marker"
+    )) {
+    Assert-Contains -Text $uiJob -Expected $token -Message "UI lane is missing '$token'."
 }
 
 $runnerUses = [regex]::Matches(
     $workflow,
     "(?m)^\s+\./scripts/Invoke-CiTest\.ps1\s*$").Count
 if ($runnerUses -ne 8) {
-    throw "Expected 8 CI test steps to use Invoke-CiTest.ps1, found $runnerUses."
+    throw "Expected all 8 non-E2E test projects to use Invoke-CiTest.ps1, found $runnerUses."
 }
 if ($workflow -match "(?m)^\s+dotnet-coverage collect\s*$") {
     throw "Workflow test steps must not invoke dotnet-coverage directly."
 }
-
 foreach ($requiredRunnerToken in @(
-    '"--logger"',
-    '"trx;LogFileName=$TrxFileName"',
-    'dotnet-coverage collect',
-    '--output-format cobertura',
-    '& dotnet @testArguments'
-)) {
+        '"--logger"',
+        '"trx;LogFileName=$TrxFileName"',
+        'dotnet-coverage collect',
+        '--output-format cobertura',
+        '& dotnet @testArguments'
+    )) {
     Assert-Contains `
         -Text $runner `
         -Expected $requiredRunnerToken `
         -Message "CI test runner is missing required token '$requiredRunnerToken'."
 }
 
-$buildJobStart = $workflow.IndexOf("  build:", [StringComparison]::Ordinal)
-$buildMsixStart = $workflow.IndexOf("  build-msix:", [StringComparison]::Ordinal)
-if ($buildJobStart -lt 0 -or $buildMsixStart -le $buildJobStart) {
-    throw "Could not isolate the Release build job."
+$e2eLanes = [ordered]@{
+    "setup-e2e" = @{
+        Output = "setup_e2e"
+        Name = "setup-connect"
+        Filter = "OpenClaw.E2ETests.Setup.SetupAndConnectTests"
+    }
+    "revocation-e2e" = @{
+        Output = "revocation_e2e"
+        Name = "revocation-recovery"
+        Filter = "OpenClaw.E2ETests.Setup.RevocationAndRecoveryTests"
+    }
+    "network-e2e" = @{
+        Output = "network_e2e"
+        Name = "network-recovery"
+        Filter = "OpenClaw.E2ETests.Setup.NetworkRecoveryTests"
+    }
 }
-$buildJob = $workflow.Substring($buildJobStart, $buildMsixStart - $buildJobStart)
-if ($buildJob.Contains("Build WinUI Tray App (Release)", [StringComparison]::Ordinal)) {
-    throw "Release packaging must not compile once before dotnet publish compiles the payload."
+foreach ($lane in $e2eLanes.GetEnumerator()) {
+    $job = Get-JobBlock $lane.Key
+    foreach ($token in @(
+            "needs.change-classification.outputs.$($lane.Value.Output) == 'true'",
+            "OPENCLAW_RUN_E2E: 1",
+            "./scripts/Invoke-CiE2e.ps1",
+            "-Name $($lane.Value.Name)",
+            $lane.Value.Filter,
+            "TestResults/E2E/"
+        )) {
+        Assert-Contains `
+            -Text $job `
+            -Expected $token `
+            -Message "E2E lane '$($lane.Key)' is missing '$token'."
+    }
 }
-foreach ($publishToken in @(
-    "dotnet publish src/OpenClaw.Tray.WinUI",
-    "--self-contained",
-    "--no-restore",
-    "-p:Version=`$env:OPENCLAW_BUILD_VERSION",
-    "-p:InformationalVersion=`$env:OPENCLAW_BUILD_VERSION",
-    "Test-ReleaseNativeDependencies.ps1 -PayloadPath publish"
-)) {
+foreach ($proofName in @(
+        "RealGateway_SystemRun_ExecutesThroughWindowsNodeMxcSandbox",
+        "RealGateway_SystemRun_BlocksWritesToTrayDataDirectoryInMxcSandbox",
+        "UnownedListenerIsRejectedThenOwnedTunnelRecoversWithoutRepairing",
+        "InitialHandshakeListenerReplacementWithholdsCredentialFrame",
+        "InitialNodeHandshakeListenerReplacementWithholdsCredentialFrame"
+    )) {
     Assert-Contains `
-        -Text $buildJob `
-        -Expected $publishToken `
-        -Message "Release publish contract is missing '$publishToken'."
+        -Text $e2eRunner `
+        -Expected $proofName `
+        -Message "E2E runner lost proof assertion '$proofName'."
+}
+foreach ($skipReasonToken in @(
+        '$mxcProof.SelectSingleNode("Output/ErrorInfo/Message")',
+        '$mxcProof.SelectSingleNode("Output/StdOut")',
+        '$null -ne $_'
+    )) {
+    Assert-Contains `
+        -Text $e2eRunner `
+        -Expected $skipReasonToken `
+        -Message "E2E runner lost null-safe MXC skip-reason handling '$skipReasonToken'."
+}
+
+$metadataJob = Get-JobBlock "metadata"
+foreach ($token in @(
+        "needs: change-classification",
+        "outputs.x64_release == 'true' || needs.change-classification.outputs.arm64_release == 'true'",
+        "gittools/actions/gitversion/setup@v4",
+        "gittools/actions/gitversion/execute@v4",
+        "semVer: `${{ steps.release_version.outputs.semVer }}",
+        "majorMinorPatch: `${{ steps.release_version.outputs.majorMinorPatch }}",
+        "isPrerelease: `${{ steps.release_version.outputs.isPrerelease }}",
+        "isStableCorrection: `${{ steps.release_version.outputs.isStableCorrection }}",
+        "Test-OpenClawStableCorrectionRelease.ps1"
+    )) {
+    Assert-Contains -Text $metadataJob -Expected $token -Message "Metadata job is missing '$token'."
+}
+Assert-NotContains `
+    -Text $metadataJob `
+    -Unexpected "fast-validation" `
+    -Message "Release metadata must start independently of validation lanes."
+
+$releaseBuilds = [ordered]@{
+    "build-x64" = @{
+        Output = "x64_release"
+        Runtime = "win-x64"
+        Runner = "windows-latest"
+        Native = "Test-ReleaseNativeDependencies.ps1 -PayloadPath publish -RequireAppLocalVCRuntime"
+    }
+    "build-arm64" = @{
+        Output = "arm64_release"
+        Runtime = "win-arm64"
+        Runner = "windows-11-arm"
+        Native = "Test-ReleaseNativeDependencies.ps1 -PayloadPath publish -RequireAppLocalVCRuntime -SkipNativeLoadProbe"
+    }
+}
+foreach ($build in $releaseBuilds.GetEnumerator()) {
+    $job = Get-JobBlock $build.Key
+    foreach ($token in @(
+            "needs: [change-classification, metadata]",
+            "needs.change-classification.outputs.$($build.Value.Output) == 'true'",
+            "runs-on: $($build.Value.Runner)",
+            "OPENCLAW_BUILD_VERSION: `${{ needs.metadata.outputs.semVer }}",
+            "dotnet publish src/OpenClaw.Tray.WinUI -c Release -r $($build.Value.Runtime) --self-contained --no-restore",
+            $build.Value.Native,
+            'Verify GitVersion assembly metadata'
+        )) {
+        Assert-Contains -Text $job -Expected $token -Message "Release build '$($build.Key)' is missing '$token'."
+    }
+    Assert-NotContains `
+        -Text $job `
+        -Unexpected "core-tests" `
+        -Message "Release builds must start in parallel with tests and E2E."
+}
+
+$ciGateJob = Get-JobBlock "ci-gate"
+foreach ($token in @(
+        "name: CI Gate",
+        "if: `${{ always() }}",
+        "needs: [change-classification, fast-validation, proof-pool-contracts, metadata, core-tests, tray-tests, ui-tests, setup-e2e, revocation-e2e, network-e2e, build-x64, build-arm64]",
+        "./scripts/Assert-CiGateResults.ps1",
+        "-FullRequired `$env:FULL_REQUIRED",
+        "-CoreRequired `$env:CORE_REQUIRED",
+        "-TrayRequired `$env:TRAY_REQUIRED",
+        "-UiRequired `$env:UI_REQUIRED",
+        "-SetupE2eRequired `$env:SETUP_E2E_REQUIRED",
+        "-RevocationE2eRequired `$env:REVOCATION_E2E_REQUIRED",
+        "-NetworkE2eRequired `$env:NETWORK_E2E_REQUIRED",
+        "-X64ReleaseRequired `$env:X64_RELEASE_REQUIRED",
+        "-Arm64ReleaseRequired `$env:ARM64_RELEASE_REQUIRED",
+        "-MetadataResult `$env:METADATA_RESULT"
+    )) {
+    Assert-Contains -Text $ciGateJob -Expected $token -Message "Stable CI Gate is missing '$token'."
+}
+
+$releaseJob = Get-JobBlock "release"
+foreach ($token in @(
+        "needs: [change-classification, metadata, build-x64, build-arm64, ci-gate]",
+        "needs.ci-gate.result == 'success'",
+        "needs.metadata.outputs.semVer",
+        "needs.metadata.outputs.isPrerelease",
+        "needs.metadata.outputs.isStableCorrection"
+    )) {
+    Assert-Contains -Text $releaseJob -Expected $token -Message "Tag release is missing '$token'."
 }
 
 $triggerPaths = @(
+    ".github/workflows/ci.yml",
     ".github/proof-pools.json",
     ".github/proof-pools.schema.json",
     "scripts/validate-proof-pools.ps1",
@@ -298,4 +467,4 @@ try {
     }
 }
 
-Write-Host "CI workflow contracts passed: PR cancellation, docs-only routing, stable gate enforcement, fail-closed proof routing, conditional coverage, TRX logging, and single-pass Release publish." -ForegroundColor Green
+Write-Host "CI workflow contracts passed: conservative lane routing, stable gate enforcement, decoupled metadata/release builds, preserved test inventory, and fail-closed proof routing." -ForegroundColor Green

--- a/scripts/test-ci-workflow-contract.ps1
+++ b/scripts/test-ci-workflow-contract.ps1
@@ -170,6 +170,10 @@ foreach ($lane in $testLanes.GetEnumerator()) {
         -Message "Test lane '$($lane.Key)' does not consume its classifier output."
     Assert-Contains `
         -Text $job `
+        -Expected "fetch-depth: 0" `
+        -Message "Test lane '$($lane.Key)' must fetch full history for GitVersion.MsBuild."
+    Assert-Contains `
+        -Text $job `
         -Expected "OPENCLAW_CI_COLLECT_COVERAGE: `${{ github.event_name != 'pull_request' }}" `
         -Message "Test lane '$($lane.Key)' does not preserve push/tag coverage."
     Assert-Contains `
@@ -251,6 +255,7 @@ $e2eLanes = [ordered]@{
 foreach ($lane in $e2eLanes.GetEnumerator()) {
     $job = Get-JobBlock $lane.Key
     foreach ($token in @(
+            "fetch-depth: 0",
             "needs.change-classification.outputs.$($lane.Value.Output) == 'true'",
             "OPENCLAW_RUN_E2E: 1",
             "./scripts/Invoke-CiE2e.ps1",
@@ -290,6 +295,7 @@ foreach ($skipReasonToken in @(
 $metadataJob = Get-JobBlock "metadata"
 foreach ($token in @(
         "needs: change-classification",
+        "fetch-depth: 0",
         "outputs.x64_release == 'true' || needs.change-classification.outputs.arm64_release == 'true'",
         "gittools/actions/gitversion/setup@v4",
         "gittools/actions/gitversion/execute@v4",
@@ -324,6 +330,7 @@ foreach ($build in $releaseBuilds.GetEnumerator()) {
     $job = Get-JobBlock $build.Key
     foreach ($token in @(
             "needs: [change-classification, metadata]",
+            "fetch-depth: 0",
             "needs.change-classification.outputs.$($build.Value.Output) == 'true'",
             "runs-on: $($build.Value.Runner)",
             "OPENCLAW_BUILD_VERSION: `${{ needs.metadata.outputs.semVer }}",
@@ -338,6 +345,12 @@ foreach ($build in $releaseBuilds.GetEnumerator()) {
         -Unexpected "core-tests" `
         -Message "Release builds must start in parallel with tests and E2E."
 }
+
+$buildMsixJob = Get-JobBlock "build-msix"
+Assert-Contains `
+    -Text $buildMsixJob `
+    -Expected "fetch-depth: 0" `
+    -Message "The paused MSIX build must retain full history before it can be re-enabled."
 
 $ciGateJob = Get-JobBlock "ci-gate"
 foreach ($token in @(

--- a/tests/OpenClaw.Tray.Tests/ReleaseSigningWorkflowTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ReleaseSigningWorkflowTests.cs
@@ -91,7 +91,7 @@ public sealed class ReleaseSigningWorkflowTests
         Assert.Contains("/DvcRedist=vc_redist.arm64.exe", workflow);
         Assert.DoesNotContain("copy vc_redist.x64.exe publish-x64", workflow);
         Assert.DoesNotContain("copy vc_redist.x64.exe publish-arm64", workflow);
-        Assert.Contains("OpenClawTray-${{ needs.test.outputs.semVer }}-win-arm64.zip", workflow);
+        Assert.Contains("OpenClawTray-${{ needs.metadata.outputs.semVer }}-win-arm64.zip", workflow);
         Assert.Contains("AfterInstall: InstallVCRuntime", installer);
         Assert.Contains("Exec(", installer);
         Assert.Contains("ResultCode = 3010", installer);
@@ -120,7 +120,7 @@ public sealed class ReleaseSigningWorkflowTests
         var workflow = File.ReadAllText(Path.Combine(TestRepositoryPaths.GetRepositoryRoot(), ".github", "workflows", "ci.yml"));
 
         Assert.Contains("if: false # MSIX distribution is paused; ship Inno setup and portable ZIP artifacts only.", workflow);
-        Assert.Contains("needs: [change-classification, fast-validation, test, e2etests, build, ci-gate]", workflow);
+        Assert.Contains("needs: [change-classification, metadata, build-x64, build-arm64, ci-gate]", workflow);
         Assert.DoesNotContain("Download win-x64 MSIX artifact", workflow);
         Assert.DoesNotContain("Download win-arm64 MSIX artifact", workflow);
         Assert.DoesNotContain("Sign Release MSIX Packages", workflow);

--- a/tests/OpenClaw.Tray.Tests/VersioningContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/VersioningContractTests.cs
@@ -83,7 +83,7 @@ public sealed class VersioningContractTests
             "- name: Revalidate stable correction release ordering",
             workflow);
         Assert.Contains(
-            "if: needs.test.outputs.isStableCorrection == 'true'",
+            "if: needs.metadata.outputs.isStableCorrection == 'true'",
             workflow);
         Assert.Contains(
             "semVer: ${{ steps.release_version.outputs.semVer }}",
@@ -95,7 +95,7 @@ public sealed class VersioningContractTests
             "-p:Version=$env:OPENCLAW_BUILD_VERSION",
             workflow);
         Assert.Contains(
-            "prerelease: ${{ needs.test.outputs.isPrerelease }}",
+            "prerelease: ${{ needs.metadata.outputs.isPrerelease }}",
             workflow);
         Assert.DoesNotContain(
             "prerelease: ${{ contains(github.ref_name, '-') }}",
@@ -187,7 +187,7 @@ public sealed class VersioningContractTests
         Assert.True(publishIndex > revalidateIndex, "Correction ordering must be revalidated before publication.");
 
         Assert.Contains(
-            "make_latest: ${{ needs.test.outputs.isPrerelease == 'true' && 'false' || 'true' }}",
+            "make_latest: ${{ needs.metadata.outputs.isPrerelease == 'true' && 'false' || 'true' }}",
             workflow);
         Assert.Contains("$majorMinorPatch = $validation.BaseVersion", workflow);
         Assert.Contains(


### PR DESCRIPTION
## Summary

Reduce ordinary code pull request latency by selecting conservative validation lanes from explicit path-impact booleans while preserving fail-closed full validation for infrastructure, setup, connection, shared protocol, unknown, main, and tag changes.

## Required proof pools

- `none`: this changes GitHub-hosted CI orchestration and contracts, not a product surface that requires a custom Windows host class.

## Old and new lane mapping

| Change class | Previous | New |
|---|---|---|
| Docs or agent-skill prose | Fast validation only | Fast validation only |
| CLI or WinNode CLI | Full serialized tests, all E2E, x64 and ARM64 publish | Core and CLI tests only |
| Tray or UI | Full serialized tests, all E2E, x64 and ARM64 publish | Tray plus UI/accessibility lanes, with E2E only for setup/connection paths |
| Setup, connection, Shared/protocol | Full serialized tests, all E2E, x64 and ARM64 publish | Required unit/UI lanes plus relevant or comprehensive existing E2E shards |
| Workflow/build/package/installer/classifier or unknown | Full serialized tests, all E2E, x64 and ARM64 publish | Fail-closed full tests and E2E plus x64 publish smoke |
| Main and tags | Full validation and both publishes | Full validation and x64 plus ARM64 publishes |

The former serialized Windows test job is now three clean-runner lanes: core/CLI, tray/setup/integration, and UI/functional/accessibility. Each restores and builds its own project graph, preserves all eight test projects and TRX artifacts, retains coverage on push/tag, settings isolation, integration gating, and WindowsAppRuntime installation. The existing three E2E shards are not multiplied.

## Preserved invariants

- Unknown paths, invalid SHAs, empty diffs, mixed unrecognized changes, workflow/build/package/installer/classifier contracts, main, and tags fail closed.
- The proof-pool malformed-contract matrix remains governed by `Get-CiProofPoolRegressionDecision.ps1`, now in an independent job.
- GitVersion preserves `semVer`, `majorMinorPatch`, `isPrerelease`, `isStableCorrection`, and stable-correction validation.
- Release publish preserves native dependency and assembly metadata checks.
- The stable always-running **CI Gate** requires success for every selected lane, requires intentional skips for unselected lanes, and rejects failed classification, missing outputs, failures, cancellation, or unexpected results.
- Existing PR-scoped concurrency is unchanged. CodeQL is unchanged.

## Expected timing

Measured baseline: full PR run `33815204229` spent 22m11s in the serialized test job, including 6m48s in proof contracts and 3m28s in accessibility. Existing E2E shards took 9m33s to 14m43s; x64 and ARM64 publish took 5m13s and 6m17s. Docs fast-path run `33819700640` completed in 51s.

| Change class | Expected wall-clock |
|---|---:|
| Docs or skill prose | About 1 minute |
| CLI-only | 5 to 7 minutes |
| Tray/UI | 8 to 12 minutes |
| Setup/connection/Shared | 10 to 16 minutes, governed by required E2E |
| Build/workflow infrastructure | 10 to 16 minutes |

The full infrastructure path duplicates checkout, SDK setup, and cache restore across three test runners, but removes the serialized proof matrix and parallelizes lanes. Estimated full-path runner minutes stay within 15% of the prior full run, below the 30% rejection threshold. Ordinary code paths use substantially fewer runner minutes.

## Validation

- `OPENCLAW_REPO_ROOT=<worktree>; .\build.ps1` - passed
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore` - 3,905 passed, 32 skipped
- isolated `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore` - 2,833 passed
- all eight split-lane test project graphs restored and built on clean project boundaries
- classifier, CI Gate, workflow, release-ordering, docs, skill, and proof-decision contracts - passed
- malformed proof-pool matrix - 75 invalid contracts rejected by 3 modes
- `actionlint .github/workflows/ci.yml` - only the documented pre-existing intentional `build-msix` `if: false` diagnostic
- `git diff --check` - passed
- rubber-duck review - two clean-runner/conservative mapping findings fixed; final review reported no findings

## Real behavior proof

Current-head classifier output for this CI infrastructure pull request:

```json
{"classification":"full","core_tests":true,"tray_tests":true,"ui_tests":true,"setup_e2e":true,"revocation_e2e":true,"network_e2e":true,"x64_release":true,"arm64_release":false,"full":true}
```

Table-driven classifier contracts also prove representative CLI-only changes omit E2E/UI/release, UI-only changes require tray/UI/accessibility without setup E2E/release, setup/connection changes require E2E, Shared/protocol and infrastructure changes take full paths, and main/tags require both release architectures.

## Rollback boundary

Revert this commit to restore the merged docs-only/full classifier, serialized `test` job, full E2E matrix, and release build matrix. No product runtime or persisted data format changes are involved.