### PR TITLE
Avoid duplicate advanced CodeQL scans

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,12 +12,9 @@ on:
           - all
           - csharp
           - actions
-      advanced_setup:
-        description: Run advanced CodeQL instead of repository default setup
-        required: false
-        default: false
-        type: boolean
   push:
+    branches: [main, master]
+    tags: ["**"]
     paths:
       - ".github/codeql/**"
       - ".github/workflows/**"
@@ -69,7 +66,7 @@ jobs:
       - name: Decide whether to run advanced CodeQL
         id: advanced-setup
         run: |
-          if [ "${{ vars.OPENCLAW_CODEQL_ADVANCED_SETUP }}" = "true" ] || { [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.advanced_setup }}" = "true" ]; }; then
+          if [ "${{ vars.OPENCLAW_CODEQL_ADVANCED_SETUP }}" = "true" ]; then
             echo "enabled=true" >> "$GITHUB_OUTPUT"
             echo "Advanced CodeQL enabled for this run." >> "$GITHUB_STEP_SUMMARY"
           else
@@ -77,7 +74,7 @@ jobs:
             {
               echo "Advanced CodeQL is disabled for this repository workflow."
               echo "The repository currently uses GitHub CodeQL default setup; default setup and advanced setup cannot upload SARIF for the same repository at the same time."
-              echo "If maintainers disable default setup, set OPENCLAW_CODEQL_ADVANCED_SETUP=true or dispatch this workflow with advanced_setup=true."
+              echo "After maintainers disable default setup, set OPENCLAW_CODEQL_ADVANCED_SETUP=true and dispatch this workflow."
             } >> "$GITHUB_STEP_SUMMARY"
           fi
 

--- a/scripts/test-ci-workflow-contract.ps1
+++ b/scripts/test-ci-workflow-contract.ps1
@@ -17,10 +17,12 @@ if ([string]::IsNullOrWhiteSpace($RepoRoot)) {
 }
 $repoRootPath = [System.IO.Path]::GetFullPath($RepoRoot)
 $workflowPath = Join-Path $repoRootPath ".github\workflows\ci.yml"
+$codeQlWorkflowPath = Join-Path $repoRootPath ".github\workflows\codeql.yml"
 $selectorPath = Join-Path $repoRootPath "scripts\Get-CiProofPoolRegressionDecision.ps1"
 $runnerPath = Join-Path $repoRootPath "scripts\Invoke-CiTest.ps1"
 $e2eRunnerPath = Join-Path $repoRootPath "scripts\Invoke-CiE2e.ps1"
 $workflow = Get-Content -LiteralPath $workflowPath -Raw
+$codeQlWorkflow = Get-Content -LiteralPath $codeQlWorkflowPath -Raw
 $runner = Get-Content -LiteralPath $runnerPath -Raw
 $e2eRunner = Get-Content -LiteralPath $e2eRunnerPath -Raw
 
