### PR TITLE
docs: improve LocalAi module documentation and agent coding rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,14 @@ Notes:
 
 Run the required validation above for every code change, then add the targeted path that matches the touched subsystem.
 
+## Coding rules
+
+- Avoid generating functions with high cyclomatic complexity.
+- Bias to break down code into smaller functions solving specific problems (single responsibility).
+- Prefer using functional idioms using functions to compose logic rather than nested and verbose procedural code.
+- Apply SOLID principles where possible, single responsibility, open/closed, Liskov substitution, interface segregation, and dependency inversion.
+- Add a top-level module documentation describing what's the purpose of the module, how it fits in the general architecture and an example usage of its main purpose.
+
 ### MXC / `system.run` / Windows node command execution
 
 When changing MXC sandboxing, `system.run`, exec approvals, Windows node command execution, gateway setup/connect E2E behavior, or files under `src\OpenClaw.Shared\Mxc`, run:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,14 +43,6 @@ Notes:
 
 Run the required validation above for every code change, then add the targeted path that matches the touched subsystem.
 
-## Coding rules
-
-- Avoid generating functions with high cyclomatic complexity.
-- Bias to break down code into smaller functions solving specific problems (single responsibility).
-- Prefer using functional idioms using functions to compose logic rather than nested and verbose procedural code.
-- Apply SOLID principles where possible, single responsibility, open/closed, Liskov substitution, interface segregation, and dependency inversion.
-- Add a top-level module documentation describing what's the purpose of the module, how it fits in the general architecture and an example usage of its main purpose.
-
 ### MXC / `system.run` / Windows node command execution
 
 When changing MXC sandboxing, `system.run`, exec approvals, Windows node command execution, gateway setup/connect E2E behavior, or files under `src\OpenClaw.Shared\Mxc`, run:
