### PR TITLE
fix(setup): allow optional wizard text input

### DIFF
--- a/src/OpenClaw.SetupEngine.UI/Pages/WizardPage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/WizardPage.xaml.cs
@@ -298,6 +298,20 @@ public sealed partial class WizardPage : Page
                 return;
             }
 
+            var validationError = WizardPayloadHelpers.ExtractCurrentStepValidationError(payload, _stepId);
+            if (!string.IsNullOrWhiteSpace(validationError))
+            {
+                BusyRing.Visibility = Visibility.Collapsed;
+                BusyRing.IsActive = false;
+                StatusText.Text = "A few quick questions to connect your agent";
+                SecondaryButton.IsEnabled = true;
+                ShowRecoveryActions();
+                UpdateContinueState();
+                ErrorText.Text = validationError;
+                ErrorText.Visibility = Visibility.Visible;
+                return;
+            }
+
             if (!payload.TryGetProperty("step", out var step))
             {
                 ShowError("Gateway wizard returned an invalid response.");
@@ -851,7 +865,8 @@ public sealed partial class WizardPage : Page
             if (generation != _operationGeneration)
                 return;
 
-            AppendTranscriptTurn(answeredQuestion, answeredLabel);
+            if (string.IsNullOrWhiteSpace(WizardPayloadHelpers.ExtractCurrentStepValidationError(payload, _stepId)))
+                AppendTranscriptTurn(answeredQuestion, answeredLabel);
             await ApplyPayloadAsync(payload);
             ScrollActiveIntoView();
         }
@@ -1056,7 +1071,7 @@ public sealed partial class WizardPage : Page
             return true;
 
         if (_stepType == "text")
-            return !WizardSelection.ShouldDisableContinue(_stepType, value?.ToString());
+            return WizardSelection.CanSubmitTextAnswer(_stepType);
 
         return !WizardSelection.ShouldDisableContinue(_stepType, GetSelectedOptionValues(), _options.Select(o => o.Value).ToArray());
     }
@@ -1083,7 +1098,7 @@ public sealed partial class WizardPage : Page
             return;
 
         PrimaryButton.IsEnabled = _stepType == "text"
-            ? !WizardSelection.ShouldDisableContinue(_stepType, _sensitive ? SecretInput.Password : TextInput.Text)
+            ? WizardSelection.CanSubmitTextAnswer(_stepType)
             : !WizardSelection.ShouldDisableContinue(
                 _stepType,
                 GetSelectedOptionValues(),

--- a/src/OpenClaw.SetupEngine.UI/WizardPayloadHelpers.cs
+++ b/src/OpenClaw.SetupEngine.UI/WizardPayloadHelpers.cs
@@ -9,6 +9,29 @@ namespace OpenClaw.SetupEngine.UI;
 internal static class WizardPayloadHelpers
 {
     /// <summary>
+    /// Returns a validation error only when the gateway kept the client on the
+    /// current step. This distinguishes rejected answers from terminal errors.
+    /// </summary>
+    public static string ExtractCurrentStepValidationError(JsonElement payload, string currentStepId)
+    {
+        if (payload.ValueKind != JsonValueKind.Object
+            || string.IsNullOrWhiteSpace(currentStepId)
+            || !payload.TryGetProperty("error", out var error)
+            || error.ValueKind != JsonValueKind.String
+            || string.IsNullOrWhiteSpace(error.GetString())
+            || !payload.TryGetProperty("step", out var step)
+            || step.ValueKind != JsonValueKind.Object
+            || !step.TryGetProperty("id", out var id)
+            || id.ValueKind != JsonValueKind.String
+            || !string.Equals(id.GetString(), currentStepId, StringComparison.Ordinal))
+        {
+            return string.Empty;
+        }
+
+        return error.GetString()!;
+    }
+
+    /// <summary>
     /// Reads the <c>message</c> field of a wizard step. Upstream is supposed to
     /// send a string; the Gemini CLI OAuth plugin (and possibly others) nests a
     /// note object instead, e.g.

--- a/src/OpenClaw.SetupEngine/WizardSelection.cs
+++ b/src/OpenClaw.SetupEngine/WizardSelection.cs
@@ -39,6 +39,9 @@ public static class WizardSelection
     public static bool ShouldDisableContinue(string stepType, IReadOnlyCollection<string> selectedValues, IReadOnlyCollection<string> optionValues) =>
         RequiresSelection(stepType) && !HasValidSelection(stepType, selectedValues, optionValues);
 
-    public static bool ShouldDisableContinue(string stepType, string? textInput) =>
-        stepType == "text" && string.IsNullOrWhiteSpace(textInput);
+    // Text validation belongs to the gateway because the wire protocol does not
+    // expose whether a text step is required. Always submit the current value so
+    // optional empty answers can advance and required fields can return their
+    // authoritative validation message.
+    public static bool CanSubmitTextAnswer(string stepType) => stepType == "text";
 }

--- a/tests/OpenClaw.SetupEngine.Tests/WizardSelectionTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/WizardSelectionTests.cs
@@ -57,12 +57,11 @@ public class WizardSelectionTests
     }
 
     [Theory]
