### PR TITLE
feat: add interactive global triage dashboard

### DIFF
--- a/.agents/skills/global-repo-triage/README.md
+++ b/.agents/skills/global-repo-triage/README.md
@@ -1,28 +1,33 @@
 # OpenClaw Windows Node Global Triage
 
-This portable skill reproduces the full maintainer sweep used for
+This skill reproduces the full maintainer sweep used for
 `openclaw/openclaw-windows-node`. It combines the repository's scheduled
 read-only triage report with source review, proof-pool scheduling, active-owner
-auditing, adversarial review, landing order, and release planning.
+auditing, adversarial review, landing order, release planning, and a live
+interactive canvas.
 
 ## Install
 
-Unzip the package so this file exists:
+Repository use is automatic because the skill and canvas extension are checked
+in together:
 
 ```text
-%USERPROFILE%\.copilot\skills\global-repo-triage\SKILL.md
+.agents\skills\global-repo-triage\SKILL.md
+.github\extensions\openclaw-triage-dashboard\extension.mjs
 ```
 
-Restart Copilot if the skill is not discovered immediately.
+For portable user installation, copy both directories to the matching user skill
+and extension locations. Restart Copilot if discovery does not refresh.
 
 ## Recommended prompt
 
 ```text
 Run the OpenClaw Windows Node global triage. Read every open issue and PR,
 compare with the previous report, identify what can safely land today, audit
-active ownership, schedule required proof pools, and save the full Markdown
-report plus execution handoff. Do not mutate GitHub until I approve the queue.
+active ownership, schedule required proof pools, save the evidence artifacts,
+and open the live triage canvas. Do not mutate GitHub until I approve an action.
 ```
 
-The `examples` folder contains the two real reports that established the format.
-
+The canvas refreshes checks and plan gates automatically. `Prepare merge` sends a
+guarded request into the current Copilot session; it does not merge directly.
+The `examples` folder contains the two reports that established decision quality.

--- a/.agents/skills/global-repo-triage/README.md
+++ b/.agents/skills/global-repo-triage/README.md
@@ -28,6 +28,7 @@ active ownership, schedule required proof pools, save the evidence artifacts,
 and open the live triage canvas. Do not mutate GitHub until I approve an action.
 ```
 
-The canvas refreshes checks and plan gates automatically. `Prepare merge` sends a
-guarded request into the current Copilot session; it does not merge directly.
+The canvas refreshes checks and plan gates automatically. Item actions create or
+reuse one dedicated child project session per PR or issue. `Prepare merge` sends
+a guarded request to that session; it does not merge directly.
 The `examples` folder contains the two reports that established decision quality.

--- a/.agents/skills/global-repo-triage/README.md
+++ b/.agents/skills/global-repo-triage/README.md
@@ -28,7 +28,8 @@ active ownership, schedule required proof pools, save the evidence artifacts,
 and open the live triage canvas. Do not mutate GitHub until I approve an action.
 ```
 
-The canvas refreshes checks and plan gates automatically. Item actions create or
-reuse one dedicated child project session per PR or issue. `Prepare merge` sends
-a guarded request to that session; it does not merge directly.
+The canvas refreshes checks and plan gates automatically. Its Plan tab is the
+single ordered source for execution priorities. Item actions create or reuse one
+dedicated child project session per PR or issue. `Prepare merge` sends a guarded
+request to that session; it does not merge directly.
 The `examples` folder contains the two reports that established decision quality.

--- a/.agents/skills/global-repo-triage/README.md
+++ b/.agents/skills/global-repo-triage/README.md
@@ -1,23 +1,22 @@
 # OpenClaw Windows Node Global Triage
 
-This skill reproduces the full maintainer sweep used for
+This portable skill reproduces the full maintainer sweep used for
 `openclaw/openclaw-windows-node`. It combines the repository's scheduled
 read-only triage report with source review, proof-pool scheduling, active-owner
-auditing, adversarial review, landing order, release planning, and a live
-interactive canvas.
+auditing, adversarial review, landing order, and release planning. It can also
+open a live interactive canvas when requested.
 
 ## Install
 
-Repository use is automatic because the skill and canvas extension are checked
-in together:
+Unzip the package so this file exists:
 
 ```text
-.agents\skills\global-repo-triage\SKILL.md
-.github\extensions\openclaw-triage-dashboard\extension.mjs
+%USERPROFILE%\.copilot\skills\global-repo-triage\SKILL.md
 ```
 
-For portable user installation, copy both directories to the matching user skill
-and extension locations. Restart Copilot if discovery does not refresh.
+Restart Copilot if the skill is not discovered immediately. The optional
+interactive dashboard is available when the repository also contains
+`.github\extensions\openclaw-triage-dashboard\extension.mjs`.
 
 ## Recommended prompt
 
@@ -25,11 +24,11 @@ and extension locations. Restart Copilot if discovery does not refresh.
 Run the OpenClaw Windows Node global triage. Read every open issue and PR,
 compare with the previous report, identify what can safely land today, audit
 active ownership, schedule required proof pools, save the evidence artifacts,
-and open the live triage canvas. Do not mutate GitHub until I approve an action.
+and save the full Markdown report plus execution handoff. Open the live triage
+canvas too. Do not mutate GitHub until I approve an action.
 ```
 
-The canvas refreshes checks and plan gates automatically. Its Plan tab is the
-single ordered source for execution priorities. Item actions create or reuse one
-dedicated child project session per PR or issue. `Prepare merge` sends a guarded
-request to that session; it does not merge directly.
-The `examples` folder contains the two reports that established decision quality.
+The `examples` folder contains the two real reports that established the Markdown
+format. When requested, the canvas supplements that report with live checks,
+plan gates, and guarded child-session actions. It does not replace the report or
+merge directly.

--- a/.agents/skills/global-repo-triage/SKILL.md
+++ b/.agents/skills/global-repo-triage/SKILL.md
@@ -7,8 +7,9 @@ description: "Run complete OpenClaw Windows Node issue and PR triage, including 
 
 Run a complete maintainer triage of `openclaw/openclaw-windows-node`. Read every
 open issue and pull request, identify safe landing lanes, schedule OpenClaw's
-Windows proof pools, and produce the same evidence-backed Markdown report used
-for the August 27 and September 1 maintainer sweeps.
+Windows proof pools, and open the interactive OpenClaw triage canvas. The canvas
+keeps GitHub checks and plan gates current while preserving the evidence-backed
+decision quality established by the August 27 and September 1 reports.
 
 This skill is repository-specific. If the current repository is not
 `openclaw/openclaw-windows-node`, stop and say that this skill applies only to
@@ -30,16 +31,18 @@ Use when the user asks for:
 Create these session artifacts:
 
 ```text
-global-triage-YYYY-MM-DD.md
+global-triage-YYYY-MM-DD.json
 triage-YYYY-MM-DD\issues-summary.csv
 triage-YYYY-MM-DD\prs-summary.csv
 triage-YYYY-MM-DD\pr-<number>.patch
 ```
 
 Keep raw JSON when practical. Do not add triage artifacts to the repository.
-Use `templates\global-triage-report.md` as the report skeleton and
+Use `templates\triage-state.template.json` as the interactive state contract.
+Use `templates\global-triage-report.md` only when the user requests a Markdown
+export. The Markdown examples remain decision-quality references:
 `examples\global-triage-2026-08-27.md` plus
-`examples\global-triage-2026-09-01.md` as quality references.
+`examples\global-triage-2026-09-01.md`.
 
 ## Ground rules
 
@@ -64,6 +67,10 @@ Use `templates\global-triage-report.md` as the report skeleton and
 8. **Do not revive stale architecture wholesale.** Transplant the smallest
    useful fix onto current owners rather than rebasing obsolete god-object or
    pre-ledger branches.
+9. **Canvas actions are requests, not mutations.** The dashboard may refresh
+   read-only GitHub state and send a guarded action request into the current
+   Copilot session. It must never merge, close, label, comment, push, rerun CI,
+   or delete a session directly.
 
 ## Decision vocabulary
 
@@ -232,7 +239,8 @@ use the repository workflow's guarded
 
 ## 7. Review likely landing candidates
 
-Use direct review for small changes. Invoke `hanselman-code-review` for:
+Use direct review for small changes. Invoke the checked-in `autoreview` skill
+with a multi-reviewer panel when available for:
 
 - more than 300 changed lines
 - security, auth, setup, storage, release, signing, installer, shell, MXC,
@@ -241,8 +249,10 @@ Use direct review for small changes. Invoke `hanselman-code-review` for:
 - conflicting GitHub state or disputed findings
 - any candidate below 95% recommendation confidence that might still be taken
 
-Cross-reference both reviewers in the report, then verify each accepted finding
-against the code. Do not paste raw reviewer output as the decision.
+Cross-reference the panel with the primary review, then verify each accepted
+finding against the code. If only one isolated engine is available, record that
+limitation and lower recommendation confidence rather than naming an unavailable
+skill. Do not paste raw reviewer output as the decision.
 
 ## 8. Build the landing and release plan
 
@@ -288,37 +298,61 @@ For release planning:
 - never move or reuse a published tag
 - require x64/ARM64 signed installer and portable ZIP verification
 
-## 9. Write the proven report format
+## 9. Publish the interactive dashboard
 
-The Markdown report must use this order:
+Write `global-triage-YYYY-MM-DD.json` using
+`templates\triage-state.template.json`. Every item needs:
 
-1. `# OpenClaw Windows Node global triage`
-2. Snapshot sentence with exact open issue and PR counts plus collection scope
-3. `## Change since <prior date>`
-4. `## Executive queue`
-5. `## Pull requests`
-6. `## Issues`
-7. `## Active ownership audit`
-8. `## Adversarial review` for selected risky candidates
-9. `## Day plan`
-10. `## Automation and testability`
+- its PR or issue number, title, URL, decision, both confidence values, effort,
+  risk, owner, and concrete next action
+- exact reviewed head SHA for PRs
+- expected required check names
+- review status and proof status
+- every applicable proof-pool ID, validated against
+  `.github\proof-pools.json`
+- dependencies on other items in the same triage
 
-The PR table columns are:
+Populate `report` so the dashboard tabs preserve the report template's
+decision context:
 
-```text
-Item | Type / signal | Decision | Take confidence |
-Recommendation confidence | Effort | Risk | Owner / required validation
-```
+- `changes`
+- `executiveQueue`
+- `ownership`
+- `reviews`
+- `dayPlan`
+- `automation`
 
-The issue table columns are:
+Represent the day plan as ordered steps. A plan step may declare `gates` that
+point to an item's `inventory`, `review`, `checks`, `proof`, or `landing` stage.
+The canvas derives each gated step's live status whenever GitHub checks change.
 
-```text
-Item | Signal | Decision | Take confidence |
-Recommendation confidence | Effort | Risk | Owner / next action
-```
+Then:
 
-Every row needs a concrete owner and next action. Cover all open items, including
-low-priority and declined work.
+1. Call `list_canvas_capabilities` for `openclaw-triage-dashboard`.
+2. Open `openclaw-triage-dashboard` with the JSON object as input and use a
+   stable instance ID such as `global-triage-YYYY-MM-DD`.
+3. Reopen that same instance ID whenever triage decisions, proof status, review
+   status, expected checks, or plan steps change.
+4. Leave the canvas open. It refreshes GitHub PR and issue state at the declared
+   30-to-300-second interval and pushes updates to the panel.
+
+The canvas exposes:
+
+- search and readiness filters
+- live check totals and missing expected jobs
+- item stages and plan-gate status
+- proof, review, exact-head, draft, and mergeability gates
+- `Request next step`, which sends a read-only-by-default request into this
+  session
+- `Prepare merge`, enabled only for an exact-head `TAKE` at 90% or higher with
+  complete review and proof, clean merge state, and all expected checks present
+  and passing
+
+`Prepare merge` must only ask this session to re-fetch evidence and request
+explicit confirmation. The extension never calls a GitHub mutation command.
+
+When the user requests a Markdown export, use the historical section order and
+tables in `templates\global-triage-report.md`. The canvas is the primary handoff.
 
 ## Completion bar
 
@@ -332,4 +366,9 @@ Do not call the triage complete until:
 - proof pools and human hosts are scheduled explicitly
 - a numbered day plan identifies safe parallelism and dependency order
 - release contents and exclusions are explicit when a release is discussed
-- the Markdown report, CSV summaries, and reviewed PR patches are saved
+- the versioned triage-state JSON, CSV summaries, and reviewed PR patches are
+  saved
+- the dashboard opens successfully and its fetched item count matches the state
+  artifact
+- every plan gate references an item and stage in the state artifact
+- merge requests remain chat-routed and confirmation-gated

--- a/.agents/skills/global-repo-triage/SKILL.md
+++ b/.agents/skills/global-repo-triage/SKILL.md
@@ -340,7 +340,8 @@ Write `global-triage-YYYY-MM-DD.json` using
 - its PR or issue number, title, URL, decision, both confidence values, effort,
   risk, owner, and concrete next action
 - exact reviewed head SHA for PRs
-- expected required check names
+- expected required check names for PRs; issues must use an empty `expectedChecks`
+  array
 - review status and proof status
 - every applicable proof-pool ID, validated against
   `.github\proof-pools.json`
@@ -358,7 +359,8 @@ Use `plan` as the single ordered execution plan. Set each step's optional
 `horizon` to `today` or `later`; omitted values default to `today`. A plan step
 may declare `dependsOn` with other plan-step IDs and `gates` that point to an
 item's `inventory`, `review`, `checks`, `proof`, or `landing` stage. Dependencies
-must form an acyclic graph. The canvas derives each gated step's live status
+must form an acyclic graph. The `landing` stage applies only to pull requests.
+The canvas derives each gated step's live status
 whenever GitHub checks change. It renders connected steps as dependency lanes
 and independent steps as parallel work. Plan order breaks ties within a lane.
 Do not repeat plan steps in `report`.

--- a/.agents/skills/global-repo-triage/SKILL.md
+++ b/.agents/skills/global-repo-triage/SKILL.md
@@ -7,9 +7,9 @@ description: "Run complete OpenClaw Windows Node issue and PR triage, including 
 
 Run a complete maintainer triage of `openclaw/openclaw-windows-node`. Read every
 open issue and pull request, identify safe landing lanes, schedule OpenClaw's
-Windows proof pools, and open the interactive OpenClaw triage canvas. The canvas
-keeps GitHub checks and plan gates current while preserving the evidence-backed
-decision quality established by the August 27 and September 1 reports.
+Windows proof pools, and produce the same evidence-backed Markdown report used
+for the August 27 and September 1 maintainer sweeps. Open the interactive
+OpenClaw triage canvas when the user requests it as an additional handoff.
 
 This skill is repository-specific. If the current repository is not
 `openclaw/openclaw-windows-node`, stop and say that this skill applies only to
@@ -31,6 +31,7 @@ Use when the user asks for:
 Create these session artifacts:
 
 ```text
+global-triage-YYYY-MM-DD.md
 global-triage-YYYY-MM-DD.json
 triage-YYYY-MM-DD\issues-summary.csv
 triage-YYYY-MM-DD\prs-summary.csv
@@ -38,11 +39,11 @@ triage-YYYY-MM-DD\pr-<number>.patch
 ```
 
 Keep raw JSON when practical. Do not add triage artifacts to the repository.
-Use `templates\triage-state.template.json` as the interactive state contract.
-Use `templates\global-triage-report.md` only when the user requests a Markdown
-export. The Markdown examples remain decision-quality references:
+Use `templates\global-triage-report.md` as the report skeleton and
 `examples\global-triage-2026-08-27.md` plus
-`examples\global-triage-2026-09-01.md`.
+`examples\global-triage-2026-09-01.md` as quality references. Use
+`templates\triage-state.template.json` only when producing the optional
+interactive dashboard.
 
 ## Ground rules
 
@@ -240,8 +241,7 @@ use the repository workflow's guarded
 
 ## 7. Review likely landing candidates
 
-Use direct review for small changes. Invoke the checked-in `autoreview` skill
-with a multi-reviewer panel when available for:
+Use direct review for small changes. Invoke `hanselman-code-review` for:
 
 - more than 300 changed lines
 - security, auth, setup, storage, release, signing, installer, shell, MXC,
@@ -250,10 +250,8 @@ with a multi-reviewer panel when available for:
 - conflicting GitHub state or disputed findings
 - any candidate below 95% recommendation confidence that might still be taken
 
-Cross-reference the panel with the primary review, then verify each accepted
-finding against the code. If only one isolated engine is available, record that
-limitation and lower recommendation confidence rather than naming an unavailable
-skill. Do not paste raw reviewer output as the decision.
+Cross-reference both reviewers in the report, then verify each accepted finding
+against the code. Do not paste raw reviewer output as the decision.
 
 ## 8. Build the landing and release plan
 
@@ -299,7 +297,42 @@ For release planning:
 - never move or reuse a published tag
 - require x64/ARM64 signed installer and portable ZIP verification
 
-## 9. Publish the interactive dashboard
+## 9. Write the proven report format
+
+The Markdown report must use this order:
+
+1. `# OpenClaw Windows Node global triage`
+2. Snapshot sentence with exact open issue and PR counts plus collection scope
+3. `## Change since <prior date>`
+4. `## Executive queue`
+5. `## Pull requests`
+6. `## Issues`
+7. `## Active ownership audit`
+8. `## Adversarial review` for selected risky candidates
+9. `## Day plan`
+10. `## Automation and testability`
+
+The PR table columns are:
+
+```text
+Item | Type / signal | Decision | Take confidence |
+Recommendation confidence | Effort | Risk | Owner / required validation
+```
+
+The issue table columns are:
+
+```text
+Item | Signal | Decision | Take confidence |
+Recommendation confidence | Effort | Risk | Owner / next action
+```
+
+Every row needs a concrete owner and next action. Cover all open items, including
+low-priority and declined work.
+
+## 10. Optionally publish the interactive dashboard
+
+Only produce the interactive canvas when the user requests it in addition to the
+static Markdown report.
 
 Write `global-triage-YYYY-MM-DD.json` using
 `templates\triage-state.template.json`. Every item needs:
@@ -358,9 +391,6 @@ find the exact `Triage PR #<number>` or `Triage Issue #<number>` session and
 append to it, or create it once when absent. The extension never calls a GitHub
 mutation command.
 
-When the user requests a Markdown export, use the historical section order and
-tables in `templates\global-triage-report.md`. The canvas is the primary handoff.
-
 ## Completion bar
 
 Do not call the triage complete until:
@@ -371,10 +401,13 @@ Do not call the triage complete until:
 - issue-to-PR ownership and duplicate risks are mapped
 - active ownership is audited
 - proof pools and human hosts are scheduled explicitly
-- the ordered plan identifies safe parallelism and dependency order
+- a numbered day plan identifies safe parallelism and dependency order
 - release contents and exclusions are explicit when a release is discussed
-- the versioned triage-state JSON, CSV summaries, and reviewed PR patches are
-  saved
+- the Markdown report, CSV summaries, and reviewed PR patches are saved
+
+When the optional dashboard was requested, also require:
+
+- the versioned triage-state JSON is saved
 - the dashboard opens successfully and its fetched item count matches the state
   artifact
 - every plan gate references an item and stage in the state artifact

--- a/.agents/skills/global-repo-triage/SKILL.md
+++ b/.agents/skills/global-repo-triage/SKILL.md
@@ -32,7 +32,6 @@ Create these session artifacts:
 
 ```text
 global-triage-YYYY-MM-DD.md
-global-triage-YYYY-MM-DD.json
 triage-YYYY-MM-DD\issues-summary.csv
 triage-YYYY-MM-DD\prs-summary.csv
 triage-YYYY-MM-DD\pr-<number>.patch
@@ -332,7 +331,8 @@ low-priority and declined work.
 ## 10. Optionally publish the interactive dashboard
 
 Only produce the interactive canvas when the user requests it in addition to the
-static Markdown report.
+static Markdown report. Create `global-triage-YYYY-MM-DD.json` as its session
+state artifact.
 
 Write `global-triage-YYYY-MM-DD.json` using
 `templates\triage-state.template.json`. Every item needs:

--- a/.agents/skills/global-repo-triage/SKILL.md
+++ b/.agents/skills/global-repo-triage/SKILL.md
@@ -101,7 +101,7 @@ Read:
 Confirm the deterministic triage implementation is healthy:
 
 ```powershell
-node --test .github\scripts\repository-triage.test.cjs
+node --test .github\scripts\repository-triage.test.cjs .github\extensions\openclaw-triage-dashboard\triage-state.test.mjs
 ```
 
 Prefer the latest successful scheduled `Repository Triage Report` artifact as
@@ -317,15 +317,18 @@ Populate `report` so the dashboard tabs preserve the report template's
 decision context:
 
 - `changes`
-- `executiveQueue`
 - `ownership`
 - `reviews`
-- `dayPlan`
 - `automation`
 
-Represent the day plan as ordered steps. A plan step may declare `gates` that
-point to an item's `inventory`, `review`, `checks`, `proof`, or `landing` stage.
-The canvas derives each gated step's live status whenever GitHub checks change.
+Use `plan` as the single ordered execution plan. Set each step's optional
+`horizon` to `today` or `later`; omitted values default to `today`. A plan step
+may declare `dependsOn` with other plan-step IDs and `gates` that point to an
+item's `inventory`, `review`, `checks`, `proof`, or `landing` stage. Dependencies
+must form an acyclic graph. The canvas derives each gated step's live status
+whenever GitHub checks change. It renders connected steps as dependency lanes
+and independent steps as parallel work. Plan order breaks ties within a lane.
+Do not repeat plan steps in `report`.
 
 Then:
 
@@ -368,7 +371,7 @@ Do not call the triage complete until:
 - issue-to-PR ownership and duplicate risks are mapped
 - active ownership is audited
 - proof pools and human hosts are scheduled explicitly
-- a numbered day plan identifies safe parallelism and dependency order
+- the ordered plan identifies safe parallelism and dependency order
 - release contents and exclusions are explicit when a release is discussed
 - the versioned triage-state JSON, CSV summaries, and reviewed PR patches are
   saved

--- a/.agents/skills/global-repo-triage/SKILL.md
+++ b/.agents/skills/global-repo-triage/SKILL.md
@@ -68,9 +68,10 @@ export. The Markdown examples remain decision-quality references:
    useful fix onto current owners rather than rebasing obsolete god-object or
    pre-ledger branches.
 9. **Canvas actions are requests, not mutations.** The dashboard may refresh
-   read-only GitHub state and send a guarded action request into the current
-   Copilot session. It must never merge, close, label, comment, push, rerun CI,
-   or delete a session directly.
+   read-only GitHub state and route a guarded action request to one dedicated
+   child project session per item. Reuse that session for later actions on the
+   same PR or issue. The dashboard must never merge, close, label, comment, push,
+   rerun CI, or delete a session directly.
 
 ## Decision vocabulary
 
@@ -342,14 +343,17 @@ The canvas exposes:
 - live check totals and missing expected jobs
 - item stages and plan-gate status
 - proof, review, exact-head, draft, and mergeability gates
-- `Request next step`, which sends a read-only-by-default request into this
-  session
+- `Request next step`, which creates or reuses the item's child project session
+  and sends a read-only-by-default request there
 - `Prepare merge`, enabled only for an exact-head `TAKE` at 90% or higher with
   complete review and proof, clean merge state, and all expected checks present
   and passing
 
-`Prepare merge` must only ask this session to re-fetch evidence and request
-explicit confirmation. The extension never calls a GitHub mutation command.
+`Prepare merge` must only ask the item's child session to re-fetch evidence and
+request explicit confirmation. Every item action uses the same routing rule:
+find the exact `Triage PR #<number>` or `Triage Issue #<number>` session and
+append to it, or create it once when absent. The extension never calls a GitHub
+mutation command.
 
 When the user requests a Markdown export, use the historical section order and
 tables in `templates\global-triage-report.md`. The canvas is the primary handoff.
@@ -371,4 +375,5 @@ Do not call the triage complete until:
 - the dashboard opens successfully and its fetched item count matches the state
   artifact
 - every plan gate references an item and stage in the state artifact
-- merge requests remain chat-routed and confirmation-gated
+- item actions remain child-session-routed and merge requests stay
+  confirmation-gated

--- a/.agents/skills/global-repo-triage/templates/triage-state.template.json
+++ b/.agents/skills/global-repo-triage/templates/triage-state.template.json
@@ -1,0 +1,87 @@
+{
+  "schemaVersion": 1,
+  "repo": "openclaw/openclaw-windows-node",
+  "title": "OpenClaw Windows Node global triage",
+  "scope": "All open issues and pull requests as of 2026-09-03.",
+  "generatedAt": "2026-09-03T22:00:00Z",
+  "refreshSeconds": 60,
+  "items": [
+    {
+      "type": "pr",
+      "number": 1308,
+      "title": "Example pull request",
+      "url": "https://github.com/openclaw/openclaw-windows-node/pull/1308",
+      "decision": "TAKE_AFTER_CHECKS",
+      "takeConfidence": 88,
+      "recommendationConfidence": 98,
+      "effort": "Quick",
+      "risk": "Low",
+      "owner": "Maintainer",
+      "nextAction": "Wait for the exact-head test and both architecture builds.",
+      "proofPools": [],
+      "proofStatus": "not-applicable",
+      "reviewStatus": "complete",
+      "reviewedHeadSha": "0123456789abcdef0123456789abcdef01234567",
+      "expectedChecks": [
+        "test",
+        "build (win-x64)",
+        "build (win-arm64)"
+      ],
+      "dependencies": []
+    }
+  ],
+  "report": {
+    "changes": [
+      {
+        "change": "New pull requests",
+        "items": "#1308"
+      }
+    ],
+    "executiveQueue": [
+      "Land PR #1308 after its exact-head checks pass."
+    ],
+    "ownership": [
+      {
+        "item": "#1308",
+        "assessment": "Maintainer-owned and actively moving."
+      }
+    ],
+    "reviews": [
+      {
+        "item": "#1308",
+        "title": "Example pull request",
+        "decision": "TAKE_AFTER_CHECKS",
+        "summary": "No actionable source finding remains. Exact-head checks are the final gate."
+      }
+    ],
+    "dayPlan": [
+      "Wait for exact-head checks on PR #1308, then request guarded merge preparation."
+    ],
+    "automation": [
+      {
+        "opportunity": "Detect missing expected checks",
+        "why": "Zero failures does not prove that required jobs ran.",
+        "owner": "Repository triage workflow",
+        "effort": "Quick",
+        "notes": "Compare live check names with expectedChecks."
+      }
+    ]
+  },
+  "plan": [
+    {
+      "id": "land-1308",
+      "title": "Land PR #1308 after exact-head checks",
+      "detail": "The plan status follows the PR check gate.",
+      "itemNumbers": [
+        1308
+      ],
+      "gates": [
+        {
+          "itemNumber": 1308,
+          "stage": "checks"
+        }
+      ],
+      "status": "pending"
+    }
+  ]
+}

--- a/.agents/skills/global-repo-triage/templates/triage-state.template.json
+++ b/.agents/skills/global-repo-triage/templates/triage-state.template.json
@@ -28,6 +28,25 @@
         "build (win-arm64)"
       ],
       "dependencies": []
