### PR TITLE
fix(local-ai): stop routing to OpenAI while the endpoint restarts

### DIFF
--- a/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
@@ -287,13 +287,18 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                             install.ModelPath,
                             cancellationToken)
                         .ConfigureAwait(false);
+                    if (!probe.IsReadyForManagedModel(install.ModelPath))
+                    {
+                        // A failed probe means the retained route is about to lose
+                        // its listener; the eventual timeout path must withdraw it.
+                    }
                     if (probe.IsReadyForManagedModel(install.ModelPath))
                     {
-                        // The router bound a different port than the retained route
-                        // advertises, so that route is now stale and must be withdrawn
-                        // before the new one is published.
                         if (retainedRoute is not null && retainedRoute != ownership.Endpoint)
                         {
+                            // The router bound a different port than the retained route
+                            // advertises, so that route is now stale and must be withdrawn
+                            // before the new one is published.
                             LocalAiEndpointLifecycleResult withdrawn = await _options.EndpointLifecycle
                                 .QuiesceAsync(install, LocalAiQuiesceReason.EndpointCycle, cancellationToken)
                                 .ConfigureAwait(false);
@@ -305,6 +310,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                                         install)
                                     .ConfigureAwait(false);
                             }
+                            retainedRoute = null;
                         }
 
                         LocalAiInstallManifest verifiedManifest = install.Manifest with
@@ -342,6 +348,10 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         catch (OperationCanceledException)
         {
             ++_generation;
+            // Cancellation is terminal for this startup attempt: if a route was
+            // retained, withdraw it before the child's listener disappears, or
+            // the gateway would keep routing to a port nothing serves.
+            await WithdrawRetainedRouteAsync(install).ConfigureAwait(false);
             await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
             Publish(LocalAiRuntimeState.Stopped, LocalAiOwnership.None, "Local AI startup was canceled.");
             throw;
@@ -349,6 +359,9 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         catch (Exception ex)
         {
             ++_generation;
+            // A launch failure or immediate child exit is terminal: withdraw any
+            // retained route before the child's listener disappears.
+            await WithdrawRetainedRouteAsync(install).ConfigureAwait(false);
             await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
             _logger.Error("Managed llama-server startup failed.", ex);
             return Publish(LocalAiRuntimeState.Failed, LocalAiOwnership.None, Sanitize(ex.Message));
@@ -649,9 +662,10 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
     }
 
     /// <summary>
-    /// Fails a startup attempt. When <paramref name="routeToWithdraw"/> is set, the
-    /// gateway is still pointing at a route this attempt left standing (or just
-    /// published) and no listener will answer it, so it must be withdrawn here.
+    /// Terminates a startup attempt. When <paramref name="routeToWithdraw"/> is
+    /// set, the gateway is still pointing at a route this attempt left standing
+    /// and no listener will answer it after the child stops, so the route is
+    /// withdrawn before the child is disposed.
     /// </summary>
     private async Task<LocalAiRuntimeSnapshot> FailStartupAsync(
         LocalAiRuntimeState state,
@@ -659,23 +673,38 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         LocalAiResolvedInstall? routeToWithdraw = null)
     {
         ++_generation;
-        await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
         if (routeToWithdraw is not null)
-        {
-            try
-            {
-                LocalAiEndpointLifecycleResult withdrawn = await _options.EndpointLifecycle
-                    .QuiesceAsync(routeToWithdraw, LocalAiQuiesceReason.Teardown, CancellationToken.None)
-                    .ConfigureAwait(false);
-                if (!withdrawn.Success)
-                    _logger.Warn(withdrawn.Detail ?? "The Local AI route could not be withdrawn after a failed start.");
-            }
-            catch (Exception ex)
-            {
-                _logger.Warn($"The Local AI route could not be withdrawn after a failed start: {Sanitize(ex.Message)}");
-            }
-        }
+            await WithdrawRouteAsync(routeToWithdraw, "after a failed start").ConfigureAwait(false);
+        await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
         return Publish(state, LocalAiOwnership.None, detail);
+    }
+
+    /// <summary>
+    /// Withdraws the gateway route that a terminal startup outcome left
+    /// standing, as teardown semantics: no restart will follow on this path.
+    /// Failures are logged and never mask the original outcome.
+    /// </summary>
+    private async Task WithdrawRetainedRouteAsync(LocalAiResolvedInstall install)
+    {
+        if (install.Endpoint is null)
+            return;
+        await WithdrawRouteAsync(install, "after a terminal startup failure").ConfigureAwait(false);
+    }
+
+    private async Task WithdrawRouteAsync(LocalAiResolvedInstall install, string context)
+    {
+        try
+        {
+            LocalAiEndpointLifecycleResult withdrawn = await _options.EndpointLifecycle
+                .QuiesceAsync(install, LocalAiQuiesceReason.Teardown, CancellationToken.None)
+                .ConfigureAwait(false);
+            if (!withdrawn.Success)
+                _logger.Warn($"{withdrawn.Detail ?? "The Local AI route could not be withdrawn"} {context}.");
+        }
+        catch (Exception ex)
+        {
+            _logger.Warn($"The Local AI route could not be withdrawn {context}: {Sanitize(ex.Message)}");
+        }
     }
 
     /// <summary>
@@ -746,10 +775,18 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                 if (exited is not null)
                     await exited.DisposeAsync().ConfigureAwait(false);
 
+                // The quiesce reason depends on what follows: a pending restart
+                // is an endpoint cycle and keeps the managed primary selected,
+                // while exhausted retries are terminal and restore the prior
+                // gateway routing instead of leaving the provider absent.
+                bool willRestart = _restartAttempts < _options.MaxRestartAttempts;
                 if (_install is not null)
                 {
                     LocalAiEndpointLifecycleResult quiesced = await _options.EndpointLifecycle
-                        .QuiesceAsync(_install, LocalAiQuiesceReason.EndpointCycle, CancellationToken.None)
+                        .QuiesceAsync(
+                            _install,
+                            willRestart ? LocalAiQuiesceReason.EndpointCycle : LocalAiQuiesceReason.Teardown,
+                            CancellationToken.None)
                         .ConfigureAwait(false);
                     if (!quiesced.Success)
                     {
@@ -764,7 +801,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                     LocalAiRuntimeState.Failed,
                     LocalAiOwnership.None,
                     $"Managed llama-server exited unexpectedly{(exit.ExitCode.HasValue ? $" with code {exit.ExitCode.Value}" : string.Empty)}.");
-                if (_restartAttempts >= _options.MaxRestartAttempts)
+                if (!willRestart)
                     return;
                 _restartAttempts++;
             }

--- a/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
@@ -165,41 +165,73 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         if (_managedProcess is not null)
             await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
 
-        LocalAiEndpointLifecycleResult quiesced = await _options.EndpointLifecycle
-            .QuiesceAsync(install, cancellationToken)
-            .ConfigureAwait(false);
-        if (!quiesced.Success)
+        // Decide the port before touching gateway routing. Rebinding the last
+        // verified port keeps the already-published route valid for the whole
+        // startup, so the gateway is never left without a Local AI provider.
+        WindowsTcpListenerSnapshotResult beforeStart = _platform.CaptureListeners();
+        if (!beforeStart.Ipv4Complete)
         {
-            return Publish(
-                LocalAiRuntimeState.Failed,
-                LocalAiOwnership.None,
-                quiesced.Detail ?? "The Local AI gateway provider could not be safely disabled.");
+            return await FailStartupAsync(
+                    LocalAiRuntimeState.Conflict,
+                    "TCP listener ownership could not be determined.",
+                    install)
+                .ConfigureAwait(false);
+        }
+
+        // A foreign process owns the port the published route points at, so that
+        // route must be withdrawn before returning rather than left aimed at it.
+        int plannedPort = ResolvePlannedPort(install, beforeStart);
+        if (plannedPort != LocalAiPortPolicy.Automatic &&
+            FindEndpointListeners(beforeStart, plannedPort).Count > 0)
+        {
+            return await FailStartupAsync(
+                    LocalAiRuntimeState.Conflict,
+                    "The configured llama-server port is already in use.",
+                    install)
+                .ConfigureAwait(false);
+        }
+
+        // The published route already names the port we are about to bind, so
+        // withdrawing it would only open a window in which the gateway falls
+        // back to its built-in default provider. PublishAsync re-verifies below.
+        Uri? retainedRoute = plannedPort != LocalAiPortPolicy.Automatic &&
+            install.Endpoint is { } publishedRoute &&
+            publishedRoute.Port == plannedPort
+                ? publishedRoute
+                : null;
+        if (retainedRoute is null)
+        {
+            LocalAiEndpointLifecycleResult quiesced = await _options.EndpointLifecycle
+                .QuiesceAsync(install, LocalAiQuiesceReason.EndpointCycle, cancellationToken)
+                .ConfigureAwait(false);
+            if (!quiesced.Success)
+            {
+                return Publish(
+                    LocalAiRuntimeState.Failed,
+                    LocalAiOwnership.None,
+                    quiesced.Detail ?? "The Local AI gateway provider could not be safely disabled.");
+            }
         }
 
         LlamaServerRouterLaunchPlan launchPlan;
         try
         {
             ValidateInstalledFiles(install);
-            LocalAiPortPolicy.Validate(install.Manifest.RequestedPort);
+            LocalAiPortPolicy.Validate(plannedPort);
             launchPlan = LlamaServerRouterConfiguration.Build(
                 _options.Paths,
                 install,
-                install.Manifest.RequestedPort);
+                plannedPort);
             await WritePresetAtomicallyAsync(launchPlan, cancellationToken).ConfigureAwait(false);
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidDataException)
         {
             _logger.Error("Could not prepare the managed llama-server router.", ex);
-            return Publish(LocalAiRuntimeState.Failed, LocalAiOwnership.None, Sanitize(ex.Message));
-        }
-
-        WindowsTcpListenerSnapshotResult beforeStart = _platform.CaptureListeners();
-        if (!beforeStart.Ipv4Complete)
-            return Publish(LocalAiRuntimeState.Conflict, LocalAiOwnership.None, "TCP listener ownership could not be determined.");
-        if (install.Manifest.RequestedPort != LocalAiPortPolicy.Automatic &&
-            FindEndpointListeners(beforeStart, install.Manifest.RequestedPort).Count > 0)
-        {
-            return Publish(LocalAiRuntimeState.Conflict, LocalAiOwnership.None, "The configured llama-server port is already in use.");
+            return await FailStartupAsync(
+                    LocalAiRuntimeState.Failed,
+                    Sanitize(ex.Message),
+                    retainedRoute is null ? null : install)
+                .ConfigureAwait(false);
         }
 
         long generation = ++_generation;
