### PR TITLE
fix(setup): let uninstall recover from absent WSL distro

### DIFF
--- a/src/OpenClaw.SetupEngine/WindowsNodeBootstrapContextStep.cs
+++ b/src/OpenClaw.SetupEngine/WindowsNodeBootstrapContextStep.cs
@@ -178,6 +178,21 @@ public sealed class WindowsNodeBootstrapContextStep : SetupStep
         var distro = ctx.DistroName;
         if (string.IsNullOrWhiteSpace(distro))
             return null;
+        var registered = await ctx.Commands.RunAsync(
+            WslConstants.WslExePath,
+            ["--list", "--quiet"],
+            TimeSpan.FromSeconds(15),
+            ct: ct);
+        if (registered.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                "Could not inspect WSL distributions while cleaning legacy Windows node context: " +
+                FirstNonEmpty(registered.Stderr, registered.Stdout));
+        }
+
+        if (!WslInstallSupport.ContainsDistro(registered.Stdout, distro))
+            return null;
+
 
         var user = ctx.Config.Wsl.User;
         var (home, result) = await QueryLinuxHomeAsync(ctx, distro, user, ct);
@@ -261,7 +276,7 @@ public sealed class WindowsNodeBootstrapContextStep : SetupStep
         if (result.ExitCode == 0)
             return false;
 
-        var output = FirstNonEmpty(result.Stderr, result.Stdout);
+        var output = string.Concat(result.Stderr, '\n', result.Stdout);
         return output.Contains("There is no distribution with the supplied name", StringComparison.OrdinalIgnoreCase) ||
                output.Contains("WSL_E_DISTRO_NOT_FOUND", StringComparison.OrdinalIgnoreCase);
     }

--- a/src/OpenClaw.SetupEngine/WindowsNodeBootstrapContextStep.cs
+++ b/src/OpenClaw.SetupEngine/WindowsNodeBootstrapContextStep.cs
@@ -185,6 +185,8 @@ public sealed class WindowsNodeBootstrapContextStep : SetupStep
             ct: ct);
         if (registered.ExitCode != 0)
         {
+            if (IsWslUnavailableResult(registered) || IsMissingDistroResult(registered))
+                return null;
             throw new InvalidOperationException(
                 "Could not inspect WSL distributions while cleaning legacy Windows node context: " +
                 FirstNonEmpty(registered.Stderr, registered.Stdout));
@@ -277,9 +279,20 @@ public sealed class WindowsNodeBootstrapContextStep : SetupStep
             return false;
 
         var output = string.Concat(result.Stderr, '\n', result.Stdout);
+
         return output.Contains("There is no distribution with the supplied name", StringComparison.OrdinalIgnoreCase) ||
                output.Contains("WSL_E_DISTRO_NOT_FOUND", StringComparison.OrdinalIgnoreCase);
     }
+
+    // A conclusive "WSL is unavailable" answer still proves no app-owned distro can
+    // hold legacy Windows node context, so uninstall has nothing to clean. Only an
+    // ambiguous inspection failure (timeout, access denied, empty output) stays an
+    // explicit error. Matches ExistingConfigDetector.InterpretDistroList and the
+    // lenient uninstall behavior in StartGatewayStep and CleanupStaleDistroStep.
+    internal static bool IsWslUnavailableResult(CommandResult result)
+        => result.ExitCode != 0
+            && (WslViabilityInspector.LooksUnavailable(result)
+                || result.Stderr.Contains("Failed to start process", StringComparison.Ordinal));
 
     internal static async Task<string?> ResolveLinuxHomeAsync(SetupContext ctx, string distro, string user, CancellationToken ct)
     {

--- a/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
@@ -4715,6 +4715,19 @@ public class SetupStepsTests : IDisposable
     }
 
     [Fact]