+    },
+    {
+      "type": "issue",
+      "number": 1309,
+      "title": "Example issue",
+      "url": "https://github.com/openclaw/openclaw-windows-node/issues/1309",
+      "decision": "NEEDS_INFO",
+      "takeConfidence": 60,
+      "recommendationConfidence": 95,
+      "effort": "Unknown",
+      "risk": "Low",
+      "owner": "Author",
+      "nextAction": "Clarify the expected behavior.",
+      "proofPools": [],
+      "proofStatus": "blocked",
+      "reviewStatus": "blocked",
+      "reviewedHeadSha": "",
+      "expectedChecks": [],
+      "dependencies": []
     }
   ],
   "report": {
@@ -75,6 +94,23 @@
         {
           "itemNumber": 1308,
           "stage": "checks"
+        }
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "clarify-1309",
+      "title": "Clarify issue #1309",
+      "detail": "The plan follows issue inventory and review state.",
+      "dependsOn": [],
+      "horizon": "later",
+      "itemNumbers": [
+        1309
+      ],
+      "gates": [
+        {
+          "itemNumber": 1309,
+          "stage": "inventory"
         }
       ],
       "status": "pending"

--- a/.agents/skills/global-repo-triage/templates/triage-state.template.json
+++ b/.agents/skills/global-repo-triage/templates/triage-state.template.json
@@ -37,9 +37,6 @@
         "items": "#1308"
       }
     ],