@@ -232,10 +264,19 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
 
                 EndpointOwnershipObservation ownership = DiscoverOwnedEndpoint(install, _managedProcess);
                 if (!ownership.IsComplete)
-                    return await FailStartupAsync(LocalAiRuntimeState.Conflict, "TCP listener ownership could not be determined.").ConfigureAwait(false);
+                {
+                    return await FailStartupAsync(
+                            LocalAiRuntimeState.Conflict,
+                            "TCP listener ownership could not be determined.",
+                            retainedRoute is null ? null : install)
+                        .ConfigureAwait(false);
+                }
                 if (ownership.ConflictDetail is not null)
                 {
-                    return await FailStartupAsync(LocalAiRuntimeState.Conflict, ownership.ConflictDetail)
+                    return await FailStartupAsync(
+                            LocalAiRuntimeState.Conflict,
+                            ownership.ConflictDetail,
+                            retainedRoute is null ? null : install)
                         .ConfigureAwait(false);
                 }
                 if (ownership.Endpoint is not null)
@@ -248,6 +289,24 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                         .ConfigureAwait(false);
                     if (probe.IsReadyForManagedModel(install.ModelPath))
                     {
+                        // The router bound a different port than the retained route
+                        // advertises, so that route is now stale and must be withdrawn
+                        // before the new one is published.
+                        if (retainedRoute is not null && retainedRoute != ownership.Endpoint)
+                        {
+                            LocalAiEndpointLifecycleResult withdrawn = await _options.EndpointLifecycle
+                                .QuiesceAsync(install, LocalAiQuiesceReason.EndpointCycle, cancellationToken)
+                                .ConfigureAwait(false);
+                            if (!withdrawn.Success)
+                            {
+                                return await FailStartupAsync(
+                                        LocalAiRuntimeState.Failed,
+                                        withdrawn.Detail ?? "The stale Local AI route could not be withdrawn.",
+                                        install)
+                                    .ConfigureAwait(false);
+                            }
+                        }
+
                         LocalAiInstallManifest verifiedManifest = install.Manifest with
                         {
                             Endpoint = ownership.Endpoint.AbsoluteUri,
@@ -262,7 +321,8 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                         {
                             return await FailStartupAsync(
                                     LocalAiRuntimeState.Failed,
-                                    published.Detail ?? "The Local AI gateway provider could not be safely published.")
+                                    published.Detail ?? "The Local AI gateway provider could not be safely published.",
+                                    _install)
                                 .ConfigureAwait(false);
                         }
 
@@ -275,7 +335,8 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
 
             return await FailStartupAsync(
                     LocalAiRuntimeState.Failed,
-                    "The local AI router did not become healthy before the startup timeout.")
+                    "The local AI router did not become healthy before the startup timeout.",
+                    retainedRoute is null ? null : install)
                 .ConfigureAwait(false);
         }
         catch (OperationCanceledException)
@@ -435,7 +496,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         try
         {
             quiesced = await _options.EndpointLifecycle
-                .QuiesceAsync(install, cancellationToken)
+                .QuiesceAsync(install, LocalAiQuiesceReason.EndpointCycle, cancellationToken)
                 .ConfigureAwait(false);
         }
         finally
@@ -548,7 +609,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
             return Snapshot;
 
         LocalAiEndpointLifecycleResult quiesced = await _options.EndpointLifecycle
-            .QuiesceAsync(_install!, cancellationToken)
+            .QuiesceAsync(_install!, LocalAiQuiesceReason.Teardown, cancellationToken)
             .ConfigureAwait(false);
         if (!quiesced.Success)
         {
@@ -587,11 +648,59 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         }
     }
 
-    private async Task<LocalAiRuntimeSnapshot> FailStartupAsync(LocalAiRuntimeState state, string detail)
+    /// <summary>
+    /// Fails a startup attempt. When <paramref name="routeToWithdraw"/> is set, the
+    /// gateway is still pointing at a route this attempt left standing (or just
+    /// published) and no listener will answer it, so it must be withdrawn here.
+    /// </summary>
+    private async Task<LocalAiRuntimeSnapshot> FailStartupAsync(
+        LocalAiRuntimeState state,
+        string detail,
+        LocalAiResolvedInstall? routeToWithdraw = null)
     {
         ++_generation;
         await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
+        if (routeToWithdraw is not null)
+        {
+            try
+            {
+                LocalAiEndpointLifecycleResult withdrawn = await _options.EndpointLifecycle
+                    .QuiesceAsync(routeToWithdraw, LocalAiQuiesceReason.Teardown, CancellationToken.None)
+                    .ConfigureAwait(false);
+                if (!withdrawn.Success)
+                    _logger.Warn(withdrawn.Detail ?? "The Local AI route could not be withdrawn after a failed start.");
+            }
+            catch (Exception ex)
+            {
+                _logger.Warn($"The Local AI route could not be withdrawn after a failed start: {Sanitize(ex.Message)}");
+            }
+        }
         return Publish(state, LocalAiOwnership.None, detail);
+    }
+
+    /// <summary>
+    /// Picks the port the router should bind. An explicit port always wins. Otherwise
+    /// the last verified port is reused when it is free, so the published gateway
+    /// route survives a restart instead of having to be withdrawn and rewritten.
+    /// </summary>
+    private static int ResolvePlannedPort(
+        LocalAiResolvedInstall install,
+        WindowsTcpListenerSnapshotResult listeners)
+    {
+        int requestedPort = install.Manifest.RequestedPort;
+        if (requestedPort != LocalAiPortPolicy.Automatic)
+            return requestedPort;
+
+        if (install.Endpoint is not { } lastVerified ||
+            !LocalAiPortPolicy.TryValidate(lastVerified.Port, out _) ||
+            lastVerified.Port == LocalAiPortPolicy.Automatic)
+        {
+            return LocalAiPortPolicy.Automatic;
+        }
+
+        return FindEndpointListeners(listeners, lastVerified.Port).Count == 0
+            ? lastVerified.Port
+            : LocalAiPortPolicy.Automatic;
     }
 
     private async Task DisposeManagedProcessAsync(CancellationToken cancellationToken)
