### PR TITLE
improve(ci): reduce core NuGet cache payload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,13 +230,38 @@ jobs:
       with:
         dotnet-version: 10.0.x
 
+    - name: Configure core NuGet cache
+      # Keep the core graph out of the repository-wide NuGet cache used by every other lane.
+      shell: pwsh
+      run: '"NUGET_PACKAGES=$env:RUNNER_TEMP\openclaw-core-nuget-packages" >> $env:GITHUB_ENV'
+
     - name: Cache NuGet packages
       continue-on-error: true
       uses: actions/cache@v6
       with:
-        path: ~/.nuget/packages
-        key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props') }}
-        restore-keys: nuget-${{ runner.os }}-
+        path: ${{ env.NUGET_PACKAGES }}
+        # SDK/config and imported MSBuild files can change restore behavior or shared package references.
+        # These project files are the complete transitive graph restored by the core lane.
+        key: >-
+          nuget-core-${{ runner.os }}-${{ hashFiles(
+            'global.json',
+            'NuGet.Config',
+            'Directory.Build.props',
+            'src/Directory.Build.props',
+            'src/Directory.Build.targets',
+            'tests/Directory.Build.props',
+            'tests/OpenClaw.TestSupport/Directory.Build.props',
+            'tests/OpenClaw.Shared.TestHost/Directory.Build.props',
+            'src/OpenClaw.Shared/OpenClaw.Shared.csproj',
+            'src/OpenClaw.Connection/OpenClaw.Connection.csproj',
+            'src/OpenClaw.Cli/OpenClaw.Cli.csproj',
+            'src/OpenClaw.WinNode.Cli/OpenClaw.WinNode.Cli.csproj',
+            'tests/OpenClaw.TestSupport/OpenClaw.TestSupport.csproj',
+            'tests/OpenClaw.Shared.TestHost/OpenClaw.Shared.TestHost.csproj',
+            'tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj',
+            'tests/OpenClaw.Connection.Tests/OpenClaw.Connection.Tests.csproj',
+            'tests/OpenClaw.WinNode.Cli.Tests/OpenClaw.WinNode.Cli.Tests.csproj'
+          ) }}
 
     - name: Restore core test projects
       run: |

--- a/docs/TEST_COVERAGE.md
+++ b/docs/TEST_COVERAGE.md
@@ -130,11 +130,15 @@ separate TRX artifact:
 | `tray-tests` | Tray, SetupEngine, Tray Integration |
 | `ui-tests` | FunctionalUI, Tray UI, Axe.Windows accessibility |
 
-All three use the same repository-wide NuGet cache key. This change does not
-introduce per-lane cache keys or cross-job build artifact sharing. Tray settings
-remain isolated through `OPENCLAW_TRAY_DATA_DIR`, integration tests retain
-`OPENCLAW_RUN_INTEGRATION=1`, UI tests install WindowsAppRuntime, and every test
-project continues to publish TRX output.
+The core lane uses a dedicated runner-temp NuGet package directory and a key
+scoped to its complete transitive project graph plus the SDK, NuGet, and imported
+MSBuild manifests that affect restore. It has no fallback to the repository-wide
+cache. Tray, UI, E2E, and release lanes retain the existing repository-wide
+NuGet cache behavior. Only downloaded NuGet packages are cached; build outputs,
+test results, source, SDK installs, and Node packages remain uncached. Tray
+settings remain isolated through `OPENCLAW_TRAY_DATA_DIR`, integration tests
+retain `OPENCLAW_RUN_INTEGRATION=1`, UI tests install WindowsAppRuntime, and
+every test project continues to publish TRX output.
 
 `fast-validation` still runs for every invocation and owns repository hygiene,
 documentation, agent-skill, classifier, gate, workflow, and release-ordering

--- a/scripts/test-ci-workflow-contract.ps1
+++ b/scripts/test-ci-workflow-contract.ps1
@@ -73,6 +73,29 @@ function Get-JobBlock {
         $nextMatch.Index - $startMatch.Index)
 }
 