@@ -50,25 +52,237 @@ function Assert-NotContains {
 
 function Get-JobBlock {
     param(
-        [Parameter(Mandatory)][string]$Name
+        [Parameter(Mandatory)][string]$Name,
+        [string]$Text = $workflow
     )
 
     $escapedName = [regex]::Escape($Name)
-    $startMatch = [regex]::Match($workflow, "(?m)^  ${escapedName}:\r?$")
+    $startMatch = [regex]::Match($Text, "(?m)^  ${escapedName}:\r?$")
     if (-not $startMatch.Success) {
         throw "Could not find CI job '$Name'."
     }
     $jobHeadingPattern = [regex]::new("(?m)^  [a-zA-Z0-9_-]+:\r?$")
     $nextMatch = $jobHeadingPattern.Match(
-        $workflow,
+        $Text,
         $startMatch.Index + $startMatch.Length)
     if (-not $nextMatch.Success) {
-        return $workflow.Substring($startMatch.Index)
+        return $Text.Substring($startMatch.Index)
     }
-    return $workflow.Substring(
+    return $Text.Substring(
         $startMatch.Index,
         $nextMatch.Index - $startMatch.Index)
 }
+
+function Get-WorkflowTriggerBlock {
+    param(
+        [Parameter(Mandatory)][string]$Text,
+        [Parameter(Mandatory)][string]$Name
+    )
+
+    $escapedName = [regex]::Escape($Name)
+    $startMatch = [regex]::Match($Text, "(?m)^  ${escapedName}:\r?$")
+    if (-not $startMatch.Success) {
+        throw "Could not find workflow trigger '$Name'."
+    }
+
+    $nextMatch = [regex]::Match(
+        $Text.Substring($startMatch.Index + $startMatch.Length),
+        "(?m)^(?:  [a-zA-Z0-9_-]+:|[a-zA-Z0-9_-]+:)\r?$")
+    if (-not $nextMatch.Success) {
+        return $Text.Substring($startMatch.Index)
+    }
+
+    return $Text.Substring(
+        $startMatch.Index,
+        $startMatch.Length + $nextMatch.Index)
+}
+
+function Get-InlineYamlList {
+    param(
+        [Parameter(Mandatory)][string]$Text,
+        [Parameter(Mandatory)][string]$Name
+    )
+
+    $escapedName = [regex]::Escape($Name)
+    $match = [regex]::Match(
+        $Text,
+        "(?m)^\s+${escapedName}:\s*\[(?<values>[^\]]*)\]\s*$")
+    if (-not $match.Success) {
+        throw "Could not find inline YAML list '$Name'."
+    }
+
+    return @($match.Groups["values"].Value.Split(",") |
+        ForEach-Object { $_.Trim().Trim('"', "'") })
+}
+
+function Get-YamlBlockList {
+    param(
+        [Parameter(Mandatory)][string]$Text,
+        [Parameter(Mandatory)][string]$Name
+    )
+
+    $escapedName = [regex]::Escape($Name)
+    $match = [regex]::Match(
+        $Text,
+        "(?ms)^\s+${escapedName}:\s*\r?\n(?<items>(?:\s+-\s+.+\r?\n?)+)")
+    if (-not $match.Success) {
+        throw "Could not find YAML block list '$Name'."
+    }
+
+    return @([regex]::Matches($match.Groups["items"].Value, "(?m)^\s+-\s+['`"]?(?<value>.+?)['`"]?\s*$") |
+        ForEach-Object { $_.Groups["value"].Value })
+}
+
+function Test-PathMatches {
+    param(
+        [Parameter(Mandatory)][string[]]$Patterns,
+        [Parameter(Mandatory)][string]$Path
+    )
+
+    foreach ($pattern in $Patterns) {
+        if ([System.Management.Automation.WildcardPattern]::new(
+                $pattern,
+                [System.Management.Automation.WildcardOptions]::None).IsMatch($Path)) {
+            return $true
+        }
+    }
+
+    return $false
+}
+
+function Test-CodeQlTrigger {
+    param(
+        [Parameter(Mandatory)][ValidateSet("push", "pull_request", "schedule", "workflow_dispatch")]
+        [string]$EventName,
+        [string]$RefName,
+        [string]$Path
+    )
+
+    if ($EventName -in @("schedule", "workflow_dispatch")) {
+        return $true
+    }
+
+    if ($EventName -eq "push") {
+        if ($RefName.StartsWith("refs/tags/", [StringComparison]::Ordinal)) {
+            return $codeQlPushTags.Count -gt 0
+        }
+        if ($RefName -notin $codeQlPushBranches) {
+            return $false
+        }
+        return Test-PathMatches -Patterns $codeQlPushPaths -Path $Path
+    }
+
+    if ($RefName -notin $codeQlPullRequestBranches) {
+        return $false
+    }
+    return Test-PathMatches -Patterns $codeQlPullRequestPaths -Path $Path
+}
+
+$codeQlPush = Get-WorkflowTriggerBlock -Text $codeQlWorkflow -Name "push"
+$codeQlPullRequest = Get-WorkflowTriggerBlock -Text $codeQlWorkflow -Name "pull_request"
+$codeQlPushBranches = @(Get-InlineYamlList -Text $codeQlPush -Name "branches")
+$codeQlPushTags = @(Get-InlineYamlList -Text $codeQlPush -Name "tags")
+$codeQlPushPaths = @(Get-YamlBlockList -Text $codeQlPush -Name "paths")
+$codeQlPullRequestBranches = @(Get-InlineYamlList -Text $codeQlPullRequest -Name "branches")
+$codeQlPullRequestPaths = @(Get-YamlBlockList -Text $codeQlPullRequest -Name "paths")
+
+$expectedCodeQlPaths = @(
+    ".github/codeql/**",
+    ".github/workflows/**",
+    "src/**",
+    "tests/**",
+    "*.sln",
+    "*.slnx",
+    "*.props",
+    "*.targets",
+    "global.json",
+    "NuGet.Config",
+    "package.json",
+    "package-lock.json"
+)
+if (($codeQlPushBranches -join ",") -ne "main,master") {
+    throw "CodeQL branch pushes must be limited to main and master."
+}
+if (($codeQlPushTags -join ",") -ne "**") {
+    throw "CodeQL must preserve scanning for all tag pushes."
+}
+if (($codeQlPullRequestBranches -join ",") -ne "main,master") {
+    throw "CodeQL pull requests must continue to target main and master."
+}
+if (($codeQlPushPaths -join "`n") -cne ($expectedCodeQlPaths -join "`n")) {
+    throw "CodeQL push path filters changed unexpectedly."
+}
+if (($codeQlPullRequestPaths -join "`n") -cne ($expectedCodeQlPaths -join "`n")) {
+    throw "CodeQL pull request path filters changed unexpectedly."
+}
+$codeQlTriggerCases = @(
+    @{ Name = "feature branch code push"; Event = "push"; Ref = "feature/example"; Path = "src/OpenClaw.Shared/Example.cs"; Expected = $false },
+    @{ Name = "main code push"; Event = "push"; Ref = "main"; Path = "src/OpenClaw.Shared/Example.cs"; Expected = $true },
+    @{ Name = "master code push"; Event = "push"; Ref = "master"; Path = "src/OpenClaw.Shared/Example.cs"; Expected = $true },
+    @{ Name = "release tag push"; Event = "push"; Ref = "refs/tags/v2026.9.3"; Path = "docs/release.md"; Expected = $true },
+    @{ Name = "relevant pull request"; Event = "pull_request"; Ref = "main"; Path = "src/OpenClaw.Shared/Example.cs"; Expected = $true },
+    @{ Name = "docs-only pull request"; Event = "pull_request"; Ref = "main"; Path = "docs/example.md"; Expected = $false },
+    @{ Name = "agent-skill-only pull request"; Event = "pull_request"; Ref = "main"; Path = ".agents/skills/example/SKILL.md"; Expected = $false },
+    @{ Name = "scheduled scan"; Event = "schedule"; Ref = ""; Path = ""; Expected = $true },
+    @{ Name = "manual scan"; Event = "workflow_dispatch"; Ref = ""; Path = ""; Expected = $true }
+)
+foreach ($case in $codeQlTriggerCases) {
+    $actual = Test-CodeQlTrigger `
+        -EventName $case.Event `
+        -RefName $case.Ref `
+        -Path $case.Path
+    if ($actual -ne $case.Expected) {
+        throw "CodeQL trigger case '$($case.Name)' expected '$($case.Expected)' but got '$actual'."
+    }
+}
+foreach ($requiredToken in @(
+        "workflow_dispatch:",
+        "schedule:",
+        'cron: "29 6 * * 1"',
+        "profile:",
+        "default: all",
+        "type: choice",
+        'group: codeql-${{ github.workflow }}-',
+        "cancel-in-progress: `${{ github.event_name == 'pull_request' }}",
+        "actions: read",
+        "contents: read",
+        "security-events: write",
+        'if [ "${{ vars.OPENCLAW_CODEQL_ADVANCED_SETUP }}" = "true" ]; then',
+        "inputs.profile == 'csharp'",
+        "languages: csharp",
+        "build-mode: manual",
+        "config-file: ./.github/codeql/codeql-csharp-security.yml",
+        'category: "/codeql/csharp"',
+        "inputs.profile == 'actions'",
+        "languages: actions",
+        "config-file: ./.github/codeql/codeql-actions-security.yml",
+        'category: "/codeql/actions"'
+    )) {
+    Assert-Contains `
+        -Text $codeQlWorkflow `
+        -Expected $requiredToken `
+        -Message "CodeQL workflow is missing required contract '$requiredToken'."
+}
+Assert-NotContains `
+    -Text $codeQlWorkflow `
+    -Unexpected "inputs.advanced_setup" `
+    -Message "CodeQL advanced setup must not bypass the repository-variable gate."
+foreach ($jobName in @("csharp", "actions")) {
+    $codeQlJob = Get-JobBlock -Name $jobName -Text $codeQlWorkflow
+    Assert-Contains `
+        -Text $codeQlJob `
+        -Expected "needs: advanced-setup" `
+        -Message "CodeQL job '$jobName' must depend on the advanced-setup gate."
+    Assert-Contains `
+        -Text $codeQlJob `
+        -Expected "needs.advanced-setup.outputs.enabled == 'true'" `
+        -Message "CodeQL job '$jobName' must remain disabled until the repository variable enables advanced setup."
+}
+$codeQlGateJob = Get-JobBlock -Name "advanced-setup" -Text $codeQlWorkflow
+Assert-Contains `
+    -Text $codeQlGateJob `
+    -Expected 'echo "enabled=false" >> "$GITHUB_OUTPUT"' `
+    -Message "CodeQL gate must explicitly disable advanced analysis when the repository variable is not true."
 
 Assert-Contains `
     -Text $workflow `
@@ -480,4 +694,4 @@ try {
     }
 }
 
-Write-Host "CI workflow contracts passed: conservative lane routing, stable gate enforcement, decoupled metadata/release builds, preserved test inventory, and fail-closed proof routing." -ForegroundColor Green
+Write-Host "CI workflow contracts passed: CodeQL branch/path gating, conservative lane routing, stable gate enforcement, decoupled metadata/release builds, preserved test inventory, and fail-closed proof routing." -ForegroundColor Green


### PR DESCRIPTION
## Summary

- limit advanced CodeQL branch pushes to `main` and `master`, while preserving all tag pushes, weekly schedule, and manual dispatch
- keep pull request source/build path filters so relevant PRs scan once and docs/agent-skill-only PRs avoid the remaining default-CodeQL time floor after transition
- make `OPENCLAW_CODEQL_ADVANCED_SETUP=true` the sole upload gate so manual dispatch cannot overlap repository default setup
- extend the lightweight workflow source contract with explicit trigger, path, profile, permission, concurrency, gate, C#, and Actions assertions

## Required proof pools

- `none`: workflow-only trigger/gate changes have no applicable runtime proof pool in `docs/PROOF_POOLS.md`

## Validation

- `./build.ps1`: passed, all five build groups succeeded
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore`: passed, 3,905 passed and 32 skipped
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore`: passed, 2,833 passed
- `./scripts/test-ci-workflow-contract.ps1`: passed
- `actionlint -no-color`: only the documented existing `build-msix` `if: false` diagnostic
- `actionlint -no-color -ignore 'constant expression "false" in condition'`: passed
- rubber-duck review: no blocking findings; both suggested contract hardening items were addressed

## Real behavior proof

The source contract reads `.github/workflows/codeql.yml` and proves:

- a feature-branch source push does not trigger CodeQL
- `main` and `master` source pushes do trigger CodeQL
- all tag pushes remain enabled
- a relevant source PR triggers CodeQL
- docs-only and `.agents/skills`-only PRs do not trigger CodeQL
- schedule and `workflow_dispatch` remain available
- both C# and Actions jobs depend on `needs.advanced-setup.outputs.enabled == 'true'`
- no dispatch input can bypass the repository-variable gate

Live advanced scan upload is intentionally not verified before merge because GitHub default setup is still configured and `OPENCLAW_CODEQL_ADVANCED_SETUP` is unset. This prevents overlapping SARIF uploads during the transition.

## Post-merge admin transition

Run these commands only after this PR is merged to `main`:

```powershell
$repo = "openclaw/openclaw-windows-node"

# 1. Disable CodeQL default setup.
gh api --method PATCH "repos/$repo/code-scanning/default-setup" `
  -f state=not-configured

# 2. Enable the merged advanced workflow gate.
gh variable set OPENCLAW_CODEQL_ADVANCED_SETUP `
  --repo $repo `
  --body true

# 3. Dispatch both advanced profiles from main.
gh workflow run codeql.yml `
  --repo $repo `
  --ref main `
  -f profile=all

# 4. Watch the dispatched run to completion.
$runId = gh run list `
  --repo $repo `
  --workflow codeql.yml `
  --branch main `
  --event workflow_dispatch `
  --limit 1 `
  --json databaseId `
  --jq '.[0].databaseId'
gh run watch $runId --repo $repo --exit-status

# 5. Verify advanced C# and Actions analyses were uploaded for main.
gh api "repos/$repo/code-scanning/analyses?ref=refs/heads/main&tool_name=CodeQL&per_page=20" `
  --jq '.[] | select(.category == "/codeql/csharp" or .category == "/codeql/actions") | {category,commit_sha,created_at,url}'
```

Also confirm the repository Code scanning settings page reports default setup disabled and the `CodeQL` workflow run contains successful `C# security` and `Actions security` jobs.

## Rollback

If either advanced analysis fails or uploads are missing, disable the advanced gate before restoring the prior default setup:

```powershell
$repo = "openclaw/openclaw-windows-node"

gh variable set OPENCLAW_CODEQL_ADVANCED_SETUP `
  --repo $repo `
  --body false

gh api --method PATCH "repos/$repo/code-scanning/default-setup" `
  -f state=configured `
  -f query_suite=default `
  -f schedule=weekly `
  -f threat_model=remote `
  -f runner_type=standard `
  -f "languages[]=actions" `
  -f "languages[]=csharp" `
  -f "languages[]=python"
```

This restores the currently observed default-setup profile. Keep the advanced gate false until the upload issue is resolved.