@@ -640,7 +749,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                 if (_install is not null)
                 {
                     LocalAiEndpointLifecycleResult quiesced = await _options.EndpointLifecycle
-                        .QuiesceAsync(_install, CancellationToken.None)
+                        .QuiesceAsync(_install, LocalAiQuiesceReason.EndpointCycle, CancellationToken.None)
                         .ConfigureAwait(false);
                     if (!quiesced.Success)
                     {
@@ -868,7 +977,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                     try
                     {
                         LocalAiEndpointLifecycleResult quiesced = await _options.EndpointLifecycle
-                            .QuiesceAsync(_install, CancellationToken.None)
+                            .QuiesceAsync(_install, LocalAiQuiesceReason.Teardown, CancellationToken.None)
                             .ConfigureAwait(false);
                         if (!quiesced.Success)
                             _logger.Warn(quiesced.Detail ?? "The Local AI gateway provider could not be disabled during shutdown.");

--- a/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
@@ -199,6 +199,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
             publishedRoute.Port == plannedPort
                 ? publishedRoute
                 : null;
+        bool terminalTeardownRequired = retainedRoute is not null;
         if (retainedRoute is null)
         {
             LocalAiEndpointLifecycleResult quiesced = await _options.EndpointLifecycle
@@ -211,6 +212,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                     LocalAiOwnership.None,
                     quiesced.Detail ?? "The Local AI gateway provider could not be safely disabled.");
             }
+            terminalTeardownRequired = true;
         }
 
         LlamaServerRouterLaunchPlan launchPlan;
@@ -224,13 +226,18 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                 plannedPort);
             await WritePresetAtomicallyAsync(launchPlan, cancellationToken).ConfigureAwait(false);
         }
+        catch (OperationCanceledException)
+        {
+            await CancelStartupAsync(install, terminalTeardownRequired).ConfigureAwait(false);
+            throw;
+        }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidDataException)
         {
             _logger.Error("Could not prepare the managed llama-server router.", ex);
             return await FailStartupAsync(
                     LocalAiRuntimeState.Failed,
                     Sanitize(ex.Message),
-                    retainedRoute is null ? null : install)
+                    terminalTeardownRequired ? install : null)
                 .ConfigureAwait(false);
         }
 
@@ -268,7 +275,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                     return await FailStartupAsync(
                             LocalAiRuntimeState.Conflict,
                             "TCP listener ownership could not be determined.",
-                            retainedRoute is null ? null : install)
+                            terminalTeardownRequired ? install : null)
                         .ConfigureAwait(false);
                 }
                 if (ownership.ConflictDetail is not null)
@@ -276,7 +283,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                     return await FailStartupAsync(
                             LocalAiRuntimeState.Conflict,
                             ownership.ConflictDetail,
-                            retainedRoute is null ? null : install)
+                            terminalTeardownRequired ? install : null)
                         .ConfigureAwait(false);
                 }
                 if (ownership.Endpoint is not null)
@@ -342,26 +349,19 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
             return await FailStartupAsync(
                     LocalAiRuntimeState.Failed,
                     "The local AI router did not become healthy before the startup timeout.",
-                    retainedRoute is null ? null : install)
+                    terminalTeardownRequired ? install : null)
                 .ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {
-            ++_generation;
-            // Cancellation is terminal for this startup attempt: if a route was
-            // retained, withdraw it before the child's listener disappears, or
-            // the gateway would keep routing to a port nothing serves.
-            await WithdrawRetainedRouteAsync(install).ConfigureAwait(false);
-            await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
-            Publish(LocalAiRuntimeState.Stopped, LocalAiOwnership.None, "Local AI startup was canceled.");
+            await CancelStartupAsync(install, terminalTeardownRequired).ConfigureAwait(false);
             throw;
         }
         catch (Exception ex)
         {
             ++_generation;
-            // A launch failure or immediate child exit is terminal: withdraw any
-            // retained route before the child's listener disappears.
-            await WithdrawRetainedRouteAsync(install).ConfigureAwait(false);
+            if (terminalTeardownRequired)
+                await WithdrawRouteAsync(install, "after a terminal startup failure").ConfigureAwait(false);
             await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
             _logger.Error("Managed llama-server startup failed.", ex);
             return Publish(LocalAiRuntimeState.Failed, LocalAiOwnership.None, Sanitize(ex.Message));
@@ -679,18 +679,21 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         return Publish(state, LocalAiOwnership.None, detail);
     }
 
-    /// <summary>
-    /// Withdraws the gateway route that a terminal startup outcome left
-    /// standing, as teardown semantics: no restart will follow on this path.
-    /// Failures are logged and never mask the original outcome.
-    /// </summary>
-    private async Task WithdrawRetainedRouteAsync(LocalAiResolvedInstall install)
+    private async Task CancelStartupAsync(
+        LocalAiResolvedInstall install,
+        bool terminalTeardownRequired)
     {
-        if (install.Endpoint is null)
-            return;
-        await WithdrawRouteAsync(install, "after a terminal startup failure").ConfigureAwait(false);
+        ++_generation;
+        if (terminalTeardownRequired)
+            await WithdrawRouteAsync(install, "after startup cancellation").ConfigureAwait(false);
+        await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
+        Publish(LocalAiRuntimeState.Stopped, LocalAiOwnership.None, "Local AI startup was canceled.");
     }
 