-    "executiveQueue": [
-      "Land PR #1308 after its exact-head checks pass."
-    ],
     "ownership": [
       {
         "item": "#1308",
@@ -53,9 +50,6 @@
         "decision": "TAKE_AFTER_CHECKS",
         "summary": "No actionable source finding remains. Exact-head checks are the final gate."
       }
-    ],
-    "dayPlan": [
-      "Wait for exact-head checks on PR #1308, then request guarded merge preparation."
     ],
     "automation": [
       {
@@ -72,6 +66,8 @@
       "id": "land-1308",
       "title": "Land PR #1308 after exact-head checks",
       "detail": "The plan status follows the PR check gate.",
+      "dependsOn": [],
+      "horizon": "today",
       "itemNumbers": [
         1308
       ],

--- a/.github/extensions/openclaw-triage-dashboard/extension.mjs
+++ b/.github/extensions/openclaw-triage-dashboard/extension.mjs
@@ -15,7 +15,10 @@ import {
     mergeLiveState,
     normalizeTriageInput,
 } from "./triage-state.mjs";
-import { buildSubsessionRoutingPrompt } from "./triage-actions.mjs";
+import {
+    buildSubsessionRoutingPrompt,
+    requireFreshGitHubEvidence,
+} from "./triage-actions.mjs";
 import { renderDashboardHtml } from "./triage-ui.mjs";
 
 const execFileAsync = promisify(execFile);
@@ -206,7 +209,10 @@ async function requestItemAction(entry, action, input) {
     let actionPrompt;
     let result;
     if (action === "request_merge") {
-        await refreshEntry(entry);
+        await requireFreshGitHubEvidence(
+            () => refreshEntry(entry),
+            (code, message) => new CanvasError(code, message),
+        );
         item = findItem(entry, number);
         const eligibility = canRequestMerge(item, item.live);
         if (!eligibility.eligible) {

--- a/.github/extensions/openclaw-triage-dashboard/extension.mjs
+++ b/.github/extensions/openclaw-triage-dashboard/extension.mjs
@@ -15,6 +15,7 @@ import {
     mergeLiveState,
     normalizeTriageInput,
 } from "./triage-state.mjs";
+import { buildSubsessionRoutingPrompt } from "./triage-actions.mjs";
 import { renderDashboardHtml } from "./triage-ui.mjs";
 
 const execFileAsync = promisify(execFile);
@@ -192,7 +193,7 @@ function findItem(entry, number) {
     return entry.state.items.find((item) => item.number === number);
 }
 
-async function requestChatAction(entry, action, input) {
+async function requestItemAction(entry, action, input) {
     const number = Number(input?.number);
     if (!Number.isInteger(number) || number <= 0) {
         throw new CanvasError("invalid_item", "A positive PR or issue number is required");
@@ -202,6 +203,8 @@ async function requestChatAction(entry, action, input) {
         throw new CanvasError("item_not_found", `#${number} is not in this triage`);
     }
 
+    let actionPrompt;
+    let result;
     if (action === "request_merge") {
         await refreshEntry(entry);
         item = findItem(entry, number);
@@ -214,30 +217,35 @@ async function requestChatAction(entry, action, input) {
             requestedHead.toLowerCase() !== String(item.live.headRefOid).toLowerCase()) {
             throw new CanvasError("head_changed", "The requested head no longer matches live GitHub state");
         }
-        await copilotSession.send({
-            prompt:
-                `The user selected Prepare merge for ${entry.triage.repo} PR #${number} at observed head ` +
-                `${requestedHead}. Use the global-repo-triage skill guardrails. Re-fetch the PR, exact head, ` +
-                "required checks, reviews, unresolved threads, proof declarations, real behavior evidence, " +
-                "branch protection, and mergeability. Do not mutate GitHub yet. Present the fresh evidence and " +
-                "ask for explicit confirmation before merging.",
-        });
-        return { queued: true, action, number, headSha: requestedHead };
+        actionPrompt =
+            `The user selected Prepare merge for ${entry.triage.repo} PR #${number} at observed head ` +
+            `${requestedHead}. Use the global-repo-triage skill guardrails. Re-fetch the PR, exact head, ` +
+            "required checks, reviews, unresolved threads, proof declarations, real behavior evidence, " +
+            "branch protection, and mergeability. Do not mutate GitHub yet. Present the fresh evidence and " +
+            "ask for explicit confirmation before merging.";
+        result = { headSha: requestedHead };
+    } else if (action === "request_next_action") {
+        actionPrompt =
+            `The user selected Request next step for ${entry.triage.repo} ${item.type.toUpperCase()} #${number} ` +
+            "from the interactive triage canvas. Invoke the global-repo-triage skill, refresh this item's " +
+            "current GitHub evidence, and continue only the smallest safe next action. Preserve the read-only " +
+            "default for GitHub mutations and ask for confirmation before any merge, close, label, comment, " +
+            "push, rerun, or session deletion.";
+        result = {};
+    } else {
+        throw new CanvasError("unsupported_action", "Unsupported triage action");
     }
 
-    if (action === "request_next_action") {
-        await copilotSession.send({
-            prompt:
-                `The user selected Request next step for ${entry.triage.repo} ${item.type.toUpperCase()} #${number} ` +
-                "from the interactive triage canvas. Invoke the global-repo-triage skill, refresh this item's " +
-                "current GitHub evidence, and continue only the smallest safe next action. Preserve the read-only " +
-                "default for GitHub mutations and ask for confirmation before any merge, close, label, comment, " +
-                "push, rerun, or session deletion.",
-        });
-        return { queued: true, action, number };
-    }
-
-    throw new CanvasError("unsupported_action", "Unsupported triage action");
+    const routing = buildSubsessionRoutingPrompt(entry.triage.repo, item, actionPrompt);
+    await copilotSession.send({ prompt: routing.prompt });
+    return {
+        queued: true,
+        subsessionRoutingQueued: true,
+        sessionName: routing.sessionName,
+        action,
+        number,
+        ...result,
+    };
 }
 
 async function readJsonBody(request) {
@@ -309,7 +317,7 @@ async function handleRequest(entry, request, response) {
         }
         if (request.method === "POST" && url.pathname === "/action") {
             const input = await readJsonBody(request);
-            const result = await requestChatAction(entry, input.action, input);
+            const result = await requestItemAction(entry, input.action, input);
             writeJson(response, 202, result);
             return;
         }
@@ -429,17 +437,17 @@ const dashboard = createCanvas({
         },
         {
             name: "request_next_action",
-            description: "Send a guarded next-step request for one triage item into the current session.",
+            description: "Route a guarded next-step request to the item's dedicated child session.",
             inputSchema: itemActionSchema,
             handler: async (context) => {
                 const entry = instances.get(context.instanceId);
                 if (!entry) throw new CanvasError("instance_not_found", "Triage canvas is not open");
-                return requestChatAction(entry, "request_next_action", context.input);
+                return requestItemAction(entry, "request_next_action", context.input);
             },
         },
         {
             name: "request_merge",
-            description: "Request fresh merge verification and confirmation in the current session.",
+            description: "Route fresh merge verification to the item's dedicated child session.",
             inputSchema: {
                 type: "object",
                 required: ["number", "headSha"],
@@ -452,7 +460,7 @@ const dashboard = createCanvas({
             handler: async (context) => {
                 const entry = instances.get(context.instanceId);
                 if (!entry) throw new CanvasError("instance_not_found", "Triage canvas is not open");
-                return requestChatAction(entry, "request_merge", context.input);
+                return requestItemAction(entry, "request_merge", context.input);
             },
         },
     ],

--- a/.github/extensions/openclaw-triage-dashboard/extension.mjs
+++ b/.github/extensions/openclaw-triage-dashboard/extension.mjs
@@ -11,18 +11,19 @@ import {
     joinSession,
 } from "@github/copilot-sdk/extension";
 import {
-    canRequestMerge,
     mergeLiveState,
     normalizeTriageInput,
 } from "./triage-state.mjs";
 import {
-    buildSubsessionRoutingPrompt,
-    requireFreshGitHubEvidence,
+    requestHostMatches,
+    requestItemAction,
+    requestTokenMatches,
 } from "./triage-actions.mjs";
 import { renderDashboardHtml } from "./triage-ui.mjs";
 
 const execFileAsync = promisify(execFile);
 const instances = new Map();
+const instanceStarts = new Map();
 const extensionDirectory = dirname(fileURLToPath(import.meta.url));
 const repositoryRoot = dirname(dirname(dirname(extensionDirectory)));
 let copilotSession;
@@ -120,7 +121,7 @@ async function collectLiveState(repo, items) {
         item.type === "pr"
             ? !pullRequestNumbers.has(item.number)
             : !issueNumbers.has(item.number));
-    const missingResults = await Promise.all(missing.map(async (item) => {
+    const missingResults = await Promise.allSettled(missing.map(async (item) => {
         const fields = item.type === "pr"
             ? "number,title,url,state,isDraft,mergeable,mergeStateStatus,reviewDecision,headRefOid,updatedAt,labels,statusCheckRollup"
             : "number,title,url,state,stateReason,updatedAt,labels";
@@ -133,9 +134,21 @@ async function collectLiveState(repo, items) {
         return { type: item.type, value };
     }));
     for (const result of missingResults) {
-        (result.type === "pr" ? pullRequests : issues).push(result.value);
+        if (result.status === "fulfilled") {
+            (result.value.type === "pr" ? pullRequests : issues).push(result.value.value);
+        }
     }
-    return { pullRequests, issues };
+    const failedLookups = missingResults
+        .map((result, index) => result.status === "rejected" ? missing[index] : null)
+        .filter(Boolean)
+        .map((item) => `${item.type.toUpperCase()} #${item.number}`);
+    return {
+        pullRequests,
+        issues,
+        refreshWarning: failedLookups.length > 0
+            ? `Live lookup failed for ${failedLookups.join(", ")}. Other items are current.`
+            : "",
+    };
 }
 
 function safeErrorMessage(error) {
@@ -166,92 +179,47 @@ function sendState(entry) {
     }
 }
 
-async function refreshEntry(entry) {
+async function refreshEntry(entry, force = false) {
     if (entry.refreshPromise) {
-        return entry.refreshPromise;
+        if (!force) {
+            return entry.refreshPromise;
+        }
+        await entry.refreshPromise;
+        if (entry.refreshPromise) {
+            return refreshEntry(entry, true);
+        }
     }
-    entry.refreshPromise = (async () => {
+    const refreshPromise = (async () => {
         try {
             const live = await collectLiveState(entry.triage.repo, entry.triage.items);
             entry.pullRequests = live.pullRequests;
             entry.issues = live.issues;
-            entry.state = mergeLiveState(entry.triage, entry.pullRequests, entry.issues);
+            entry.state = {
+                ...mergeLiveState(entry.triage, entry.pullRequests, entry.issues),
+                refreshWarning: live.refreshWarning,
+            };
         } catch (error) {
-            entry.state = mergeLiveState(
-                entry.triage,
-                entry.pullRequests,
-                entry.issues,
-                safeErrorMessage(error),
-            );
-        } finally {
-            entry.refreshPromise = null;
+            entry.state = {
+                ...mergeLiveState(
+                    entry.triage,
+                    entry.pullRequests,
+                    entry.issues,
+                    safeErrorMessage(error),
+                ),
+                refreshWarning: "",
+            };
         }
         sendState(entry);
         return entry.state;
     })();
-    return entry.refreshPromise;
-}
-
-function findItem(entry, number) {
-    return entry.state.items.find((item) => item.number === number);
-}
-
-async function requestItemAction(entry, action, input) {
-    const number = Number(input?.number);
-    if (!Number.isInteger(number) || number <= 0) {
-        throw new CanvasError("invalid_item", "A positive PR or issue number is required");
-    }
-    let item = findItem(entry, number);
-    if (!item) {
-        throw new CanvasError("item_not_found", `#${number} is not in this triage`);
-    }
-
-    let actionPrompt;
-    let result;
-    if (action === "request_merge") {
-        await requireFreshGitHubEvidence(
-            () => refreshEntry(entry),
-            (code, message) => new CanvasError(code, message),
-        );
-        item = findItem(entry, number);
-        const eligibility = canRequestMerge(item, item.live);
-        if (!eligibility.eligible) {
-            throw new CanvasError("merge_not_ready", eligibility.reasons.join("; "));
+    entry.refreshPromise = refreshPromise;
+    try {
+        return await refreshPromise;
+    } finally {
+        if (entry.refreshPromise === refreshPromise) {
+            entry.refreshPromise = null;
         }
-        const requestedHead = String(input?.headSha ?? "");
-        if (!/^[0-9a-f]{7,64}$/i.test(requestedHead) ||
-            requestedHead.toLowerCase() !== String(item.live.headRefOid).toLowerCase()) {
-            throw new CanvasError("head_changed", "The requested head no longer matches live GitHub state");
-        }
-        actionPrompt =
-            `The user selected Prepare merge for ${entry.triage.repo} PR #${number} at observed head ` +
-            `${requestedHead}. Use the global-repo-triage skill guardrails. Re-fetch the PR, exact head, ` +
-            "required checks, reviews, unresolved threads, proof declarations, real behavior evidence, " +
-            "branch protection, and mergeability. Do not mutate GitHub yet. Present the fresh evidence and " +
-            "ask for explicit confirmation before merging.";
-        result = { headSha: requestedHead };
-    } else if (action === "request_next_action") {
-        actionPrompt =
-            `The user selected Request next step for ${entry.triage.repo} ${item.type.toUpperCase()} #${number} ` +
-            "from the interactive triage canvas. Invoke the global-repo-triage skill, refresh this item's " +
-            "current GitHub evidence, and continue only the smallest safe next action. Preserve the read-only " +
-            "default for GitHub mutations and ask for confirmation before any merge, close, label, comment, " +
-            "push, rerun, or session deletion.";
-        result = {};
-    } else {
-        throw new CanvasError("unsupported_action", "Unsupported triage action");
     }
-
-    const routing = buildSubsessionRoutingPrompt(entry.triage.repo, item, actionPrompt);
-    await copilotSession.send({ prompt: routing.prompt });
-    return {
-        queued: true,
-        subsessionRoutingQueued: true,
-        sessionName: routing.sessionName,
-        action,
-        number,
-        ...result,
-    };
 }
 
 async function readJsonBody(request) {
@@ -273,12 +241,12 @@ function writeJson(response, statusCode, value) {
     response.end(JSON.stringify(value));
 }
 
-function tokenMatches(request, entry) {
-    return request.headers["x-triage-token"] === entry.actionToken;
-}
-
 async function handleRequest(entry, request, response) {
     const url = new URL(request.url ?? "/", "http://127.0.0.1");
+    if (!requestHostMatches(request, entry.host)) {
+        writeJson(response, 403, { error: "Request host rejected" });
+        return;
+    }
     if (request.method === "GET" && url.pathname === "/") {
         response.writeHead(200, {
             "Cache-Control": "no-store",
@@ -288,16 +256,24 @@ async function handleRequest(entry, request, response) {
             "Content-Type": "text/html; charset=utf-8",
             "X-Content-Type-Options": "nosniff",
         });
-        response.end(renderDashboardHtml(entry.actionToken));
+        response.end(renderDashboardHtml());
         return;
     }
 
     if (request.method === "GET" && url.pathname === "/state") {
+        if (!requestTokenMatches(request, url, entry.actionToken)) {
+            writeJson(response, 403, { error: "Action token rejected" });
+            return;
+        }
         writeJson(response, 200, entry.state);
         return;
     }
 
     if (request.method === "GET" && url.pathname === "/events") {
+        if (!requestTokenMatches(request, url, entry.actionToken)) {
+            writeJson(response, 403, { error: "Action token rejected" });
+            return;
+        }
         response.writeHead(200, {
             "Cache-Control": "no-cache",
             "Connection": "keep-alive",
@@ -310,7 +286,7 @@ async function handleRequest(entry, request, response) {
         return;
     }
 
-    if (request.method === "POST" && !tokenMatches(request, entry)) {
+    if (request.method === "POST" && !requestTokenMatches(request, url, entry.actionToken)) {
         writeJson(response, 403, { error: "Action token rejected" });
         return;
     }
@@ -323,7 +299,11 @@ async function handleRequest(entry, request, response) {
         }
         if (request.method === "POST" && url.pathname === "/action") {
             const input = await readJsonBody(request);
-            const result = await requestItemAction(entry, input.action, input);
+            const result = await requestItemAction(entry, input.action, input, {
+                createError: (code, message) => new CanvasError(code, message),
+                refresh: () => refreshEntry(entry, true),
+                send: (message) => copilotSession.send(message),
+            });
             writeJson(response, 202, result);
             return;
         }
@@ -341,6 +321,7 @@ async function startInstance(instanceId, triage) {
     const entry = {
         actionToken: randomBytes(24).toString("hex"),
         eventClients: new Set(),
+        host: "",
         issues: [],
         pullRequests: [],
         refreshPromise: null,
@@ -366,14 +347,40 @@ async function startInstance(instanceId, triage) {
     const address = server.address();
     const port = typeof address === "object" && address ? address.port : 0;
     entry.server = server;
-    entry.url = `http://127.0.0.1:${port}/`;
+    entry.host = `127.0.0.1:${port}`;
+    entry.url = `http://${entry.host}/#token=${entry.actionToken}`;
+    instances.set(instanceId, entry);
+    return entry;
+}
+
+async function getOrStartInstance(instanceId, triage) {
+    const existing = instances.get(instanceId);
+    if (existing) {
+        return existing;
+    }
+    let pending = instanceStarts.get(instanceId);
+    if (!pending) {
+        pending = startInstance(instanceId, triage);
+        instanceStarts.set(instanceId, pending);
+    }
+    try {
+        return await pending;
+    } finally {
+        if (instanceStarts.get(instanceId) === pending) {
+            instanceStarts.delete(instanceId);
+        }
+    }
+}
+
+function reconfigureInstance(entry, triage) {
+    entry.triage = triage;
+    entry.state = mergeLiveState(triage, entry.pullRequests, entry.issues);
+    clearInterval(entry.timer);
     entry.timer = setInterval(() => {
         refreshEntry(entry).catch(() => {});
     }, triage.refreshSeconds * 1_000);
     entry.timer.unref();
-    instances.set(instanceId, entry);
-    refreshEntry(entry).catch(() => {});
-    return entry;
+    refreshEntry(entry, true).catch(() => {});
 }
 
 async function closeInstance(instanceId) {
@@ -448,7 +455,11 @@ const dashboard = createCanvas({
             handler: async (context) => {
                 const entry = instances.get(context.instanceId);
                 if (!entry) throw new CanvasError("instance_not_found", "Triage canvas is not open");
-                return requestItemAction(entry, "request_next_action", context.input);
+                return requestItemAction(entry, "request_next_action", context.input, {
+                    createError: (code, message) => new CanvasError(code, message),
+                    refresh: () => refreshEntry(entry, true),
+                    send: (message) => copilotSession.send(message),
+                });
             },
         },
         {
@@ -466,20 +477,18 @@ const dashboard = createCanvas({
             handler: async (context) => {
                 const entry = instances.get(context.instanceId);
                 if (!entry) throw new CanvasError("instance_not_found", "Triage canvas is not open");
-                return requestItemAction(entry, "request_merge", context.input);
+                return requestItemAction(entry, "request_merge", context.input, {
+                    createError: (code, message) => new CanvasError(code, message),
+                    refresh: () => refreshEntry(entry, true),
+                    send: (message) => copilotSession.send(message),
+                });
             },
         },
     ],
     open: async (context) => {
         const triage = normalizeTriageInput(context.input);
-        let entry = instances.get(context.instanceId);
-        if (!entry) {
-            entry = await startInstance(context.instanceId, triage);
-        } else {
-            entry.triage = triage;
-            entry.state = mergeLiveState(triage, entry.pullRequests, entry.issues);
-            refreshEntry(entry).catch(() => {});
-        }
+        const entry = await getOrStartInstance(context.instanceId, triage);
+        reconfigureInstance(entry, triage);
         return {
             title: triage.title,
             status: `Live checks every ${triage.refreshSeconds}s`,

--- a/.github/extensions/openclaw-triage-dashboard/extension.mjs
+++ b/.github/extensions/openclaw-triage-dashboard/extension.mjs
@@ -1,0 +1,480 @@
+import { execFile, execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { createServer } from "node:http";
+import { homedir } from "node:os";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
+import {
+    CanvasError,
+    createCanvas,
+    joinSession,
+} from "@github/copilot-sdk/extension";
+import {
+    canRequestMerge,
+    mergeLiveState,
+    normalizeTriageInput,
+} from "./triage-state.mjs";
+import { renderDashboardHtml } from "./triage-ui.mjs";
+
+const execFileAsync = promisify(execFile);
+const instances = new Map();
+const extensionDirectory = dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = dirname(dirname(dirname(extensionDirectory)));
+let copilotSession;
+let ghPath;
+
+function pathIsInside(candidate, parent) {
+    const child = resolve(candidate);
+    const root = resolve(parent);
+    const relativePath = relative(root, child);
+    return relativePath === "" || (!relativePath.startsWith("..") && !isAbsolute(relativePath));
+}
+
+function resolveGhPath() {
+    const candidates = [
+        process.env.ProgramFiles && join(process.env.ProgramFiles, "GitHub CLI", "gh.exe"),
+        process.env.LOCALAPPDATA && join(process.env.LOCALAPPDATA, "Programs", "GitHub CLI", "gh.exe"),
+    ].filter(Boolean);
+
+    const windowsDirectory = process.env.WINDIR ?? "C:\\Windows";
+    const wherePath = join(windowsDirectory, "System32", "where.exe");
+    if (existsSync(wherePath)) {
+        try {
+            const output = execFileSync(wherePath, ["gh.exe"], {
+                cwd: homedir(),
+                encoding: "utf8",
+                stdio: ["ignore", "pipe", "ignore"],
+                windowsHide: true,
+            });
+            candidates.push(...output.split(/\r?\n/).map((entry) => entry.trim()).filter(Boolean));
+        } catch {
+            // Fall through to the fixed installation candidates.
+        }
+    }
+
+    const ghPath = candidates.find((candidate) =>
+        existsSync(candidate) && !pathIsInside(candidate, repositoryRoot));
+    if (!ghPath) {
+        throw new Error("GitHub CLI was not found outside the repository");
+    }
+    return ghPath;
+}
+
+function getGhPath() {
+    ghPath ??= resolveGhPath();
+    return ghPath;
+}
+
+async function runGhJson(argumentsList) {
+    let lastError;
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+        try {
+            const { stdout } = await execFileAsync(getGhPath(), argumentsList, {
+                cwd: homedir(),
+                encoding: "utf8",
+                maxBuffer: 16 * 1024 * 1024,
+                timeout: 45_000,
+                windowsHide: true,
+            });
+            return JSON.parse(stdout);
+        } catch (error) {
+            lastError = error;
+            const message = error instanceof Error ? error.message : String(error);
+            if (attempt === 0 && /HTTP 50[234]|ETIMEDOUT|timed out/i.test(message)) {
+                await new Promise((resolveDelay) => setTimeout(resolveDelay, 1_500));
+                continue;
+            }
+            throw error;
+        }
+    }
+    throw lastError;
+}
+
+async function collectLiveState(repo, items) {
+    const [pullRequests, issues] = await Promise.all([
+        runGhJson([
+            "pr", "list",
+            "--repo", repo,
+            "--state", "open",
+            "--limit", "1000",
+            "--json",
+            "number,title,url,state,isDraft,mergeable,mergeStateStatus,reviewDecision,headRefOid,updatedAt,labels,statusCheckRollup",
+        ]),
+        runGhJson([
+            "issue", "list",
+            "--repo", repo,
+            "--state", "open",
+            "--limit", "1000",
+            "--json",
+            "number,title,url,state,stateReason,updatedAt,labels",
+        ]),
+    ]);
+    const pullRequestNumbers = new Set(pullRequests.map((item) => item.number));
+    const issueNumbers = new Set(issues.map((item) => item.number));
+    const missing = items.filter((item) =>
+        item.type === "pr"
+            ? !pullRequestNumbers.has(item.number)
+            : !issueNumbers.has(item.number));
+    const missingResults = await Promise.all(missing.map(async (item) => {
+        const fields = item.type === "pr"
+            ? "number,title,url,state,isDraft,mergeable,mergeStateStatus,reviewDecision,headRefOid,updatedAt,labels,statusCheckRollup"
+            : "number,title,url,state,stateReason,updatedAt,labels";
+        const value = await runGhJson([
+            item.type, "view",
+            String(item.number),
+            "--repo", repo,
+            "--json", fields,
+        ]);
+        return { type: item.type, value };
+    }));
+    for (const result of missingResults) {
+        (result.type === "pr" ? pullRequests : issues).push(result.value);
+    }
+    return { pullRequests, issues };
+}
+
+function safeErrorMessage(error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const usefulLine = message
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .find((line) => /^HTTP \d{3}:|timed out|ETIMEDOUT/i.test(line));
+    return (usefulLine ?? "GitHub refresh failed. Use Refresh now to retry.")
+        .replaceAll(repositoryRoot, "<repo>")
+        .slice(0, 500);
+}
+
+function clientErrorMessage(error) {
+    return (error instanceof Error ? error.message : String(error))
+        .replaceAll(repositoryRoot, "<repo>")
+        .slice(0, 500);
+}
+
+function sendState(entry) {
+    const payload = `event: state\ndata: ${JSON.stringify(entry.state)}\n\n`;
+    for (const client of entry.eventClients) {
+        try {
+            client.write(payload);
+        } catch {
+            entry.eventClients.delete(client);
+        }
+    }
+}
+
+async function refreshEntry(entry) {
+    if (entry.refreshPromise) {
+        return entry.refreshPromise;
+    }
+    entry.refreshPromise = (async () => {
+        try {
+            const live = await collectLiveState(entry.triage.repo, entry.triage.items);
+            entry.pullRequests = live.pullRequests;
+            entry.issues = live.issues;
+            entry.state = mergeLiveState(entry.triage, entry.pullRequests, entry.issues);
+        } catch (error) {
+            entry.state = mergeLiveState(
+                entry.triage,
+                entry.pullRequests,
+                entry.issues,
+                safeErrorMessage(error),
+            );
+        } finally {
+            entry.refreshPromise = null;
+        }
+        sendState(entry);
+        return entry.state;
+    })();
+    return entry.refreshPromise;
+}
+
+function findItem(entry, number) {
+    return entry.state.items.find((item) => item.number === number);
+}
+
+async function requestChatAction(entry, action, input) {
+    const number = Number(input?.number);
+    if (!Number.isInteger(number) || number <= 0) {
+        throw new CanvasError("invalid_item", "A positive PR or issue number is required");
+    }
+    let item = findItem(entry, number);
+    if (!item) {
+        throw new CanvasError("item_not_found", `#${number} is not in this triage`);
+    }
+
+    if (action === "request_merge") {
+        await refreshEntry(entry);
+        item = findItem(entry, number);
+        const eligibility = canRequestMerge(item, item.live);
+        if (!eligibility.eligible) {
+            throw new CanvasError("merge_not_ready", eligibility.reasons.join("; "));
+        }
+        const requestedHead = String(input?.headSha ?? "");
+        if (!/^[0-9a-f]{7,64}$/i.test(requestedHead) ||
+            requestedHead.toLowerCase() !== String(item.live.headRefOid).toLowerCase()) {
+            throw new CanvasError("head_changed", "The requested head no longer matches live GitHub state");
+        }
+        await copilotSession.send({
+            prompt:
+                `The user selected Prepare merge for ${entry.triage.repo} PR #${number} at observed head ` +
+                `${requestedHead}. Use the global-repo-triage skill guardrails. Re-fetch the PR, exact head, ` +
+                "required checks, reviews, unresolved threads, proof declarations, real behavior evidence, " +
+                "branch protection, and mergeability. Do not mutate GitHub yet. Present the fresh evidence and " +
+                "ask for explicit confirmation before merging.",
+        });
+        return { queued: true, action, number, headSha: requestedHead };
+    }
+
+    if (action === "request_next_action") {
+        await copilotSession.send({
+            prompt:
+                `The user selected Request next step for ${entry.triage.repo} ${item.type.toUpperCase()} #${number} ` +
+                "from the interactive triage canvas. Invoke the global-repo-triage skill, refresh this item's " +
+                "current GitHub evidence, and continue only the smallest safe next action. Preserve the read-only " +
+                "default for GitHub mutations and ask for confirmation before any merge, close, label, comment, " +
+                "push, rerun, or session deletion.",
+        });
+        return { queued: true, action, number };
+    }
+
+    throw new CanvasError("unsupported_action", "Unsupported triage action");
+}
+
+async function readJsonBody(request) {
+    let body = "";
+    for await (const chunk of request) {
+        body += chunk;
+        if (body.length > 8_192) {
+            throw new Error("Request body is too large");
+        }
+    }
+    return body ? JSON.parse(body) : {};
+}
+
+function writeJson(response, statusCode, value) {
+    response.writeHead(statusCode, {
+        "Cache-Control": "no-store",
+        "Content-Type": "application/json; charset=utf-8",
+    });
+    response.end(JSON.stringify(value));
+}
+
+function tokenMatches(request, entry) {
+    return request.headers["x-triage-token"] === entry.actionToken;
+}
+
+async function handleRequest(entry, request, response) {
+    const url = new URL(request.url ?? "/", "http://127.0.0.1");
+    if (request.method === "GET" && url.pathname === "/") {
+        response.writeHead(200, {
+            "Cache-Control": "no-store",
+            "Content-Security-Policy":
+                "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; " +
+                "connect-src 'self'; base-uri 'none'; form-action 'none'",
+            "Content-Type": "text/html; charset=utf-8",
+            "X-Content-Type-Options": "nosniff",
+        });
+        response.end(renderDashboardHtml(entry.actionToken));
+        return;
+    }
+
+    if (request.method === "GET" && url.pathname === "/state") {
+        writeJson(response, 200, entry.state);
+        return;
+    }
+
+    if (request.method === "GET" && url.pathname === "/events") {
+        response.writeHead(200, {
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "Content-Type": "text/event-stream",
+            "X-Accel-Buffering": "no",
+        });
+        response.write(`event: state\ndata: ${JSON.stringify(entry.state)}\n\n`);
+        entry.eventClients.add(response);
+        request.on("close", () => entry.eventClients.delete(response));
+        return;
+    }
+
+    if (request.method === "POST" && !tokenMatches(request, entry)) {
+        writeJson(response, 403, { error: "Action token rejected" });
+        return;
+    }
+
+    try {
+        if (request.method === "POST" && url.pathname === "/refresh") {
+            await readJsonBody(request);
+            writeJson(response, 200, { state: await refreshEntry(entry) });
+            return;
+        }
+        if (request.method === "POST" && url.pathname === "/action") {
+            const input = await readJsonBody(request);
+            const result = await requestChatAction(entry, input.action, input);
+            writeJson(response, 202, result);
+            return;
+        }
+    } catch (error) {
+        const statusCode = error instanceof CanvasError ? 409 : 400;
+        writeJson(response, statusCode, { error: clientErrorMessage(error) });
+        return;
+    }
+
+    writeJson(response, 404, { error: "Not found" });
+}
+
+async function startInstance(instanceId, triage) {
+    const { randomBytes } = await import("node:crypto");
+    const entry = {
+        actionToken: randomBytes(24).toString("hex"),
+        eventClients: new Set(),
+        issues: [],
+        pullRequests: [],
+        refreshPromise: null,
+        server: null,
+        state: mergeLiveState(triage, [], []),
+        timer: null,
+        triage,
+        url: "",
+    };
+    const server = createServer((request, response) => {
+        handleRequest(entry, request, response).catch((error) => {
+            if (!response.headersSent) {
+                writeJson(response, 500, { error: safeErrorMessage(error) });
+            } else {
+                response.destroy();
+            }
+        });
+    });
+    await new Promise((resolveListen, rejectListen) => {
+        server.once("error", rejectListen);
+        server.listen(0, "127.0.0.1", resolveListen);
+    });
+    const address = server.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+    entry.server = server;
+    entry.url = `http://127.0.0.1:${port}/`;
+    entry.timer = setInterval(() => {
+        refreshEntry(entry).catch(() => {});
+    }, triage.refreshSeconds * 1_000);
+    entry.timer.unref();
+    instances.set(instanceId, entry);
+    refreshEntry(entry).catch(() => {});
+    return entry;
+}
+
+async function closeInstance(instanceId) {
+    const entry = instances.get(instanceId);
+    if (!entry) {
+        return;
+    }
+    instances.delete(instanceId);
+    clearInterval(entry.timer);
+    for (const client of entry.eventClients) {
+        client.end();
+    }
+    await new Promise((resolveClose) => entry.server.close(resolveClose));
+}
+
+const inputSchema = {
+    type: "object",
+    required: ["schemaVersion", "repo", "title", "scope", "generatedAt", "items"],
+    properties: {
+        schemaVersion: { const: 1 },
+        repo: { type: "string" },
+        title: { type: "string" },
+        scope: { type: "string" },
+        generatedAt: { type: "string" },
+        refreshSeconds: { type: "integer", minimum: 30, maximum: 300 },
+        items: { type: "array", minItems: 1, maxItems: 1000 },
+        plan: { type: "array", maxItems: 1000 },
+        report: {
+            type: "object",
+            properties: {
+                changes: { type: "array", maxItems: 100 },
+                executiveQueue: { type: "array", maxItems: 100 },
+                ownership: { type: "array", maxItems: 100 },
+                reviews: { type: "array", maxItems: 100 },
+                dayPlan: { type: "array", maxItems: 100 },
+                automation: { type: "array", maxItems: 100 },
+            },
+            additionalProperties: false,
+        },
+    },
+    additionalProperties: false,
+};
+
+const itemActionSchema = {
+    type: "object",
+    required: ["number"],
+    properties: {
+        number: { type: "integer", minimum: 1 },
+    },
+    additionalProperties: false,
+};
+
+const dashboard = createCanvas({
+    id: "openclaw-triage-dashboard",
+    displayName: "OpenClaw triage",
+    description: "Shows live OpenClaw triage checks, landing-plan progress, proof gates, and guarded actions.",
+    inputSchema,
+    actions: [
+        {
+            name: "refresh",
+            description: "Refresh GitHub checks and item state now.",
+            handler: async (context) => {
+                const entry = instances.get(context.instanceId);
+                if (!entry) throw new CanvasError("instance_not_found", "Triage canvas is not open");
+                return refreshEntry(entry);
+            },
+        },
+        {
+            name: "request_next_action",
+            description: "Send a guarded next-step request for one triage item into the current session.",
+            inputSchema: itemActionSchema,
+            handler: async (context) => {
+                const entry = instances.get(context.instanceId);
+                if (!entry) throw new CanvasError("instance_not_found", "Triage canvas is not open");
+                return requestChatAction(entry, "request_next_action", context.input);
+            },
+        },
+        {
+            name: "request_merge",
+            description: "Request fresh merge verification and confirmation in the current session.",
+            inputSchema: {
+                type: "object",
+                required: ["number", "headSha"],
+                properties: {
+                    number: { type: "integer", minimum: 1 },
+                    headSha: { type: "string", pattern: "^[0-9a-fA-F]{7,64}$" },
+                },
+                additionalProperties: false,
+            },
+            handler: async (context) => {
+                const entry = instances.get(context.instanceId);
+                if (!entry) throw new CanvasError("instance_not_found", "Triage canvas is not open");
+                return requestChatAction(entry, "request_merge", context.input);
+            },
+        },
+    ],
+    open: async (context) => {
+        const triage = normalizeTriageInput(context.input);
+        let entry = instances.get(context.instanceId);
+        if (!entry) {
+            entry = await startInstance(context.instanceId, triage);
+        } else {
+            entry.triage = triage;
+            entry.state = mergeLiveState(triage, entry.pullRequests, entry.issues);
+            refreshEntry(entry).catch(() => {});
+        }
+        return {
+            title: triage.title,
+            status: `Live checks every ${triage.refreshSeconds}s`,
+            url: entry.url,
+        };
+    },
+    onClose: async (context) => {
+        await closeInstance(context.instanceId);
+    },
+});
+
+copilotSession = await joinSession({ canvases: [dashboard] });

--- a/.github/extensions/openclaw-triage-dashboard/extension.mjs
+++ b/.github/extensions/openclaw-triage-dashboard/extension.mjs
@@ -423,7 +423,7 @@ const itemActionSchema = {
 const dashboard = createCanvas({
     id: "openclaw-triage-dashboard",
     displayName: "OpenClaw triage",
-    description: "Shows live OpenClaw triage checks, landing-plan progress, proof gates, and guarded actions.",
+    description: "Shows live OpenClaw triage checks, execution-plan progress, proof gates, and guarded actions.",
     inputSchema,
     actions: [
         {

--- a/.github/extensions/openclaw-triage-dashboard/triage-actions.mjs
+++ b/.github/extensions/openclaw-triage-dashboard/triage-actions.mjs
@@ -1,3 +1,5 @@
+import { canRequestMerge } from "./triage-state.mjs";
+
 function itemKind(type) {
     return type === "pr" ? "PR" : "Issue";
 }
@@ -17,11 +19,12 @@ export function buildSubsessionRoutingPrompt(repo, item, actionPrompt) {
             "Use that project's ID for any create_session call.\n" +
             `2. Call list_sessions_and_chats and look for an existing child project session named ` +
             `"${sessionName}" in the current project and repository.\n` +
-            "3. If it exists, call send_session_message with the action below so the work is appended " +
-            "to that session.\n" +
-            `4. If it does not exist, call create_session with the resolved project_id, name "${sessionName}", ` +
-            "coordinate_with_creator enabled, base_branch unset, and a kickoff using the action below in autopilot mode.\n" +
-            "5. Do not create a duplicate session. Briefly report whether the child session was created or reused.\n\n" +
+            "3. If exactly one matching session exists, verify its project repository is the exact repository above, " +
+            "then call send_session_message with the action below so the work is appended to that session.\n" +
+            "4. If more than one matching session exists, stop and report the ambiguity. Do not pick one or create another.\n" +
+            `5. If no matching session exists, call create_session with the resolved project_id, name "${sessionName}", ` +
+            "coordinate_with_creator enabled, base_branch unset, and a kickoff using the action below in interactive mode.\n" +
+            "6. Do not create a duplicate session. Briefly report whether the child session was created or reused.\n\n" +
             `Action for the child session:\n${actionPrompt}`,
     };
 }
@@ -35,4 +38,82 @@ export async function requireFreshGitHubEvidence(refresh, createError = (_, mess
         );
     }
     return state;
+}
+
+function fail(createError, code, message) {
+    throw createError(code, message);
+}
+
+export async function requestItemAction(entry, action, input, {
+    createError = (code, message) => Object.assign(new Error(message), { code }),
+    refresh,
+    send,
+} = {}) {
+    const number = Number(input?.number);
+    if (!Number.isInteger(number) || number <= 0) {
+        fail(createError, "invalid_item", "A positive PR or issue number is required");
+    }
+    let item = entry.state.items.find((candidate) => candidate.number === number);
+    if (!item) {
+        fail(createError, "item_not_found", `#${number} is not in this triage`);
+    }
+
+    let actionPrompt;
+    let result;
+    if (action === "request_merge") {
+        await requireFreshGitHubEvidence(
+            refresh,
+            createError,
+        );
+        item = entry.state.items.find((candidate) => candidate.number === number);
+        if (!item) {
+            fail(createError, "item_not_found", `#${number} is no longer in this triage`);
+        }
+        const eligibility = canRequestMerge(item, item.live);
+        if (!eligibility.eligible) {
+            fail(createError, "merge_not_ready", eligibility.reasons.join("; "));
+        }
+        const requestedHead = String(input?.headSha ?? "");
+        if (!/^[0-9a-f]{7,64}$/i.test(requestedHead) ||
+            requestedHead.toLowerCase() !== String(item.live.headRefOid).toLowerCase()) {
+            fail(createError, "head_changed", "The requested head no longer matches live GitHub state");
+        }
+        actionPrompt =
+            `The user selected Prepare merge for ${entry.triage.repo} PR #${number} at observed head ` +
+            `${requestedHead}. Use the global-repo-triage skill guardrails. Re-fetch the PR, exact head, ` +
+            "required checks, reviews, unresolved threads, proof declarations, real behavior evidence, " +
+            "branch protection, and mergeability. Do not mutate GitHub yet. Present the fresh evidence and " +
+            "ask for explicit confirmation before merging.";
+        result = { headSha: requestedHead };
+    } else if (action === "request_next_action") {
+        actionPrompt =
+            `The user selected Request next step for ${entry.triage.repo} ${item.type.toUpperCase()} #${number} ` +
+            "from the interactive triage canvas. Invoke the global-repo-triage skill, refresh this item's " +
+            "current GitHub evidence, and continue only the smallest safe next action. Preserve the read-only " +
+            "default for GitHub mutations and ask for confirmation before any merge, close, label, comment, " +
+            "push, rerun, or session deletion.";
+        result = {};
+    } else {
+        fail(createError, "unsupported_action", "Unsupported triage action");
+    }
+
+    const routing = buildSubsessionRoutingPrompt(entry.triage.repo, item, actionPrompt);
+    await send({ prompt: routing.prompt });
+    return {
+        queued: true,
+        subsessionRoutingQueued: true,
+        sessionName: routing.sessionName,
+        action,
+        number,
+        ...result,
+    };
+}
+
+export function requestHostMatches(request, expectedHost) {
+    return request.headers.host === expectedHost;
+}
+
+export function requestTokenMatches(request, url, actionToken) {
+    return request.headers["x-triage-token"] === actionToken ||
+        url.searchParams.get("token") === actionToken;
 }

--- a/.github/extensions/openclaw-triage-dashboard/triage-actions.mjs
+++ b/.github/extensions/openclaw-triage-dashboard/triage-actions.mjs
@@ -44,6 +44,29 @@ function fail(createError, code, message) {
     throw createError(code, message);
 }
 
+export function itemDependencyBlocker(state, number) {
+    const plan = Array.isArray(state?.plan) ? state.plan : [];
+    const linkedSteps = plan.filter((step) => step.itemNumbers.includes(number));
+    if (linkedSteps.length === 0) {
+        return "";
+    }
+    const planById = new Map(plan.map((step) => [step.id, step]));
+    const runnableStep = linkedSteps.some((step) =>
+        step.dependsOn.every((dependencyId) =>
+            planById.get(dependencyId)?.liveStatus === "done"));
+    if (runnableStep) {
+        return "";
+    }
+    const unresolved = [...new Set(linkedSteps.flatMap((step) =>
+        step.dependsOn
+            .map((dependencyId) => planById.get(dependencyId))
+            .filter((dependency) => dependency?.liveStatus !== "done")
+            .map((dependency) => dependency.title)))];
+    return unresolved.length > 0
+        ? `Complete dependencies first: ${unresolved.join(", ")}`
+        : "Complete plan dependencies first";
+}
+
 export async function requestItemAction(entry, action, input, {
     createError = (code, message) => Object.assign(new Error(message), { code }),
     refresh,
@@ -69,6 +92,10 @@ export async function requestItemAction(entry, action, input, {
         if (!item) {
             fail(createError, "item_not_found", `#${number} is no longer in this triage`);
         }
+        const dependencyBlocker = itemDependencyBlocker(entry.state, number);
+        if (dependencyBlocker) {
+            fail(createError, "plan_dependencies_incomplete", dependencyBlocker);
+        }
         const eligibility = canRequestMerge(item, item.live);
         if (!eligibility.eligible) {
             fail(createError, "merge_not_ready", eligibility.reasons.join("; "));
@@ -86,6 +113,10 @@ export async function requestItemAction(entry, action, input, {
             "ask for explicit confirmation before merging.";
         result = { headSha: requestedHead };
     } else if (action === "request_next_action") {
+        const dependencyBlocker = itemDependencyBlocker(entry.state, number);
+        if (dependencyBlocker) {
+            fail(createError, "plan_dependencies_incomplete", dependencyBlocker);
+        }
         actionPrompt =
             `The user selected Request next step for ${entry.triage.repo} ${item.type.toUpperCase()} #${number} ` +
             "from the interactive triage canvas. Invoke the global-repo-triage skill, refresh this item's " +

--- a/.github/extensions/openclaw-triage-dashboard/triage-actions.mjs
+++ b/.github/extensions/openclaw-triage-dashboard/triage-actions.mjs
@@ -1,0 +1,27 @@
+function itemKind(type) {
+    return type === "pr" ? "PR" : "Issue";
+}
+
+export function buildSubsessionRoutingPrompt(repo, item, actionPrompt) {
+    const kind = itemKind(item.type);
+    const sessionName = `Triage ${kind} #${item.number}`;
+    const identity = `${repo} ${kind} #${item.number}`;
+
+    return {
+        sessionName,
+        prompt:
+            `Route this dashboard action to the dedicated child project session for ${identity}. ` +
+            "Do not execute the item work in this parent session.\n\n" +
+            "Use the app session tools as follows:\n" +
+            `1. Call list_projects and resolve the project whose GitHub repository is exactly "${repo}". ` +
+            "Use that project's ID for any create_session call.\n" +
+            `2. Call list_sessions_and_chats and look for an existing child project session named ` +
+            `"${sessionName}" in the current project and repository.\n` +
+            "3. If it exists, call send_session_message with the action below so the work is appended " +
+            "to that session.\n" +
+            `4. If it does not exist, call create_session with the resolved project_id, name "${sessionName}", ` +
+            "coordinate_with_creator enabled, base_branch unset, and a kickoff using the action below in autopilot mode.\n" +
+            "5. Do not create a duplicate session. Briefly report whether the child session was created or reused.\n\n" +
+            `Action for the child session:\n${actionPrompt}`,
+    };
+}

--- a/.github/extensions/openclaw-triage-dashboard/triage-actions.mjs
+++ b/.github/extensions/openclaw-triage-dashboard/triage-actions.mjs
@@ -25,3 +25,14 @@ export function buildSubsessionRoutingPrompt(repo, item, actionPrompt) {
             `Action for the child session:\n${actionPrompt}`,
     };
 }
+
+export async function requireFreshGitHubEvidence(refresh, createError = (_, message) => new Error(message)) {
+    const state = await refresh();
+    if (state.refreshError) {
+        throw createError(
+            "refresh_failed",
+            `Fresh GitHub evidence is required before preparing a merge: ${state.refreshError}`,
+        );
+    }
+    return state;
+}

--- a/.github/extensions/openclaw-triage-dashboard/triage-plan.mjs
+++ b/.github/extensions/openclaw-triage-dashboard/triage-plan.mjs
@@ -1,0 +1,144 @@
+export function buildPlanLanes(plan, legacyDayPlan = [], legacyQueue = []) {
+    if (!plan.length) {
+        const legacySteps = [...new Set([...legacyQueue, ...legacyDayPlan])];
+        return legacySteps.map((title, index) => ({
+            id: `legacy-${index}`,
+            kind: "independent",
+            levels: [[{
+                dependsOn: [],
+                id: `legacy-${index}`,
+                itemNumbers: [],
+                legacy: true,
+                liveStatus: "pending",
+                title,
+            }]],
+            title: "Independent task",
+        }));
+    }
+
+    const byId = new Map(plan.map((step) => [step.id, step]));
+    const neighbors = new Map(plan.map((step) => [step.id, new Set()]));
+    for (const step of plan) {
+        for (const dependency of step.dependsOn) {
+            neighbors.get(step.id).add(dependency);
+            neighbors.get(dependency).add(step.id);
+        }
+    }
+
+    const visited = new Set();
+    const components = [];
+    for (const step of plan) {
+        if (visited.has(step.id)) continue;
+        const ids = [];
+        const pending = [step.id];
+        visited.add(step.id);
+        while (pending.length) {
+            const id = pending.shift();
+            ids.push(id);
+            for (const neighbor of neighbors.get(id)) {
+                if (visited.has(neighbor)) continue;
+                visited.add(neighbor);
+                pending.push(neighbor);
+            }
+        }
+        components.push(ids);
+    }
+
+    return components.map((ids) => {
+        const componentIds = new Set(ids);
+        const remaining = new Set(ids);
+        const ordered = [];
+        while (remaining.size) {
+            const ready = plan.filter((step) =>
+                remaining.has(step.id) &&
+                step.dependsOn.every((dependency) =>
+                    !componentIds.has(dependency) || !remaining.has(dependency)));
+            for (const step of ready) {
+                ordered.push(step);
+                remaining.delete(step.id);
+            }
+        }
+
+        const depthById = new Map();
+        for (const step of ordered) {
+            const dependencyDepths = step.dependsOn
+                .filter((dependency) => componentIds.has(dependency))
+                .map((dependency) => depthById.get(dependency));
+            depthById.set(step.id, dependencyDepths.length
+                ? Math.max(...dependencyDepths) + 1
+                : 0);
+        }
+        const levels = [];
+        for (const step of ordered) {
+            const depth = depthById.get(step.id);
+            levels[depth] ??= [];
+            levels[depth].push(step);
+        }
+        const kind = ordered.length === 1
+            ? "independent"
+            : levels.every((level) => level.length === 1)
+                ? "sequential"
+                : "parallel";
+        return {
+            id: ordered.map((step) => step.id).join("--"),
+            kind,
+            levels,
+            title: kind === "sequential"
+                ? "Sequential workstream"
+                : kind === "parallel"
+                    ? "Parallel workstream"
+                    : "Independent task",
+        };
+    });
+}
+
+export function limitPlanLanes(lanes, visibleCount) {
+    const count = Math.max(1, visibleCount);
+    return {
+        hiddenCount: Math.max(0, lanes.length - count),
+        lanes: lanes.slice(0, count),
+    };
+}
+
+export function limitLaneLevels(levels, visibleCount) {
+    let remaining = Math.max(1, visibleCount);
+    const visibleLevels = [];
+    let total = 0;
+    for (const level of levels) {
+        total += level.length;
+        if (remaining <= 0) continue;
+        const visible = level.slice(0, remaining);
+        if (visible.length) visibleLevels.push(visible);
+        remaining -= visible.length;
+    }
+    const visibleTotal = visibleLevels.reduce((sum, level) => sum + level.length, 0);
+    return {
+        hiddenCount: total - visibleTotal,
+        levels: visibleLevels,
+    };
+}
+
+export function limitPlanRows(lanes, visibleCount) {
+    let remaining = Math.max(1, visibleCount);
+    const visibleLanes = [];
+    const total = lanes.reduce((sum, lane) =>
+        sum + lane.levels.reduce((laneSum, level) => laneSum + level.length, 0), 0);
+    for (const lane of lanes) {
+        if (remaining <= 0) break;
+        const window = limitLaneLevels(lane.levels, remaining);
+        const visible = window.levels.reduce((sum, level) => sum + level.length, 0);
+        if (!visible) continue;
+        visibleLanes.push({
+            ...lane,
+            levels: window.levels,
+            totalSteps: lane.levels.reduce((sum, level) => sum + level.length, 0),
+        });
+        remaining -= visible;
+    }
+    const visible = visibleLanes.reduce((sum, lane) =>
+        sum + lane.levels.reduce((laneSum, level) => laneSum + level.length, 0), 0);
+    return {
+        hiddenCount: total - visible,
+        lanes: visibleLanes,
+    };
+}

--- a/.github/extensions/openclaw-triage-dashboard/triage-state.mjs
+++ b/.github/extensions/openclaw-triage-dashboard/triage-state.mjs
@@ -17,6 +17,8 @@ export const KNOWN_PROOF_POOLS = new Set([
     "windows-winui-interactive",
 ]);
 
+export const SUPPORTED_REPOSITORY = "openclaw/openclaw-windows-node";
+
 const FAILED_CONCLUSIONS = new Set([
     "ACTION_REQUIRED",
     "CANCELLED",
@@ -101,6 +103,8 @@ function normalizeItem(item, index) {
     );
     assert(type !== "pr" || expectedChecks.length > 0,
         `items[${index}].expectedChecks must name at least one required check for pull requests`);
+    assert(type !== "issue" || expectedChecks.length === 0,
+        `items[${index}].expectedChecks must be empty for issues`);
 
     return {
         id: `${type}-${number}`,
@@ -136,12 +140,12 @@ function normalizeItem(item, index) {
     };
 }
 
-function normalizePlanStep(step, index, itemNumbers) {
+function normalizePlanStep(step, index, itemTypes) {
     assert(step && typeof step === "object" && !Array.isArray(step), `plan[${index}] must be an object`);
     const numbers = (step.itemNumbers ?? []).map((entry, itemIndex) =>
         normalizeNumber(entry, `plan[${index}].itemNumbers[${itemIndex}]`));
     for (const number of numbers) {
-        assert(itemNumbers.has(number), `plan[${index}] references item #${number} outside this triage`);
+        assert(itemTypes.has(number), `plan[${index}] references item #${number} outside this triage`);
     }
     const gates = (step.gates ?? []).map((gate, gateIndex) => {
         assert(gate && typeof gate === "object" && !Array.isArray(gate),
@@ -150,15 +154,18 @@ function normalizePlanStep(step, index, itemNumbers) {
             gate.itemNumber,
             `plan[${index}].gates[${gateIndex}].itemNumber`,
         );
-        assert(itemNumbers.has(itemNumber),
+        assert(itemTypes.has(itemNumber),
             `plan[${index}].gates[${gateIndex}] references item #${itemNumber} outside this triage`);
+        const stage = normalizeStatus(
+            gate.stage,
+            `plan[${index}].gates[${gateIndex}].stage`,
+            new Set(["checks", "inventory", "landing", "proof", "review"]),
+        );
+        assert(stage !== "landing" || itemTypes.get(itemNumber) === "pr",
+            `plan[${index}].gates[${gateIndex}] cannot use landing for an issue`);
         return {
             itemNumber,
-            stage: normalizeStatus(
-                gate.stage,
-                `plan[${index}].gates[${gateIndex}].stage`,
-                new Set(["checks", "inventory", "landing", "proof", "review"]),
-            ),
+            stage,
         };
     });
     return {
@@ -185,9 +192,9 @@ function normalizePlanStep(step, index, itemNumbers) {
     };
 }
 
-function normalizePlan(steps, itemNumbers) {
+function normalizePlan(steps, itemTypes) {
     const plan = steps.map((step, index) =>
-        normalizePlanStep(step, index, itemNumbers));
+        normalizePlanStep(step, index, itemTypes));
     const planById = new Map(plan.map((step) => [step.id, step]));
     assert(planById.size === plan.length, "plan must not contain duplicate IDs");
     for (const step of plan) {
@@ -245,6 +252,8 @@ export function normalizeTriageInput(input) {
     assert(input.schemaVersion === 1, "schemaVersion must be 1");
     const repo = normalizeString(input.repo, "repo", 200);
     assert(/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo), "repo must use owner/name format");
+    assert(repo.toLowerCase() === SUPPORTED_REPOSITORY,
+        `repo must be ${SUPPORTED_REPOSITORY}`);
     assert(Array.isArray(input.items) && input.items.length > 0 && input.items.length <= 1_000,
         "items must contain between 1 and 1000 entries");
     const items = input.items.map(normalizeItem);
@@ -252,10 +261,21 @@ export function normalizeTriageInput(input) {
     assert(itemIds.size === items.length, "items must not contain duplicate type/number pairs");
     const itemNumbers = new Set(items.map((item) => item.number));
     assert(itemNumbers.size === items.length, "items must not contain duplicate numbers");
+    for (const item of items) {
+        const parsedUrl = new URL(item.url);
+        const expectedPath = `/${repo}/${item.type === "pr" ? "pull" : "issues"}/${item.number}`;
+        assert(
+            parsedUrl.protocol === "https:" &&
+                parsedUrl.hostname.toLowerCase() === "github.com" &&
+                parsedUrl.pathname.toLowerCase() === expectedPath.toLowerCase(),
+            `items must link to their canonical ${repo} GitHub URL`,
+        );
+    }
     const refreshSeconds = input.refreshSeconds ?? 60;
     assert(Number.isInteger(refreshSeconds) && refreshSeconds >= 30 && refreshSeconds <= 300,
         "refreshSeconds must be an integer from 30 to 300");
-    const plan = normalizePlan(input.plan ?? [], itemNumbers);
+    const itemTypes = new Map(items.map((item) => [item.number, item.type]));
+    const plan = normalizePlan(input.plan ?? [], itemTypes);
 
     return {
         schemaVersion: 1,
@@ -279,9 +299,8 @@ function checkConclusion(check) {
 }
 
 export function summarizeChecks(checks, expectedChecks = []) {
-    const relevant = Array.isArray(checks)
-        ? checks.filter((check) => checkConclusion(check) !== "SKIPPED")
-        : [];
+    const observed = Array.isArray(checks) ? checks : [];
+    const relevant = observed.filter((check) => checkConclusion(check) !== "SKIPPED");
     const failed = relevant.filter((check) => FAILED_CONCLUSIONS.has(checkConclusion(check)));
     const pending = relevant.filter((check) => {
         const conclusion = checkConclusion(check);
@@ -290,7 +309,7 @@ export function summarizeChecks(checks, expectedChecks = []) {
             !COMPLETED_CONCLUSIONS.has(conclusion) &&
             (status !== "COMPLETED" || !conclusion);
     });
-    const names = relevant.map(checkName).filter(Boolean);
+    const names = observed.map(checkName).filter(Boolean);
     const missing = expectedChecks.filter((expected) =>
         !names.some((name) => name.toLowerCase() === expected.toLowerCase()));
 

--- a/.github/extensions/openclaw-triage-dashboard/triage-state.mjs
+++ b/.github/extensions/openclaw-triage-dashboard/triage-state.mjs
@@ -161,6 +161,16 @@ function normalizePlanStep(step, index, itemNumbers) {
         id: normalizeString(step.id, `plan[${index}].id`, 100),
         title: normalizeString(step.title, `plan[${index}].title`, 500),
         detail: normalizeOptionalString(step.detail, `plan[${index}].detail`),
+        dependsOn: normalizeStringArray(
+            step.dependsOn ?? [],
+            `plan[${index}].dependsOn`,
+            100,
+        ),
+        horizon: normalizeStatus(
+            step.horizon ?? "today",
+            `plan[${index}].horizon`,
+            new Set(["later", "today"]),
+        ),
         itemNumbers: numbers,
         gates,
         status: normalizeStatus(
@@ -169,6 +179,34 @@ function normalizePlanStep(step, index, itemNumbers) {
             new Set(["blocked", "done", "in_progress", "pending"]),
         ),
     };
+}
+
+function normalizePlan(steps, itemNumbers) {
+    const plan = steps.map((step, index) =>
+        normalizePlanStep(step, index, itemNumbers));
+    const planById = new Map(plan.map((step) => [step.id, step]));
+    assert(planById.size === plan.length, "plan must not contain duplicate IDs");
+    for (const step of plan) {
+        for (const dependency of step.dependsOn) {
+            assert(dependency !== step.id, `plan step ${step.id} must not depend on itself`);
+            assert(planById.has(dependency),
+                `plan step ${step.id} depends on unknown step ${dependency}`);
+        }
+    }
+    const visiting = new Set();
+    const visited = new Set();
+    const visit = (step) => {
+        if (visited.has(step.id)) return;
+        assert(!visiting.has(step.id), `plan contains a dependency cycle at ${step.id}`);
+        visiting.add(step.id);
+        for (const dependency of step.dependsOn) {
+            visit(planById.get(dependency));
+        }
+        visiting.delete(step.id);
+        visited.add(step.id);
+    };
+    for (const step of plan) visit(step);
+    return plan;
 }
 
 function normalizeReportEntry(entry, field, index, keys) {
@@ -209,9 +247,11 @@ export function normalizeTriageInput(input) {
     const itemIds = new Set(items.map((item) => item.id));
     assert(itemIds.size === items.length, "items must not contain duplicate type/number pairs");
     const itemNumbers = new Set(items.map((item) => item.number));
+    assert(itemNumbers.size === items.length, "items must not contain duplicate numbers");
     const refreshSeconds = input.refreshSeconds ?? 60;
     assert(Number.isInteger(refreshSeconds) && refreshSeconds >= 30 && refreshSeconds <= 300,
         "refreshSeconds must be an integer from 30 to 300");
+    const plan = normalizePlan(input.plan ?? [], itemNumbers);
 
     return {
         schemaVersion: 1,
@@ -221,7 +261,7 @@ export function normalizeTriageInput(input) {
         generatedAt: normalizeString(input.generatedAt, "generatedAt", 100),
         refreshSeconds,
         items,
-        plan: (input.plan ?? []).map((step, index) => normalizePlanStep(step, index, itemNumbers)),
+        plan,
         report: normalizeReport(input.report),
     };
 }

--- a/.github/extensions/openclaw-triage-dashboard/triage-state.mjs
+++ b/.github/extensions/openclaw-triage-dashboard/triage-state.mjs
@@ -1,0 +1,368 @@
+export const DECISIONS = new Set([
+    "TAKE",
+    "TAKE_AFTER_CHECKS",
+    "NEEDS_HUMAN_TEST",
+    "NEEDS_INFO",
+    "HOLD_FOR_AUTHOR",
+    "DECLINE",
+]);
+
+export const KNOWN_PROOF_POOLS = new Set([
+    "windows-11-sac-on",
+    "windows-wsl-mxc",
+    "windows-11-arm64",
+    "windows-wsl-dgx-blackwell",
+    "windows-clean-installer-upgrade",
+    "windows-wsl-gateway-e2e",
+    "windows-winui-interactive",
+]);
+
+const FAILED_CONCLUSIONS = new Set([
+    "ACTION_REQUIRED",
+    "CANCELLED",
+    "ERROR",
+    "FAILURE",
+    "STARTUP_FAILURE",
+    "STALE",
+    "TIMED_OUT",
+]);
+
+const COMPLETED_CONCLUSIONS = new Set(["NEUTRAL", "SKIPPED", "SUCCESS"]);
+const PROOF_COMPLETE = new Set(["passed", "not-applicable"]);
+
+function assert(condition, message) {
+    if (!condition) {
+        throw new Error(message);
+    }
+}
+
+function normalizeString(value, field, maximum = 2_000) {
+    assert(typeof value === "string" && value.trim(), `${field} must be a non-empty string`);
+    const normalized = value.trim();
+    assert(normalized.length <= maximum, `${field} is too long`);
+    return normalized;
+}
+
+function normalizeOptionalString(value, field, maximum = 2_000) {
+    if (value == null || value === "") {
+        return "";
+    }
+    return normalizeString(value, field, maximum);
+}
+
+function normalizeConfidence(value, field) {
+    assert(Number.isInteger(value) && value >= 0 && value <= 100, `${field} must be an integer from 0 to 100`);
+    return value;
+}
+
+function normalizeNumber(value, field) {
+    assert(Number.isInteger(value) && value > 0, `${field} must be a positive integer`);
+    return value;
+}
+
+function normalizeUrl(value, field) {
+    const normalized = normalizeString(value, field, 1_000);
+    let parsed;
+    try {
+        parsed = new URL(normalized);
+    } catch {
+        throw new Error(`${field} must be a valid HTTP or HTTPS URL`);
+    }
+    assert(
+        parsed.protocol === "http:" || parsed.protocol === "https:",
+        `${field} must be a valid HTTP or HTTPS URL`,
+    );
+    return normalized;
+}
+
+function normalizeStatus(value, field, allowed) {
+    assert(allowed.has(value), `${field} has an unsupported value`);
+    return value;
+}
+
+function normalizeStringArray(value, field, maximum = 100) {
+    assert(Array.isArray(value) && value.length <= maximum, `${field} must be an array with at most ${maximum} entries`);
+    return value.map((entry, index) => normalizeString(entry, `${field}[${index}]`, 200));
+}
+
+function normalizeItem(item, index) {
+    assert(item && typeof item === "object" && !Array.isArray(item), `items[${index}] must be an object`);
+    const type = normalizeStatus(item.type, `items[${index}].type`, new Set(["pr", "issue"]));
+    const number = normalizeNumber(item.number, `items[${index}].number`);
+    const proofPools = normalizeStringArray(item.proofPools ?? [], `items[${index}].proofPools`, 10);
+    for (const pool of proofPools) {
+        assert(KNOWN_PROOF_POOLS.has(pool), `items[${index}].proofPools contains unknown pool ${pool}`);
+    }
+
+    return {
+        id: `${type}-${number}`,
+        type,
+        number,
+        title: normalizeString(item.title, `items[${index}].title`, 500),
+        url: normalizeUrl(item.url, `items[${index}].url`),
+        decision: normalizeStatus(item.decision, `items[${index}].decision`, DECISIONS),
+        takeConfidence: normalizeConfidence(item.takeConfidence, `items[${index}].takeConfidence`),
+        recommendationConfidence: normalizeConfidence(
+            item.recommendationConfidence,
+            `items[${index}].recommendationConfidence`,
+        ),
+        effort: normalizeOptionalString(item.effort, `items[${index}].effort`, 100),
+        risk: normalizeOptionalString(item.risk, `items[${index}].risk`, 100),
+        owner: normalizeString(item.owner, `items[${index}].owner`, 300),
+        nextAction: normalizeString(item.nextAction, `items[${index}].nextAction`),
+        proofPools,
+        proofStatus: normalizeStatus(
+            item.proofStatus,
+            `items[${index}].proofStatus`,
+            new Set(["blocked", "not-applicable", "passed", "required"]),
+        ),
+        reviewStatus: normalizeStatus(
+            item.reviewStatus,
+            `items[${index}].reviewStatus`,
+            new Set(["blocked", "complete", "required"]),
+        ),
+        reviewedHeadSha: normalizeOptionalString(item.reviewedHeadSha, `items[${index}].reviewedHeadSha`, 64),
+        expectedChecks: normalizeStringArray(
+            item.expectedChecks ?? [],
+            `items[${index}].expectedChecks`,
+            30,
+        ),
+        dependencies: (item.dependencies ?? []).map((entry, dependencyIndex) =>
+            normalizeNumber(entry, `items[${index}].dependencies[${dependencyIndex}]`)),
+    };
+}
+
+function normalizePlanStep(step, index, itemNumbers) {
+    assert(step && typeof step === "object" && !Array.isArray(step), `plan[${index}] must be an object`);
+    const numbers = (step.itemNumbers ?? []).map((entry, itemIndex) =>
+        normalizeNumber(entry, `plan[${index}].itemNumbers[${itemIndex}]`));
+    for (const number of numbers) {
+        assert(itemNumbers.has(number), `plan[${index}] references item #${number} outside this triage`);
+    }
+    const gates = (step.gates ?? []).map((gate, gateIndex) => {
+        assert(gate && typeof gate === "object" && !Array.isArray(gate),
+            `plan[${index}].gates[${gateIndex}] must be an object`);
+        const itemNumber = normalizeNumber(
+            gate.itemNumber,
+            `plan[${index}].gates[${gateIndex}].itemNumber`,
+        );
+        assert(itemNumbers.has(itemNumber),
+            `plan[${index}].gates[${gateIndex}] references item #${itemNumber} outside this triage`);
+        return {
+            itemNumber,
+            stage: normalizeStatus(
+                gate.stage,
+                `plan[${index}].gates[${gateIndex}].stage`,
+                new Set(["checks", "inventory", "landing", "proof", "review"]),
+            ),
+        };
+    });
+    return {
+        id: normalizeString(step.id, `plan[${index}].id`, 100),
+        title: normalizeString(step.title, `plan[${index}].title`, 500),
+        detail: normalizeOptionalString(step.detail, `plan[${index}].detail`),
+        itemNumbers: numbers,
+        gates,
+        status: normalizeStatus(
+            step.status,
+            `plan[${index}].status`,
+            new Set(["blocked", "done", "in_progress", "pending"]),
+        ),
+    };
+}
+
+function normalizeReportEntry(entry, field, index, keys) {
+    assert(entry && typeof entry === "object" && !Array.isArray(entry), `${field}[${index}] must be an object`);
+    return Object.fromEntries(keys.map((key) => [
+        key,
+        normalizeOptionalString(entry[key], `${field}[${index}].${key}`, 2_000),
+    ]));
+}
+
+function normalizeReport(report = {}) {
+    assert(report && typeof report === "object" && !Array.isArray(report), "report must be an object");
+    const normalizeEntries = (field, keys, maximum = 100) => {
+        const entries = report[field] ?? [];
+        assert(Array.isArray(entries) && entries.length <= maximum,
+            `report.${field} must be an array with at most ${maximum} entries`);
+        return entries.map((entry, index) =>
+            normalizeReportEntry(entry, `report.${field}`, index, keys));
+    };
+    return {
+        changes: normalizeEntries("changes", ["change", "items"]),
+        executiveQueue: normalizeStringArray(report.executiveQueue ?? [], "report.executiveQueue", 100),
+        ownership: normalizeEntries("ownership", ["item", "assessment"]),
+        reviews: normalizeEntries("reviews", ["item", "title", "decision", "summary"]),
+        dayPlan: normalizeStringArray(report.dayPlan ?? [], "report.dayPlan", 100),
+        automation: normalizeEntries("automation", ["opportunity", "why", "owner", "effort", "notes"]),
+    };
+}
+
+export function normalizeTriageInput(input) {
+    assert(input && typeof input === "object" && !Array.isArray(input), "canvas input must be an object");
+    assert(input.schemaVersion === 1, "schemaVersion must be 1");
+    const repo = normalizeString(input.repo, "repo", 200);
+    assert(/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo), "repo must use owner/name format");
+    assert(Array.isArray(input.items) && input.items.length > 0 && input.items.length <= 1_000,
+        "items must contain between 1 and 1000 entries");
+    const items = input.items.map(normalizeItem);
+    const itemIds = new Set(items.map((item) => item.id));
+    assert(itemIds.size === items.length, "items must not contain duplicate type/number pairs");
+    const itemNumbers = new Set(items.map((item) => item.number));
+    const refreshSeconds = input.refreshSeconds ?? 60;
+    assert(Number.isInteger(refreshSeconds) && refreshSeconds >= 30 && refreshSeconds <= 300,
+        "refreshSeconds must be an integer from 30 to 300");
+
+    return {
+        schemaVersion: 1,
+        repo,
+        title: normalizeString(input.title, "title", 500),
+        scope: normalizeString(input.scope, "scope", 1_000),
+        generatedAt: normalizeString(input.generatedAt, "generatedAt", 100),
+        refreshSeconds,
+        items,
+        plan: (input.plan ?? []).map((step, index) => normalizePlanStep(step, index, itemNumbers)),
+        report: normalizeReport(input.report),
+    };
+}
+
+function checkName(check) {
+    return String(check?.name ?? check?.context ?? "").trim();
+}
+
+function checkConclusion(check) {
+    return String(check?.conclusion ?? check?.state ?? "").toUpperCase();
+}
+
+export function summarizeChecks(checks, expectedChecks = []) {
+    const relevant = Array.isArray(checks)
+        ? checks.filter((check) => checkConclusion(check) !== "SKIPPED")
+        : [];
+    const failed = relevant.filter((check) => FAILED_CONCLUSIONS.has(checkConclusion(check)));
+    const pending = relevant.filter((check) => {
+        const conclusion = checkConclusion(check);
+        const status = String(check?.status ?? "").toUpperCase();
+        return !FAILED_CONCLUSIONS.has(conclusion) &&
+            !COMPLETED_CONCLUSIONS.has(conclusion) &&
+            (status !== "COMPLETED" || !conclusion);
+    });
+    const names = relevant.map(checkName).filter(Boolean);
+    const missing = expectedChecks.filter((expected) =>
+        !names.some((name) => name.toLowerCase() === expected.toLowerCase()));
+
+    return {
+        total: relevant.length,
+        passed: relevant.length - failed.length - pending.length,
+        failed: failed.length,
+        pending: pending.length,
+        missing,
+        failedNames: failed.map(checkName).filter(Boolean),
+        pendingNames: pending.map(checkName).filter(Boolean),
+    };
+}
+
+export function deriveItemStages(item, live) {
+    const checks = summarizeChecks(live?.statusCheckRollup, item.expectedChecks);
+    const checksStatus = live == null || checks.missing.length > 0
+        ? "blocked"
+        : checks.failed > 0
+            ? "blocked"
+            : checks.pending > 0
+                ? "in_progress"
+                : "done";
+    const reviewStatus = item.reviewStatus === "complete"
+        ? "done"
+        : item.reviewStatus === "required"
+            ? "pending"
+            : "blocked";
+    const proofStatus = PROOF_COMPLETE.has(item.proofStatus)
+        ? "done"
+        : item.proofStatus === "required"
+            ? "pending"
+            : "blocked";
+
+    return {
+        inventory: live == null ? "blocked" : "done",
+        review: reviewStatus,
+        checks: checksStatus,
+        proof: proofStatus,
+        landing: canRequestMerge(item, live).eligible ? "done" : "blocked",
+    };
+}
+
+export function canRequestMerge(item, live) {
+    const reasons = [];
+    if (item.type !== "pr") reasons.push("Only pull requests can merge");
+    if (item.decision !== "TAKE") reasons.push("Decision must be TAKE");
+    if (item.takeConfidence < 90) reasons.push("Take confidence must be at least 90%");
+    if (item.reviewStatus !== "complete") reasons.push("Review is incomplete");
+    if (!PROOF_COMPLETE.has(item.proofStatus)) reasons.push("Required proof is incomplete");
+    if (!live) {
+        reasons.push("Live GitHub status is unavailable");
+        return { eligible: false, reasons };
+    }
+
+    if (String(live.state).toUpperCase() !== "OPEN") reasons.push("Pull request is not open");
+    if (live.isDraft) reasons.push("Pull request is still a draft");
+    if (String(live.mergeStateStatus).toUpperCase() !== "CLEAN") reasons.push("Merge state is not clean");
+    const checks = summarizeChecks(live.statusCheckRollup, item.expectedChecks);
+    if (checks.failed > 0) reasons.push(`${checks.failed} check(s) failed`);
+    if (checks.pending > 0) reasons.push(`${checks.pending} check(s) pending`);
+    if (checks.missing.length > 0) reasons.push(`Missing expected checks: ${checks.missing.join(", ")}`);
+    if (!item.reviewedHeadSha) {
+        reasons.push("Reviewed head SHA is missing");
+    } else if (String(live.headRefOid).toLowerCase() !== item.reviewedHeadSha.toLowerCase()) {
+        reasons.push("Live head differs from the reviewed head");
+    }
+    return { eligible: reasons.length === 0, reasons };
+}
+
+export function mergeLiveState(triage, pullRequests, issues, error = "") {
+    const pullRequestMap = new Map((pullRequests ?? []).map((item) => [item.number, item]));
+    const issueMap = new Map((issues ?? []).map((item) => [item.number, item]));
+    const items = triage.items.map((item) => {
+        const live = item.type === "pr" ? pullRequestMap.get(item.number) : issueMap.get(item.number);
+        const checks = item.type === "pr"
+            ? summarizeChecks(live?.statusCheckRollup, item.expectedChecks)
+            : null;
+        const mergeRequest = canRequestMerge(item, live);
+        return {
+            ...item,
+            live: live ?? null,
+            checks,
+            stages: deriveItemStages(item, live),
+            mergeRequest,
+        };
+    });
+
+    const itemMap = new Map(items.map((item) => [item.number, item]));
+    const plan = triage.plan.map((step) => {
+        const gateStatuses = step.gates.map((gate) => itemMap.get(gate.itemNumber)?.stages[gate.stage] ?? "blocked");
+        let liveStatus = step.status;
+        if (gateStatuses.length > 0) {
+            liveStatus = gateStatuses.every((status) => status === "done")
+                ? "done"
+                : gateStatuses.some((status) => status === "blocked")
+                    ? "blocked"
+                    : gateStatuses.some((status) => status === "in_progress")
+                        ? "in_progress"
+                        : "pending";
+        }
+        return { ...step, liveStatus };
+    });
+
+    return {
+        ...triage,
+        items,
+        plan,
+        liveUpdatedAt: new Date().toISOString(),
+        refreshError: error,
+        summary: {
+            total: items.length,
+            ready: items.filter((item) => item.mergeRequest.eligible).length,
+            blocked: items.filter((item) => Object.values(item.stages).includes("blocked")).length,
+            checksRunning: items.filter((item) => item.checks?.pending > 0).length,
+            needsProof: items.filter((item) => !PROOF_COMPLETE.has(item.proofStatus)).length,
+        },
+    };
+}

--- a/.github/extensions/openclaw-triage-dashboard/triage-state.mjs
+++ b/.github/extensions/openclaw-triage-dashboard/triage-state.mjs
@@ -94,6 +94,14 @@ function normalizeItem(item, index) {
         assert(KNOWN_PROOF_POOLS.has(pool), `items[${index}].proofPools contains unknown pool ${pool}`);
     }
 
+    const expectedChecks = normalizeStringArray(
+        item.expectedChecks ?? [],
+        `items[${index}].expectedChecks`,
+        30,
+    );
+    assert(type !== "pr" || expectedChecks.length > 0,
+        `items[${index}].expectedChecks must name at least one required check for pull requests`);
+
     return {
         id: `${type}-${number}`,
         type,
@@ -122,11 +130,7 @@ function normalizeItem(item, index) {
             new Set(["blocked", "complete", "required"]),
         ),
         reviewedHeadSha: normalizeOptionalString(item.reviewedHeadSha, `items[${index}].reviewedHeadSha`, 64),
-        expectedChecks: normalizeStringArray(
-            item.expectedChecks ?? [],
-            `items[${index}].expectedChecks`,
-            30,
-        ),
+        expectedChecks,
         dependencies: (item.dependencies ?? []).map((entry, dependencyIndex) =>
             normalizeNumber(entry, `items[${index}].dependencies[${dependencyIndex}]`)),
     };
@@ -326,7 +330,9 @@ export function deriveItemStages(item, live) {
         review: reviewStatus,
         checks: checksStatus,
         proof: proofStatus,
-        landing: canRequestMerge(item, live).eligible ? "done" : "blocked",
+        ...(item.type === "pr"
+            ? { landing: canRequestMerge(item, live).eligible ? "done" : "blocked" }
+            : {}),
     };
 }
 
@@ -376,7 +382,10 @@ export function mergeLiveState(triage, pullRequests, issues, error = "") {
     });
 
     const itemMap = new Map(items.map((item) => [item.number, item]));
-    const plan = triage.plan.map((step) => {
+    const planById = new Map(triage.plan.map((step) => [step.id, step]));
+    const liveStatusById = new Map();
+    const resolvePlanStatus = (step) => {
+        if (liveStatusById.has(step.id)) return liveStatusById.get(step.id);
         const gateStatuses = step.gates.map((gate) => itemMap.get(gate.itemNumber)?.stages[gate.stage] ?? "blocked");
         let liveStatus = step.status;
         if (gateStatuses.length > 0) {
@@ -388,8 +397,16 @@ export function mergeLiveState(triage, pullRequests, issues, error = "") {
                         ? "in_progress"
                         : "pending";
         }
-        return { ...step, liveStatus };
-    });
+        const dependenciesComplete = step.dependsOn.every((dependencyId) =>
+            resolvePlanStatus(planById.get(dependencyId)) === "done");
+        if (!dependenciesComplete) liveStatus = "blocked";
+        liveStatusById.set(step.id, liveStatus);
+        return liveStatus;
+    };
+    const plan = triage.plan.map((step) => ({
+        ...step,
+        liveStatus: resolvePlanStatus(step),
+    }));
 
     return {
         ...triage,

--- a/.github/extensions/openclaw-triage-dashboard/triage-state.test.mjs
+++ b/.github/extensions/openclaw-triage-dashboard/triage-state.test.mjs
@@ -9,6 +9,12 @@ import {
     summarizeChecks,
 } from "./triage-state.mjs";
 import { buildSubsessionRoutingPrompt } from "./triage-actions.mjs";
+import {
+    buildPlanLanes,
+    limitLaneLevels,
+    limitPlanLanes,
+    limitPlanRows,
+} from "./triage-plan.mjs";
 import { renderDashboardHtml } from "./triage-ui.mjs";
 
 function inputItem(overrides = {}) {
@@ -61,6 +67,8 @@ test("normalizes a versioned triage dashboard input", () => {
             id: "land-1308",
             title: "Land #1308",
             detail: "After checks.",
+            dependsOn: [],
+            horizon: "later",
             itemNumbers: [1308],
             gates: [{ itemNumber: 1308, stage: "landing" }],
             status: "pending",
@@ -69,6 +77,8 @@ test("normalizes a versioned triage dashboard input", () => {
 
     assert.equal(result.items[0].id, "pr-1308");
     assert.equal(result.refreshSeconds, 60);
+    assert.equal(result.plan[0].horizon, "later");
+    assert.deepEqual(result.plan[0].dependsOn, []);
     assert.equal(result.report.dayPlan.length, 0);
 });
 
@@ -102,6 +112,20 @@ test("rejects non-HTTP item links", () => {
         generatedAt: "2026-09-03T22:00:00Z",
         items: [inputItem({ url: "javascript:alert(1)" })],
     }), /valid HTTP or HTTPS URL/);
+});
+
+test("rejects duplicate item numbers across item types", () => {
+    assert.throws(() => normalizeTriageInput({
+        schemaVersion: 1,
+        repo: "openclaw/openclaw-windows-node",
+        title: "Global triage",
+        scope: "All open work",
+        generatedAt: "2026-09-03T22:00:00Z",
+        items: [
+            inputItem({ type: "pr", number: 42 }),
+            inputItem({ type: "issue", number: 42 }),
+        ],
+    }), /items must not contain duplicate numbers/);
 });
 
 test("summarizes failed, pending, skipped, and missing checks", () => {
@@ -183,6 +207,114 @@ test("updates plan status from linked live gates", () => {
     const result = mergeLiveState(triage, [livePr()], []);
 
     assert.equal(result.plan[0].liveStatus, "done");
+    assert.equal(result.plan[0].horizon, "today");
+});
+
+test("builds sequential and independent dependency lanes", () => {
+    const lanes = buildPlanLanes([
+        { id: "prove", dependsOn: [], title: "Prove", liveStatus: "pending" },
+        { id: "decide", dependsOn: ["prove"], title: "Decide", liveStatus: "blocked" },
+        { id: "port", dependsOn: [], title: "Port", liveStatus: "pending" },
+    ]);
+
+    assert.equal(lanes[0].kind, "sequential");
+    assert.deepEqual(lanes[0].levels.map((level) => level.map((step) => step.id)), [["prove"], ["decide"]]);
+    assert.equal(lanes[1].kind, "independent");
+    assert.equal(lanes[1].levels[0][0].id, "port");
+});
+
+test("builds stable branched dependency levels", () => {
+    const lanes = buildPlanLanes([
+        { id: "root", dependsOn: [], title: "Root", liveStatus: "done" },
+        { id: "left", dependsOn: ["root"], title: "Left", liveStatus: "pending" },
+        { id: "right", dependsOn: ["root"], title: "Right", liveStatus: "pending" },
+        { id: "join", dependsOn: ["left", "right"], title: "Join", liveStatus: "blocked" },
+    ]);
+
+    assert.equal(lanes.length, 1);
+    assert.equal(lanes[0].kind, "parallel");
+    assert.deepEqual(
+        lanes[0].levels.map((level) => level.map((step) => step.id)),
+        [["root"], ["left", "right"], ["join"]],
+    );
+    assert.deepEqual(lanes[0].levels[2][0].dependsOn, ["left", "right"]);
+});
+
+test("limits large plans by both workstream and step count", () => {
+    const lanes = Array.from({ length: 20 }, (_, index) => ({
+        id: `lane-${index}`,
+        levels: [[{ id: `step-${index}` }]],
+    }));
+    const laneWindow = limitPlanLanes(lanes, 12);
+    assert.equal(laneWindow.lanes.length, 12);
+    assert.equal(laneWindow.hiddenCount, 8);
+
+    const levels = Array.from({ length: 20 }, (_, index) => [[{ id: `chain-${index}` }]])
+        .flat();
+    const levelWindow = limitLaneLevels(levels, 12);
+    assert.equal(levelWindow.levels.flat().length, 12);
+    assert.equal(levelWindow.hiddenCount, 8);
+
+    const rowWindow = limitPlanRows([
+        { id: "large", levels: [Array.from({ length: 20 }, (_, index) => ({ id: `a-${index}` }))] },
+        { id: "other", levels: [[{ id: "b-0" }]] },
+    ], 12);
+    assert.equal(rowWindow.lanes.length, 1);
+    assert.equal(rowWindow.lanes[0].levels.flat().length, 12);
+    assert.equal(rowWindow.hiddenCount, 9);
+});
+
+test("uses legacy queue and day-plan guidance only when no structured plan exists", () => {
+    const lanes = buildPlanLanes(
+        [],
+        ["Shared task", "Day task"],
+        ["Queue task", "Shared task"],
+    );
+
+    assert.equal(lanes.length, 3);
+    assert.deepEqual(
+        lanes.map((lane) => lane.levels[0][0].title),
+        ["Queue task", "Shared task", "Day task"],
+    );
+    assert.equal(lanes[0].levels[0][0].legacy, true);
+});
+
+test("rejects unknown and cyclic plan dependencies", () => {
+    const base = {
+        schemaVersion: 1,
+        repo: "openclaw/openclaw-windows-node",
+        title: "Global triage",
+        scope: "All open work",
+        generatedAt: "2026-09-03T22:00:00Z",
+        items: [inputItem()],
+    };
+    assert.throws(() => normalizeTriageInput({
+        ...base,
+        plan: [{
+            id: "one",
+            title: "One",
+            itemNumbers: [1308],
+            dependsOn: ["missing"],
+            status: "pending",
+        }],
+    }), /depends on unknown step missing/);
+    assert.throws(() => normalizeTriageInput({
+        ...base,
+        plan: [
+            { id: "one", title: "One", itemNumbers: [1308], dependsOn: ["two"], status: "pending" },
+            { id: "two", title: "Two", itemNumbers: [1308], dependsOn: ["one"], status: "pending" },
+        ],
+    }), /dependency cycle/);
+    assert.throws(() => normalizeTriageInput({
+        ...base,
+        plan: [{
+            id: "one",
+            title: "One",
+            itemNumbers: [1308],
+            dependsOn: ["one"],
+            status: "pending",
+        }],
+    }), /must not depend on itself/);
 });
 
 test("the checked-in skill template satisfies the canvas contract", () => {
@@ -206,9 +338,30 @@ test("the renderer exposes live filters and guarded action controls", () => {
     assert.match(html, /Filter by verdict/);
     assert.match(html, /Sort: confidence/);
     assert.match(html, /role="tablist"/);
+    assert.match(html, /data-tab="plan"/);
+    assert.doesNotMatch(html, /data-tab="day-plan"/);
+    assert.doesNotMatch(html, /data-tab="queue"/);
+    assert.match(html, /aria-labelledby="tab-plan-button"/);
+    assert.match(html, /<h2 class="sr-only">Plan<\/h2>/);
+    assert.match(html, /take"/);
+    assert.match(html, /Depends on/);
+    assert.match(html, /No linked action/);
+    assert.doesNotMatch(html, /Compact view/);
+    assert.match(html, /Show next/);
+    assert.match(html, /plan rows/);
+    assert.match(html, /limitPlanRows/);
+    assert.match(html, /limitLaneLevels/);
+    assert.match(html, /plan-node-decision/);
+    assert.match(html, /Can run in parallel/);
     assert.match(html, /data-tab="automation"/);
     assert.match(html, /Request next step/);
     assert.match(html, /Prepare merge/);
+    assert.match(html, /function createItemActions/);
+    assert.equal(html.match(/createItemActions\(/g)?.length, 3);
+    assert.match(html, /plan-button-groups/);
+    assert.match(html, /aria-describedby/);
+    assert.match(html, /Why merge is blocked for/);
+    assert.match(html, /Request next step for/);
     assert.match(html, /EventSource/);
 });
 

--- a/.github/extensions/openclaw-triage-dashboard/triage-state.test.mjs
+++ b/.github/extensions/openclaw-triage-dashboard/triage-state.test.mjs
@@ -8,7 +8,10 @@ import {
     normalizeTriageInput,
     summarizeChecks,
 } from "./triage-state.mjs";
-import { buildSubsessionRoutingPrompt } from "./triage-actions.mjs";
+import {
+    buildSubsessionRoutingPrompt,
+    requireFreshGitHubEvidence,
+} from "./triage-actions.mjs";
 import {
     buildPlanLanes,
     limitLaneLevels,
@@ -459,6 +462,25 @@ test("issue actions use a distinct stable child session name", () => {
 
     assert.equal(routing.sessionName, "Triage Issue #42");
     assert.match(routing.prompt, /openclaw\/openclaw-windows-node Issue #42/);
+});
+
+test("merge routing stops before sending when fresh GitHub evidence is unavailable", async () => {
+    let sendCount = 0;
+    const requestMerge = async () => {
+        await requireFreshGitHubEvidence(
+            async () => ({ refreshError: "HTTP 503: unavailable" }),
+            (code, message) => Object.assign(new Error(message), { code }),
+        );
+        sendCount += 1;
+    };
+
+    await assert.rejects(
+        requestMerge,
+        (error) =>
+            error.code === "refresh_failed" &&
+            /Fresh GitHub evidence is required/.test(error.message),
+    );
+    assert.equal(sendCount, 0);
 });
 
 test("the extension contains no direct GitHub mutation command", () => {

--- a/.github/extensions/openclaw-triage-dashboard/triage-state.test.mjs
+++ b/.github/extensions/openclaw-triage-dashboard/triage-state.test.mjs
@@ -10,6 +10,7 @@ import {
 } from "./triage-state.mjs";
 import {
     buildSubsessionRoutingPrompt,
+    itemDependencyBlocker,
     requestHostMatches,
     requestItemAction,
     requestTokenMatches,
@@ -500,6 +501,7 @@ test("the renderer exposes live filters and guarded action controls", () => {
     assert.match(html, /Request next step/);
     assert.match(html, /Prepare merge/);
     assert.match(html, /function createItemActions/);
+    assert.match(html, /function itemDependencyBlocker/);
     assert.equal(html.match(/createItemActions\(/g)?.length, 3);
     assert.match(html, /plan-button-groups/);
     assert.match(html, /aria-describedby/);
@@ -557,6 +559,81 @@ test("merge routing stops before sending when fresh GitHub evidence is unavailab
             /Fresh GitHub evidence is required/.test(error.message),
     );
     assert.equal(sendCount, 0);
+});
+
+test("action routing enforces plan dependencies for every entry point", async () => {
+    const triage = normalizeTriageInput({
+        schemaVersion: 1,
+        repo: "openclaw/openclaw-windows-node",
+        title: "Global triage",
+        scope: "All open work",
+        generatedAt: "2026-09-03T22:00:00Z",
+        items: [inputItem()],
+        plan: [
+            {
+                id: "collect-proof",
+                title: "Collect proof",
+                itemNumbers: [],
+                status: "pending",
+            },
+            {
+                id: "land",
+                title: "Land PR",
+                dependsOn: ["collect-proof"],
+                itemNumbers: [1308],
+                status: "pending",
+            },
+        ],
+    });
+    const entry = {
+        triage,
+        state: mergeLiveState(triage, [livePr()], []),
+    };
+    let sendCount = 0;
+    const dependencies = {
+        refresh: async () => entry.state,
+        send: async () => {
+            sendCount += 1;
+        },
+    };
+
+    assert.match(itemDependencyBlocker(entry.state, 1308), /Complete dependencies first: Collect proof/);
+    for (const [action, input] of [
+        ["request_next_action", { number: 1308 }],
+        ["request_merge", { number: 1308, headSha: "abc1234" }],
+    ]) {
+        await assert.rejects(
+            requestItemAction(entry, action, input, dependencies),
+            (error) => error.code === "plan_dependencies_incomplete",
+        );
+    }
+    assert.equal(sendCount, 0);
+
+    assert.equal(itemDependencyBlocker({
+        plan: [
+            {
+                id: "blocked",
+                title: "Blocked path",
+                itemNumbers: [1308],
+                dependsOn: ["collect-proof"],
+                liveStatus: "blocked",
+            },
+            {
+                id: "runnable",
+                title: "Runnable path",
+                itemNumbers: [1308],
+                dependsOn: [],
+                liveStatus: "pending",
+            },
+            {
+                id: "collect-proof",
+                title: "Collect proof",
+                itemNumbers: [],
+                dependsOn: [],
+                liveStatus: "pending",
+            },
+        ],
+    }, 1308), "");
 });
 
 test("action routing rejects unsupported and stale requests before sending", async () => {

--- a/.github/extensions/openclaw-triage-dashboard/triage-state.test.mjs
+++ b/.github/extensions/openclaw-triage-dashboard/triage-state.test.mjs
@@ -10,6 +10,9 @@ import {
 } from "./triage-state.mjs";
 import {
     buildSubsessionRoutingPrompt,
+    requestHostMatches,
+    requestItemAction,
+    requestTokenMatches,
     requireFreshGitHubEvidence,
 } from "./triage-actions.mjs";
 import {
@@ -117,6 +120,25 @@ test("rejects non-HTTP item links", () => {
     }), /valid HTTP or HTTPS URL/);
 });
 
+test("binds inputs and item links to the OpenClaw repository", () => {
+    const base = {
+        schemaVersion: 1,
+        title: "Global triage",
+        scope: "All open work",
+        generatedAt: "2026-09-03T22:00:00Z",
+    };
+    assert.throws(() => normalizeTriageInput({
+        ...base,
+        repo: "attacker/other-repo",
+        items: [inputItem()],
+    }), /repo must be openclaw\/openclaw-windows-node/);
+    assert.throws(() => normalizeTriageInput({
+        ...base,
+        repo: "openclaw/openclaw-windows-node",
+        items: [inputItem({ url: "https://example.com/pull/1308" })],
+    }), /canonical openclaw\/openclaw-windows-node GitHub URL/);
+});
+
 test("rejects duplicate item numbers across item types", () => {
     assert.throws(() => normalizeTriageInput({
         schemaVersion: 1,
@@ -126,7 +148,13 @@ test("rejects duplicate item numbers across item types", () => {
         generatedAt: "2026-09-03T22:00:00Z",
         items: [
             inputItem({ type: "pr", number: 42 }),
-            inputItem({ type: "issue", number: 42 }),
+            inputItem({
+                type: "issue",
+                number: 42,
+                url: "https://github.com/openclaw/openclaw-windows-node/issues/42",
+                expectedChecks: [],
+                reviewedHeadSha: "",
+            }),
         ],
     }), /items must not contain duplicate numbers/);
 });
@@ -142,16 +170,59 @@ test("requires expected checks for pull requests", () => {
     }), /must name at least one required check/);
 });
 
+test("rejects check requirements and landing gates for issues", () => {
+    const issue = inputItem({
+        type: "issue",
+        number: 42,
+        url: "https://github.com/openclaw/openclaw-windows-node/issues/42",
+        expectedChecks: ["CI Gate"],
+        reviewedHeadSha: "",
+    });
+    const base = {
+        schemaVersion: 1,
+        repo: "openclaw/openclaw-windows-node",
+        title: "Global triage",
+        scope: "All open work",
+        generatedAt: "2026-09-03T22:00:00Z",
+    };
+    assert.throws(() => normalizeTriageInput({
+        ...base,
+        items: [issue],
+    }), /expectedChecks must be empty for issues/);
+    assert.throws(() => normalizeTriageInput({
+        ...base,
+        items: [{ ...issue, expectedChecks: [] }],
+        plan: [{
+            id: "close-issue",
+            title: "Close issue",
+            itemNumbers: [42],
+            gates: [{ itemNumber: 42, stage: "landing" }],
+            status: "pending",
+        }],
+    }), /cannot use landing for an issue/);
+});
+
 test("summarizes failed, pending, skipped, and missing checks", () => {
     const result = summarizeChecks([
         { name: "test", status: "COMPLETED", conclusion: "FAILURE" },
         { name: "build", status: "IN_PROGRESS", conclusion: "" },
         { name: "optional", status: "COMPLETED", conclusion: "SKIPPED" },
-    ], ["test", "build", "security"]);
+    ], ["test", "build", "optional", "security"]);
 
     assert.equal(result.failed, 1);
     assert.equal(result.pending, 1);
     assert.deepEqual(result.missing, ["security"]);
+});
+
+test("recognizes lane-skipped expected checks as observed", () => {
+    const result = summarizeChecks([
+        { name: "CI Gate", status: "COMPLETED", conclusion: "SUCCESS" },
+        { name: "Core and CLI tests", status: "COMPLETED", conclusion: "SKIPPED" },
+    ], ["CI Gate", "Core and CLI tests"]);
+
+    assert.deepEqual(result.missing, []);
+    assert.equal(result.failed, 0);
+    assert.equal(result.pending, 0);
 });
 
 test("treats legacy error statuses as failed checks", () => {
@@ -396,6 +467,9 @@ test("the checked-in skill template satisfies the canvas contract", () => {
 
     assert.equal(result.schemaVersion, 1);
     assert.equal(result.plan[0].gates[0].stage, "checks");
+    assert.equal(result.items[1].type, "issue");
+    assert.deepEqual(result.items[1].expectedChecks, []);
+    assert.equal(result.plan[1].gates[0].stage, "inventory");
 });
 
 test("the renderer exposes live filters and guarded action controls", () => {
@@ -449,6 +523,8 @@ test("item actions route to one reusable child session", () => {
     assert.match(routing.prompt, /list_sessions_and_chats/);
     assert.match(routing.prompt, /send_session_message/);
     assert.match(routing.prompt, /create_session/);
+    assert.match(routing.prompt, /If more than one matching session exists, stop/);
+    assert.match(routing.prompt, /interactive mode/);
     assert.match(routing.prompt, /Do not create a duplicate session/);
     assert.match(routing.prompt, /Refresh the evidence/);
 });
@@ -483,6 +559,82 @@ test("merge routing stops before sending when fresh GitHub evidence is unavailab
     assert.equal(sendCount, 0);
 });
 
+test("action routing rejects unsupported and stale requests before sending", async () => {
+    const triage = normalizeTriageInput({
+        schemaVersion: 1,
+        repo: "openclaw/openclaw-windows-node",
+        title: "Global triage",
+        scope: "All open work",
+        generatedAt: "2026-09-03T22:00:00Z",
+        items: [inputItem({ reviewedHeadSha: "abc1234" })],
+    });
+    const entry = {
+        triage,
+        state: mergeLiveState(triage, [livePr({ headRefOid: "abc1234" })], []),
+    };
+    let sendCount = 0;
+    const dependencies = {
+        refresh: async () => entry.state,
+        send: async () => {
+            sendCount += 1;
+        },
+    };
+
+    await assert.rejects(
+        requestItemAction(entry, "delete_item", { number: 1308 }, dependencies),
+        (error) => error.code === "unsupported_action",
+    );
+    await assert.rejects(
+        requestItemAction(entry, "request_merge", { number: 1308, headSha: "different" }, dependencies),
+        (error) => error.code === "head_changed",
+    );
+    assert.equal(sendCount, 0);
+});
+
+test("action routing sends exactly once after fresh exact-head verification", async () => {
+    const triage = normalizeTriageInput({
+        schemaVersion: 1,
+        repo: "openclaw/openclaw-windows-node",
+        title: "Global triage",
+        scope: "All open work",
+        generatedAt: "2026-09-03T22:00:00Z",
+        items: [inputItem({ reviewedHeadSha: "abc1234" })],
+    });
+    const entry = {
+        triage,
+        state: mergeLiveState(triage, [livePr({ headRefOid: "abc1234" })], []),
+    };
+    const sent = [];
+    const result = await requestItemAction(entry, "request_merge", {
+        number: 1308,
+        headSha: "abc1234",
+    }, {
+        refresh: async () => entry.state,
+        send: async (message) => sent.push(message),
+    });
+
+    assert.equal(result.queued, true);
+    assert.equal(sent.length, 1);
+    assert.match(sent[0].prompt, /Do not mutate GitHub yet/);
+});
+
+test("loopback request guards require the bound host and action token", () => {
+    const request = {
+        headers: {
+            host: "127.0.0.1:32123",
+            "x-triage-token": "secret",
+        },
+    };
+    assert.equal(requestHostMatches(request, "127.0.0.1:32123"), true);
+    assert.equal(requestHostMatches(request, "rebound.example:32123"), false);
+    assert.equal(requestTokenMatches(request, new URL("http://127.0.0.1/action"), "secret"), true);
+    assert.equal(requestTokenMatches(
+        { headers: { host: "127.0.0.1:32123" } },
+        new URL("http://127.0.0.1/events?token=secret"),
+        "secret",
+    ), true);
+});
+
 test("the extension contains no direct GitHub mutation command", () => {
     const source = readFileSync(new URL("./extension.mjs", import.meta.url), "utf8");
     const actionSource = readFileSync(new URL("./triage-actions.mjs", import.meta.url), "utf8");
@@ -495,5 +647,5 @@ test("the extension contains no direct GitHub mutation command", () => {
         assert.doesNotMatch(candidate, /["']run["']\s*,\s*["']rerun["']/);
         assert.doesNotMatch(candidate, /gh\s+pr\s+merge/i);
     }
-    assert.equal(source.match(/copilotSession\.send/g)?.length, 1);
+    assert.equal(actionSource.match(/await send\(/g)?.length, 1);
 });

--- a/.github/extensions/openclaw-triage-dashboard/triage-state.test.mjs
+++ b/.github/extensions/openclaw-triage-dashboard/triage-state.test.mjs
@@ -1,0 +1,223 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import {
+    canRequestMerge,
+    mergeLiveState,
+    KNOWN_PROOF_POOLS,
+    normalizeTriageInput,
+    summarizeChecks,
+} from "./triage-state.mjs";
+import { renderDashboardHtml } from "./triage-ui.mjs";
+
+function inputItem(overrides = {}) {
+    return {
+        type: "pr",
+        number: 1308,
+        title: "Interactive triage",
+        url: "https://github.com/openclaw/openclaw-windows-node/pull/1308",
+        decision: "TAKE",
+        takeConfidence: 96,
+        recommendationConfidence: 99,
+        effort: "Quick",
+        risk: "Low",
+        owner: "maintainer",
+        nextAction: "Merge after fresh verification.",
+        proofPools: [],
+        proofStatus: "not-applicable",
+        reviewStatus: "complete",
+        reviewedHeadSha: "abc123",
+        expectedChecks: ["test", "build (win-x64)"],
+        dependencies: [],
+        ...overrides,
+    };
+}
+
+function livePr(overrides = {}) {
+    return {
+        number: 1308,
+        state: "OPEN",
+        isDraft: false,
+        mergeStateStatus: "CLEAN",
+        headRefOid: "abc123",
+        statusCheckRollup: [
+            { name: "test", status: "COMPLETED", conclusion: "SUCCESS" },
+            { name: "build (win-x64)", status: "COMPLETED", conclusion: "SUCCESS" },
+        ],
+        ...overrides,
+    };
+}
+
+test("normalizes a versioned triage dashboard input", () => {
+    const result = normalizeTriageInput({
+        schemaVersion: 1,
+        repo: "openclaw/openclaw-windows-node",
+        title: "Global triage",
+        scope: "All open work",
+        generatedAt: "2026-09-03T22:00:00Z",
+        items: [inputItem()],
+        plan: [{
+            id: "land-1308",
+            title: "Land #1308",
+            detail: "After checks.",
+            itemNumbers: [1308],
+            gates: [{ itemNumber: 1308, stage: "landing" }],
+            status: "pending",
+        }],
+    });
+
+    assert.equal(result.items[0].id, "pr-1308");
+    assert.equal(result.refreshSeconds, 60);
+    assert.equal(result.report.dayPlan.length, 0);
+});
+
+test("rejects unknown proof pool identifiers", () => {
+    assert.throws(() => normalizeTriageInput({
+        schemaVersion: 1,
+        repo: "openclaw/openclaw-windows-node",
+        title: "Global triage",
+        scope: "All open work",
+        generatedAt: "2026-09-03T22:00:00Z",
+        items: [inputItem({ proofPools: ["invented-pool"] })],
+    }), /unknown pool/);
+});
+
+test("keeps the proof-pool allowlist aligned with the repository registry", () => {
+    const registryUrl = new URL("../../../.github/proof-pools.json", import.meta.url);
+    const registry = JSON.parse(readFileSync(registryUrl, "utf8"));
+
+    assert.deepEqual(
+        [...KNOWN_PROOF_POOLS].sort(),
+        registry.pools.map((pool) => pool.id).sort(),
+    );
+});
+
+test("rejects non-HTTP item links", () => {
+    assert.throws(() => normalizeTriageInput({
+        schemaVersion: 1,
+        repo: "openclaw/openclaw-windows-node",
+        title: "Global triage",
+        scope: "All open work",
+        generatedAt: "2026-09-03T22:00:00Z",
+        items: [inputItem({ url: "javascript:alert(1)" })],
+    }), /valid HTTP or HTTPS URL/);
+});
+
+test("summarizes failed, pending, skipped, and missing checks", () => {
+    const result = summarizeChecks([
+        { name: "test", status: "COMPLETED", conclusion: "FAILURE" },
+        { name: "build", status: "IN_PROGRESS", conclusion: "" },
+        { name: "optional", status: "COMPLETED", conclusion: "SKIPPED" },
+    ], ["test", "build", "security"]);
+
+    assert.equal(result.failed, 1);
+    assert.equal(result.pending, 1);
+    assert.deepEqual(result.missing, ["security"]);
+});
+
+test("treats legacy error statuses as failed checks", () => {
+    const result = summarizeChecks([
+        { context: "legacy-status", state: "ERROR" },
+    ]);
+
+    assert.equal(result.failed, 1);
+    assert.equal(result.pending, 0);
+});
+
+test("permits a merge request only for a reviewed exact-head TAKE", () => {
+    const item = inputItem();
+    assert.deepEqual(canRequestMerge(item, livePr()), { eligible: true, reasons: [] });
+
+    const stale = canRequestMerge(item, livePr({ headRefOid: "new-head" }));
+    assert.equal(stale.eligible, false);
+    assert.match(stale.reasons.join(" "), /reviewed head/);
+});
+
+test("blocks draft, proof-incomplete, and TAKE_AFTER_CHECKS items", () => {
+    const item = inputItem({
+        decision: "TAKE_AFTER_CHECKS",
+        proofStatus: "required",
+    });
+    const result = canRequestMerge(item, livePr({ isDraft: true }));
+
+    assert.equal(result.eligible, false);
+    assert.match(result.reasons.join(" "), /Decision must be TAKE/);
+    assert.match(result.reasons.join(" "), /proof is incomplete/);
+    assert.match(result.reasons.join(" "), /still a draft/);
+});
+
+test("merges live GitHub state into stage and summary projections", () => {
+    const triage = normalizeTriageInput({
+        schemaVersion: 1,
+        repo: "openclaw/openclaw-windows-node",
+        title: "Global triage",
+        scope: "All open work",
+        generatedAt: "2026-09-03T22:00:00Z",
+        items: [inputItem()],
+        plan: [],
+    });
+    const result = mergeLiveState(triage, [livePr()], []);
+
+    assert.equal(result.summary.ready, 1);
+    assert.equal(result.items[0].stages.checks, "done");
+    assert.equal(result.items[0].stages.landing, "done");
+});
+
+test("updates plan status from linked live gates", () => {
+    const triage = normalizeTriageInput({
+        schemaVersion: 1,
+        repo: "openclaw/openclaw-windows-node",
+        title: "Global triage",
+        scope: "All open work",
+        generatedAt: "2026-09-03T22:00:00Z",
+        items: [inputItem()],
+        plan: [{
+            id: "land",
+            title: "Land the PR",
+            itemNumbers: [1308],
+            gates: [{ itemNumber: 1308, stage: "landing" }],
+            status: "pending",
+        }],
+    });
+    const result = mergeLiveState(triage, [livePr()], []);
+
+    assert.equal(result.plan[0].liveStatus, "done");
+});
+
+test("the checked-in skill template satisfies the canvas contract", () => {
+    const templateUrl = new URL(
+        "../../../.agents/skills/global-repo-triage/templates/triage-state.template.json",
+        import.meta.url,
+    );
+    const template = JSON.parse(readFileSync(templateUrl, "utf8"));
+    const result = normalizeTriageInput(template);
+
+    assert.equal(result.schemaVersion, 1);
+    assert.equal(result.plan[0].gates[0].stage, "checks");
+});
+
+test("the renderer exposes live filters and guarded action controls", () => {
+    const html = renderDashboardHtml("token");
+
+    assert.match(html, /Search all triage items/);
+    assert.match(html, /Show pull requests/);
+    assert.match(html, /Show issues/);
+    assert.match(html, /Filter by verdict/);
+    assert.match(html, /Sort: confidence/);
+    assert.match(html, /role="tablist"/);
+    assert.match(html, /data-tab="automation"/);
+    assert.match(html, /Request next step/);
+    assert.match(html, /Prepare merge/);
+    assert.match(html, /EventSource/);
+});
+
+test("the extension contains no direct GitHub mutation command", () => {
+    const source = readFileSync(new URL("./extension.mjs", import.meta.url), "utf8");
+
+    assert.doesNotMatch(
+        source,
+        /["'](?:pr|issue)["']\s*,\s*["'](?:merge|close|comment|edit|reopen)["']/,
+    );
+    assert.doesNotMatch(source, /["']run["']\s*,\s*["']rerun["']/);
+    assert.doesNotMatch(source, /gh\s+pr\s+merge/i);
+});

--- a/.github/extensions/openclaw-triage-dashboard/triage-state.test.mjs
+++ b/.github/extensions/openclaw-triage-dashboard/triage-state.test.mjs
@@ -128,6 +128,17 @@ test("rejects duplicate item numbers across item types", () => {
     }), /items must not contain duplicate numbers/);
 });
 
+test("requires expected checks for pull requests", () => {
+    assert.throws(() => normalizeTriageInput({
+        schemaVersion: 1,
+        repo: "openclaw/openclaw-windows-node",
+        title: "Global triage",
+        scope: "All open work",
+        generatedAt: "2026-09-03T22:00:00Z",
+        items: [inputItem({ expectedChecks: [] })],
+    }), /must name at least one required check/);
+});
+
 test("summarizes failed, pending, skipped, and missing checks", () => {
     const result = summarizeChecks([
         { name: "test", status: "COMPLETED", conclusion: "FAILURE" },
@@ -188,6 +199,29 @@ test("merges live GitHub state into stage and summary projections", () => {
     assert.equal(result.items[0].stages.landing, "done");
 });
 
+test("does not classify issues as landing blocked", () => {
+    const issue = inputItem({
+        type: "issue",
+        number: 42,
+        url: "https://github.com/openclaw/openclaw-windows-node/issues/42",
+        expectedChecks: [],
+        reviewedHeadSha: "",
+    });
+    const triage = normalizeTriageInput({
+        schemaVersion: 1,
+        repo: "openclaw/openclaw-windows-node",
+        title: "Global triage",
+        scope: "All open work",
+        generatedAt: "2026-09-03T22:00:00Z",
+        items: [issue],
+        plan: [],
+    });
+    const result = mergeLiveState(triage, [], [{ number: 42, state: "OPEN" }]);
+
+    assert.equal(result.summary.blocked, 0);
+    assert.equal("landing" in result.items[0].stages, false);
+});
+
 test("updates plan status from linked live gates", () => {
     const triage = normalizeTriageInput({
         schemaVersion: 1,
@@ -208,6 +242,38 @@ test("updates plan status from linked live gates", () => {
 
     assert.equal(result.plan[0].liveStatus, "done");
     assert.equal(result.plan[0].horizon, "today");
+});
+
+test("blocks downstream plan steps until dependencies complete", () => {
+    const triage = normalizeTriageInput({
+        schemaVersion: 1,
+        repo: "openclaw/openclaw-windows-node",
+        title: "Global triage",
+        scope: "All open work",
+        generatedAt: "2026-09-03T22:00:00Z",
+        items: [inputItem()],
+        plan: [
+            {
+                id: "prove",
+                title: "Prove the PR",
+                itemNumbers: [1308],
+                gates: [],
+                status: "pending",
+            },
+            {
+                id: "land",
+                title: "Land the PR",
+                dependsOn: ["prove"],
+                itemNumbers: [1308],
+                gates: [{ itemNumber: 1308, stage: "landing" }],
+                status: "pending",
+            },
+        ],
+    });
+    const result = mergeLiveState(triage, [livePr()], []);
+
+    assert.equal(result.plan[0].liveStatus, "pending");
+    assert.equal(result.plan[1].liveStatus, "blocked");
 });
 
 test("builds sequential and independent dependency lanes", () => {
@@ -362,6 +428,8 @@ test("the renderer exposes live filters and guarded action controls", () => {
     assert.match(html, /aria-describedby/);
     assert.match(html, /Why merge is blocked for/);
     assert.match(html, /Request next step for/);
+    assert.match(html, /if \(item\.type === "pr"\)/);
+    assert.match(html, /Complete dependencies first/);
     assert.match(html, /EventSource/);
 });
 

--- a/.github/extensions/openclaw-triage-dashboard/triage-state.test.mjs
+++ b/.github/extensions/openclaw-triage-dashboard/triage-state.test.mjs
@@ -8,6 +8,7 @@ import {
     normalizeTriageInput,
     summarizeChecks,
 } from "./triage-state.mjs";
+import { buildSubsessionRoutingPrompt } from "./triage-actions.mjs";
 import { renderDashboardHtml } from "./triage-ui.mjs";
 
 function inputItem(overrides = {}) {
@@ -211,13 +212,45 @@ test("the renderer exposes live filters and guarded action controls", () => {
     assert.match(html, /EventSource/);
 });
 
+test("item actions route to one reusable child session", () => {
+    const routing = buildSubsessionRoutingPrompt(
+        "openclaw/openclaw-windows-node",
+        { type: "pr", number: 1158 },
+        "Refresh the evidence.",
+    );
+
+    assert.equal(routing.sessionName, "Triage PR #1158");
+    assert.match(routing.prompt, /list_projects/);
+    assert.match(routing.prompt, /project_id/);
+    assert.match(routing.prompt, /list_sessions_and_chats/);
+    assert.match(routing.prompt, /send_session_message/);
+    assert.match(routing.prompt, /create_session/);
+    assert.match(routing.prompt, /Do not create a duplicate session/);
+    assert.match(routing.prompt, /Refresh the evidence/);
+});
+
+test("issue actions use a distinct stable child session name", () => {
+    const routing = buildSubsessionRoutingPrompt(
+        "openclaw/openclaw-windows-node",
+        { type: "issue", number: 42 },
+        "Assess the issue.",
+    );
+
+    assert.equal(routing.sessionName, "Triage Issue #42");
+    assert.match(routing.prompt, /openclaw\/openclaw-windows-node Issue #42/);
+});
+
 test("the extension contains no direct GitHub mutation command", () => {
     const source = readFileSync(new URL("./extension.mjs", import.meta.url), "utf8");
+    const actionSource = readFileSync(new URL("./triage-actions.mjs", import.meta.url), "utf8");
 
-    assert.doesNotMatch(
-        source,
-        /["'](?:pr|issue)["']\s*,\s*["'](?:merge|close|comment|edit|reopen)["']/,
-    );
-    assert.doesNotMatch(source, /["']run["']\s*,\s*["']rerun["']/);
-    assert.doesNotMatch(source, /gh\s+pr\s+merge/i);
+    for (const candidate of [source, actionSource]) {
+        assert.doesNotMatch(
+            candidate,
+            /["'](?:pr|issue)["']\s*,\s*["'](?:merge|close|comment|edit|reopen)["']/,
+        );
+        assert.doesNotMatch(candidate, /["']run["']\s*,\s*["']rerun["']/);
+        assert.doesNotMatch(candidate, /gh\s+pr\s+merge/i);
+    }
+    assert.equal(source.match(/copilotSession\.send/g)?.length, 1);
 });

--- a/.github/extensions/openclaw-triage-dashboard/triage-ui.mjs
+++ b/.github/extensions/openclaw-triage-dashboard/triage-ui.mjs
@@ -3,6 +3,7 @@ import {
     limitLaneLevels,
     limitPlanRows,
 } from "./triage-plan.mjs";
+import { itemDependencyBlocker } from "./triage-actions.mjs";
 
 export function renderDashboardHtml() {
     return `<!doctype html>
@@ -562,6 +563,7 @@ export function renderDashboardHtml() {
     ${buildPlanLanes.toString()}
     ${limitLaneLevels.toString()}
     ${limitPlanRows.toString()}
+    ${itemDependencyBlocker.toString()}
     let state = null;
     let selectedType = "pr";
     let visiblePlanRowCount = 12;
@@ -1080,7 +1082,12 @@ export function renderDashboardHtml() {
           stages.append(element("span", "stage status-" + value, name + " " + statusLabel(value)));
         }
 
-        const controls = createItemActions(item);
+        const controls = createItemActions(
+          item,
+          false,
+          "item",
+          itemDependencyBlocker(state, item.number),
+        );
         footer.append(stages, controls.actions);
         row.append(footer);
         if (controls.gate) row.append(controls.gate);

--- a/.github/extensions/openclaw-triage-dashboard/triage-ui.mjs
+++ b/.github/extensions/openclaw-triage-dashboard/triage-ui.mjs
@@ -1,0 +1,790 @@
+function escapeScriptValue(value) {
+    return JSON.stringify(value).replaceAll("<", "\\u003c");
+}
+
+export function renderDashboardHtml(actionToken) {
+    return `<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>OpenClaw triage</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --github-bg: var(--bgColor-default, var(--background-color-default, Canvas));
+      --github-inset: var(--bgColor-inset, color-mix(in srgb, CanvasText 4%, Canvas));
+      --github-muted: var(--fgColor-muted, var(--text-color-muted, GrayText));
+      --github-border: var(--borderColor-default, var(--border-color-default, ButtonBorder));
+      --github-border-muted: var(--borderColor-muted, var(--border-color-default, ButtonBorder));
+      --github-accent: var(--fgColor-accent, var(--true-color-blue, #0969da));
+      --github-open: var(--fgColor-open, var(--true-color-green, #1a7f37));
+      --github-danger: var(--fgColor-danger, var(--true-color-red, #cf222e));
+      --github-attention: var(--fgColor-attention, var(--true-color-yellow, #9a6700));
+      --github-button: var(--button-default-bgColor-rest, var(--background-color-default, ButtonFace));
+      --github-button-hover: var(--button-default-bgColor-hover, color-mix(in srgb, CanvasText 8%, Canvas));
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: var(--github-bg);
+      color: var(--fgColor-default, var(--text-color-default, CanvasText));
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      font-size: var(--text-body-medium, 14px);
+      line-height: var(--leading-body-medium, 20px);
+    }
+    button, input, select { font: inherit; }
+    button:focus-visible, input:focus-visible, select:focus-visible, a:focus-visible {
+      outline: 2px solid var(--color-focus-outline, Highlight);
+      outline-offset: 2px;
+    }
+    main { max-width: 1012px; margin: 0 auto; padding: 24px 16px 48px; }
+    header { display: flex; align-items: baseline; justify-content: space-between; gap: 16px; }
+    .header-status { display: flex; align-items: center; gap: 8px; flex-shrink: 0; }
+    h1 {
+      margin: 0 0 2px;
+      font-family: var(--font-sans-display, var(--font-sans, "Segoe UI", sans-serif));
+      font-size: var(--text-title-medium, 20px);
+      line-height: var(--leading-title-medium, 26px);
+      font-weight: var(--font-weight-semibold, 600);
+    }
+    h2 {
+      margin: 20px 0 8px;
+      font-size: var(--text-body-medium, 14px);
+      line-height: var(--leading-body-medium, 20px);
+      font-weight: var(--font-weight-semibold, 600);
+    }
+    p { margin: 0; }
+    .muted { color: var(--github-muted); }
+    .tabs {
+      display: flex;
+      gap: 8px;
+      margin-top: 16px;
+      overflow-x: auto;
+      border-bottom: 1px solid var(--github-border);
+    }
+    .tab {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      min-height: 40px;
+      margin-bottom: -1px;
+      padding: 8px 10px;
+      border: 0;
+      border-bottom: 2px solid transparent;
+      background: transparent;
+      color: var(--github-muted);
+      font: inherit;
+      white-space: nowrap;
+      cursor: pointer;
+    }
+    .tab:hover { color: inherit; border-bottom-color: var(--github-border); }
+    .tab[aria-selected="true"] {
+      color: inherit;
+      border-bottom-color: var(--underlineNav-borderColor-active, #fd8c73);
+      font-weight: 600;
+    }
+    .tab-count {
+      min-width: 20px;
+      padding: 0 6px;
+      border-radius: 999px;
+      background: color-mix(in srgb, CanvasText 10%, transparent);
+      font-size: 12px;
+      font-weight: 500;
+      line-height: 20px;
+      text-align: center;
+    }
+    .tab-panel { padding-top: 16px; }
+    .metrics {
+      display: block;
+      margin-bottom: 10px;
+      color: var(--github-muted);
+      font-size: 12px;
+    }
+    .toolbar {
+      display: flex;
+      align-items: center;
+      margin-bottom: 16px;
+    }
+    .control {
+      min-height: 32px;
+      border: 1px solid var(--github-border);
+      border-radius: 6px;
+      background: var(--github-button);
+      color: inherit;
+      padding: 5px 12px;
+      font-weight: 500;
+      box-shadow: 0 1px 0 color-mix(in srgb, CanvasText 4%, transparent);
+    }
+    .search-wrap {
+      position: relative;
+      display: flex;
+      flex: 1;
+      align-items: center;
+    }
+    .search-wrap svg {
+      position: absolute;
+      left: 12px;
+      width: 16px;
+      height: 16px;
+      color: var(--github-muted);
+      pointer-events: none;
+    }
+    input.control {
+      width: 100%;
+      min-width: 220px;
+      background: var(--github-bg);
+      padding-left: 36px;
+      font-weight: 400;
+      box-shadow: inset 0 1px 0 color-mix(in srgb, CanvasText 4%, transparent);
+    }
+    .select-wrap { position: relative; display: inline-flex; align-items: center; }
+    .select-wrap select { appearance: none; padding-right: 30px; cursor: pointer; }
+    .select-wrap svg {
+      position: absolute;
+      right: 10px;
+      width: 12px;
+      height: 12px;
+      color: var(--github-muted);
+      pointer-events: none;
+    }
+    .list-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      min-height: 49px;
+      padding: 8px 16px;
+      border: 1px solid var(--github-border);
+      border-radius: 6px 6px 0 0;
+      background: var(--github-inset);
+    }
+    .type-toggle { display: flex; align-items: center; gap: 18px; }
+    .type-toggle button {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      border: 0;
+      background: transparent;
+      color: var(--github-muted);
+      font: inherit;
+      cursor: pointer;
+    }
+    .type-toggle button:hover { color: inherit; }
+    .type-toggle button[aria-pressed="true"] { color: inherit; font-weight: 600; }
+    .type-toggle svg { width: 16px; height: 16px; }
+    .type-count { color: var(--github-muted); font-weight: 400; }
+    .filter-controls { display: flex; align-items: center; margin-right: -8px; }
+    .filter-controls .control {
+      min-height: 32px;
+      border: 0;
+      background: transparent;
+      padding-left: 10px;
+      box-shadow: none;
+      font-weight: 400;
+    }
+    .filter-controls .control:hover { color: var(--github-accent); }
+    button.control { cursor: pointer; }
+    button.control:hover:not(:disabled) {
+      background: var(--github-button-hover);
+    }
+    button.primary {
+      border-color: var(--color-focus-outline, Highlight);
+      background: var(--color-focus-outline, Highlight);
+      color: var(--color-white, HighlightText);
+    }
+    button:disabled { cursor: not-allowed; opacity: 0.55; }
+    .icon-control {
+      display: inline-grid;
+      place-items: center;
+      width: 28px;
+      min-height: 28px;
+      padding: 0;
+    }
+    .icon-control svg { width: 16px; height: 16px; }
+    .icon-control:disabled svg { animation: refresh-spin 800ms linear infinite; }
+    @keyframes refresh-spin { to { transform: rotate(360deg); } }
+    @media (prefers-reduced-motion: reduce) {
+      .icon-control:disabled svg { animation: none; }
+    }
+    .plan, .items {
+      border: 1px solid var(--github-border);
+      border-radius: 6px;
+      overflow: hidden;
+    }
+    .items { border-top: 0; border-radius: 0 0 6px 6px; }
+    .plan-row, .item {
+      border-bottom: 1px solid var(--github-border-muted);
+      padding: 12px 16px;
+    }
+    .plan-row:last-child, .item:last-child { border-bottom: 0; }
+    .plan-row { display: grid; grid-template-columns: 84px 1fr; align-items: start; gap: 10px; }
+    .plan-row p { margin-top: 1px; }
+    .report-box {
+      border: 1px solid var(--github-border);
+      border-radius: 6px;
+      overflow: hidden;
+    }
+    .report-row {
+      display: grid;
+      grid-template-columns: minmax(140px, 24%) 1fr;
+      gap: 16px;
+      padding: 12px 16px;
+      border-bottom: 1px solid var(--github-border-muted);
+    }
+    .report-row:last-child { border-bottom: 0; }
+    .report-row strong { font-weight: 600; }
+    .report-fields { display: grid; gap: 3px; }
+    .report-field { color: var(--github-muted); }
+    .report-field b { color: inherit; font-weight: 600; }
+    .numbered-list { margin: 0; padding: 8px 16px 8px 44px; }
+    .numbered-list li { padding: 5px 0 5px 4px; }
+    .empty-state { padding: 32px 16px; color: var(--github-muted); text-align: center; }
+    .item:hover { background: var(--github-inset); }
+    .item-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; min-width: 0; }
+    .item-heading-main { display: flex; align-items: center; gap: 6px; min-width: 0; }
+    .item-icon { width: 16px; height: 16px; flex: 0 0 16px; color: var(--github-open); }
+    .item-title { color: inherit; font-weight: 600; text-decoration: none; }
+    .item-title:hover { color: var(--github-accent); }
+    .item-decision {
+      flex-shrink: 0;
+      color: var(--github-muted);
+      font-size: var(--text-body-medium, 14px);
+      line-height: var(--leading-body-medium, 20px);
+      white-space: nowrap;
+    }
+    .badges, .stages, .actions { display: flex; flex-wrap: wrap; gap: 5px; }
+    .badge, .stage {
+      display: inline-flex;
+      align-items: center;
+      min-height: 20px;
+      border: 1px solid transparent;
+      border-radius: 999px;
+      padding: 1px 7px;
+      font-size: var(--text-caption, 12px);
+      line-height: 16px;
+      white-space: nowrap;
+    }
+    .label-pr { display: none; }
+    .label-success {
+      border-color: color-mix(in srgb, var(--github-open) 30%, transparent);
+      background: color-mix(in srgb, var(--github-open) 12%, transparent);
+      color: var(--github-open);
+    }
+    .label-attention {
+      border-color: color-mix(in srgb, var(--github-attention) 35%, transparent);
+      background: color-mix(in srgb, var(--github-attention) 13%, transparent);
+      color: var(--github-attention);
+    }
+    .label-danger {
+      border-color: color-mix(in srgb, var(--github-danger) 30%, transparent);
+      background: color-mix(in srgb, var(--github-danger) 10%, transparent);
+      color: var(--github-danger);
+    }
+    .status-done { color: var(--true-color-green, #1a7f37); }
+    .status-in_progress, .status-pending { color: var(--true-color-blue, #0969da); }
+    .status-blocked { color: var(--true-color-red, #cf222e); }
+    .item-meta { display: flex; flex-wrap: wrap; gap: 4px 12px; margin-top: 4px; font-size: var(--text-caption, 12px); }
+    .item-body { margin-top: 4px; max-width: 100ch; }
+    .item-footer { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-top: 6px; }
+    .stage { border: 0; padding: 0; }
+    .stage::before { content: "●"; margin-right: 4px; font-size: 8px; }
+    .actions { flex-shrink: 0; }
+    .actions button { min-height: 26px; padding: 2px 8px; font-size: var(--text-caption, 12px); }
+    .gate { margin-top: 5px; color: var(--github-muted); font-size: var(--text-caption, 12px); }
+    .gate summary { cursor: pointer; }
+    .gate p { margin-top: 3px; }
+    .error {
+      margin-top: 16px;
+      border-left: 3px solid var(--true-color-red, #cf222e);
+      padding: 8px 12px;
+    }
+    .notice {
+      position: fixed;
+      right: 20px;
+      bottom: 20px;
+      max-width: 420px;
+      border: 1px solid var(--border-color-default, ButtonBorder);
+      border-radius: 8px;
+      background: var(--background-color-default, Canvas);
+      box-shadow: 0 8px 24px color-mix(in srgb, CanvasText 15%, transparent);
+      padding: 12px 14px;
+    }
+    .hidden { display: none; }
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+    @media (max-width: 700px) {
+      main { padding: 14px 12px 40px; }
+      header { display: block; }
+      .item-head, .item-heading-main { flex-wrap: wrap; }
+      .item-decision { margin-left: auto; }
+      .plan-row { grid-template-columns: 1fr; gap: 6px; }
+      .report-row { grid-template-columns: 1fr; gap: 4px; }
+      .item-footer { align-items: flex-start; flex-direction: column; }
+      .list-header { align-items: flex-start; flex-direction: column; gap: 6px; }
+      .filter-controls { width: 100%; margin: 0; overflow-x: auto; }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <div>
+        <h1 id="title">OpenClaw triage</h1>
+        <p id="scope" class="muted">Loading current triage state...</p>
+      </div>
+      <div class="header-status">
+        <p id="updated" class="muted"></p>
+        <button id="refresh" class="control icon-control" type="button" aria-label="Refresh GitHub status" title="Refresh GitHub status">
+          <svg viewBox="0 0 16 16" aria-hidden="true">
+            <path fill="currentColor" d="M8 2.5a5.5 5.5 0 0 0-5.19 3.67.75.75 0 1 1-1.42-.5A7 7 0 0 1 12.6 2.74V1.5a.75.75 0 0 1 1.5 0v3.25a.75.75 0 0 1-.75.75H10.1a.75.75 0 0 1 0-1.5h1.48A5.48 5.48 0 0 0 8 2.5Zm6.13 7.08a.75.75 0 0 1 .48.95A7 7 0 0 1 3.4 13.26v1.24a.75.75 0 0 1-1.5 0v-3.25a.75.75 0 0 1 .75-.75H5.9a.75.75 0 0 1 0 1.5H4.42A5.5 5.5 0 0 0 13.18 10a.75.75 0 0 1 .95-.42Z"/>
+          </svg>
+        </button>
+      </div>
+    </header>
+    <div id="error" class="error hidden" role="alert"></div>
+    <nav class="tabs" role="tablist" aria-label="Triage report sections">
+      <button class="tab" role="tab" aria-selected="true" aria-controls="tab-items" data-tab="items">Items <span id="count-items" class="tab-count">0</span></button>
+      <button class="tab" role="tab" aria-selected="false" aria-controls="tab-landing" data-tab="landing">Landing plan <span id="count-landing" class="tab-count">0</span></button>
+      <button class="tab" role="tab" aria-selected="false" aria-controls="tab-changes" data-tab="changes">Changes <span id="count-changes" class="tab-count">0</span></button>
+      <button class="tab" role="tab" aria-selected="false" aria-controls="tab-queue" data-tab="queue">Queue <span id="count-queue" class="tab-count">0</span></button>
+      <button class="tab" role="tab" aria-selected="false" aria-controls="tab-ownership" data-tab="ownership">Ownership <span id="count-ownership" class="tab-count">0</span></button>
+      <button class="tab" role="tab" aria-selected="false" aria-controls="tab-reviews" data-tab="reviews">Reviews <span id="count-reviews" class="tab-count">0</span></button>
+      <button class="tab" role="tab" aria-selected="false" aria-controls="tab-day-plan" data-tab="day-plan">Day plan <span id="count-day-plan" class="tab-count">0</span></button>
+      <button class="tab" role="tab" aria-selected="false" aria-controls="tab-automation" data-tab="automation">Automation <span id="count-automation" class="tab-count">0</span></button>
+    </nav>
+    <section id="tab-items" class="tab-panel" role="tabpanel">
+      <h2 class="sr-only">Items</h2>
+      <section id="metrics" class="metrics" aria-label="Triage summary"></section>
+      <div class="toolbar">
+        <label class="search-wrap">
+          <span class="sr-only">Search triage items</span>
+          <svg viewBox="0 0 16 16" aria-hidden="true"><path fill="currentColor" d="M10.5 6.5a4 4 0 1 0-8 0 4 4 0 0 0 8 0Zm-.73 4.33a5.5 5.5 0 1 1 1.06-1.06l3.95 3.95a.75.75 0 1 1-1.06 1.06l-3.95-3.95Z"/></svg>
+          <input id="search" class="control" type="search" placeholder="Search all triage items">
+        </label>
+      </div>
+      <div class="list-header">
+        <div class="type-toggle" role="group" aria-label="Item type">
+          <button id="type-pr" type="button" aria-pressed="true" aria-label="Show pull requests">
+            <svg viewBox="0 0 16 16" aria-hidden="true"><path fill="currentColor" d="M1.75 3.5a1.75 1.75 0 1 1 2.5 1.58v5.84a1.75 1.75 0 1 1-1.5 0V5.08A1.75 1.75 0 0 1 1.75 3.5Zm8.5-1.75a.75.75 0 0 1 .75.75v1.75h.25A2.75 2.75 0 0 1 14 7v3.92a1.75 1.75 0 1 1-1.5 0V7c0-.69-.56-1.25-1.25-1.25H11V7.5a.75.75 0 0 1-1.28.53l-2.5-2.5a.75.75 0 0 1 0-1.06l2.5-2.5a.75.75 0 0 1 .53-.22Z"/></svg>
+            Pull requests <span id="type-pr-count" class="type-count">0</span>
+          </button>
+          <button id="type-issue" type="button" aria-pressed="false" aria-label="Show issues">
+            <svg viewBox="0 0 16 16" aria-hidden="true"><path fill="currentColor" d="M8 1.25a6.75 6.75 0 1 1 0 13.5 6.75 6.75 0 0 1 0-13.5Zm0 1.5a5.25 5.25 0 1 0 0 10.5 5.25 5.25 0 0 0 0-10.5Zm0 7.5a1 1 0 1 1 0 2 1 1 0 0 1 0-2Zm.75-5.5v4h-1.5v-4h1.5Z"/></svg>
+            Issues <span id="type-issue-count" class="type-count">0</span>
+          </button>
+        </div>
+        <div class="filter-controls">
+          <span class="select-wrap"><select id="verdict-filter" class="control" aria-label="Filter by verdict">
+            <option value="all">Verdict</option>
+          </select><svg viewBox="0 0 16 16" aria-hidden="true"><path fill="currentColor" d="M4.4 6.2a.75.75 0 0 1 1.05 0L8 8.75l2.55-2.55a.75.75 0 0 1 1.05 1.06l-3.08 3.08a.75.75 0 0 1-1.04 0L4.4 7.26a.75.75 0 0 1 0-1.06Z"/></svg></span>
+          <span class="select-wrap"><select id="readiness-filter" class="control" aria-label="Filter by readiness">
+            <option value="all">Status</option>
+            <option value="ready">Merge ready</option>
+            <option value="checks">Checks running</option>
+            <option value="proof">Needs proof</option>
+            <option value="blocked">Blocked</option>
+          </select><svg viewBox="0 0 16 16" aria-hidden="true"><path fill="currentColor" d="M4.4 6.2a.75.75 0 0 1 1.05 0L8 8.75l2.55-2.55a.75.75 0 0 1 1.05 1.06l-3.08 3.08a.75.75 0 0 1-1.04 0L4.4 7.26a.75.75 0 0 1 0-1.06Z"/></svg></span>
+          <span class="select-wrap"><select id="sort" class="control" aria-label="Sort items">
+            <option value="confidence-desc">Sort: confidence</option>
+            <option value="confidence-asc">Lowest confidence</option>
+            <option value="number-desc">Newest</option>
+          </select><svg viewBox="0 0 16 16" aria-hidden="true"><path fill="currentColor" d="M4.4 6.2a.75.75 0 0 1 1.05 0L8 8.75l2.55-2.55a.75.75 0 0 1 1.05 1.06l-3.08 3.08a.75.75 0 0 1-1.04 0L4.4 7.26a.75.75 0 0 1 0-1.06Z"/></svg></span>
+        </div>
+      </div>
+      <div id="items" class="items"></div>
+    </section>
+    <section id="tab-landing" class="tab-panel hidden" role="tabpanel">
+      <div id="plan" class="plan"></div>
+    </section>
+    <section id="tab-changes" class="tab-panel hidden" role="tabpanel"><div id="changes" class="report-box"></div></section>
+    <section id="tab-queue" class="tab-panel hidden" role="tabpanel"><div id="queue" class="report-box"></div></section>
+    <section id="tab-ownership" class="tab-panel hidden" role="tabpanel"><div id="ownership" class="report-box"></div></section>
+    <section id="tab-reviews" class="tab-panel hidden" role="tabpanel"><div id="reviews" class="report-box"></div></section>
+    <section id="tab-day-plan" class="tab-panel hidden" role="tabpanel"><div id="day-plan" class="report-box"></div></section>
+    <section id="tab-automation" class="tab-panel hidden" role="tabpanel"><div id="automation" class="report-box"></div></section>
+  </main>
+  <div id="notice" class="notice hidden" role="status"></div>
+  <script>
+    const actionToken = ${escapeScriptValue(actionToken)};
+    let state = null;
+    let selectedType = "pr";
+
+    function element(tag, className, text) {
+      const node = document.createElement(tag);
+      if (className) node.className = className;
+      if (text != null) node.textContent = text;
+      return node;
+    }
+
+    function itemIcon(type) {
+      const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+      svg.setAttribute("class", "item-icon");
+      svg.setAttribute("viewBox", "0 0 16 16");
+      svg.setAttribute("aria-hidden", "true");
+      const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+      path.setAttribute("fill", "currentColor");
+      path.setAttribute("d", type === "pr"
+        ? "M1.75 3.5a1.75 1.75 0 1 1 2.5 1.58v5.84a1.75 1.75 0 1 1-1.5 0V5.08A1.75 1.75 0 0 1 1.75 3.5Zm8.5-1.75a.75.75 0 0 1 .75.75v1.75h.25A2.75 2.75 0 0 1 14 7v3.92a1.75 1.75 0 1 1-1.5 0V7c0-.69-.56-1.25-1.25-1.25H11V7.5a.75.75 0 0 1-1.28.53l-2.5-2.5a.75.75 0 0 1 0-1.06l2.5-2.5a.75.75 0 0 1 .53-.22Z"
+        : "M8 1.25a6.75 6.75 0 1 1 0 13.5 6.75 6.75 0 0 1 0-13.5Zm0 1.5a5.25 5.25 0 1 0 0 10.5 5.25 5.25 0 0 0 0-10.5Zm0 7.5a1 1 0 1 1 0 2 1 1 0 0 1 0-2Zm.75-5.5v4h-1.5v-4h1.5Z");
+      svg.append(path);
+      return svg;
+    }
+
+    function showNotice(message) {
+      const notice = document.getElementById("notice");
+      notice.textContent = message;
+      notice.classList.remove("hidden");
+      window.clearTimeout(showNotice.timer);
+      showNotice.timer = window.setTimeout(() => notice.classList.add("hidden"), 5000);
+    }
+
+    function statusLabel(value) {
+      return String(value || "pending").replace("_", " ");
+    }
+
+    function readiness(item) {
+      if (item.mergeRequest.eligible) return { label: "Ready", variant: "success" };
+      if (item.decision === "NEEDS_INFO") return { label: "Decision needed", variant: "attention" };
+      if (item.decision === "HOLD_FOR_AUTHOR" || item.decision === "DECLINE") {
+        return { label: "Code blocked", variant: "danger" };
+      }
+      if (item.proofStatus === "required" || item.proofStatus === "blocked") {
+        return { label: "Needs proof", variant: "attention" };
+      }
+      if (item.checks && item.checks.pending > 0) return { label: "CI running", variant: "attention" };
+      return { label: "Maintainer review", variant: "attention" };
+    }
+
+    function renderMetrics(summary) {
+      const root = document.getElementById("metrics");
+      root.textContent = summary.total + " items · " +
+        summary.ready + " merge ready · " +
+        summary.checksRunning + " checks running · " +
+        summary.needsProof + " need proof · " +
+        summary.blocked + " blocked";
+    }
+
+    function renderPlan(plan) {
+      const root = document.getElementById("plan");
+      root.replaceChildren();
+      if (!plan.length) {
+        root.append(element("p", "plan-row muted", "No landing plan was supplied."));
+        return;
+      }
+      for (const step of plan) {
+        const row = element("div", "plan-row");
+        row.append(element("span", "badge status-" + step.liveStatus, statusLabel(step.liveStatus)));
+        const body = element("div");
+        body.append(element("strong", "", step.title));
+        if (step.detail) body.append(element("p", "muted", step.detail));
+        row.append(body);
+        root.append(row);
+      }
+    }
+
+    function renderEmpty(root, message) {
+      root.replaceChildren(element("p", "empty-state", message));
+    }
+
+    function renderNumbered(rootId, entries, emptyMessage) {
+      const root = document.getElementById(rootId);
+      root.replaceChildren();
+      if (!entries.length) {
+        renderEmpty(root, emptyMessage);
+        return;
+      }
+      const list = element("ol", "numbered-list");
+      for (const entry of entries) list.append(element("li", "", entry));
+      root.append(list);
+    }
+
+    function renderRecords(rootId, entries, primaryKey, fields, emptyMessage) {
+      const root = document.getElementById(rootId);
+      root.replaceChildren();
+      if (!entries.length) {
+        renderEmpty(root, emptyMessage);
+        return;
+      }
+      for (const entry of entries) {
+        const row = element("div", "report-row");
+        row.append(element("strong", "", entry[primaryKey] || "—"));
+        const details = element("div", "report-fields");
+        for (const [key, label] of fields) {
+          if (!entry[key]) continue;
+          const field = element("div", "report-field");
+          field.append(element("b", "", label + ": "), document.createTextNode(entry[key]));
+          details.append(field);
+        }
+        row.append(details);
+        root.append(row);
+      }
+    }
+
+    function renderReport(report) {
+      renderRecords("changes", report.changes, "change", [["items", "Items"]], "No change summary was supplied.");
+      renderNumbered("queue", report.executiveQueue, "No executive queue was supplied.");
+      renderRecords("ownership", report.ownership, "item", [["assessment", "Assessment"]], "No ownership audit was supplied.");
+      renderRecords(
+        "reviews",
+        report.reviews,
+        "item",
+        [["title", "Title"], ["decision", "Decision"], ["summary", "Assessment"]],
+        "No adversarial review summary was supplied.",
+      );
+      renderNumbered("day-plan", report.dayPlan, "No day plan was supplied.");
+      renderRecords(
+        "automation",
+        report.automation,
+        "opportunity",
+        [["why", "Why"], ["owner", "Owner"], ["effort", "Effort"], ["notes", "Notes"]],
+        "No automation opportunities were supplied.",
+      );
+      const counts = {
+        items: state.items.length,
+        landing: state.plan.length,
+        changes: report.changes.length,
+        queue: report.executiveQueue.length,
+        ownership: report.ownership.length,
+        reviews: report.reviews.length,
+        "day-plan": report.dayPlan.length,
+        automation: report.automation.length,
+      };
+      for (const [name, count] of Object.entries(counts)) {
+        document.getElementById("count-" + name).textContent = String(count);
+      }
+    }
+
+    function selectTab(name) {
+      for (const tab of document.querySelectorAll("[data-tab]")) {
+        const selected = tab.dataset.tab === name;
+        tab.setAttribute("aria-selected", String(selected));
+        tab.tabIndex = selected ? 0 : -1;
+        document.getElementById("tab-" + tab.dataset.tab).classList.toggle("hidden", !selected);
+      }
+    }
+
+    function itemMatches(item) {
+      const query = document.getElementById("search").value.trim().toLowerCase();
+      const verdictFilter = document.getElementById("verdict-filter").value;
+      const readinessFilter = document.getElementById("readiness-filter").value;
+      const haystack = [item.number, item.title, item.owner, item.decision, item.nextAction].join(" ").toLowerCase();
+      if (query && !haystack.includes(query)) return false;
+      if (item.type !== selectedType) return false;
+      if (verdictFilter !== "all" && item.decision !== verdictFilter) return false;
+      if (readinessFilter === "ready") return item.mergeRequest.eligible;
+      if (readinessFilter === "checks") return item.checks && item.checks.pending > 0;
+      if (readinessFilter === "proof") return item.proofStatus === "required" || item.proofStatus === "blocked";
+      if (readinessFilter === "blocked") return Object.values(item.stages).includes("blocked");
+      return true;
+    }
+
+    function sortItems(items) {
+      const sort = document.getElementById("sort").value;
+      return [...items].sort((left, right) => {
+        if (sort === "confidence-asc") {
+          return left.takeConfidence - right.takeConfidence || right.number - left.number;
+        }
+        if (sort === "number-desc") return right.number - left.number;
+        return right.takeConfidence - left.takeConfidence || right.number - left.number;
+      });
+    }
+
+    function renderVerdictOptions(items) {
+      const select = document.getElementById("verdict-filter");
+      const selected = select.value;
+      const verdicts = [...new Set(items.map((item) => item.decision))].sort();
+      select.replaceChildren(new Option("Verdict", "all"));
+      for (const verdict of verdicts) {
+        select.append(new Option(verdict, verdict));
+      }
+      select.value = verdicts.includes(selected) ? selected : "all";
+    }
+
+    async function post(path, body) {
+      const response = await fetch(path, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Triage-Token": actionToken,
+        },
+        body: JSON.stringify(body),
+      });
+      const result = await response.json();
+      if (!response.ok) throw new Error(result.error || "Request failed");
+      return result;
+    }
+
+    function renderItems(items) {
+      const root = document.getElementById("items");
+      root.replaceChildren();
+      const visible = sortItems(items.filter(itemMatches));
+      if (!visible.length) {
+        root.append(element("p", "item muted", "No items match this filter."));
+        return;
+      }
+
+      for (const item of visible) {
+        const itemReadiness = readiness(item);
+        const row = element("article", "item status-" + itemReadiness.variant);
+        const head = element("div", "item-head");
+        const headingMain = element("div", "item-heading-main");
+        const link = element("a", "item-title", "#" + item.number + " " + item.title);
+        link.href = item.url;
+        link.target = "_blank";
+        link.rel = "noreferrer";
+        headingMain.append(
+          itemIcon(item.type),
+          element("span", "badge label-" + itemReadiness.variant, itemReadiness.label),
+          link,
+        );
+        head.append(
+          headingMain,
+          element("span", "item-decision", item.decision + " · " + item.takeConfidence + "% take"),
+        );
+        row.append(head);
+
+        const meta = element("div", "item-meta muted");
+        meta.append(
+          element("span", "", item.owner),
+          element("span", "", (item.risk || "Unknown") + " risk"),
+          element("span", "", item.live ? String(item.live.mergeStateStatus || item.live.state) : "Live unavailable"),
+        );
+        if (item.checks) {
+          meta.append(element("span", "", item.checks.passed + " passed · " +
+            item.checks.failed + " failed · " + item.checks.pending + " pending"));
+        }
+        row.append(meta, element("p", "item-body", item.nextAction));
+
+        const footer = element("div", "item-footer");
+        const stages = element("div", "stages");
+        for (const [name, value] of Object.entries(item.stages)) {
+          stages.append(element("span", "stage status-" + value, name + " " + statusLabel(value)));
+        }
+
+        const actions = element("div", "actions");
+        const next = element("button", "control", "Request next step");
+        next.type = "button";
+        next.addEventListener("click", async () => {
+          next.disabled = true;
+          try {
+            await post("/action", { action: "request_next_action", number: item.number });
+            showNotice("Next-step request sent to this Copilot session.");
+          } catch (error) {
+            showNotice(error.message);
+          } finally {
+            next.disabled = false;
+          }
+        });
+        const merge = element("button", "control primary", "Prepare merge");
+        merge.type = "button";
+        merge.disabled = !item.mergeRequest.eligible;
+        merge.title = item.mergeRequest.eligible ? "Request fresh merge verification in chat" : item.mergeRequest.reasons.join("; ");
+        merge.addEventListener("click", async () => {
+          merge.disabled = true;
+          try {
+            await post("/action", {
+              action: "request_merge",
+              number: item.number,
+              headSha: item.live.headRefOid,
+            });
+            showNotice("Guarded merge request sent to this Copilot session.");
+          } catch (error) {
+            showNotice(error.message);
+            merge.disabled = false;
+          }
+        });
+        actions.append(next, merge);
+        footer.append(stages, actions);
+        row.append(footer);
+        if (!item.mergeRequest.eligible && item.mergeRequest.reasons.length) {
+          const gate = element("details", "gate");
+          gate.append(
+            element("summary", "", "Why merge is blocked"),
+            element("p", "", item.mergeRequest.reasons.join("; ")),
+          );
+          row.append(gate);
+        }
+        root.append(row);
+      }
+    }
+
+    function render(nextState) {
+      state = nextState;
+      document.getElementById("title").textContent = state.title;
+      document.getElementById("scope").textContent = state.scope;
+      document.getElementById("updated").textContent = "Live " +
+        new Date(state.liveUpdatedAt).toLocaleTimeString();
+      const error = document.getElementById("error");
+      error.textContent = state.refreshError || "";
+      error.classList.toggle("hidden", !state.refreshError);
+      renderMetrics(state.summary);
+      document.getElementById("type-pr-count").textContent =
+        String(state.items.filter((item) => item.type === "pr").length);
+      document.getElementById("type-issue-count").textContent =
+        String(state.items.filter((item) => item.type === "issue").length);
+      renderPlan(state.plan);
+      renderReport(state.report);
+      renderVerdictOptions(state.items);
+      renderItems(state.items);
+    }
+
+    async function loadState() {
+      const response = await fetch("/state", { cache: "no-store" });
+      if (!response.ok) throw new Error("Unable to load triage state");
+      render(await response.json());
+    }
+
+    document.getElementById("search").addEventListener("input", () => state && renderItems(state.items));
+    for (const id of ["verdict-filter", "readiness-filter", "sort"]) {
+      document.getElementById(id).addEventListener("change", () => state && renderItems(state.items));
+    }
+    for (const type of ["pr", "issue"]) {
+      document.getElementById("type-" + type).addEventListener("click", () => {
+        selectedType = type;
+        document.getElementById("type-pr").setAttribute("aria-pressed", String(type === "pr"));
+        document.getElementById("type-issue").setAttribute("aria-pressed", String(type === "issue"));
+        if (state) renderItems(state.items);
+      });
+    }
+    for (const tab of document.querySelectorAll("[data-tab]")) {
+      tab.addEventListener("click", () => selectTab(tab.dataset.tab));
+      tab.addEventListener("keydown", (event) => {
+        if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
+        const tabs = [...document.querySelectorAll("[data-tab]")];
+        const offset = event.key === "ArrowRight" ? 1 : -1;
+        const next = tabs[(tabs.indexOf(tab) + offset + tabs.length) % tabs.length];
+        selectTab(next.dataset.tab);
+        next.focus();
+      });
+    }
+    document.getElementById("refresh").addEventListener("click", async (event) => {
+      event.currentTarget.disabled = true;
+      try {
+        const result = await post("/refresh", {});
+        render(result.state);
+        showNotice("GitHub status refreshed.");
+      } catch (error) {
+        showNotice(error.message);
+      } finally {
+        event.currentTarget.disabled = false;
+      }
+    });
+
+    const events = new EventSource("/events");
+    events.addEventListener("state", (event) => render(JSON.parse(event.data)));
+    events.addEventListener("error", () => showNotice("Live updates disconnected. Use Refresh now to retry."));
+    loadState().catch((error) => showNotice(error.message));
+  </script>
+</body>
+</html>`;
+}

--- a/.github/extensions/openclaw-triage-dashboard/triage-ui.mjs
+++ b/.github/extensions/openclaw-triage-dashboard/triage-ui.mjs
@@ -4,11 +4,7 @@ import {
     limitPlanRows,
 } from "./triage-plan.mjs";
 
-function escapeScriptValue(value) {
-    return JSON.stringify(value).replaceAll("<", "\\u003c");
-}
-
-export function renderDashboardHtml(actionToken) {
+export function renderDashboardHtml() {
     return `<!doctype html>
 <html>
 <head>
@@ -558,7 +554,11 @@ export function renderDashboardHtml(actionToken) {
   </main>
   <div id="notice" class="notice hidden" role="status"></div>
   <script>
-    const actionToken = ${escapeScriptValue(actionToken)};
+    const actionParameters = new URLSearchParams(window.location.hash.slice(1));
+    const fragmentToken = actionParameters.get("token") || "";
+    if (fragmentToken) sessionStorage.setItem("triageActionToken", fragmentToken);
+    const actionToken = fragmentToken || sessionStorage.getItem("triageActionToken") || "";
+    window.history.replaceState(null, "", window.location.pathname);
     ${buildPlanLanes.toString()}
     ${limitLaneLevels.toString()}
     ${limitPlanRows.toString()}
@@ -1098,8 +1098,9 @@ export function renderDashboardHtml(actionToken) {
       document.getElementById("updated").textContent = "Live " +
         new Date(state.liveUpdatedAt).toLocaleTimeString();
       const error = document.getElementById("error");
-      error.textContent = state.refreshError || "";
-      error.classList.toggle("hidden", !state.refreshError);
+      const refreshMessage = state.refreshError || state.refreshWarning || "";
+      error.textContent = refreshMessage;
+      error.classList.toggle("hidden", !refreshMessage);
       renderMetrics(state.summary);
       document.getElementById("type-pr-count").textContent =
         String(state.items.filter((item) => item.type === "pr").length);
@@ -1113,7 +1114,7 @@ export function renderDashboardHtml(actionToken) {
     }
 
     async function loadState() {
-      const response = await fetch("/state", { cache: "no-store" });
+      const response = await fetch("/state?token=" + encodeURIComponent(actionToken), { cache: "no-store" });
       if (!response.ok) throw new Error("Unable to load triage state");
       render(await response.json());
     }
@@ -1154,7 +1155,7 @@ export function renderDashboardHtml(actionToken) {
       }
     });
 
-    const events = new EventSource("/events");
+    const events = new EventSource("/events?token=" + encodeURIComponent(actionToken));
     events.addEventListener("state", (event) => render(JSON.parse(event.data)));
     events.addEventListener("error", () => showNotice("Live updates disconnected. Use Refresh now to retry."));
     loadState().catch((error) => showNotice(error.message));

--- a/.github/extensions/openclaw-triage-dashboard/triage-ui.mjs
+++ b/.github/extensions/openclaw-triage-dashboard/triage-ui.mjs
@@ -1,3 +1,9 @@
+import {
+    buildPlanLanes,
+    limitLaneLevels,
+    limitPlanRows,
+} from "./triage-plan.mjs";
+
 function escapeScriptValue(value) {
     return JSON.stringify(value).replaceAll("<", "\\u003c");
 }
@@ -207,19 +213,148 @@ export function renderDashboardHtml(actionToken) {
     @media (prefers-reduced-motion: reduce) {
       .icon-control:disabled svg { animation: none; }
     }
-    .plan, .items {
+    .items {
       border: 1px solid var(--github-border);
       border-radius: 6px;
       overflow: hidden;
     }
     .items { border-top: 0; border-radius: 0 0 6px 6px; }
-    .plan-row, .item {
+    .item {
       border-bottom: 1px solid var(--github-border-muted);
       padding: 12px 16px;
     }
-    .plan-row:last-child, .item:last-child { border-bottom: 0; }
-    .plan-row { display: grid; grid-template-columns: 84px 1fr; align-items: start; gap: 10px; }
-    .plan-row p { margin-top: 1px; }
+    .item:last-child { border-bottom: 0; }
+    .plan {
+      display: block;
+    }
+    .plan-overview {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      margin-bottom: 10px;
+      flex-wrap: wrap;
+    }
+    .plan-summary { color: var(--github-muted); font-size: 12px; }
+    .plan-lane {
+      overflow: hidden;
+      border: 1px solid var(--github-border);
+      border-radius: 6px;
+      background: var(--github-bg);
+    }
+    .plan-lane + .plan-lane { margin-top: 16px; }
+    .plan-lane-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+      padding: 8px 12px;
+      border-bottom: 1px solid var(--github-border);
+      background: var(--github-inset);
+      font-size: var(--text-body-medium, 14px);
+    }
+    .plan-lane-header h3 { margin: 0; font-size: inherit; }
+    .plan-lane-kind { color: var(--github-muted); font-size: 12px; }
+    .lane-level {
+      position: relative;
+      display: block;
+    }
+    .plan-node {
+      position: relative;
+      min-width: 0;
+      padding: 12px 16px 12px 40px;
+      border-bottom: 1px solid var(--github-border-muted);
+    }
+    .lane-level:last-child .plan-node:last-child { border-bottom: 0; }
+    .plan-node::before {
+      position: absolute;
+      top: 17px;
+      left: 20px;
+      width: 10px;
+      height: 10px;
+      border: 2px solid var(--github-muted);
+      border-radius: 50%;
+      background: var(--github-bg);
+      content: "";
+      z-index: 1;
+    }
+    .plan-status-done::before {
+      border-color: var(--github-open);
+      background: color-mix(in srgb, var(--github-open) 18%, var(--github-bg));
+    }
+    .plan-status-in_progress::before, .plan-status-pending::before {
+      border-color: var(--github-accent);
+      background: color-mix(in srgb, var(--github-accent) 18%, var(--github-bg));
+    }
+    .plan-status-blocked::before {
+      border-color: var(--github-danger);
+      background: color-mix(in srgb, var(--github-danger) 16%, var(--github-bg));
+    }
+    .plan-lane:not(.plan-lane-independent) .plan-node::after {
+      position: absolute;
+      top: 27px;
+      bottom: -13px;
+      left: 25px;
+      width: 2px;
+      background: var(--github-border);
+      content: "";
+    }
+    .plan-lane:not(.plan-lane-independent) .lane-level:last-child .plan-node:last-child::after {
+      display: none;
+    }
+    .plan-node-head {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+    }
+    .plan-node-heading-main { display: flex; align-items: center; gap: 6px; min-width: 0; }
+    .plan-node-title { color: inherit; font-weight: 600; text-decoration: none; }
+    .plan-node-title[href]:hover { color: var(--github-accent); }
+    .plan-node-decision {
+      display: flex;
+      align-items: flex-end;
+      flex-direction: column;
+      flex-shrink: 0;
+      color: var(--github-muted);
+      white-space: nowrap;
+    }
+    .plan-node-decision a { color: inherit; text-decoration: none; }
+    .plan-node-decision a:hover { color: var(--github-accent); }
+    .plan-node-meta {
+      display: flex;
+      gap: 4px 12px;
+      margin-top: 4px;
+      flex-wrap: wrap;
+      color: var(--github-muted);
+      font-size: 12px;
+    }
+    .plan-node p { margin: 3px 0 0; }
+    .plan-dependencies {
+      display: contents;
+      color: var(--github-muted);
+      font-size: 12px;
+    }
+    .dependency-edge {
+      display: inline;
+    }
+    .plan-actions { margin-top: 6px; }
+    .plan-item-meta + .plan-item-meta { margin-top: 8px; }
+    .plan-node-footer { margin-top: 6px; }
+    .plan-button-groups { display: flex; gap: 8px; flex-wrap: wrap; }
+    .action-item-number { align-self: center; color: var(--github-muted); font-size: 12px; }
+    .plan-action {
+      display: flex;
+      gap: 6px;
+      margin-top: 4px;
+    }
+    .plan-action strong { flex: 0 0 auto; color: var(--github-muted); }
+    .plan-more {
+      display: flex;
+      grid-column: 1 / -1;
+      justify-content: center;
+      gap: 8px;
+    }
     .report-box {
       border: 1px solid var(--github-border);
       border-radius: 6px;
@@ -281,6 +416,16 @@ export function renderDashboardHtml(actionToken) {
       background: color-mix(in srgb, var(--github-danger) 10%, transparent);
       color: var(--github-danger);
     }
+    .label-accent {
+      border-color: color-mix(in srgb, var(--github-accent) 30%, transparent);
+      background: color-mix(in srgb, var(--github-accent) 12%, transparent);
+      color: var(--github-accent);
+    }
+    .label-neutral {
+      border-color: color-mix(in srgb, var(--github-muted) 30%, transparent);
+      background: color-mix(in srgb, var(--github-muted) 10%, transparent);
+      color: var(--github-muted);
+    }
     .status-done { color: var(--true-color-green, #1a7f37); }
     .status-in_progress, .status-pending { color: var(--true-color-blue, #0969da); }
     .status-blocked { color: var(--true-color-red, #cf222e); }
@@ -327,7 +472,8 @@ export function renderDashboardHtml(actionToken) {
       header { display: block; }
       .item-head, .item-heading-main { flex-wrap: wrap; }
       .item-decision { margin-left: auto; }
-      .plan-row { grid-template-columns: 1fr; gap: 6px; }
+      .plan-node-head { align-items: flex-start; flex-direction: column; gap: 4px; }
+      .plan-node-decision { align-items: flex-start; white-space: normal; }
       .report-row { grid-template-columns: 1fr; gap: 4px; }
       .item-footer { align-items: flex-start; flex-direction: column; }
       .list-header { align-items: flex-start; flex-direction: column; gap: 6px; }
@@ -354,12 +500,10 @@ export function renderDashboardHtml(actionToken) {
     <div id="error" class="error hidden" role="alert"></div>
     <nav class="tabs" role="tablist" aria-label="Triage report sections">
       <button class="tab" role="tab" aria-selected="true" aria-controls="tab-items" data-tab="items">Items <span id="count-items" class="tab-count">0</span></button>
-      <button class="tab" role="tab" aria-selected="false" aria-controls="tab-landing" data-tab="landing">Landing plan <span id="count-landing" class="tab-count">0</span></button>
+      <button id="tab-plan-button" class="tab" role="tab" aria-selected="false" aria-controls="tab-plan" data-tab="plan">Plan <span id="count-plan" class="tab-count">0</span></button>
       <button class="tab" role="tab" aria-selected="false" aria-controls="tab-changes" data-tab="changes">Changes <span id="count-changes" class="tab-count">0</span></button>
-      <button class="tab" role="tab" aria-selected="false" aria-controls="tab-queue" data-tab="queue">Queue <span id="count-queue" class="tab-count">0</span></button>
       <button class="tab" role="tab" aria-selected="false" aria-controls="tab-ownership" data-tab="ownership">Ownership <span id="count-ownership" class="tab-count">0</span></button>
       <button class="tab" role="tab" aria-selected="false" aria-controls="tab-reviews" data-tab="reviews">Reviews <span id="count-reviews" class="tab-count">0</span></button>
-      <button class="tab" role="tab" aria-selected="false" aria-controls="tab-day-plan" data-tab="day-plan">Day plan <span id="count-day-plan" class="tab-count">0</span></button>
       <button class="tab" role="tab" aria-selected="false" aria-controls="tab-automation" data-tab="automation">Automation <span id="count-automation" class="tab-count">0</span></button>
     </nav>
     <section id="tab-items" class="tab-panel" role="tabpanel">
@@ -403,21 +547,24 @@ export function renderDashboardHtml(actionToken) {
       </div>
       <div id="items" class="items"></div>
     </section>
-    <section id="tab-landing" class="tab-panel hidden" role="tabpanel">
+    <section id="tab-plan" class="tab-panel hidden" role="tabpanel" aria-labelledby="tab-plan-button">
+      <h2 class="sr-only">Plan</h2>
       <div id="plan" class="plan"></div>
     </section>
     <section id="tab-changes" class="tab-panel hidden" role="tabpanel"><div id="changes" class="report-box"></div></section>
-    <section id="tab-queue" class="tab-panel hidden" role="tabpanel"><div id="queue" class="report-box"></div></section>
     <section id="tab-ownership" class="tab-panel hidden" role="tabpanel"><div id="ownership" class="report-box"></div></section>
     <section id="tab-reviews" class="tab-panel hidden" role="tabpanel"><div id="reviews" class="report-box"></div></section>
-    <section id="tab-day-plan" class="tab-panel hidden" role="tabpanel"><div id="day-plan" class="report-box"></div></section>
     <section id="tab-automation" class="tab-panel hidden" role="tabpanel"><div id="automation" class="report-box"></div></section>
   </main>
   <div id="notice" class="notice hidden" role="status"></div>
   <script>
     const actionToken = ${escapeScriptValue(actionToken)};
+    ${buildPlanLanes.toString()}
+    ${limitLaneLevels.toString()}
+    ${limitPlanRows.toString()}
     let state = null;
     let selectedType = "pr";
+    let visiblePlanRowCount = 12;
 
     function element(tag, className, text) {
       const node = document.createElement(tag);
@@ -465,6 +612,19 @@ export function renderDashboardHtml(actionToken) {
       return { label: "Maintainer review", variant: "attention" };
     }
 
+    function planStatusVariant(status) {
+      if (status === "done") return "success";
+      if (status === "blocked") return "danger";
+      if (status === "in_progress" || status === "pending") return "accent";
+      return "neutral";
+    }
+
+    function restorePlanFocus(preferredId, secondaryId) {
+      (document.getElementById(preferredId) ??
+        document.getElementById(secondaryId) ??
+        document.getElementById("tab-plan-button"))?.focus();
+    }
+
     function renderMetrics(summary) {
       const root = document.getElementById("metrics");
       root.textContent = summary.total + " items · " +
@@ -474,21 +634,175 @@ export function renderDashboardHtml(actionToken) {
         summary.blocked + " blocked";
     }
 
-    function renderPlan(plan) {
+    function renderPlan(plan, legacyDayPlan, legacyQueue, items) {
       const root = document.getElementById("plan");
       root.replaceChildren();
-      if (!plan.length) {
-        root.append(element("p", "plan-row muted", "No landing plan was supplied."));
+      const lanes = buildPlanLanes(plan, legacyDayPlan, legacyQueue);
+      if (!lanes.length) {
+        root.append(element("p", "plan-empty muted", "No plan was supplied."));
         return;
       }
-      for (const step of plan) {
-        const row = element("div", "plan-row");
-        row.append(element("span", "badge status-" + step.liveStatus, statusLabel(step.liveStatus)));
-        const body = element("div");
-        body.append(element("strong", "", step.title));
-        if (step.detail) body.append(element("p", "muted", step.detail));
-        row.append(body);
-        root.append(row);
+      const itemByNumber = new Map(items.map((item) => [item.number, item]));
+      const planStepById = new Map(plan.map((step) => [step.id, step]));
+      const allSteps = lanes.flatMap((lane) => lane.levels.flat());
+      const overview = element("div", "plan-overview");
+      const summary = element("div", "plan-summary");
+      const summaryParts = [
+        allSteps.length + " steps",
+        lanes.length + " workstreams",
+      ];
+      for (const status of ["in_progress", "blocked", "pending", "done"]) {
+        const count = allSteps.filter((step) => step.liveStatus === status).length;
+        if (!count) continue;
+        summaryParts.push(count + " " + statusLabel(status));
+      }
+      summary.textContent = summaryParts.join(" · ");
+      overview.append(summary);
+      root.append(overview);
+
+      const rowWindow = limitPlanRows(lanes, visiblePlanRowCount);
+      for (const lane of rowWindow.lanes) {
+        const container = element("article", "plan-lane plan-lane-" + lane.kind);
+        const header = element("header", "plan-lane-header");
+        header.append(
+          element("h3", "", lane.title),
+          element(
+            "span",
+            "plan-lane-kind",
+            lane.kind === "independent"
+              ? "Can run in parallel"
+              : lane.totalSteps + " linked steps",
+          ),
+        );
+        container.append(header);
+        for (const steps of lane.levels) {
+          const level = element("div", "lane-level");
+          for (const step of steps) {
+            const node = element(
+              "div",
+              "plan-node plan-status-" + step.liveStatus,
+            );
+            const head = element("div", "plan-node-head");
+            const headingMain = element("div", "plan-node-heading-main");
+            const linkedItems = step.itemNumbers
+              .map((number) => itemByNumber.get(number))
+              .filter(Boolean);
+            const title = element("span", "plan-node-title", step.title);
+            headingMain.append(
+              element(
+                "span",
+                "badge label-" + planStatusVariant(step.liveStatus),
+                statusLabel(step.liveStatus),
+              ),
+              title,
+            );
+            const decision = element("div", "plan-node-decision");
+            if (linkedItems.length) {
+              for (const item of linkedItems) {
+                const itemDecision = element("div", "");
+                const itemLink = element("a", "", "#" + item.number);
+                itemLink.href = item.url;
+                itemLink.target = "_blank";
+                itemLink.rel = "noreferrer";
+                itemDecision.append(
+                  itemLink,
+                  document.createTextNode(
+                    " " + item.decision + " · " + item.takeConfidence + "% take",
+                  ),
+                );
+                decision.append(itemDecision);
+              }
+            } else {
+              decision.textContent = "No linked item";
+            }
+            head.append(
+              headingMain,
+              decision,
+            );
+            node.append(head);
+            const meta = element("div", "plan-node-meta");
+            if (step.horizon) {
+              meta.append(element("span", "", step.horizon === "today" ? "Today" : "Later"));
+            }
+            if (step.dependsOn.length) {
+              const dependencies = element("div", "plan-dependencies");
+              for (const dependencyId of step.dependsOn) {
+                const dependency = planStepById.get(dependencyId);
+                dependencies.append(element(
+                  "div",
+                  "dependency-edge",
+                  "Depends on " + (dependency?.title ?? dependencyId),
+                ));
+              }
+              meta.append(dependencies);
+            }
+            if (meta.childNodes.length) node.append(meta);
+            if (step.detail) node.append(element("p", "muted", step.detail));
+            const metadataItems = linkedItems.length ? linkedItems : [null];
+            const footer = element("div", "item-footer plan-node-footer");
+            const nextActions = element("div", "plan-actions");
+            for (const item of metadataItems) {
+              const metadata = element("div", "plan-item-meta");
+              const action = element("div", "plan-action");
+              action.append(
+                element("strong", "", item ? "Next for #" + item.number + ":" : "Next:"),
+                element("span", "", item?.nextAction ?? "No linked action"),
+              );
+              metadata.append(action);
+              nextActions.append(metadata);
+            }
+            footer.append(nextActions);
+            const mergeGates = element("div", "");
+            if (linkedItems.length) {
+              const buttonGroups = element("div", "plan-button-groups");
+              for (const item of linkedItems) {
+                const controls = createItemActions(
+                  item,
+                  linkedItems.length > 1,
+                  "plan-" + step.id,
+                );
+                buttonGroups.append(controls.actions);
+                if (controls.gate) mergeGates.append(controls.gate);
+              }
+              footer.append(buttonGroups);
+            }
+            node.append(footer);
+            if (mergeGates.childNodes.length) node.append(mergeGates);
+            level.append(node);
+          }
+          container.append(level);
+        }
+        root.append(container);
+      }
+      if (rowWindow.hiddenCount > 0 || visiblePlanRowCount > 12) {
+        const laneControls = element("div", "plan-more");
+        if (rowWindow.hiddenCount > 0) {
+          const moreRows = element(
+            "button",
+            "control",
+            "Show next " + Math.min(12, rowWindow.hiddenCount) + " plan rows",
+          );
+          moreRows.id = "plan-more-rows";
+          moreRows.type = "button";
+          moreRows.addEventListener("click", () => {
+            visiblePlanRowCount += 12;
+            renderPlan(plan, legacyDayPlan, legacyQueue, items);
+            restorePlanFocus("plan-more-rows", "plan-fewer-rows");
+          });
+          laneControls.append(moreRows);
+        }
+        if (visiblePlanRowCount > 12) {
+          const fewerRows = element("button", "control", "Show first 12 plan rows");
+          fewerRows.id = "plan-fewer-rows";
+          fewerRows.type = "button";
+          fewerRows.addEventListener("click", () => {
+            visiblePlanRowCount = 12;
+            renderPlan(plan, legacyDayPlan, legacyQueue, items);
+            restorePlanFocus("plan-more-rows", "plan-fewer-rows");
+          });
+          laneControls.append(fewerRows);
+        }
+        root.append(laneControls);
       }
     }
 
@@ -532,7 +846,6 @@ export function renderDashboardHtml(actionToken) {
 
     function renderReport(report) {
       renderRecords("changes", report.changes, "change", [["items", "Items"]], "No change summary was supplied.");
-      renderNumbered("queue", report.executiveQueue, "No executive queue was supplied.");
       renderRecords("ownership", report.ownership, "item", [["assessment", "Assessment"]], "No ownership audit was supplied.");
       renderRecords(
         "reviews",
@@ -541,7 +854,6 @@ export function renderDashboardHtml(actionToken) {
         [["title", "Title"], ["decision", "Decision"], ["summary", "Assessment"]],
         "No adversarial review summary was supplied.",
       );
-      renderNumbered("day-plan", report.dayPlan, "No day plan was supplied.");
       renderRecords(
         "automation",
         report.automation,
@@ -551,12 +863,11 @@ export function renderDashboardHtml(actionToken) {
       );
       const counts = {
         items: state.items.length,
-        landing: state.plan.length,
+        plan: buildPlanLanes(state.plan, report.dayPlan, report.executiveQueue)
+          .reduce((total, lane) => total + lane.levels.flat().length, 0),
         changes: report.changes.length,
-        queue: report.executiveQueue.length,
         ownership: report.ownership.length,
         reviews: report.reviews.length,
-        "day-plan": report.dayPlan.length,
         automation: report.automation.length,
       };
       for (const [name, count] of Object.entries(counts)) {
@@ -624,6 +935,76 @@ export function renderDashboardHtml(actionToken) {
       return result;
     }
 
+    function createItemActions(item, showItemNumber = false, idPrefix = "item") {
+      const typeLabel = item.type === "pr" ? "Pull request" : "Issue";
+      const shortTypeLabel = item.type === "pr" ? "PR" : "Issue";
+      const identity = typeLabel + " #" + item.number;
+      const controlId = idPrefix + "-" + item.type + "-" + item.number;
+      const actions = element("div", "actions");
+      actions.setAttribute("role", "group");
+      actions.setAttribute("aria-label", identity + " actions");
+      if (showItemNumber) {
+        actions.append(element(
+          "span",
+          "action-item-number",
+          shortTypeLabel + " #" + item.number,
+        ));
+      }
+      const next = element("button", "control", "Request next step");
+      next.id = controlId + "-next";
+      next.type = "button";
+      next.setAttribute("aria-label", "Request next step for " + identity);
+      next.addEventListener("click", async () => {
+        next.disabled = true;
+        try {
+          const result = await post("/action", {
+            action: "request_next_action",
+            number: item.number,
+          });
+          showNotice("Routing request queued for " + result.sessionName + ".");
+        } catch (error) {
+          showNotice(error.message);
+        } finally {
+          next.disabled = false;
+        }
+      });
+      const merge = element("button", "control primary", "Prepare merge");
+      merge.id = controlId + "-merge";
+      merge.type = "button";
+      merge.setAttribute("aria-label", "Prepare merge for " + identity);
+      merge.disabled = !item.mergeRequest.eligible;
+      merge.title = item.mergeRequest.eligible
+        ? "Request fresh merge verification in the item session"
+        : item.mergeRequest.reasons.join("; ");
+      merge.addEventListener("click", async () => {
+        merge.disabled = true;
+        try {
+          const result = await post("/action", {
+            action: "request_merge",
+            number: item.number,
+            headSha: item.live.headRefOid,
+          });
+          showNotice("Routing request queued for " + result.sessionName + ".");
+        } catch (error) {
+          showNotice(error.message);
+          merge.disabled = false;
+        }
+      });
+      actions.append(next, merge);
+      let gate = null;
+      if (!item.mergeRequest.eligible && item.mergeRequest.reasons.length) {
+        const reasonId = controlId + "-merge-reasons";
+        merge.setAttribute("aria-describedby", reasonId);
+        gate = element("details", "gate");
+        gate.id = reasonId;
+        gate.append(
+          element("summary", "", "Why merge is blocked for " + identity),
+          element("p", "", item.mergeRequest.reasons.join("; ")),
+        );
+      }
+      return { actions, gate };
+    }
+
     function renderItems(items) {
       const root = document.getElementById("items");
       root.replaceChildren();
@@ -671,55 +1052,19 @@ export function renderDashboardHtml(actionToken) {
           stages.append(element("span", "stage status-" + value, name + " " + statusLabel(value)));
         }
 
-        const actions = element("div", "actions");
-        const next = element("button", "control", "Request next step");
-        next.type = "button";
-        next.addEventListener("click", async () => {
-          next.disabled = true;
-          try {
-            const result = await post("/action", { action: "request_next_action", number: item.number });
-            showNotice("Routing request queued for " + result.sessionName + ".");
-          } catch (error) {
-            showNotice(error.message);
-          } finally {
-            next.disabled = false;
-          }
-        });
-        const merge = element("button", "control primary", "Prepare merge");
-        merge.type = "button";
-        merge.disabled = !item.mergeRequest.eligible;
-        merge.title = item.mergeRequest.eligible ? "Request fresh merge verification in the item session" : item.mergeRequest.reasons.join("; ");
-        merge.addEventListener("click", async () => {
-          merge.disabled = true;
-          try {
-            const result = await post("/action", {
-              action: "request_merge",
-              number: item.number,
-              headSha: item.live.headRefOid,
-            });
-            showNotice("Routing request queued for " + result.sessionName + ".");
-          } catch (error) {
-            showNotice(error.message);
-            merge.disabled = false;
-          }
-        });
-        actions.append(next, merge);
-        footer.append(stages, actions);
+        const controls = createItemActions(item);
+        footer.append(stages, controls.actions);
         row.append(footer);
-        if (!item.mergeRequest.eligible && item.mergeRequest.reasons.length) {
-          const gate = element("details", "gate");
-          gate.append(
-            element("summary", "", "Why merge is blocked"),
-            element("p", "", item.mergeRequest.reasons.join("; ")),
-          );
-          row.append(gate);
-        }
+        if (controls.gate) row.append(controls.gate);
         root.append(row);
       }
     }
 
     function render(nextState) {
       state = nextState;
+      const planFocusId = document.activeElement?.id?.startsWith("plan-")
+        ? document.activeElement.id
+        : null;
       document.getElementById("title").textContent = state.title;
       document.getElementById("scope").textContent = state.scope;
       document.getElementById("updated").textContent = "Live " +
@@ -732,7 +1077,8 @@ export function renderDashboardHtml(actionToken) {
         String(state.items.filter((item) => item.type === "pr").length);
       document.getElementById("type-issue-count").textContent =
         String(state.items.filter((item) => item.type === "issue").length);
-      renderPlan(state.plan);
+      renderPlan(state.plan, state.report.dayPlan, state.report.executiveQueue, state.items);
+      if (planFocusId) restorePlanFocus(planFocusId);
       renderReport(state.report);
       renderVerdictOptions(state.items);
       renderItems(state.items);

--- a/.github/extensions/openclaw-triage-dashboard/triage-ui.mjs
+++ b/.github/extensions/openclaw-triage-dashboard/triage-ui.mjs
@@ -677,8 +677,8 @@ export function renderDashboardHtml(actionToken) {
         next.addEventListener("click", async () => {
           next.disabled = true;
           try {
-            await post("/action", { action: "request_next_action", number: item.number });
-            showNotice("Next-step request sent to this Copilot session.");
+            const result = await post("/action", { action: "request_next_action", number: item.number });
+            showNotice("Routing request queued for " + result.sessionName + ".");
           } catch (error) {
             showNotice(error.message);
           } finally {
@@ -688,16 +688,16 @@ export function renderDashboardHtml(actionToken) {
         const merge = element("button", "control primary", "Prepare merge");
         merge.type = "button";
         merge.disabled = !item.mergeRequest.eligible;
-        merge.title = item.mergeRequest.eligible ? "Request fresh merge verification in chat" : item.mergeRequest.reasons.join("; ");
+        merge.title = item.mergeRequest.eligible ? "Request fresh merge verification in the item session" : item.mergeRequest.reasons.join("; ");
         merge.addEventListener("click", async () => {
           merge.disabled = true;
           try {
-            await post("/action", {
+            const result = await post("/action", {
               action: "request_merge",
               number: item.number,
               headSha: item.live.headRefOid,
             });
-            showNotice("Guarded merge request sent to this Copilot session.");
+            showNotice("Routing request queued for " + result.sessionName + ".");
           } catch (error) {
             showNotice(error.message);
             merge.disabled = false;

--- a/.github/extensions/openclaw-triage-dashboard/triage-ui.mjs
+++ b/.github/extensions/openclaw-triage-dashboard/triage-ui.mjs
@@ -741,6 +741,13 @@ export function renderDashboardHtml(actionToken) {
             const metadataItems = linkedItems.length ? linkedItems : [null];
             const footer = element("div", "item-footer plan-node-footer");
             const nextActions = element("div", "plan-actions");
+            const unresolvedDependencies = step.dependsOn
+              .map((dependencyId) => planStepById.get(dependencyId))
+              .filter((dependency) => dependency?.liveStatus !== "done");
+            const dependencyBlocker = unresolvedDependencies.length
+              ? "Complete dependencies first: " +
+                unresolvedDependencies.map((dependency) => dependency.title).join(", ")
+              : "";
             for (const item of metadataItems) {
               const metadata = element("div", "plan-item-meta");
               const action = element("div", "plan-action");
@@ -760,6 +767,7 @@ export function renderDashboardHtml(actionToken) {
                   item,
                   linkedItems.length > 1,
                   "plan-" + step.id,
+                  dependencyBlocker,
                 );
                 buttonGroups.append(controls.actions);
                 if (controls.gate) mergeGates.append(controls.gate);
@@ -935,7 +943,12 @@ export function renderDashboardHtml(actionToken) {
       return result;
     }
 
-    function createItemActions(item, showItemNumber = false, idPrefix = "item") {
+    function createItemActions(
+      item,
+      showItemNumber = false,
+      idPrefix = "item",
+      disabledReason = "",
+    ) {
       const typeLabel = item.type === "pr" ? "Pull request" : "Issue";
       const shortTypeLabel = item.type === "pr" ? "PR" : "Issue";
       const identity = typeLabel + " #" + item.number;
@@ -954,6 +967,8 @@ export function renderDashboardHtml(actionToken) {
       next.id = controlId + "-next";
       next.type = "button";
       next.setAttribute("aria-label", "Request next step for " + identity);
+      next.disabled = Boolean(disabledReason);
+      if (disabledReason) next.title = disabledReason;
       next.addEventListener("click", async () => {
         next.disabled = true;
         try {
@@ -968,38 +983,51 @@ export function renderDashboardHtml(actionToken) {
           next.disabled = false;
         }
       });
-      const merge = element("button", "control primary", "Prepare merge");
-      merge.id = controlId + "-merge";
-      merge.type = "button";
-      merge.setAttribute("aria-label", "Prepare merge for " + identity);
-      merge.disabled = !item.mergeRequest.eligible;
-      merge.title = item.mergeRequest.eligible
-        ? "Request fresh merge verification in the item session"
-        : item.mergeRequest.reasons.join("; ");
-      merge.addEventListener("click", async () => {
-        merge.disabled = true;
-        try {
-          const result = await post("/action", {
-            action: "request_merge",
-            number: item.number,
-            headSha: item.live.headRefOid,
-          });
-          showNotice("Routing request queued for " + result.sessionName + ".");
-        } catch (error) {
-          showNotice(error.message);
-          merge.disabled = false;
-        }
-      });
-      actions.append(next, merge);
+      let merge = null;
+      if (item.type === "pr") {
+        merge = element("button", "control primary", "Prepare merge");
+        merge.id = controlId + "-merge";
+        merge.type = "button";
+        merge.setAttribute("aria-label", "Prepare merge for " + identity);
+        merge.disabled = Boolean(disabledReason) || !item.mergeRequest.eligible;
+        merge.title = disabledReason || (item.mergeRequest.eligible
+          ? "Request fresh merge verification in the item session"
+          : item.mergeRequest.reasons.join("; "));
+        merge.addEventListener("click", async () => {
+          merge.disabled = true;
+          try {
+            const result = await post("/action", {
+              action: "request_merge",
+              number: item.number,
+              headSha: item.live.headRefOid,
+            });
+            showNotice("Routing request queued for " + result.sessionName + ".");
+          } catch (error) {
+            showNotice(error.message);
+            merge.disabled = false;
+          }
+        });
+      }
+      actions.append(next);
+      if (merge) actions.append(merge);
       let gate = null;
-      if (!item.mergeRequest.eligible && item.mergeRequest.reasons.length) {
-        const reasonId = controlId + "-merge-reasons";
-        merge.setAttribute("aria-describedby", reasonId);
+      const reasons = [
+        ...(disabledReason ? [disabledReason] : []),
+        ...(item.type === "pr" && !item.mergeRequest.eligible
+          ? item.mergeRequest.reasons
+          : []),
+      ];
+      if (reasons.length) {
+        const reasonId = controlId + "-action-reasons";
+        next.setAttribute("aria-describedby", reasonId);
+        if (merge) merge.setAttribute("aria-describedby", reasonId);
         gate = element("details", "gate");
         gate.id = reasonId;
         gate.append(
-          element("summary", "", "Why merge is blocked for " + identity),
-          element("p", "", item.mergeRequest.reasons.join("; ")),
+          element("summary", "", disabledReason
+            ? "Why actions are blocked for " + identity
+            : "Why merge is blocked for " + identity),
+          element("p", "", [...new Set(reasons)].join("; ")),
         );
       }
       return { actions, gate };

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
           exit 1
         fi
 
-    - name: Test repository triage automation
-      run: node --test .github/scripts/repository-triage.test.cjs
+    - name: Test repository triage automation and dashboard
+      run: node --test .github/scripts/repository-triage.test.cjs .github/extensions/openclaw-triage-dashboard/triage-state.test.mjs
 
   test:
     needs: repo-hygiene

--- a/.github/workflows/repository-triage.yml
+++ b/.github/workflows/repository-triage.yml
@@ -36,7 +36,7 @@ jobs:
           persist-credentials: false
 
       - name: Run deterministic triage tests
-        run: node --test .github/scripts/repository-triage.test.cjs
+        run: node --test .github/scripts/repository-triage.test.cjs .github/extensions/openclaw-triage-dashboard/triage-state.test.mjs
 
       - name: Build triage report
         uses: actions/github-script@v9
@@ -81,7 +81,7 @@ jobs:
           persist-credentials: false
 
       - name: Run deterministic triage tests before mutation
-        run: node --test .github/scripts/repository-triage.test.cjs
+        run: node --test .github/scripts/repository-triage.test.cjs .github/extensions/openclaw-triage-dashboard/triage-state.test.mjs
 
       - name: Re-check and remove allowlisted expired labels
         uses: actions/github-script@v9


### PR DESCRIPTION
## Summary

- add an optional project-scoped Copilot canvas for live OpenClaw global triage
- combine queue and day planning into dependency-aware workstream lanes with restrained item-style rows and guarded actions
- route next-step and merge-preparation requests to stable child sessions without directly mutating GitHub
- preserve the mandatory static Markdown report, its exact ten-section order, and `hanselman-code-review` for risky candidates

## Required proof pools

`none` - this changes a Copilot extension canvas and skill documentation, not the Windows tray, gateway, MCP, or node runtime. Current-head canvas runtime proof is recorded below.

## Validation

- `node --test .github\extensions\openclaw-triage-dashboard\triage-state.test.mjs` - 25 passed
- `.\build.ps1` - passed
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore` - 3,903 passed, 34 skipped
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore` - 2,833 passed
- autoreview command: `python .agents\skills\autoreview\scripts\autoreview --mode local --stream-engine-output` - blocked by Codex websocket authentication (`401 Unauthorized`)
- fallback read-only review found one missing behavioral assertion; fixed by proving refresh failure stops before session routing; final fallback rereview found no actionable findings
- rubber-duck closeout found no blockers

## Real behavior proof

At current head, the project extension reloaded as ready and declared canvas `openclaw-triage-dashboard` with `refresh`, `request_next_action`, and `request_merge` actions. The populated four-PR dashboard opened successfully at a loopback-only URL, including dependency lanes and the corrected `hanselman-code-review` automation guidance. A live `refresh` action completed with `refreshError: ""`.

Merge preparation requires a fresh successful GitHub refresh, an exact reviewed head, `TAKE` at 90% or higher, complete review and proof, clean mergeability, and all declared checks passing. Failed refreshes reject before child-session routing. The extension contains no direct merge, close, comment, label, rerun, push, or deletion path.

## Report compatibility

The static report remains independently requestable and mandatory. Its established order is unchanged:

1. `# OpenClaw Windows Node global triage`
2. snapshot sentence
3. `## Change since <prior date>`
4. `## Executive queue`
5. `## Pull requests`
6. `## Issues`
7. `## Active ownership audit`
8. `## Adversarial review`
9. `## Day plan`
10. `## Automation and testability`

Dashboard JSON is required only when the optional canvas is requested.