+function Get-StepBlock {
+    param(
+        [Parameter(Mandatory)][string]$Text,
+        [Parameter(Mandatory)][string]$Name
+    )
+
+    $escapedName = [regex]::Escape($Name)
+    $startMatch = [regex]::Match($Text, "(?m)^    - name: ${escapedName}\r?$")
+    if (-not $startMatch.Success) {
+        throw "Could not find CI step '$Name'."
+    }
+    $stepHeadingPattern = [regex]::new("(?m)^    - (?:name:|uses:)")
+    $nextMatch = $stepHeadingPattern.Match(
+        $Text,
+        $startMatch.Index + $startMatch.Length)
+    if (-not $nextMatch.Success) {
+        return $Text.Substring($startMatch.Index)
+    }
+    return $Text.Substring(
+        $startMatch.Index,
+        $nextMatch.Index - $startMatch.Index)
+}
+
 function Get-WorkflowTriggerBlock {
     param(
         [Parameter(Mandatory)][string]$Text,
@@ -392,10 +415,6 @@ foreach ($lane in $testLanes.GetEnumerator()) {
         -Message "Test lane '$($lane.Key)' does not preserve push/tag coverage."
     Assert-Contains `
         -Text $job `
-        -Expected "key: nuget-`${{ runner.os }}-`${{ hashFiles('**/*.csproj', '**/Directory.Packages.props') }}" `
-        -Message "Test lane '$($lane.Key)' must retain the shared NuGet cache key."
-    Assert-Contains `
-        -Text $job `
         -Expected "name: $($lane.Value.Artifact)" `
         -Message "Test lane '$($lane.Key)' is missing its TRX artifact."
     foreach ($project in $lane.Value.Projects) {
@@ -405,6 +424,73 @@ foreach ($lane in $testLanes.GetEnumerator()) {
             -Message "Test lane '$($lane.Key)' lost project '$project'."
     }
 }
+
+$coreJob = Get-JobBlock "core-tests"
+$coreCacheStep = Get-StepBlock -Text $coreJob -Name "Cache NuGet packages"
+foreach ($token in @(
+        "Configure core NuGet cache",
+        "shell: pwsh",
+        '"NUGET_PACKAGES=$env:RUNNER_TEMP\openclaw-core-nuget-packages" >> $env:GITHUB_ENV',
+        'path: ${{ env.NUGET_PACKAGES }}',
+        'nuget-core-${{ runner.os }}-${{ hashFiles(',
+        "'global.json'",
+        "'NuGet.Config'",
+        "'Directory.Build.props'",
+        "'src/Directory.Build.props'",
+        "'src/Directory.Build.targets'",
+        "'tests/Directory.Build.props'",
+        "'tests/OpenClaw.TestSupport/Directory.Build.props'",
+        "'tests/OpenClaw.Shared.TestHost/Directory.Build.props'",
+        "'src/OpenClaw.Shared/OpenClaw.Shared.csproj'",
+        "'src/OpenClaw.Connection/OpenClaw.Connection.csproj'",
+        "'src/OpenClaw.Cli/OpenClaw.Cli.csproj'",
+        "'src/OpenClaw.WinNode.Cli/OpenClaw.WinNode.Cli.csproj'",
+        "'tests/OpenClaw.TestSupport/OpenClaw.TestSupport.csproj'",
+        "'tests/OpenClaw.Shared.TestHost/OpenClaw.Shared.TestHost.csproj'",
+        "'tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj'",
+        "'tests/OpenClaw.Connection.Tests/OpenClaw.Connection.Tests.csproj'",
+        "'tests/OpenClaw.WinNode.Cli.Tests/OpenClaw.WinNode.Cli.Tests.csproj'"
+    )) {
+    Assert-Contains -Text $coreJob -Expected $token -Message "Core NuGet cache is missing '$token'."
+}
+foreach ($token in @(
+        "path: ~/.nuget/packages",
+        'key: nuget-${{ runner.os }}-',
+        'restore-keys: nuget-${{ runner.os }}-',
+        "'**/*.csproj'",
+        "'**/Directory.Packages.props'",
+        "bin/",
+        "obj/",
+        "TestResults",
+        "node_modules",
+        ".dotnet"
+    )) {
+    Assert-NotContains -Text $coreCacheStep -Unexpected $token -Message "Core NuGet cache must not contain '$token'."
+}
+
+$coreJobIndex = $workflow.IndexOf($coreJob, [StringComparison]::Ordinal)
+if ($coreJobIndex -lt 0) {
+    throw "Could not isolate the core job from the workflow."
+}
+$nonCoreWorkflow = $workflow.Remove($coreJobIndex, $coreJob.Length)
+foreach ($token in @(
+        "path: ~/.nuget/packages",
+        'key: nuget-${{ runner.os }}-${{ hashFiles(''**/*.csproj'', ''**/Directory.Packages.props'') }}',
+        'restore-keys: nuget-${{ runner.os }}-'
+    )) {
+    $count = ([regex]::Matches($nonCoreWorkflow, [regex]::Escape($token))).Count
+    if ($count -ne 8) {
+        throw "Expected 8 unchanged non-core cache entries for '$token', found $count."
+    }
+}
+Assert-NotContains `
+    -Text $nonCoreWorkflow `
+    -Unexpected "NUGET_PACKAGES" `
+    -Message "Only the core job may override NUGET_PACKAGES."
+Assert-NotContains `
+    -Text $nonCoreWorkflow `
+    -Unexpected "nuget-core-" `
+    -Message "Only the core job may use the isolated NuGet cache key."
 
 $trayJob = Get-JobBlock "tray-tests"
 foreach ($token in @(
@@ -694,4 +780,4 @@ try {
     }
 }
 
-Write-Host "CI workflow contracts passed: CodeQL branch/path gating, conservative lane routing, stable gate enforcement, decoupled metadata/release builds, preserved test inventory, and fail-closed proof routing." -ForegroundColor Green
+Write-Host "CI workflow contracts passed: CodeQL branch/path gating, conservative lane routing, isolated core NuGet caching, stable gate enforcement, decoupled metadata/release builds, preserved test inventory, and fail-closed proof routing." -ForegroundColor Green

--- a/tests/OpenClaw.Tray.Tests/CiNugetCacheWorkflowTests.cs
+++ b/tests/OpenClaw.Tray.Tests/CiNugetCacheWorkflowTests.cs
@@ -1,0 +1,216 @@
+using System.Xml.Linq;
+
+namespace OpenClaw.Tray.Tests;
+
+public sealed class CiNugetCacheWorkflowTests
+{
+    private static readonly string[] CoreEntryProjects =
+    [
+        "tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj",
+        "tests/OpenClaw.Connection.Tests/OpenClaw.Connection.Tests.csproj",
+        "tests/OpenClaw.WinNode.Cli.Tests/OpenClaw.WinNode.Cli.Tests.csproj",
+    ];
+
+    [Fact]
+    public void CoreLane_UsesDedicatedPackageCacheWithoutChangingOtherLanes()
+    {
+        var workflow = ReadWorkflow();
+        var coreJob = ExtractJob(workflow, "core-tests", "tray-tests");
+        var otherJobs = workflow.Remove(workflow.IndexOf(coreJob, StringComparison.Ordinal), coreJob.Length);
+
+        Assert.Contains(
+            @"""NUGET_PACKAGES=$env:RUNNER_TEMP\openclaw-core-nuget-packages"" >> $env:GITHUB_ENV",
+            coreJob,
+            StringComparison.Ordinal);
+        Assert.True(
+            coreJob.IndexOf("- name: Configure core NuGet cache", StringComparison.Ordinal) <
+            coreJob.IndexOf("- name: Cache NuGet packages", StringComparison.Ordinal));
+        Assert.Contains("shell: pwsh", coreJob, StringComparison.Ordinal);
+        Assert.Contains(@"path: ${{ env.NUGET_PACKAGES }}", coreJob, StringComparison.Ordinal);
+        Assert.Contains("nuget-core-${{ runner.os }}-${{ hashFiles(", coreJob, StringComparison.Ordinal);
+        Assert.DoesNotContain("restore-keys:", coreJob, StringComparison.Ordinal);
+
+        Assert.DoesNotContain("NUGET_PACKAGES:", otherJobs, StringComparison.Ordinal);
+        Assert.DoesNotContain("nuget-core-", otherJobs, StringComparison.Ordinal);
+        Assert.Equal(8, CountOccurrences(otherJobs, "path: ~/.nuget/packages"));
+        Assert.Equal(
+            8,
+            CountOccurrences(
+                otherJobs,
+                "key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props') }}"));
+        Assert.Equal(8, CountOccurrences(otherJobs, "restore-keys: nuget-${{ runner.os }}-"));
+    }
+
+    [Fact]
+    public void CoreLane_CachesOnlyTheDedicatedPackageDirectory()
+    {
+        var coreJob = ExtractJob(ReadWorkflow(), "core-tests", "tray-tests");
+        var cacheStep = ExtractStep(coreJob, "Cache NuGet packages", "Restore core test projects");
+
+        Assert.Equal(1, CountOccurrences(cacheStep, "path:"));
+        Assert.Contains(@"path: ${{ env.NUGET_PACKAGES }}", cacheStep, StringComparison.Ordinal);
+        Assert.DoesNotContain("${{ github.workspace }}", cacheStep, StringComparison.Ordinal);
+
+        foreach (var forbiddenPath in new[] { "bin/", "obj/", "TestResults", "node_modules", ".dotnet" })
+            Assert.DoesNotContain(forbiddenPath, cacheStep, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void CoreCacheKey_HashesEveryRestoreGraphManifest()
+    {
+        var root = TestRepositoryPaths.GetRepositoryRoot();
+        var coreJob = ExtractJob(ReadWorkflow(), "core-tests", "tray-tests");
+        var cacheStep = ExtractStep(coreJob, "Cache NuGet packages", "Restore core test projects");
+
+        var projectGraph = GetProjectGraph(root);
+        Assert.Equal(9, projectGraph.Count);
+
+        foreach (var buildInput in GetBuildInputs(root, projectGraph))
+            Assert.Contains($"'{buildInput}'", cacheStep, StringComparison.Ordinal);
+
+        foreach (var project in projectGraph)
+            Assert.Contains($"'{project}'", cacheStep, StringComparison.Ordinal);
+
+        Assert.DoesNotContain("'**/*.csproj'", cacheStep, StringComparison.Ordinal);
+        Assert.DoesNotContain("'**/Directory.Packages.props'", cacheStep, StringComparison.Ordinal);
+    }
+
+    private static SortedSet<string> GetProjectGraph(string root)
+    {
+        var pending = new Stack<string>(CoreEntryProjects);
+        var graph = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        while (pending.TryPop(out var project))
+        {
+            var normalizedProject = project.Replace('\\', '/');
+            if (!graph.Add(normalizedProject))
+                continue;
+
+            var projectPath = Path.Combine(root, normalizedProject.Replace('/', Path.DirectorySeparatorChar));
+            var projectDirectory = Path.GetDirectoryName(projectPath)
+                ?? throw new InvalidOperationException($"Project has no directory: {projectPath}");
+            var document = XDocument.Load(projectPath);
+
+            foreach (var reference in document
+                         .Descendants()
+                         .Where(element => element.Name.LocalName == "ProjectReference"))
+            {
+                var include = reference.Attribute("Include")?.Value;
+                Assert.False(string.IsNullOrWhiteSpace(include), $"ProjectReference has no Include in {project}");
+
+                var referencedPath = Path.GetFullPath(Path.Combine(projectDirectory, include));
+                pending.Push(Path.GetRelativePath(root, referencedPath).Replace('\\', '/'));
+            }
+        }
+
+        return graph;
+    }
+
+    private static SortedSet<string> GetBuildInputs(string root, IEnumerable<string> projectGraph)
+    {
+        var inputs = new SortedSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "global.json",
+            "NuGet.Config",
+        };
+
+        foreach (var project in projectGraph)
+        {
+            var projectPath = Path.Combine(root, project.Replace('/', Path.DirectorySeparatorChar));
+            var projectDirectory = Path.GetDirectoryName(projectPath)
+                ?? throw new InvalidOperationException($"Project has no directory: {projectPath}");
+
+            foreach (var fileName in new[] { "Directory.Build.props", "Directory.Build.targets" })
+            {
+                var buildFile = FindNearestBuildFile(root, projectDirectory, fileName);
+                if (buildFile is not null)
+                    AddBuildFileAndImports(root, buildFile, inputs);
+            }
+        }
+
+        return inputs;
+    }
+
+    private static string? FindNearestBuildFile(string root, string projectDirectory, string fileName)
+    {
+        var rootPath = Path.GetFullPath(root);
+        var directory = new DirectoryInfo(projectDirectory);
+        while (directory is not null)
+        {
+            var candidate = Path.Combine(directory.FullName, fileName);
+            if (File.Exists(candidate))
+                return candidate;
+
+            if (string.Equals(directory.FullName, rootPath, StringComparison.OrdinalIgnoreCase))
+                break;
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+
+    private static void AddBuildFileAndImports(
+        string root,
+        string buildFile,
+        ISet<string> inputs)
+    {
+        var relativePath = Path.GetRelativePath(root, buildFile).Replace('\\', '/');
+        if (!inputs.Add(relativePath))
+            return;
+
+        var buildDirectory = Path.GetDirectoryName(buildFile)
+            ?? throw new InvalidOperationException($"Build file has no directory: {buildFile}");
+        var document = XDocument.Load(buildFile);
+        foreach (var import in document.Descendants().Where(element => element.Name.LocalName == "Import"))
+        {
+            var project = import.Attribute("Project")?.Value;
+            if (string.IsNullOrWhiteSpace(project) || project.Contains("$(", StringComparison.Ordinal))
+                continue;
+
+            var importedPath = Path.GetFullPath(Path.Combine(buildDirectory, project));
+            if (File.Exists(importedPath))
+                AddBuildFileAndImports(root, importedPath, inputs);
+        }
+    }
+
+    private static string ReadWorkflow()
+    {
+        return File.ReadAllText(
+                Path.Combine(TestRepositoryPaths.GetRepositoryRoot(), ".github", "workflows", "ci.yml"))
+            .Replace("\r\n", "\n", StringComparison.Ordinal);
+    }
+
+    private static string ExtractJob(string workflow, string jobName, string nextJobName)
+    {
+        var start = workflow.IndexOf($"  {jobName}:", StringComparison.Ordinal);
+        var end = workflow.IndexOf($"\n  {nextJobName}:", start, StringComparison.Ordinal);
+
+        Assert.True(start >= 0, $"Could not find workflow job {jobName}.");
+        Assert.True(end > start, $"Could not find workflow job after {jobName}.");
+        return workflow[start..end];
+    }
+
+    private static string ExtractStep(string job, string stepName, string nextStepName)
+    {
+        var start = job.IndexOf($"    - name: {stepName}", StringComparison.Ordinal);
+        var end = job.IndexOf($"\n    - name: {nextStepName}", start, StringComparison.Ordinal);
+
+        Assert.True(start >= 0, $"Could not find workflow step {stepName}.");
+        Assert.True(end > start, $"Could not find workflow step after {stepName}.");
+        return job[start..end];
+    }
+
+    private static int CountOccurrences(string value, string search)
+    {
+        var count = 0;
+        var offset = 0;
+        while ((offset = value.IndexOf(search, offset, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            offset += search.Length;
+        }
+
+        return count;
+    }
+}


### PR DESCRIPTION
## What Problem This Solves

The Core and CLI tests job restored the repository-wide NuGet cache, approximately 3.26 GB, even though it needs only the Shared, Connection, and WinNode CLI project graph. The measured baseline was 78 seconds for cache restore and 4m45s for the job.

## Why This Change Was Made

Give only `core-tests` a runner-temp `NUGET_PACKAGES` directory and an exact `nuget-core` cache key covering its complete transitive project graph plus every SDK, NuGet, and effective MSBuild input. There is no fallback to the global key. Tray, UI, E2E, x64, ARM64, and MSIX cache behavior is unchanged.

## User Impact

No product behavior changes. The identical-head warm benchmark reduces core cache restore by 71 seconds and the total core job by 51 seconds.

## Evidence

Head `02c2acbe4dc6daaa784e43f3649819070d63768d` met the acceptance bar.

| Measurement | Baseline | Cold miss | Warm hit | Warm change |
|---|---:|---:|---:|---:|
| Cache action | 78s | 1s miss | 7s restore | 71s faster (91.0%) |
| Explicit restore | 24s | 17s | 15s | 9s faster (37.5%) |
| Build | 67s | 53s | 56s | 11s faster (16.4%) |
| Shared / Connection / WinNode tests | ~97s | 38s / 64s / 9s | 40s / 63s / 10s | 113s warm total; test variance was slower |
| Core job | 4m45s | 3m26s | 3m34s | 51s faster (17.9%) |
| Cache save | N/A | 6s | 0s (primary-key hit) | No warm save |
| Cache payload | ~3.26 GB | 473,020,008 bytes (~451 MiB) | Same key/payload | 85.5% smaller |

- Cold run/job: `33837298749` attempt 1 / `100912437156`
- Warm identical-head run/job: `33837298749` attempt 2 / `100917879017`
- Cache ID/key: `7315130663` / `nuget-core-Windows-620ee6792e798dcf5316a820e89a73ff425c8549bcf50648b94671a8bc221b36`
- The cold miss completed successfully and saved the cache. The warm rerun restored the exact primary key and did not save another cache.
- Runner-minute impact improves by about 0.85 Windows runner minutes per warm core run. Cache quota adds one approximately 451 MiB core entry while the unchanged global cache remains for other lanes; this is a modest active-footprint increase relative to the 3.26 GB global payload, and each core entry is 85.5% smaller than the former payload.
- Attempt 1's unrelated Network recovery E2E was externally cancelled at 30 minutes, so CI Gate reported failure. Every other required lane, including core, passed. No implementation change was made for that unrelated cancellation.

The source contract reconstructs the three entry projects' transitive graph and discovers effective nearest/imported `Directory.Build.props` and `Directory.Build.targets` files. It fails if any graph input is absent from the cache key, if core regains a fallback, if build outputs enter the cached path, or if any of the eight non-core caches changes. The fast PowerShell workflow contract enforces the same core-only boundary.

**Recommendation: merge.** The warm cache and job both exceed the acceptance bar, the cold miss succeeds, and the storage tradeoff is proportionate to the runner-time savings.

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs or instructions
- [x] Tests or validation
- [ ] Security hardening
- [x] Chore or infrastructure

## Scope

- [ ] Tray or WinUI UX
- [ ] Windows node capability
- [ ] Local MCP or `winnode`
- [ ] Gateway, connection, or pairing
- [ ] Setup or onboarding
- [ ] Permissions, privacy, or security
- [x] Tests, CI, or docs

## Required proof pools

- `none`: This CI cache boundary needs GitHub-hosted cold/warm measurements, not a capacity-dependent custom Windows host.

## Validation

- `./build.ps1`: passed, all five product projects built
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore`: passed, 3,905 passed / 32 skipped / 0 failed
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore`: passed, 2,836 passed / 0 failed
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore --no-build --filter FullyQualifiedName~CiNugetCacheWorkflowTests`: passed, 3 passed / 0 failed
- `./scripts/test-ci-workflow-contract.ps1`: passed
- `actionlint .github/workflows/ci.yml`: passed with only the documented pre-existing `build-msix` `if: false` diagnostic ignored
- Rubber-duck review: no findings after the final workflow and contract changes

## Real Behavior Proof

- Environment tested: GitHub-hosted `windows-latest`; local Windows 11 with .NET SDK 10.0.303
- PR head or commit tested: `02c2acbe4dc6daaa784e43f3649819070d63768d`
- Exact steps or command run: cold full PR run, then direct rerun of successful core job on the identical run/head
- Evidence after fix: cold miss saved cache ID `7315130663`; warm job restored all 473,020,008 bytes from the exact primary key in 7 seconds
- Observed result: 451 MiB warm payload, 3m34s warm core job, acceptance bar exceeded
- Screenshot or artifact links verified? (`Yes`/`No`/`N/A`): N/A
- Not verified or blocked: Full attempt 1 gate was blocked only by the unrelated 30-minute Network recovery E2E cancellation

## Security Impact

- New permissions or capabilities? (`Yes`/`No`): No
- Secrets or tokens handling changed? (`Yes`/`No`): No
- New or changed network calls? (`Yes`/`No`): No
- Command or tool execution surface changed? (`Yes`/`No`): No
- Data access scope changed? (`Yes`/`No`): No
- If any answer is `Yes`, explain the risk and mitigation: N/A

## Compatibility and Migration

- Backward compatible? (`Yes`/`No`): Yes
- Config or environment changes? (`Yes`/`No`): Yes, CI-only `NUGET_PACKAGES` for `core-tests`
- Migration needed? (`Yes`/`No`): No
- If yes, list the exact upgrade steps: N/A

## Review Conversations

- [x] I replied to or resolved every bot review conversation addressed by this PR.
- [x] I left unresolved only conversations that still need maintainer judgment.