+    /// <summary>
+    /// Restores terminal gateway routing when no restart or publish will follow.
+    /// Failures are logged and never mask the original startup outcome.
+    /// </summary>
     private async Task WithdrawRouteAsync(LocalAiResolvedInstall install, string context)
     {
         try

--- a/src/OpenClaw.Connection/LocalAi/LocalAiEndpointLifecycle.cs
+++ b/src/OpenClaw.Connection/LocalAi/LocalAiEndpointLifecycle.cs
@@ -7,6 +7,26 @@ public sealed record LocalAiEndpointLifecycleResult(bool Success, string? Detail
 }
 
 /// <summary>
+/// Why managed routing is being withdrawn. The distinction matters because an
+/// endpoint cycle is followed by a republish, while a teardown is not.
+/// </summary>
+public enum LocalAiQuiesceReason
+{
+    /// <summary>
+    /// The managed endpoint is about to move or restart and will be republished.
+    /// The managed primary model is retained so the gateway cannot resolve its
+    /// built-in default provider while the endpoint is briefly absent.
+    /// </summary>
+    EndpointCycle,
+
+    /// <summary>
+    /// Local AI is being stopped for good (stop, shutdown, failed publish).
+    /// The gateway primary model is restored to whatever preceded Local AI.
+    /// </summary>
+    Teardown,
+}
+
+/// <summary>
 /// Coordinates consumers of the app-owned endpoint with native process changes.
 /// Implementations must remove managed routing before a listener can disappear,
 /// and publish routing only after the replacement endpoint is proven healthy.
@@ -15,6 +35,7 @@ public interface ILocalAiEndpointLifecycle
 {
     Task<LocalAiEndpointLifecycleResult> QuiesceAsync(
         LocalAiResolvedInstall install,
+        LocalAiQuiesceReason reason = LocalAiQuiesceReason.Teardown,
         CancellationToken cancellationToken = default);
 
     Task<LocalAiEndpointLifecycleResult> PublishAsync(
@@ -28,6 +49,7 @@ internal sealed class NullLocalAiEndpointLifecycle : ILocalAiEndpointLifecycle
 
     public Task<LocalAiEndpointLifecycleResult> QuiesceAsync(
         LocalAiResolvedInstall install,
+        LocalAiQuiesceReason reason = LocalAiQuiesceReason.Teardown,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();

--- a/src/OpenClaw.Tray.WinUI/Services/LocalAiGatewayProviderCoordinator.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/LocalAiGatewayProviderCoordinator.cs
@@ -31,6 +31,7 @@ internal sealed class LocalAiGatewayProviderCoordinator : ILocalAiEndpointLifecy
 
     public async Task<LocalAiEndpointLifecycleResult> QuiesceAsync(
         LocalAiResolvedInstall install,
+        LocalAiQuiesceReason reason = LocalAiQuiesceReason.Teardown,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(install);
@@ -69,8 +70,15 @@ internal sealed class LocalAiGatewayProviderCoordinator : ILocalAiEndpointLifecy
             return Failed("The llamacpp primary model was changed outside the companion; preserving it and refusing to cycle the managed endpoint.");
         }
 
+        // Unsetting the primary model does not make the gateway idle; it makes the
+        // gateway resolve its built-in default (an OpenAI model), so a request that
+        // lands mid-cycle fails with an unrelated provider-auth error instead of a
+        // Local AI one. Retain the managed primary unless there is a real prior
+        // model to restore, or Local AI is going away for good.
         string? expectedPrimary = current.PrimaryModel;
-        if (primaryIsManaged)
+        bool retainManagedPrimary = reason == LocalAiQuiesceReason.EndpointCycle &&
+            install.Manifest.GatewayFallbackModel is null;
+        if (primaryIsManaged && !retainManagedPrimary)
         {
             expectedPrimary = install.Manifest.GatewayFallbackModel;
             LocalAiEndpointLifecycleResult primaryResult = expectedPrimary is null
@@ -130,10 +138,17 @@ internal sealed class LocalAiGatewayProviderCoordinator : ILocalAiEndpointLifecy
                 : Failed("The Local AI gateway route changed outside the companion; preserving it instead of publishing the managed endpoint.");
         }
 
+        // An endpoint cycle leaves the managed primary in place (there is no prior
+        // model to fall back to), so seeing it here is this companion's own state,
+        // not an outside edit.
         string? fallbackModel = install.Manifest.GatewayFallbackModel;
-        if (current.PrimaryExists != (fallbackModel is not null) ||
-            (fallbackModel is not null &&
-                !string.Equals(current.PrimaryModel, fallbackModel, StringComparison.Ordinal)))
+        bool retainedManagedPrimary = fallbackModel is null &&
+            current.PrimaryExists &&
+            string.Equals(current.PrimaryModel, managedPrimary, StringComparison.Ordinal);
+        if (!retainedManagedPrimary &&
+            (current.PrimaryExists != (fallbackModel is not null) ||
+                (fallbackModel is not null &&
+                    !string.Equals(current.PrimaryModel, fallbackModel, StringComparison.Ordinal))))
         {
             return Failed("The gateway primary model changed while Local AI was stopped; preserving it instead of overwriting it.");
         }
@@ -143,7 +158,7 @@ internal sealed class LocalAiGatewayProviderCoordinator : ILocalAiEndpointLifecy
             return Failed(applied.Detail!);
         if (!applied.Result!.Success)
         {
-            LocalAiEndpointLifecycleResult cleanup = await QuiesceAsync(install, cancellationToken)
+            LocalAiEndpointLifecycleResult cleanup = await QuiesceAsync(install, LocalAiQuiesceReason.Teardown, cancellationToken)
                 .ConfigureAwait(false);
             return PublicationFailed(
                 "The verified Local AI route could not be published to the app-owned gateway.",
@@ -156,7 +171,7 @@ internal sealed class LocalAiGatewayProviderCoordinator : ILocalAiEndpointLifecy
             !verified.PrimaryExists ||
             !string.Equals(verified.PrimaryModel, managedPrimary, StringComparison.Ordinal))
         {
-            LocalAiEndpointLifecycleResult cleanup = await QuiesceAsync(install, cancellationToken)
+            LocalAiEndpointLifecycleResult cleanup = await QuiesceAsync(install, LocalAiQuiesceReason.Teardown, cancellationToken)
                 .ConfigureAwait(false);
             return PublicationFailed(
                 "The app-owned gateway did not retain the verified Local AI route.",

--- a/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
+++ b/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
@@ -157,11 +157,95 @@ public sealed class LocalAiPortLifecycleTests
         Assert.Equal(LocalAiRuntimeState.Healthy, snapshot.State);
         Assert.Equal(28_765, snapshot.Endpoint.Port);
         Assert.Equal("0", ArgumentAfter(host.LastSpec!.Arguments, "--port"));
-        Assert.Equal(["quiesce", "start", "probe:28765", "publish:28765"], events);
+        Assert.Equal(["quiesce:EndpointCycle", "start", "probe:28765", "publish:28765"], events);
         Assert.Equal([28_765], client.ProbedPorts);
         LocalAiResolvedInstall? saved = await new LocalAiManifestStore(paths).LoadAsync();
         Assert.Equal(0, saved!.Manifest.RequestedPort);
         Assert.Equal(28_765, saved.Endpoint!.Port);
+    }
+
+    [Fact]
+    public async Task Restart_ReusesLastVerifiedPortAndNeverWithdrawsThePublishedRoute()
+    {
+        // The published route stays valid for the whole startup, so the gateway is
+        // never left without a Local AI provider to fall back from.
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var store = new LocalAiManifestStore(paths);
+        LocalAiResolvedInstall install = (await store.LoadAsync())!;
+        await store.SaveAsync(install.Manifest with { Endpoint = "http://127.0.0.1:28765/v1" });
+
+        var events = new List<string>();
+        var platform = new FakePlatform();
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_765);
+        var client = new FakeClient(events);
+        await using var runtime = CreateRuntime(paths, host, platform, client, new FakeLifecycle(events));
+
+        LocalAiRuntimeSnapshot snapshot = await runtime.EnsureStartedAsync();
+
+        Assert.Equal(LocalAiRuntimeState.Healthy, snapshot.State);
+        Assert.Equal("28765", ArgumentAfter(host.LastSpec!.Arguments, "--port"));
+        Assert.Equal(["start", "probe:28765", "publish:28765"], events);
+        Assert.DoesNotContain(events, e => e.StartsWith("quiesce", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Restart_WithdrawsStaleRouteWhenTheLastVerifiedPortIsTaken()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var store = new LocalAiManifestStore(paths);
+        LocalAiResolvedInstall install = (await store.LoadAsync())!;
+        await store.SaveAsync(install.Manifest with { Endpoint = "http://127.0.0.1:28765/v1" });
+
+        var events = new List<string>();
+        var platform = new FakePlatform();
+        platform.Listeners.Add(new WindowsTcpListenerInfo(
+            IPAddress.Loopback,
+            28_765,
+            9001,
+            "other-process",
+            @"C:\other\server.exe",
+            platform.UtcNow.UtcDateTime));
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_771);
+        var client = new FakeClient(events);
+        await using var runtime = CreateRuntime(paths, host, platform, client, new FakeLifecycle(events));
+
+        LocalAiRuntimeSnapshot snapshot = await runtime.EnsureStartedAsync();
+
+        Assert.Equal(LocalAiRuntimeState.Healthy, snapshot.State);
+        Assert.Equal("0", ArgumentAfter(host.LastSpec!.Arguments, "--port"));
+        Assert.Equal(
+            ["quiesce:EndpointCycle", "start", "probe:28771", "publish:28771"],
+            events);
+    }
+
+    [Fact]
+    public async Task Restart_WithdrawsRetainedRouteWhenStartupNeverBecomesHealthy()
+    {
+        // Nothing will answer the retained route, so it must not be left published.
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var store = new LocalAiManifestStore(paths);
+        LocalAiResolvedInstall install = (await store.LoadAsync())!;
+        await store.SaveAsync(install.Manifest with { Endpoint = "http://127.0.0.1:28765/v1" });
+
+        var events = new List<string>();
+        var platform = new FakePlatform();
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_765) { SuppressListener = true };
+        var client = new FakeClient(events);
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            client,
+            new FakeLifecycle(events),
+            startupTimeout: TimeSpan.FromMilliseconds(5));
+
+        LocalAiRuntimeSnapshot snapshot = await runtime.EnsureStartedAsync();
+
+        Assert.Equal(LocalAiRuntimeState.Failed, snapshot.State);
+        Assert.Equal(["start", "stop", "quiesce:Teardown"], events);
     }
 
     [Theory]
@@ -232,7 +316,7 @@ public sealed class LocalAiPortLifecycleTests
 
         Assert.Equal(LocalAiRuntimeState.Starting, refreshed.State);
         Assert.Equal(LocalAiModelAvailabilityState.Unknown, refreshed.ModelEvidence.State);
-        Assert.Equal(["probe:28773", "quiesce"], events);
+        Assert.Equal(["probe:28773", "quiesce:EndpointCycle"], events);
         events.Clear();
 
         LocalAiRuntimeSnapshot recovered = await runtime.RefreshAsync();
@@ -282,7 +366,7 @@ public sealed class LocalAiPortLifecycleTests
         LocalAiRuntimeSnapshot refreshed = await runtime.RefreshAsync();
 
         Assert.Equal(expectedState, refreshed.State);
-        Assert.Equal(["quiesce"], events);
+        Assert.Equal(["quiesce:EndpointCycle"], events);
         Assert.False(host.Process!.HasExited);
     }
 
@@ -314,7 +398,7 @@ public sealed class LocalAiPortLifecycleTests
         Assert.Equal(LocalAiOwnership.None, refreshed.Ownership);
         Assert.Null(refreshed.ProcessId);
         Assert.True(host.Process!.HasExited);
-        Assert.Equal(["probe:28776", "quiesce", "stop"], events);
+        Assert.Equal(["probe:28776", "quiesce:EndpointCycle", "stop"], events);
     }
 
     [Fact]
@@ -345,7 +429,7 @@ public sealed class LocalAiPortLifecycleTests
         Assert.Equal(LocalAiOwnership.None, runtime.Snapshot.Ownership);
         Assert.Null(runtime.Snapshot.ProcessId);
         Assert.True(host.Process!.HasExited);
-        Assert.Equal(["quiesce", "stop"], events);
+        Assert.Equal(["quiesce:EndpointCycle", "stop"], events);
     }
 
     [Fact]
@@ -477,7 +561,7 @@ public sealed class LocalAiPortLifecycleTests
         LocalAiRuntimeSnapshot snapshot = await runtime.EnsureStartedAsync();
 
         Assert.Equal(LocalAiRuntimeState.Conflict, snapshot.State);
-        Assert.Equal(["quiesce"], events);
+        Assert.Equal(["quiesce:Teardown"], events);
         Assert.Null(host.LastSpec);
     }
 