@@ -60,6 +52,12 @@ When changing MXC sandboxing, `system.run`, exec approvals, Windows node command
 ```
 
 The script sets `OPENCLAW_RUN_E2E` and `OPENCLAW_RUN_MXC_E2E` itself, then runs the real WSL Gateway -> Windows node -> `system.run` MXC E2E proofs. It fails if the MXC proof skips. Use `-AllowSkip` only to document that the current host is not MXC-capable; do not report an `-AllowSkip` run as merge validation for MXC-related work.
+
+## Coding rules
+
+- Keep methods focused and reduce nested control flow when it improves readability.
+- Prefer existing repository patterns and simple, idiomatic C# over speculative abstractions.
+- Document non-obvious ownership, invariants, and public usage. Avoid boilerplate comments that only repeat the code.
 
 ## UI, MCP, and PR Proof
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-Go read @AGENTS.md and load skills from .agent/skills
+Go read @AGENTS.md and load skills from .agents/skills

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+Go read @AGENTS.md and load skills from .agent/skills

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,3 @@
-Go read @AGENTS.md and load skills from .agents/skills
+@AGENTS.md
+
+Project skills are under `.agents/skills/`; load the relevant `SKILL.md` before using a skill.

--- a/src/OpenClaw.Connection/LocalAi/LlamaServerClient.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerClient.cs
@@ -1,3 +1,17 @@
+// <summary>
+// Bounded, loopback-only health and model-state client for the managed llama-server router.
+// Parses router model metadata (path from status.args or top-level path) into
+// LlamaServerModelStatusEvidence, and LlamaServerClient polls /health plus model state to
+// produce LlamaServerRouterProbeResult used to decide when the managed endpoint is ready.
+// Usage:
+//   using var client = new LlamaServerClient();
+//   LlamaServerRouterProbeResult probe = await client.ProbeManagedModelAsync(
+//       endpoint: new Uri("http://127.0.0.1:18803"),
+//       modelAlias: "local-model",
+//       expectedModelPath: install.ModelPath,
+//       cancellationToken);
+//   if (probe.IsReadyForManagedModel(install.ModelPath)) { /* router is healthy and serving the model */ }
+// </summary>
 using System.Text.Json;
 
 namespace OpenClaw.Connection.LocalAi;

--- a/src/OpenClaw.Connection/LocalAi/LlamaServerClient.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerClient.cs
@@ -6,11 +6,15 @@
 // Usage:
 //   using var client = new LlamaServerClient();
 //   LlamaServerRouterProbeResult probe = await client.ProbeManagedModelAsync(
-//       endpoint: new Uri("http://127.0.0.1:18803"),
+//       endpoint: new Uri("http://127.0.0.1:18803/v1"),
 //       modelAlias: "local-model",
 //       expectedModelPath: install.ModelPath,
 //       cancellationToken);
-//   if (probe.IsReadyForManagedModel(install.ModelPath)) { /* router is healthy and serving the model */ }
+//   if (probe.IsHealthy &&
+//       probe.ModelState is LocalAiModelAvailabilityState.Verified or LocalAiModelAvailabilityState.Loaded)
+//   {
+//       // The public probe evidence is ready; the runtime service also validates the exact model path.
+//   }
 // </summary>
 using System.Text.Json;
 

--- a/src/OpenClaw.Connection/LocalAi/LlamaServerInferenceClient.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerInferenceClient.cs
@@ -1,3 +1,17 @@
+// <summary>
+// Setup-time inference verification for the managed llama-server router. Sends one bounded,
+// OpenAI-compatible request that intentionally triggers lazy model loading, then verifies the
+// response plus token and timing evidence. Prompt and response content are never returned or
+// logged; only llama-server's own error text surfaces on failure (LlamaServerInferenceException).
+// Usage:
+//   using var client = new LlamaServerInferenceClient();
+//   LlamaServerInferenceVerification verification = await client.VerifyAsync(
+//       endpoint: new Uri("http://127.0.0.1:18803/v1"),
+//       modelAlias: "local-model",
+//       cancellationToken);
+//   // verification.PromptTokens / CompletionTokens / timing evidence; throws
+//   // LlamaServerInferenceException with the server's own error text on failure.
+// </summary>
 using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;

--- a/src/OpenClaw.Connection/LocalAi/LlamaServerRouterConfiguration.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerRouterConfiguration.cs
@@ -1,3 +1,14 @@
+// <summary>
+// Builds the deterministic launch plan for the managed llama-server router: validates the
+// qualified install receipt against the runtime/model catalogs, emits the fixed loopback
+// argument list, environment (CUDA device pinning), and generates the lazy-load model preset
+// consumed by the router at startup.
+// Usage:
+//   var plan = LlamaServerRouterConfiguration.Build(paths, install);
+//   // plan.Arguments -> fixed loopback argv; plan.Environment -> CUDA device pinning;
+//   // plan.PresetPath / plan.PresetContent -> write PresetContent to PresetPath before launch;
+//   // plan.ModelAlias -> the model id the router exposes.
+// </summary>
 using OpenClaw.Shared.Inference.Catalog;
 using System.Collections.Immutable;
 using System.Globalization;

--- a/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
@@ -1,3 +1,15 @@
+// <summary>
+// Owns the native llama-server router process for the lifetime of the Windows companion:
+// starts it via the managed process host, polls health until ready, publishes/quiesces the
+// endpoint through ILocalAiEndpointLifecycle, and supervises restarts with bounded attempts,
+// timeouts, and capped rotating logs.
+// Usage:
+//   var runtime = new LlamaServerRuntimeService(new LlamaServerRuntimeOptions { Paths = paths });
+//   runtime.StateChanged += (_, args) => UpdateUi(args.Snapshot);
+//   LocalAiRuntimeSnapshot snapshot = await runtime.EnsureStartedAsync(cancellationToken);
+//   if (snapshot.State is LocalAiRuntimeState.Healthy) { /* endpoint ready at snapshot.Endpoint */ }
+//   await using var _ = runtime; // StopAsync/RestartAsync/RefreshAsync also available on ILocalAiRuntime
+// </summary>
 using OpenClaw.Shared;
 using System.Net;
 using System.Text;

--- a/src/OpenClaw.Connection/LocalAi/LocalAiEndpointLifecycle.cs
+++ b/src/OpenClaw.Connection/LocalAi/LocalAiEndpointLifecycle.cs
@@ -1,3 +1,13 @@
+// <summary>
+// Contract for coordinating consumers of the app-owned local AI endpoint with native process
+// changes: QuiesceAsync removes managed routing before a listener can disappear, and
+// PublishAsync publishes routing only after the replacement endpoint is proven healthy.
+// NullLocalAiEndpointLifecycle is the no-op default.
+// Usage:
+//   var lifecycle = new NullLocalAiEndpointLifecycle(); // or the app-owned routing coordinator
+//   await lifecycle.QuiesceAsync(install, cancellationToken);  // remove routing before restart
+//   await lifecycle.PublishAsync(install, cancellationToken);  // publish routing after health proof
+// </summary>
 namespace OpenClaw.Connection.LocalAi;
 
 public sealed record LocalAiEndpointLifecycleResult(bool Success, string? Detail = null)

--- a/src/OpenClaw.Connection/LocalAi/LocalAiEndpointLifecycle.cs
+++ b/src/OpenClaw.Connection/LocalAi/LocalAiEndpointLifecycle.cs
@@ -2,11 +2,15 @@
 // Contract for coordinating consumers of the app-owned local AI endpoint with native process
 // changes: QuiesceAsync removes managed routing before a listener can disappear, and
 // PublishAsync publishes routing only after the replacement endpoint is proven healthy.
-// NullLocalAiEndpointLifecycle is the no-op default.
+// The runtime options use a no-op lifecycle by default.
 // Usage:
-//   var lifecycle = new NullLocalAiEndpointLifecycle(); // or the app-owned routing coordinator
-//   await lifecycle.QuiesceAsync(install, cancellationToken);  // remove routing before restart
-//   await lifecycle.PublishAsync(install, cancellationToken);  // publish routing after health proof
+//   var options = new LlamaServerRuntimeOptions
+//   {
+//       Paths = paths,
+//       EndpointLifecycle = gatewayProviderCoordinator,
+//   };
+//   // LlamaServerRuntimeService owns QuiesceAsync/PublishAsync and treats an unsuccessful
+//   // LocalAiEndpointLifecycleResult as a failed runtime transition.
 // </summary>
 namespace OpenClaw.Connection.LocalAi;
 

--- a/src/OpenClaw.Connection/LocalAi/LocalAiGatewayProviderDefinition.cs
+++ b/src/OpenClaw.Connection/LocalAi/LocalAiGatewayProviderDefinition.cs
@@ -1,3 +1,13 @@
+// <summary>
+// Canonical gateway configuration for the companion-owned llama.cpp provider: builds the
+// provider config JSON (models.providers.llamacpp) and primary-model JSON for the gateway,
+// and compares CLI-reported (secret-redacted) provider JSON against the managed definition.
+// </summary>
+// Usage:
+//   string providerJson = LocalAiGatewayProviderDefinition.BuildProviderJson(install);
+//   // write providerJson into the gateway config at ProviderPath ("models.providers.llamacpp"),
+//   // and BuildPrimaryModel(install) at PrimaryModelPath ("agents.defaults.model.primary").
+//   bool matches = LocalAiGatewayProviderDefinition.MatchesProviderJson(cliOutputJson, install);
 using OpenClaw.Shared.Inference.Catalog;
 using System.Text.Json;
 

--- a/src/OpenClaw.Connection/LocalAi/LocalAiGatewayProviderDefinition.cs
+++ b/src/OpenClaw.Connection/LocalAi/LocalAiGatewayProviderDefinition.cs
@@ -1,12 +1,13 @@
 // <summary>
 // Canonical gateway configuration for the companion-owned llama.cpp provider: builds the
-// provider config JSON (models.providers.llamacpp) and primary-model JSON for the gateway,
+// provider config JSON (models.providers.llamacpp) and primary-model identifier for the gateway,
 // and compares CLI-reported (secret-redacted) provider JSON against the managed definition.
 // </summary>
 // Usage:
+//   // Requires a resolved install with a verified loopback Endpoint.
 //   string providerJson = LocalAiGatewayProviderDefinition.BuildProviderJson(install);
-//   // write providerJson into the gateway config at ProviderPath ("models.providers.llamacpp"),
-//   // and BuildPrimaryModel(install) at PrimaryModelPath ("agents.defaults.model.primary").
+//   string batchJson = LocalAiGatewayProviderDefinition.BuildProviderBatchJson(install);
+//   // batchJson atomically writes ProviderPath and PrimaryModelPath with valid JSON values.
 //   bool matches = LocalAiGatewayProviderDefinition.MatchesProviderJson(cliOutputJson, install);
 using OpenClaw.Shared.Inference.Catalog;
 using System.Text.Json;

--- a/src/OpenClaw.Connection/LocalAi/LocalAiManagedProcessHost.cs
+++ b/src/OpenClaw.Connection/LocalAi/LocalAiManagedProcessHost.cs
@@ -1,3 +1,19 @@
+// <summary>
+// Native Windows process host for managed local AI executables. Starts inference processes
+// inside a kill-on-close Job Object (no orphaned children), reports exits, and captures
+// stdout/stderr into bounded, sanitized, rotating log files (BoundedRotatingLogWriter).
+// </summary>
+// Usage:
+//   ILocalAiManagedProcessHost host = new WindowsLocalAiManagedProcessHost(logger);
+//   ILocalAiManagedProcess process = await host.StartProcessAsync(
+//       new LocalAiProcessStartSpec(
+//           ExecutablePath: plan.Arguments 0 executable, WorkingDirectory: paths.RootDirectory,
+//           Arguments: args, Environment: env, StandardOutputLogPath: paths.StandardOutputLogPath,
+//           StandardErrorLogPath: paths.StandardErrorLogPath, MaxLogBytes: 8 * 1024 * 1024,
+//           LogBackupCount: 2, MaxLogLineCharacters: 16 * 1024),
+//       exited: exit => OnExited(exit),
+//       cancellationToken);
+//   await process.StopAsync(TimeSpan.FromSeconds(10), cancellationToken); // job object kills children
 using Microsoft.Win32.SafeHandles;
 using OpenClaw.Shared;
 using System.Diagnostics;

--- a/src/OpenClaw.Connection/LocalAi/LocalAiManagedProcessHost.cs
+++ b/src/OpenClaw.Connection/LocalAi/LocalAiManagedProcessHost.cs
@@ -7,10 +7,10 @@
 //   ILocalAiManagedProcessHost host = new WindowsLocalAiManagedProcessHost(logger);
 //   ILocalAiManagedProcess process = await host.StartProcessAsync(
 //       new LocalAiProcessStartSpec(
-//           ExecutablePath: plan.Arguments 0 executable, WorkingDirectory: paths.RootDirectory,
-//           Arguments: args, Environment: env, StandardOutputLogPath: paths.StandardOutputLogPath,
-//           StandardErrorLogPath: paths.StandardErrorLogPath, MaxLogBytes: 8 * 1024 * 1024,
-//           LogBackupCount: 2, MaxLogLineCharacters: 16 * 1024),
+//           ExecutablePath: install.ExecutablePath, WorkingDirectory: Path.GetDirectoryName(install.ExecutablePath)!,
+//           Arguments: launchPlan.Arguments, Environment: launchPlan.Environment,
+//           StandardOutputLogPath: paths.StandardOutputLogPath, StandardErrorLogPath: paths.StandardErrorLogPath,
+//           MaxLogBytes: 8 * 1024 * 1024, LogBackupCount: 2, MaxLogLineCharacters: 16 * 1024),
 //       exited: exit => OnExited(exit),
 //       cancellationToken);
 //   await process.StopAsync(TimeSpan.FromSeconds(10), cancellationToken); // job object kills children

--- a/src/OpenClaw.Connection/LocalAi/LocalAiManagedProcessHost.cs
+++ b/src/OpenClaw.Connection/LocalAi/LocalAiManagedProcessHost.cs
@@ -2,6 +2,7 @@
 // Native Windows process host for managed local AI executables. Starts inference processes
 // inside a kill-on-close Job Object (no orphaned children), reports exits, and captures
 // stdout/stderr into bounded, sanitized, rotating log files (BoundedRotatingLogWriter).
+// These types are internal infrastructure owned by LlamaServerRuntimeService.
 // </summary>
 // Usage:
 //   ILocalAiManagedProcessHost host = new WindowsLocalAiManagedProcessHost(logger);

--- a/src/OpenClaw.Connection/LocalAi/LocalAiManifest.cs
+++ b/src/OpenClaw.Connection/LocalAi/LocalAiManifest.cs
@@ -1,3 +1,17 @@
+// <summary>
+// Canonical, companion-owned layout and persistence for local inference artifacts:
+// LocalAiPaths defines contained directory layout with reparse-point/traversal-safe path
+// resolution, LocalAiInstallManifest records the acquired runtime/model receipt, and
+// LocalAiManifestStore persists it with same-directory atomic replacement. Also holds port
+// and gateway-model validation policies shared by setup and runtime launch.
+// Usage:
+//   var paths = new LocalAiPaths(localDataDirectory);
+//   paths.EnsureDirectories();
+//   var store = new LocalAiManifestStore(paths);
+//   LocalAiResolvedInstall? install = await store.LoadAsync(cancellationToken); // null = not installed
+//   await store.SaveAsync(manifest, cancellationToken); // atomic manifest replacement
+//   string contained = paths.ResolveContainedPath("models/model.gguf", nameof(path)); // traversal-safe
+// </summary>
 using System.Collections.Immutable;
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/src/OpenClaw.Connection/LocalAi/LocalAiManifest.cs
+++ b/src/OpenClaw.Connection/LocalAi/LocalAiManifest.cs
@@ -8,9 +8,10 @@
 //   var paths = new LocalAiPaths(localDataDirectory);
 //   paths.EnsureDirectories();
 //   var store = new LocalAiManifestStore(paths);
-//   LocalAiResolvedInstall? install = await store.LoadAsync(cancellationToken); // null = not installed
+//   // null means no receipt; corrupt or unsupported receipts throw InvalidDataException.
+//   LocalAiResolvedInstall? install = await store.LoadAsync(cancellationToken);
 //   await store.SaveAsync(manifest, cancellationToken); // atomic manifest replacement
-//   string contained = paths.ResolveContainedPath("models/model.gguf", nameof(path)); // traversal-safe
+//   string contained = paths.ResolveContainedPath("models/model.gguf", "modelPath"); // traversal-safe
 // </summary>
 using System.Collections.Immutable;
 using System.Text.Json;

--- a/src/OpenClaw.Connection/LocalAi/LocalAiRuntimeModels.cs
+++ b/src/OpenClaw.Connection/LocalAi/LocalAiRuntimeModels.cs
@@ -1,3 +1,16 @@
+// <summary>
+// Shared runtime state models for the local AI subsystem: runtime/ownership/model-availability
+// enums, LocalAiModelEvidence (digest-backed model verification), LocalAiRuntimeSnapshot
+// (published state including process and KV-cache details), its change-event args, and the
+// ILocalAiRuntime contract that LlamaServerRuntimeService implements.
+// </summary>
+// Usage:
+//   runtime.StateChanged += (_, args) =>
+//   {
+//       LocalAiRuntimeSnapshot s = args.Snapshot;
+//       Log($"{s.State} ownership={s.Ownership} model={s.ModelId} at {s.Endpoint}");
+//       if (s.ModelEvidence.Availability is LocalAiModelAvailabilityState.Loaded) { /* ready */ }
+//   };
 using OpenClaw.Shared.Inference.Catalog;
 
 namespace OpenClaw.Connection.LocalAi;

--- a/src/OpenClaw.Connection/LocalAi/LocalAiRuntimeModels.cs
+++ b/src/OpenClaw.Connection/LocalAi/LocalAiRuntimeModels.cs
@@ -9,7 +9,11 @@
 //   {
 //       LocalAiRuntimeSnapshot s = args.Snapshot;
 //       Log($"{s.State} ownership={s.Ownership} model={s.ModelId} at {s.Endpoint}");
-//       if (s.ModelEvidence.Availability is LocalAiModelAvailabilityState.Loaded) { /* ready */ }
+//       if (s.ModelEvidence.State is
+//           LocalAiModelAvailabilityState.Verified or LocalAiModelAvailabilityState.Loaded)
+//       {
+//           /* ready; Verified is the healthy lazy-unloaded state */
+//       }
 //   };
 using OpenClaw.Shared.Inference.Catalog;
 


### PR DESCRIPTION
## What this improves

Agent-facing context for the Local AI subsystem was thin: the modules under `src/OpenClaw.Connection/LocalAi` did not explain their ownership boundaries or demonstrate their primary APIs, and repository coding guidance did not concisely state the existing preference for focused, idiomatic implementation.

## Changes

- add purpose and usage headers to the nine Local AI runtime, manifest, process, endpoint, router, inference, and gateway-definition modules
- keep examples aligned with the actual public API, `/v1` endpoint validation, lazy-load `Verified`/`Loaded` semantics, manifest failure behavior, and gateway batch configuration
- explicitly identify internal runtime-owned process infrastructure and lifecycle ownership
- add narrow coding guidance to `AGENTS.md` without moving the mandatory targeted-validation hierarchy
- add a portable `CLAUDE.md` import of `AGENTS.md` while preserving discovery of `.agents/skills/`

No runtime behavior, public API, dependency, workflow, or persisted format changes.

## Required proof pools

- `none`: documentation and agent-instruction changes only. The examples were compiled or checked against the current public/internal API surface; no runtime behavior changed.

## Validation

Current head: `a88d1ae9`.

- `.\build.ps1`: passed
- `dotnet test .\tests\OpenClaw.Connection.Tests\OpenClaw.Connection.Tests.csproj --no-restore --filter "FullyQualifiedName~LlamaServerClientTests|FullyQualifiedName~LlamaServerInferenceClientTests|FullyQualifiedName~LocalAiPortLifecycleTests"`: 52 passed
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore`: 3,943 passed, 32 skipped
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore`: 2,861 passed
- one initial Shared run hit the known Piper extractor PID-file lock race; the failed test passed in isolation, then the complete required validation set passed
- independent rubber-duck review: clean after correcting all copy/paste, ownership, lazy-load, heading, and skill-discovery findings

## Real behavior proof

A scratch .NET 10 console project outside the repository referenced `OpenClaw.Connection` and compiled the public examples for:

- `LlamaServerClient.ProbeManagedModelAsync` using the required `http://127.0.0.1:<port>/v1` endpoint
- `LlamaServerInferenceClient.VerifyAsync`
- `LlamaServerRouterConfiguration.Build`
- `LlamaServerRuntimeService` and `ILocalAiEndpointLifecycle` injection
- `LocalAiRuntimeSnapshot.ModelEvidence.State` with `Verified or Loaded` readiness
- `LocalAiGatewayProviderDefinition.BuildProviderJson`, `BuildProviderBatchJson`, and `MatchesProviderJson`
- `LocalAiPaths` and `LocalAiManifestStore`

The proof build succeeded with 0 warnings and 0 errors. The process-host example uses internal types by design and was verified argument-for-argument against the real `LlamaServerRuntimeService` call site.

The source comments also now document these non-obvious invariants:

- `Verified` is the healthy lazy-unloaded model state; `Loaded` means active inference
- the runtime service owns endpoint quiesce/publish transitions and treats unsuccessful lifecycle results as failures
- provider configuration requires a resolved install with a verified loopback endpoint and is applied through one batch payload
- a missing manifest returns null, while corrupt or unsupported receipts throw
- the managed process-host surface is internal runtime-owned infrastructure

Not verified / blocked: none for this documentation-only change.

## Security impact

No permissions, credentials, network calls, command surfaces, or data-access behavior changed.