+    public void WindowsNodeContext_IsMissingDistroResult_InspectsBothOutputStreams()
+    {
+        var result = new CommandResult(
+            -1,
+            "There is no distribution with the supplied name.",
+            "wsl: warning: ignored setting",
+            TimeSpan.Zero,
+            TimedOut: false);
+
+        Assert.True(WindowsNodeBootstrapContextStep.IsMissingDistroResult(result));
+    }
+
+    [Fact]
     public async Task WindowsNodeContext_Execute_RunsInWslAsConfiguredUserAndResolvesWorkspace()
     {
         var commands = new FakeCommandRunner(
@@ -5144,10 +5157,31 @@ public class SetupStepsTests : IDisposable
     }
 
     [Fact]
+    public async Task WindowsNodeContext_Rollback_SkipsLegacyCleanupWhenDistroIsAbsent()
+    {
+        var commands = new FakeCommandRunner(
+            arguments =>
+            {
+                Assert.Equal(["--list", "--quiet"], arguments);
+                return Ok("Ubuntu\n");
+            });
+        var ctx = CreateContext(commands: commands);
+
+        await new WindowsNodeBootstrapContextStep().RollbackAsync(ctx, CancellationToken.None);
+
+        Assert.Empty(commands.WslCalls);
+        Assert.Single(commands.Calls);
+    }
+
+    [Fact]
     public async Task WindowsNodeContext_Rollback_CleansLegacyEffectiveWorkspaceWithoutStateFile()
     {
         var commands = new FakeCommandRunner(
-            _ => Fail("unexpected RunAsync"),
+            arguments =>
+            {
+                Assert.Equal(["--list", "--quiet"], arguments);
+                return Ok("OpenClawGateway\n");
+            },
             (_, command, _) =>
             {
                 if (command.Contains("getent passwd"))

--- a/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
@@ -5174,6 +5174,78 @@ public class SetupStepsTests : IDisposable
     }
 
     [Fact]
+    public async Task WindowsNodeContext_Rollback_SkipsLegacyCleanupWhenWslHasNoDistributions()
+    {
+        var commands = new FakeCommandRunner(
+            arguments =>
+            {
+                Assert.Equal(["--list", "--quiet"], arguments);
+                return new CommandResult(
+                    1,
+                    "",
+                    "Windows Subsystem for Linux has no installed distributions.\n" +
+                    "Use 'wsl.exe --list --online' to list available distributions and " +
+                    "'wsl.exe --install <Distro>' to install.",
+                    TimeSpan.Zero,
+                    TimedOut: false);
+            });
+        var ctx = CreateContext(commands: commands);
+
+        await new WindowsNodeBootstrapContextStep().RollbackAsync(ctx, CancellationToken.None);
+
+        Assert.Empty(commands.WslCalls);
+        Assert.Single(commands.Calls);
+    }
+
+    [Fact]
+    public async Task WindowsNodeContext_Rollback_SkipsLegacyCleanupWhenWslExeCannotStart()
+    {
+        var commands = new FakeCommandRunner(
+            _ => new CommandResult(
+                -1,
+                "",
+                @"Failed to start process 'C:\Windows\System32\wsl.exe': The system cannot find the file specified.",
+                TimeSpan.Zero,
+                TimedOut: false));
+        var ctx = CreateContext(commands: commands);
+
+        await new WindowsNodeBootstrapContextStep().RollbackAsync(ctx, CancellationToken.None);
+
+        Assert.Empty(commands.WslCalls);
+        Assert.Single(commands.Calls);
+    }
+
+    [Fact]
+    public async Task WindowsNodeContext_Rollback_FailsWhenDistroInspectionIsAmbiguous()
+    {
+        var commands = new FakeCommandRunner(_ => Fail("Access is denied."));
+        var ctx = CreateContext(commands: commands);
+
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => new WindowsNodeBootstrapContextStep().RollbackAsync(ctx, CancellationToken.None));
+
+        Assert.Contains(
+            "Could not inspect WSL distributions while cleaning legacy Windows node context",
+            error.Message);
+        Assert.Empty(commands.WslCalls);
+    }
+
+    [Fact]
+    public async Task WindowsNodeContext_Rollback_FailsWhenDistroInspectionTimesOut()
+    {
+        var commands = new FakeCommandRunner(_ => TimedOut());
+        var ctx = CreateContext(commands: commands);
+
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => new WindowsNodeBootstrapContextStep().RollbackAsync(ctx, CancellationToken.None));
+
+        Assert.Contains(
+            "Could not inspect WSL distributions while cleaning legacy Windows node context",
+            error.Message);
+        Assert.Empty(commands.WslCalls);
+    }
+
+    [Fact]
     public async Task WindowsNodeContext_Rollback_CleansLegacyEffectiveWorkspaceWithoutStateFile()
     {
         var commands = new FakeCommandRunner(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users rerunning an uninstall would receive a failure after `OpenClawGateway-Dev` had already been removed. Legacy Windows-node context cleanup attempted a distro-specific WSL command even though the configured distro was absent.

## Why This Change Was Made

The legacy cleanup path now checks `wsl --list --quiet` before it resolves the prior distro workspace. An absent distro short-circuits cleanup successfully, while an unavailable WSL listing remains an explicit failure. Missing-distro diagnostics are recognized from either process output stream to handle an unregister race after the registration check.

An inspection failure is treated as "nothing to clean" only when WSL conclusively reports no installed distributions or `wsl.exe` cannot be launched (process start failure). Ambiguous failures such as a timeout or access denied remain explicit uninstall errors, so a hung or failing WSL never silently skips legacy cleanup.

## User Impact

A repeated uninstall now completes when its dev WSL distro has already been unregistered. It does not attempt commands against an unrelated or missing distro. On hosts where WSL is not installed at all, uninstall also completes instead of failing, while genuinely ambiguous WSL failures still stop the uninstall with a clear error.

## Evidence

- Current-head dev executable completed the destructive uninstall with `EXIT=0` after the target distro was already absent.
- Output included `Uninstalling: Inject Windows node context`, followed by `Uninstall completed successfully in 0.8s` and `UNINSTALL COMPLETE`.
- Structured autoreview reported no accepted or actionable findings for the source-equivalent patch.
- Rubber-duck review accepted the final logic and tests with no actionable finding.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs or instructions
- [x] Tests or validation
- [ ] Security hardening
- [ ] Chore or infrastructure

## Scope

- [ ] Tray or WinUI UX
- [ ] Windows node capability
- [ ] Local MCP or `winnode`
- [ ] Gateway, connection, or pairing
- [x] Setup or onboarding
- [ ] Permissions, privacy, or security
- [x] Tests, CI, or docs

## Required proof pools

- `windows-clean-installer-upgrade`: uninstall behavior changed. Not verified on this maintainer-scheduled signed-artifact pool.
  - Environment class this pool would cover: repeat-uninstall on a host with no WSL distributions or no `wsl.exe`. Now covered in-process by `WindowsNodeContext_Rollback_SkipsLegacyCleanupWhenWslHasNoDistributions` and `WindowsNodeContext_Rollback_SkipsLegacyCleanupWhenWslExeCannotStart` (and the ambiguous-failure guards `WindowsNodeContext_Rollback_FailsWhenDistroInspectionIsAmbiguous` / `...TimesOut`). Not a pool run.
- `windows-wsl-gateway-e2e`: WSL recovery behavior changed. Not verified on this maintainer-scheduled clean WSL pool.
  - Environment class this pool would cover: registered app-owned distro cleanup through the real gateway path. Now covered in-process by the rollback/restore regression tests and by real-`wsl.exe` harness proof against the registered `OpenClawGateway-Dev` distro. Not a pool run.

## Validation

- `./build.ps1`: passed.
- `dotnet build tests/OpenClaw.SetupEngine.Tests/OpenClaw.SetupEngine.Tests.csproj`: passed.
- `dotnet test tests/OpenClaw.SetupEngine.Tests/OpenClaw.SetupEngine.Tests.csproj --no-restore`: 1039 passed, 0 failed (baseline 1035 at `ebc9f176` plus 4 new rollback regression tests).
- `dotnet test tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore`: 3905 passed, 32 skipped, 0 failed.
- `dotnet test tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore`: 2833 passed, 0 failed.
- Mutant sanity check: reverting the conclusive-unavailable escape fails both new skip tests; replacing it with a bare nonzero-exit skip fails both new ambiguous-failure tests. The four tests are load-bearing.

## Real Behavior Proof

- Environment tested: native ARM64 dev build with the target `OpenClawGateway-Dev` distro absent.
- PR head or commit tested: `ebc9f176`.
- Exact steps or command run: built `OpenClaw.Tray.WinUI.exe` with `-DevBuild`, verified `app-identity.txt` equals `dev`, then ran `OpenClaw.Tray.WinUI.exe --uninstall --confirm-destructive`.
- Evidence after fix: process exit `0`; the output traversed `Inject Windows node context` without a distro query and ended with `Uninstall completed successfully in 0.8s` and `UNINSTALL COMPLETE`.
- Observed result: idempotent cleanup succeeds when the configured WSL distro is already gone.
- Screenshot or artifact links verified? `N/A`.
- Not verified or blocked: official signed-installer and clean WSL Gateway proof-pool runs are maintainer-scheduled and capacity-dependent. Local proof used dev-only data and did not expose model paths, credentials, tokens, identities, or gateway settings.
- Mitigation decision: adopt maintainer option 1 - keep the registration pre-check and the explicit inspection-failure path, with conclusive-unavailable results treated as no legacy target, so legacy teardown is idempotent without masking a real WSL failure.
- Additional proof at new head `8e89578e` (throwaway harness outside the repo, real `wsl.exe`, dev runner logging visible):
  - Absent configured distro (`OpenClawGateway-Absent-Proof`): exactly one real `wsl.exe --list --quiet` (exit 0, 235 ms), zero in-distro commands, no exception, harness printed `ABSENT-OK`.
  - Registered configured distro (`OpenClawGateway-Dev`): `wsl.exe --list --quiet`, in-distro `getent passwd "$(id -un)" | cut -d: -f6`, then the stdin-fed rollback script (exit 0), then `ExecuteAsync` restore printing `RESTORE=Success message=Windows node context injected`, then a second rollback for idempotency (exit 0), harness printed `REGISTERED-OK`.
  - Post-proof host state: `wsl.exe -l -v` still lists `OpenClawGateway-Dev` as `Running`, version 2. No distro contents, tokens, or gateway records were read or published; Windows user and profile paths redacted.
  - No destructive uninstall was rerun in this pass: `OpenClawGateway-Dev` is registered and running and hosts the live dev gateway; the CLI-level destructive-uninstall proof at `ebc9f176` above remains the CLI-level evidence.

## Security Impact

- New permissions or capabilities? `No`
- Secrets or tokens handling changed? `No`
- New or changed network calls? `No`
- Command or tool execution surface changed? `No`
- Data access scope changed? `No`

## Compatibility and Migration

- Backward compatible? `Yes`
- Config or environment changes? `No`
- Migration needed? `No`

## Review Conversations

- [x] I replied to or resolved every bot review conversation addressed by this PR.
- [x] I left unresolved only conversations that still need maintainer judgment.