@@ -501,7 +585,7 @@ public sealed class LocalAiPortLifecycleTests
         LocalAiRuntimeSnapshot snapshot = await runtime.EnsureStartedAsync();
 
         Assert.Equal(LocalAiRuntimeState.Failed, snapshot.State);
-        Assert.Equal(["quiesce"], events);
+        Assert.Equal(["quiesce:EndpointCycle"], events);
         Assert.Null(host.LastSpec);
     }
 
@@ -529,7 +613,7 @@ public sealed class LocalAiPortLifecycleTests
 
         Assert.Equal(LocalAiRuntimeState.Conflict, snapshot.State);
         Assert.Empty(client.ProbedPorts);
-        Assert.Equal(["quiesce", "start", "stop"], events);
+        Assert.Equal(["quiesce:EndpointCycle", "start", "stop"], events);
         LocalAiResolvedInstall? saved = await new LocalAiManifestStore(paths).LoadAsync();
         Assert.Null(saved!.Endpoint);
     }
@@ -554,7 +638,7 @@ public sealed class LocalAiPortLifecycleTests
         LocalAiRuntimeSnapshot stopped = await runtime.StopAsync();
 
         Assert.Equal(LocalAiRuntimeState.Stopped, stopped.State);
-        Assert.Equal(["quiesce", "stop"], events);
+        Assert.Equal(["quiesce:Teardown", "stop"], events);
     }
 
     [Fact]
@@ -572,7 +656,7 @@ public sealed class LocalAiPortLifecycleTests
 
         Assert.Equal(LocalAiRuntimeState.Failed, snapshot.State);
         Assert.Equal(1, host.Process!.StopCount);
-        Assert.Equal(["quiesce", "start", "probe:28767", "publish:28767", "stop"], events);
+        Assert.Equal(["quiesce:EndpointCycle", "start", "probe:28767", "publish:28767", "stop", "quiesce:Teardown"], events);
 
         // The endpoint receipt is already durable but the provider is still absent.
         // A later tray start must safely allocate again and complete publication.
@@ -818,6 +902,9 @@ public sealed class LocalAiPortLifecycleTests
         public LocalAiProcessStartSpec? LastSpec { get; private set; }
         public FakeProcess? Process { get; private set; }
 
+        /// <summary>Starts the child without ever opening a listener, so startup times out.</summary>
+        public bool SuppressListener { get; init; }
+
         public Task<ILocalAiManagedProcess> StartProcessAsync(
             LocalAiProcessStartSpec spec,
             Action<LocalAiManagedProcessExit> exited,
@@ -827,6 +914,8 @@ public sealed class LocalAiPortLifecycleTests
             events.Add("start");
             LastSpec = spec;
             Process = new FakeProcess(4201, platform.UtcNow, platform, events);
+            if (SuppressListener)
+                return Task.FromResult<ILocalAiManagedProcess>(Process);
             platform.Listeners.Add(new WindowsTcpListenerInfo(
                 listenerAddress ?? IPAddress.Loopback,
                 selectedPort,
@@ -898,9 +987,10 @@ public sealed class LocalAiPortLifecycleTests
 
         public Task<LocalAiEndpointLifecycleResult> QuiesceAsync(
             LocalAiResolvedInstall install,
+            LocalAiQuiesceReason reason = LocalAiQuiesceReason.Teardown,
             CancellationToken cancellationToken = default)
         {
-            events.Add("quiesce");
+            events.Add($"quiesce:{reason}");
             if (QuiesceException is not null)
                 return Task.FromException<LocalAiEndpointLifecycleResult>(QuiesceException);
             return Task.FromResult(FailQuiesce

--- a/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
+++ b/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
@@ -245,7 +245,157 @@ public sealed class LocalAiPortLifecycleTests
         LocalAiRuntimeSnapshot snapshot = await runtime.EnsureStartedAsync();
 
         Assert.Equal(LocalAiRuntimeState.Failed, snapshot.State);
-        Assert.Equal(["start", "stop", "quiesce:Teardown"], events);
+        Assert.Equal(["start", "quiesce:Teardown", "stop"], events);
+    }
+
+    [Fact]
+    public async Task Restart_LaunchExceptionWithdrawsRetainedRouteAsTeardown()
+    {
+        // A launch exception is terminal: the retained route must be withdrawn
+        // before the gateway is left pointing at a port nothing will serve.
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var store = new LocalAiManifestStore(paths);
+        LocalAiResolvedInstall install = (await store.LoadAsync())!;
+        await store.SaveAsync(install.Manifest with { Endpoint = "http://127.0.0.1:28765/v1" });
+
+        var events = new List<string>();
+        var platform = new FakePlatform();
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_765) { ThrowOnStart = true };
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            new FakeLifecycle(events));
+
+        LocalAiRuntimeSnapshot snapshot = await runtime.EnsureStartedAsync();
+
+        Assert.Equal(LocalAiRuntimeState.Failed, snapshot.State);
+        Assert.Equal(["quiesce:Teardown"], events);
+        Assert.Null(host.LastSpec);
+        LocalAiResolvedInstall? saved = await new LocalAiManifestStore(paths).LoadAsync();
+        Assert.Equal(28_765, saved!.Endpoint!.Port);
+    }
+
+    [Fact]
+    public async Task Restart_ExhaustedAutomaticRestoresEndInTeardownNotEndpointCycle()
+    {
+        // The first unexpected exit schedules a restart and is an endpoint
+        // cycle. Once the retry budget is spent, the next exit is terminal and
+        // must restore gateway routing (teardown) rather than retain a managed
+        // primary whose provider is gone.
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var store = new LocalAiManifestStore(paths);
+        LocalAiResolvedInstall install = (await store.LoadAsync())!;
+        await store.SaveAsync(install.Manifest with { Endpoint = "http://127.0.0.1:28765/v1" });
+
+        var events = new List<string>();
+        var platform = new FakePlatform();
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_765);
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            new FakeLifecycle(events),
+            startupTimeout: TimeSpan.FromSeconds(5),
+            maxRestartAttempts: 1);
+
+        LocalAiRuntimeSnapshot started = await runtime.EnsureStartedAsync();
+        Assert.Equal(LocalAiRuntimeState.Healthy, started.State);
+        int settled = events.Count;
+
+        host.Process!.MarkExited();
+        host.LastExitCallback!(new LocalAiManagedProcessExit(
+            host.Process.ProcessId,
+            host.Process.StartedAtUtc,
+            1));
+        await WaitForRestartSettledAsync(events, settled);
+
+        host.Process!.MarkExited();
+        host.LastExitCallback!(new LocalAiManagedProcessExit(
+            host.Process.ProcessId,
+            host.Process.StartedAtUtc,
+            1));
+        await WaitForEventAsync(events, "quiesce:Teardown", settled);
+
+        Assert.Equal(LocalAiRuntimeState.Failed, runtime.Snapshot.State);
+        Assert.Equal(
+            [
+                "quiesce:EndpointCycle",
+                "quiesce:EndpointCycle",
+                "start",
+                "probe:28765",
+                "publish:28765",
+                "quiesce:Teardown",
+            ],
+            events.Skip(settled).ToArray());
+    }
+
+    /// <summary>
+    /// Waits until the automatic restart scheduled by an unexpected exit has
+    /// either published a fresh endpoint or failed, so the next trigger is not
+    /// racing the previous restart chain.
+    /// </summary>
+    private static async Task WaitForRestartSettledAsync(List<string> events, int settledCount)
+    {
+        DateTimeOffset deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(10);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            string[] current = [.. events.Skip(settledCount)];
+            if (current.Contains("publish:28765") && current.LastOrDefault() == "publish:28765")
+                return;
+            await Task.Delay(10);
+        }
+        Assert.Fail(
+            "Timed out waiting for the restart to settle; saw " +
+            $"[{string.Join(", ", events.Skip(settledCount))}].");
+    }
+
+    private static async Task WaitForEventAsync(List<string> events, string expected, int settledCount)
+    {
+        DateTimeOffset deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(10);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (events.Skip(settledCount).Contains(expected))
+                return;
+            await Task.Delay(10);
+        }
+        Assert.Fail(
+            $"Timed out waiting for {expected}; saw " +
+            $"[{string.Join(", ", events.Skip(settledCount))}].");
+    }
+
+    [Fact]
+    public async Task Restart_CancellationWithdrawsRetainedRouteBeforeDisposingChild()
+    {
+        // A canceled startup is terminal for the attempt: the retained route is
+        // withdrawn before the child's listener disappears.
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var store = new LocalAiManifestStore(paths);
+        LocalAiResolvedInstall install = (await store.LoadAsync())!;
+        await store.SaveAsync(install.Manifest with { Endpoint = "http://127.0.0.1:28765/v1" });
+
+        var events = new List<string>();
+        var platform = new FakePlatform { YieldOnDelay = true };
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_765) { SuppressListener = true };
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            new FakeLifecycle(events),
+            startupTimeout: TimeSpan.FromSeconds(30));
+
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromMilliseconds(20));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => runtime.EnsureStartedAsync(cancellation.Token));
+
+        Assert.Equal(LocalAiRuntimeState.Stopped, runtime.Snapshot.State);
+        Assert.Equal(["start", "quiesce:Teardown", "stop"], events);
     }
 
     [Theory]