-    [InlineData(null, true)]
-    [InlineData("", true)]
-    [InlineData("   ", true)]
-    [InlineData("value", false)]
-    public void ContinueDisabled_ForEmptyTextInput(string? input, bool expectedDisabled)
+    [InlineData("text", true)]
+    [InlineData("select", false)]
+    [InlineData("note", false)]
+    public void TextAnswers_AreSubmittedForGatewayValidation(string stepType, bool expected)
     {
-        Assert.Equal(expectedDisabled, WizardSelection.ShouldDisableContinue("text", input));
+        Assert.Equal(expected, WizardSelection.CanSubmitTextAnswer(stepType));
     }
 }

--- a/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
@@ -1480,6 +1480,21 @@ public sealed class AppRefactorContractTests
     }
 
     [Fact]
+    public void WizardValidationError_RemainsVisibleAfterContinueStateRefresh()
+    {
+        var root = TestRepositoryPaths.GetRepositoryRoot();
+        var source = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.SetupEngine.UI", "Pages", "WizardPage.xaml.cs"));
+        var applyPayload = ExtractMethod(source, "ApplyPayloadAsync");
+
+        AssertInOrder(
+            applyPayload,
+            "ExtractCurrentStepValidationError",
+            "UpdateContinueState();",
+            "ErrorText.Text = validationError;",
+            "ErrorText.Visibility = Visibility.Visible;");
+    }
+
+    [Fact]
     public void WizardResetInputs_RemovesOverflowMoreButton()
     {
         var root = TestRepositoryPaths.GetRepositoryRoot();

--- a/tests/OpenClaw.Tray.Tests/WizardPayloadHelpersTests.cs
+++ b/tests/OpenClaw.Tray.Tests/WizardPayloadHelpersTests.cs
@@ -9,6 +9,28 @@ public class WizardPayloadHelpersTests
     private static JsonElement Parse(string json)
         => JsonDocument.Parse(json).RootElement;
 
+    [Fact]
+    public void ExtractCurrentStepValidationError_returns_error_for_rejected_answer()
+    {
+        var payload = Parse("""{"done":false,"error":"Model ID is required","step":{"id":"model","type":"text"}}""");
+
+        Assert.Equal(
+            "Model ID is required",
+            WizardPayloadHelpers.ExtractCurrentStepValidationError(payload, "model"));
+    }
+
+    [Theory]
+    [InlineData("other")]
+    [InlineData("")]
+    public void ExtractCurrentStepValidationError_ignores_non_current_steps(string currentStepId)
+    {
+        var payload = Parse("""{"done":false,"error":"Model ID is required","step":{"id":"model","type":"text"}}""");
+
+        Assert.Equal(
+            string.Empty,
+            WizardPayloadHelpers.ExtractCurrentStepValidationError(payload, currentStepId));
+    }
+
     // ---- ExtractStepMessage -----------------------------------------------
 
     [Fact]


### PR DESCRIPTION
Closes #1331

## What Problem This Solves

Fixes an issue where users configuring an OpenAI-compatible provider in Companion could not continue past **Model alias (optional)** without entering an alias.

It also resolves a related wizard-client problem where Gateway validation errors returned for a text answer could be cleared immediately, append a rejected answer to the transcript, and count the same validation retry as another step visit.

## Why This Change Was Made

The Gateway wizard protocol does not expose whether an individual text step is required, while the Gateway already owns each text prompt's authoritative validator. Companion now submits the current text value, including an empty string, and handles a successful non-terminal response containing an error plus the same step as an inline validation rejection.

This keeps optional fields usable without guessing requiredness from localized labels. Required fields remain protected by the Gateway validator.

## User Impact

Users can leave optional text fields such as **Model alias (optional)** empty and continue onboarding. If a required or invalid value is rejected by the Gateway, Companion keeps the current input visible, shows the validation message, and does not add the rejected answer to the transcript.

## Evidence

- Added focused selection-policy coverage proving text answers are submitted for Gateway validation.
- Added payload-classification coverage for current-step validation errors.
- Added a source contract protecting the UI ordering that refreshes Continue state before making the Gateway validation error visible.
- `git diff --check` passed at commit `c6b73ad1`.
- Two rubber-duck reviews were performed. The reviews identified validation-error handling and visibility-ordering gaps; both were corrected before publication.
- The Gateway contract was independently verified against OpenClaw core commit `20d0daa063c0cc5eaee98043b673d413be5945f4`: [`WizardSession.answer`](https://github.com/openclaw/openclaw/blob/20d0daa063c0cc5eaee98043b673d413be5945f4/src/wizard/session.ts) runs the prompt validator and keeps the current step pending when validation returns an error; [`wizard.next`](https://github.com/openclaw/openclaw/blob/20d0daa063c0cc5eaee98043b673d413be5945f4/src/gateway/server-methods/wizard.ts) returns a successful non-terminal payload containing that `error` plus `session.next()`, which is the same current step.
- Current-head Windows UI proof is pending because the authoring host is macOS without .NET 10, PowerShell, Windows, or Parallels. A separate Windows host is being prepared for the required proof.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs or instructions
- [x] Tests or validation
- [ ] Security hardening
- [ ] Chore or infrastructure

## Scope

- [x] Tray or WinUI UX
- [ ] Windows node capability
- [ ] Local MCP or `winnode`
- [ ] Gateway, connection, or pairing
- [x] Setup or onboarding
- [ ] Permissions, privacy, or security
- [x] Tests, CI, or docs

## Required proof pools

- `windows-winui-interactive`: the onboarding wizard's Continue state and inline Gateway validation-error behavior changed.

## Validation

Local required validation was attempted but could not start on the macOS authoring host:

- `./build.ps1` - **blocked**, PowerShell and the Windows build environment are unavailable.
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` - **blocked**, .NET 10 SDK is unavailable.
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` - **blocked**, .NET 10 SDK is unavailable.
- Focused `WizardSelectionTests` - **blocked**, .NET 10 SDK is unavailable.
- `git diff --check` - **passed**.

No automated test is reported as passing without a non-zero test count. GitHub CI and Windows proof remain required before this draft is ready for review.

## Real Behavior Proof

- Environment tested: native Windows 11 x64 on **Windows Node (CALATONPC)**, isolated Dev launch (`run-app-local.ps1 -Dev -Isolated -AllowNonMain`).
- Exact code commit tested: `c6b73ad1237e92ee7ff730ccbea70ee66ecd4991` (verified in the Windows checkout immediately after the run).
- Exact path exercised: manual setup → local gateway → custom provider → OpenAI-compatible endpoint → model ID → endpoint ID → **Model alias (optional)**.
- Before submission, Windows UI Automation reported:

```json
{"Title":"Enter value","Message":"Model alias (optional)","ButtonEnabled":true,"ValueLength":0}
```

- Continue was invoked while the alias value length was zero. The wizard advanced and UI Automation then reported:

```json
{"Action":"Invoke PrimaryButton","Result":"INVOKED_BLANK_ALIAS"}
{"Title":"Enter value","Message":"Gateway port","ButtonEnabled":true}
```

### Focused, sanitized screenshots

**Blank optional alias; Continue enabled at exact PR code commit:**

![Model alias optional left empty with Continue enabled](https://raw.githubusercontent.com/omandryk/openclaw-windows-node/proof/pr1332-windows-ui/proof/pr1332/01-empty-optional-alias-continue-enabled.png)

**After submission: the checked, value-less transcript entry records the blank answer, and the wizard is now on Gateway port:**

![Blank text answer recorded in the transcript and Gateway port step reached](https://raw.githubusercontent.com/omandryk/openclaw-windows-node/proof/pr1332-windows-ui/proof/pr1332/02-after-empty-alias-submission.png)

The image URLs and [proof notes](https://github.com/omandryk/openclaw-windows-node/tree/proof/pr1332-windows-ui/proof/pr1332) were verified publicly resolvable. Captures exclude provider endpoint, endpoint ID, model ID, API-key state, gateway records, and unrelated desktop content.

Pre-fix evidence: the reporter's original screenshot directly shows the same blank **Model alias (optional)** field with Continue disabled, but it remains private and is not republished here. Current-main source at `305bb4ef5334ded9f8541aca19c66ba2c4b08754` independently reproduces that client gate: empty text disables Continue and is rejected before `wizard.next`.

Not verified / blocked: GitHub fork CI remains `action_required` pending upstream approval.

## Security Impact

- New permissions or capabilities? (`Yes`/`No`): No
- Secrets or tokens handling changed? (`Yes`/`No`): No
- New or changed network calls? (`Yes`/`No`): No
- Command or tool execution surface changed? (`Yes`/`No`): No
- Data access scope changed? (`Yes`/`No`): No
- If any answer is `Yes`, explain the risk and mitigation: N/A

## Compatibility and Migration

- Backward compatible? (`Yes`/`No`): Yes
- Config or environment changes? (`Yes`/`No`): No
- Migration needed? (`Yes`/`No`): No
- If yes, list the exact upgrade steps: N/A

## Review Conversations

- [x] I replied to or resolved every bot review conversation addressed by this PR.
- [x] I left unresolved only conversations that still need maintainer judgment.