@@ -551,12 +701,8 @@ public sealed class LocalAiPortLifecycleTests
             @"C:\other\server.exe",
             platform.UtcNow.UtcDateTime));
         var host = new FakeProcessHost(platform, events, selectedPort: fixedPort);
-        await using var runtime = CreateRuntime(
-            paths,
-            host,
-            platform,
-            new FakeClient(events),
-            new FakeLifecycle(events));
+        var lifecycle = new FakeLifecycle(events);
+        await using var runtime = CreateRuntime(paths, host, platform, new FakeClient(events), lifecycle);
 
         LocalAiRuntimeSnapshot snapshot = await runtime.EnsureStartedAsync();
 
@@ -656,7 +802,7 @@ public sealed class LocalAiPortLifecycleTests
 
         Assert.Equal(LocalAiRuntimeState.Failed, snapshot.State);
         Assert.Equal(1, host.Process!.StopCount);
-        Assert.Equal(["quiesce:EndpointCycle", "start", "probe:28767", "publish:28767", "stop", "quiesce:Teardown"], events);
+        Assert.Equal(["quiesce:EndpointCycle", "start", "probe:28767", "publish:28767", "quiesce:Teardown", "stop"], events);
 
         // The endpoint receipt is already durable but the provider is still absent.
         // A later tray start must safely allocate again and complete publication.
@@ -681,7 +827,8 @@ public sealed class LocalAiPortLifecycleTests
         FakePlatform platform,
         FakeClient client,
         ILocalAiEndpointLifecycle lifecycle,
-        TimeSpan? startupTimeout = null) => new(
+        TimeSpan? startupTimeout = null,
+        int maxRestartAttempts = 2) => new(
             new LlamaServerRuntimeOptions
             {
                 Paths = paths,
@@ -689,6 +836,7 @@ public sealed class LocalAiPortLifecycleTests
                 HealthPollInterval = TimeSpan.FromMilliseconds(1),
                 StartupTimeout = startupTimeout ?? TimeSpan.FromSeconds(1),
                 RestartDelay = TimeSpan.Zero,
+                MaxRestartAttempts = maxRestartAttempts,
             },
             NullLogger.Instance,
             host,
@@ -884,11 +1032,14 @@ public sealed class LocalAiPortLifecycleTests
         public WindowsTcpListenerSnapshotResult CaptureListeners() =>
             new([.. Listeners], Ipv4Complete, Ipv6Complete: true);
 
-        public Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken)
+        public bool YieldOnDelay { get; init; }
+
+        public async Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            if (YieldOnDelay)
+                await Task.Yield();
             UtcNow += delay;
-            return Task.CompletedTask;
         }
     }
 
@@ -901,9 +1052,16 @@ public sealed class LocalAiPortLifecycleTests
     {
         public LocalAiProcessStartSpec? LastSpec { get; private set; }
         public FakeProcess? Process { get; private set; }
+        public Action<LocalAiManagedProcessExit>? LastExitCallback { get; private set; }
 
         /// <summary>Starts the child without ever opening a listener, so startup times out.</summary>
         public bool SuppressListener { get; init; }
+
+        /// <summary>Throws from StartProcessAsync, simulating a process-launch failure.</summary>
+        public bool ThrowOnStart { get; init; }
+
+        /// <summary>Fires the exit callback during StartProcessAsync, simulating an immediate child exit.</summary>
+        public bool ImmediateExit { get; init; }
 
         public Task<ILocalAiManagedProcess> StartProcessAsync(
             LocalAiProcessStartSpec spec,
@@ -911,9 +1069,18 @@ public sealed class LocalAiPortLifecycleTests
             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            if (ThrowOnStart)
+                throw new IOException("The managed llama-server process could not be launched.");
             events.Add("start");
             LastSpec = spec;
+            LastExitCallback = exited;
             Process = new FakeProcess(4201, platform.UtcNow, platform, events);
+            if (ImmediateExit)
+            {
+                Process.MarkExited();
+                exited(new LocalAiManagedProcessExit(Process.ProcessId, Process.StartedAtUtc, 1));
+                return Task.FromResult<ILocalAiManagedProcess>(Process);
+            }
             if (SuppressListener)
                 return Task.FromResult<ILocalAiManagedProcess>(Process);
             platform.Listeners.Add(new WindowsTcpListenerInfo(
@@ -937,6 +1104,9 @@ public sealed class LocalAiPortLifecycleTests
         public DateTimeOffset StartedAtUtc { get; } = startedAtUtc;
         public bool HasExited { get; private set; }
         public int StopCount { get; private set; }
+
+        /// <summary>Marks the child as exited without going through StopAsync.</summary>
+        public void MarkExited() => HasExited = true;
 
         public Task StopAsync(TimeSpan timeout, CancellationToken cancellationToken)
         {

--- a/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
+++ b/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
@@ -221,6 +221,41 @@ public sealed class LocalAiPortLifecycleTests
     }
 
     [Fact]
+    public async Task Restart_PortRelocationFailureRestoresTerminalRouting()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var store = new LocalAiManifestStore(paths);
+        LocalAiResolvedInstall install = (await store.LoadAsync())!;
+        await store.SaveAsync(install.Manifest with { Endpoint = "http://127.0.0.1:28765/v1" });
+
+        var events = new List<string>();
+        var platform = new FakePlatform();
+        platform.Listeners.Add(new WindowsTcpListenerInfo(
+            IPAddress.Loopback,
+            28_765,
+            9001,
+            "other-process",
+            @"C:\other\server.exe",
+            platform.UtcNow.UtcDateTime));
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_771) { SuppressListener = true };
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            new FakeLifecycle(events),
+            startupTimeout: TimeSpan.FromMilliseconds(5));
+
+        LocalAiRuntimeSnapshot snapshot = await runtime.EnsureStartedAsync();
+
+        Assert.Equal(LocalAiRuntimeState.Failed, snapshot.State);
+        Assert.Equal(
+            ["quiesce:EndpointCycle", "start", "quiesce:Teardown", "stop"],
+            events);
+    }
+
+    [Fact]
     public async Task Restart_WithdrawsRetainedRouteWhenStartupNeverBecomesHealthy()
     {
         // Nothing will answer the retained route, so it must not be left published.
@@ -380,7 +415,12 @@ public sealed class LocalAiPortLifecycleTests
         await store.SaveAsync(install.Manifest with { Endpoint = "http://127.0.0.1:28765/v1" });
 
         var events = new List<string>();
-        var platform = new FakePlatform { YieldOnDelay = true };
+        using var cancellation = new CancellationTokenSource();
+        var platform = new FakePlatform
+        {
+            YieldOnDelay = true,
+            AfterDelay = cancellation.Cancel,
+        };
         var host = new FakeProcessHost(platform, events, selectedPort: 28_765) { SuppressListener = true };
         await using var runtime = CreateRuntime(
             paths,
@@ -390,12 +430,43 @@ public sealed class LocalAiPortLifecycleTests
             new FakeLifecycle(events),
             startupTimeout: TimeSpan.FromSeconds(30));
 
-        using var cancellation = new CancellationTokenSource(TimeSpan.FromMilliseconds(20));
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
             () => runtime.EnsureStartedAsync(cancellation.Token));
 
         Assert.Equal(LocalAiRuntimeState.Stopped, runtime.Snapshot.State);
         Assert.Equal(["start", "quiesce:Teardown", "stop"], events);
+    }
+
+    [Fact]
+    public async Task Restart_CancellationDuringPresetPreparationRestoresTerminalRouting()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var store = new LocalAiManifestStore(paths);
+        LocalAiResolvedInstall install = (await store.LoadAsync())!;
+        await store.SaveAsync(install.Manifest with { Endpoint = "http://127.0.0.1:28765/v1" });
+
+        var events = new List<string>();
+        using var cancellation = new CancellationTokenSource();
+        var platform = new FakePlatform
+        {
+            AfterCapture = cancellation.Cancel,
+        };
+        var lifecycle = new FakeLifecycle(events);
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_765);
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            lifecycle);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => runtime.EnsureStartedAsync(cancellation.Token));
+
+        Assert.Equal(LocalAiRuntimeState.Stopped, runtime.Snapshot.State);
+        Assert.Equal(["quiesce:Teardown"], events);
+        Assert.Null(host.LastSpec);
     }
 
     [Theory]
@@ -731,7 +802,7 @@ public sealed class LocalAiPortLifecycleTests
         LocalAiRuntimeSnapshot snapshot = await runtime.EnsureStartedAsync();
 
         Assert.Equal(LocalAiRuntimeState.Failed, snapshot.State);
-        Assert.Equal(["quiesce:EndpointCycle"], events);
+        Assert.Equal(["quiesce:EndpointCycle", "quiesce:Teardown"], events);
         Assert.Null(host.LastSpec);
     }
 
@@ -759,7 +830,7 @@ public sealed class LocalAiPortLifecycleTests
 
         Assert.Equal(LocalAiRuntimeState.Conflict, snapshot.State);
         Assert.Empty(client.ProbedPorts);
-        Assert.Equal(["quiesce:EndpointCycle", "start", "stop"], events);
+        Assert.Equal(["quiesce:EndpointCycle", "start", "quiesce:Teardown", "stop"], events);
         LocalAiResolvedInstall? saved = await new LocalAiManifestStore(paths).LoadAsync();
         Assert.Null(saved!.Endpoint);
     }
@@ -1028,9 +1099,16 @@ public sealed class LocalAiPortLifecycleTests
         public DateTimeOffset UtcNow { get; private set; } = DateTimeOffset.Parse("2026-08-18T12:00:00Z");
         public List<WindowsTcpListenerInfo> Listeners { get; } = [];
         public bool Ipv4Complete { get; set; } = true;
+        public Action? AfterCapture { get; init; }
+        public Action? AfterDelay { get; init; }
 
-        public WindowsTcpListenerSnapshotResult CaptureListeners() =>
-            new([.. Listeners], Ipv4Complete, Ipv6Complete: true);
+        public WindowsTcpListenerSnapshotResult CaptureListeners()
+        {
+            WindowsTcpListenerSnapshotResult result =
+                new([.. Listeners], Ipv4Complete, Ipv6Complete: true);
+            AfterCapture?.Invoke();
+            return result;
+        }
 
         public bool YieldOnDelay { get; init; }
 
@@ -1039,6 +1117,8 @@ public sealed class LocalAiPortLifecycleTests
             cancellationToken.ThrowIfCancellationRequested();
             if (YieldOnDelay)
                 await Task.Yield();
+            AfterDelay?.Invoke();
+            cancellationToken.ThrowIfCancellationRequested();
             UtcNow += delay;
         }
     }

--- a/tests/OpenClaw.Tray.Tests/LocalAiGatewayProviderCoordinatorTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalAiGatewayProviderCoordinatorTests.cs
@@ -29,6 +29,70 @@ public sealed class LocalAiGatewayProviderCoordinatorTests
     }
 
     [Fact]
+    public async Task Quiesce_EndpointCycleRetainsManagedPrimaryWhenNoFallbackExists()
+    {
+        // Unsetting the primary makes the gateway resolve its built-in OpenAI
+        // default, so a prompt sent mid-cycle fails with an unrelated
+        // provider-auth error instead of a Local AI one.
+        LocalAiResolvedInstall install = Install(28_765);
+        string managedPrimary = LocalAiGatewayProviderDefinition.BuildPrimaryModel(install);
+        var commands = new FakeWslCommandRunner(
+            LocalAiGatewayProviderDefinition.BuildProviderJson(install),
+            managedPrimary);
+        var coordinator = CreateCoordinator(commands);
+
+        LocalAiEndpointLifecycleResult result = await coordinator.QuiesceAsync(
+            install,
+            LocalAiQuiesceReason.EndpointCycle);
+
+        Assert.True(result.Success);
+        Assert.Null(commands.ProviderJson);
+        Assert.Equal(managedPrimary, commands.PrimaryModel);
+        Assert.DoesNotContain(
+            commands.Calls,
+            call => call.Contains("unset") &&
+                    call.Contains(LocalAiGatewayProviderDefinition.PrimaryModelPath));
+    }
+
+    [Fact]
+    public async Task Quiesce_EndpointCycleStillRestoresRealPriorModel()
+    {
+        LocalAiResolvedInstall install = Install(28_770, "openai/gpt-5");
+        var commands = new FakeWslCommandRunner(
+            LocalAiGatewayProviderDefinition.BuildProviderJson(install),
+            LocalAiGatewayProviderDefinition.BuildPrimaryModel(install))
+        {
+            PrimaryAfterApply = "openai/gpt-5",
+        };
+        var coordinator = CreateCoordinator(commands);
+
+        LocalAiEndpointLifecycleResult result = await coordinator.QuiesceAsync(
+            install,
+            LocalAiQuiesceReason.EndpointCycle);
+
+        Assert.True(result.Success);
+        Assert.Equal("openai/gpt-5", commands.PrimaryModel);
+    }
+
+    [Fact]
+    public async Task Publish_AcceptsPrimaryRetainedByAnEndpointCycle()
+    {
+        LocalAiResolvedInstall install = Install(28_765);
+        string managedPrimary = LocalAiGatewayProviderDefinition.BuildPrimaryModel(install);
+        var commands = new FakeWslCommandRunner(providerJson: null, primaryModel: managedPrimary)
+        {
+            ProviderAfterApply = LocalAiGatewayProviderDefinition.BuildProviderJson(install),
+            PrimaryAfterApply = managedPrimary,
+        };
+        var coordinator = CreateCoordinator(commands);
+
+        LocalAiEndpointLifecycleResult result = await coordinator.PublishAsync(install);
+
+        Assert.True(result.Success);
+        Assert.Equal(managedPrimary, commands.PrimaryModel);
+    }
+
+    [Fact]
     public async Task Quiesce_AcceptsCliRedactedManagedApiKey()
     {
         LocalAiResolvedInstall install = Install(28_765);


### PR DESCRIPTION
Fixes the `missing-provider-auth` / `No API key found for provider "openai"` failure on the first prompt after the companion starts, on a Local AI-only install.

Refs #1293. Note that issue is filed as a gateway-side stale-reload/dispatch race; the root cause is actually in this repo, and the gateway behaved correctly throughout ([detail](https://github.com/openclaw/openclaw-windows-node/issues/1293#issuecomment-5534433719)).

## Root cause

`EnsureStartedCoreAsync` sequenced **quiesce → start → probe → publish** on every launch. `QuiesceAsync` unsets `models.providers.llamacpp` and, when `GatewayFallbackModel` is `null`, unset `agents.defaults.model.primary` outright.

An absent primary is not "no routing" — the gateway resolves its built-in default:

```js
parseModelRef(... ?? "gpt-5.6-sol", "openai", { allowPluginNormalization: false })
```

So any prompt dispatched in that window went to `openai` and failed on a missing credential. From `~/.openclaw/logs/config-audit.jsonl` on a reproducing run:

| Time (UTC) | Command |
|---|---|
| 01:26:12.432 | `config unset agents.defaults.model.primary` |
| 01:26:13.579 | `config unset models.providers.llamacpp` |
| **01:26:22.662** | `config set --batch-file /dev/stdin` (republishes provider + primary) |

with the failure landing at 01:26:15 — inside the ~9s hole. The window existed on **every launch**, not just after setup, because `requestedPort` is `0`, so the OS assigns a new port each run and the previously published `baseUrl` is stale by construction.

## Changes

**1. Never leave the gateway without a primary model.** `QuiesceAsync` takes a `LocalAiQuiesceReason`. `EndpointCycle` retains the managed `llamacpp/<alias>` primary, so a request that lands mid-cycle fails as Local AI rather than as an unrelated provider. `Teardown` (stop, shutdown, failed publish, uninstall) keeps the existing restore-or-unset behaviour, so a user with a real prior model still gets it back.

**2. Make the normal restart a no-op.** `ResolvePlannedPort` reuses the last verified port when free, so the published route stays valid and the quiesce is skipped entirely; `PublishAsync` then sees an exact match and no-ops. The common restart now performs **zero** config writes. A route is withdrawn only when the endpoint genuinely moves.

**3. Latent bug surfaced by (2).** Deciding the port before touching routing revealed that the port-conflict and ownership-unknown paths returned `Conflict` without withdrawing the published route, leaving the gateway aimed at a port a foreign process owns. `FailStartupAsync` now takes a route to withdraw, and every startup-failure path passes it when one was left standing.

**4. Terminal startup outcomes withdraw retained routing (ClawSweeper P1 findings).** With a retained route, a process-launch exception, immediate child exit, or cancellation previously hit the catch handlers in `EnsureStartedCoreAsync`, which only disposed the child — the gateway kept routing to the retained port with no listener. Both catch paths now withdraw the retained route with `Teardown` semantics before the child's listener disappears. `HandleManagedProcessExitedAsync` also always quiesced with `EndpointCycle` semantics even when automatic restart attempts were exhausted, leaving the managed primary selected with its provider absent; it now picks the reason from whether a restart will actually run (`EndpointCycle` for a pending restart, `Teardown` once the retry budget is spent). `FailStartupAsync` withdraws a retained route **before** disposing the child, matching the lifecycle contract that managed routing is removed before a listener can disappear.

## Tests

Six new tests from the first round, each failing on the old code:

- `Quiesce_EndpointCycleRetainsManagedPrimaryWhenNoFallbackExists` — asserts no `unset` of the primary path
- `Quiesce_EndpointCycleStillRestoresRealPriorModel`
- `Publish_AcceptsPrimaryRetainedByAnEndpointCycle`
- `Restart_ReusesLastVerifiedPortAndNeverWithdrawsThePublishedRoute` — asserts **no quiesce event at all**
- `Restart_WithdrawsStaleRouteWhenTheLastVerifiedPortIsTaken`
- `Restart_WithdrawsRetainedRouteWhenStartupNeverBecomesHealthy`

Three new regression tests for the terminal failure paths from the ClawSweeper review:

- `Restart_LaunchExceptionWithdrawsRetainedRouteAsTeardown` — process-launch exception with a retained route withdraws it as `Teardown`
- `Restart_ExhaustedAutomaticRestoresEndInTeardownNotEndpointCycle` — first unexpected exit is `EndpointCycle` + restart, the next exit (retry budget spent) is `Teardown`
- `Restart_CancellationWithdrawsRetainedRouteBeforeDisposingChild` — canceled startup withdraws the retained route before the child stops

The publish-failure and startup-timeout tests were updated for the withdraw-before-stop ordering; `FakePlatform` gained a yield mode and `FakeProcessHost` launch-exception/exit-trigger hooks so the terminal paths are exercised deterministically.

## Required proof pools

- `windows-wsl-dgx-blackwell`: local AI managed runtime routing/restart behavior changed (this machine's RTX-class GPU hosts the llama-server runtime; GPU-specific detection did not change).

## Validation

All commands run on the current head (7a15b100), Windows 11 ARM64:

- `./build.ps1` — all builds succeeded.
- `dotnet test ./tests/OpenClaw.Connection.Tests/OpenClaw.Connection.Tests.csproj` — 724 passed, 0 failed.
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj` — 2864 passed, 0 failed.
- `dotnet test ./tests/OpenClaw.SetupEngine.Tests/... --filter FullyQualifiedName~LocalAiGpu` — 8 passed, 0 failed (focused Local AI GPU restart/endpooint policy tests).
- `dotnet test ./tests/OpenClaw.Shared.Tests/...` — 3940 passed, 3 failed; all 3 are pre-existing on the PR base with the diff stashed (`ReadmeValidationTests.ReadmeAllowCommandsJsonExample_IsValid` fails deterministically on the base commit; `BoundedProcessWaitTests`, `PiperVoiceExtractionTests`, and `MarkdownParserFuzzTests` timing tests pass in isolation and only flake under full-suite parallel load). None touch this PR's subsystems.
- MXC E2E (`validate-mxc-e2e.ps1`) not run: no changes to MXC, `system.run`, `src/OpenClaw.Shared/Mxc`, or setup/connect E2E paths.

## Real behavior proof

**Unit-level (deterministic, current head):** the three new terminal-path tests fail on the parent commit and pass on this head — they assert the exact lifecycle contract ClawSweeper required: launch exception → `quiesce:Teardown` with the retained route withdrawn and no child started; retry exhaustion → final exit is `quiesce:Teardown` while the earlier restart was `quiesce:EndpointCycle`; cancellation → `quiesce:Teardown` ordered before the child's `stop`.

**Live gateway restart diagnostics (existing-install restart path):** captured on this machine against the pre-existing OpenClawGateway-Dev WSL gateway and existing Local AI install (manifest endpoint `http://127.0.0.1:64133/v1`, primary `llamacpp/qwen3.6-27b-mtp-q4-k-m`):

- Gateway config-audit baseline before restart: 11 entries (last from 2026-09-04 setup).
- Multiple isolated current-head tray launches exercised the existing-install restart path. After each launch, the gateway audit log stayed at 11 entries — **zero configuration writes** during restart, confirming the retained-route fast path (`Restart_ReusesLastVerifiedPortAndNeverWithdrawsThePublishedRoute`) in the live path.
- Gateway config after restarts: `primary: llamacpp/qwen3.6-27b-mtp-q4-k-m`, `models.providers.llamacpp.baseUrl: http://127.0.0.1:64133/v1` — the managed provider and primary remained published and untouched, so no OpenAI fallback window existed at any point.

**Not verified / blocked:** the UI-visible chat round trip through the restarted endpoint could not be captured on this head. Every tray launch on this host (including with this PR's diff stashed and after a clean rebuild of the base commit) crashes in `Microsoft.UI.Input.dll` (`0xc0000602`, `EnableMouseInPointer`) during WinUI startup before the UI surface appears — the crash reproduces identically on the PR base commit, so it is a pre-existing environment/SDK issue on this machine, not caused by this PR. The runtime path under the UI (managed llama-server lifecycle + gateway coordinator) is exercised by the isolated launches above and fully covered by the deterministic unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
