### PR TITLE
fix(setup): remove post-install gateway port ownership heuristic

### DIFF
--- a/src/OpenClaw.SetupEngine/StartGatewayStep.cs
+++ b/src/OpenClaw.SetupEngine/StartGatewayStep.cs
@@ -33,25 +33,6 @@ public sealed class StartGatewayStep : SetupStep
         var pathCmd = ctx.WslPathPrefix;
         var action = restart ? "restart" : "start";
 
-        if (!restart)
-        {
-            var portCheck = await ctx.Commands.RunInWslAsync(
-                distro, $"ss -tlnp 2>/dev/null | grep ':{ctx.Config.GatewayPort}\\b' || true",
-                TimeSpan.FromSeconds(10), ct: ct);
-
-            if (!string.IsNullOrWhiteSpace(portCheck.Stdout) && portCheck.Stdout.Contains($":{ctx.Config.GatewayPort}"))
-            {
-                if (!portCheck.Stdout.Contains("openclaw", StringComparison.OrdinalIgnoreCase))
-                {
-                    ctx.Logger.Warn($"Port {ctx.Config.GatewayPort} is in use by another process:\n{portCheck.Stdout.Trim()}");
-                    return StepResult.Fail(
-                        $"Port {ctx.Config.GatewayPort} is already in use by another process. Either stop the conflicting process or change GatewayPort in the setup config.");
-                }
-
-                ctx.Logger.Info($"Port {ctx.Config.GatewayPort} appears to be in use by openclaw — proceeding");
-            }
-        }
-
         var start = await ctx.Commands.RunInWslAsync(
             distro, $"{pathCmd} && openclaw gateway {action}", TimeSpan.FromSeconds(30), ct: ct);
 

--- a/tests/OpenClaw.SetupEngine.Tests/StartGatewayStepTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/StartGatewayStepTests.cs
@@ -1,0 +1,80 @@
+namespace OpenClaw.SetupEngine.Tests;
+
+public sealed class StartGatewayStepTests
+{
+    [Fact]
+    public async Task ExecuteAsync_StartsAndHealthChecksWithoutPortOwnershipProbe()
+    {
+        var commands = new RecordingCommandRunner(command =>
+        {
+            if (command.Contains("ss -tlnp", StringComparison.Ordinal))
+                return Ok("LISTEN 0 4096 *:18789 *:*");
+            if (command.Contains("openclaw gateway start", StringComparison.Ordinal))
+                return Ok();
+            if (command.Contains("curl -s -o /dev/null", StringComparison.Ordinal))
+                return Ok("200");
+            return Ok();
+        });
+        var config = new SetupConfig
+        {
+            GatewayPort = 18789,
+            Gateway = new GatewayConfig { HealthTimeoutSeconds = 1 }
+        };
+        var logger = new SetupLogger(filePath: null, LogLevel.Trace);
+        var journal = new TransactionJournal(filePath: null);
+        var context = new SetupContext(
+            config,
+            logger,
+            journal,
+            commands,
+            CancellationToken.None)
+        {
+            DistroName = "test-distro"
+        };
+
+        var result = await new StartGatewayStep().ExecuteAsync(
+            context,
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess, result.Message);
+        Assert.DoesNotContain(
+            commands.WslCommands,
+            command => command.Contains("ss -tlnp", StringComparison.Ordinal));
+        Assert.Contains(
+            commands.WslCommands,
+            command => command.Contains("openclaw gateway start", StringComparison.Ordinal));
+    }
+
+    private static CommandResult Ok(string stdout = "") =>
+        new(0, stdout, "", TimeSpan.Zero, TimedOut: false);
+
+    private sealed class RecordingCommandRunner(
+        Func<string, CommandResult> runInWsl) : ICommandRunner
+    {
+        public List<string> WslCommands { get; } = [];
+
+        public Task<CommandResult> RunAsync(
+            string executable,
+            string[] arguments,
+            TimeSpan timeout,
+            IReadOnlyDictionary<string, string>? environment = null,
+            string? workingDirectory = null,
+            string? stdinInput = null,
+            CancellationToken ct = default,
+            Stream? stdinStream = null) =>
+            Task.FromResult(Ok());
+
+        public Task<CommandResult> RunInWslAsync(
+            string distroName,
+            string command,
+            TimeSpan timeout,
+            IReadOnlyDictionary<string, string>? environment = null,
+            CancellationToken ct = default,
+            string? user = null,
+            bool inputViaStdin = false)
+        {
+            WslCommands.Add(command);
+            return Task.FromResult(runInWsl(command));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Remove the post-install `ss -tlnp` process-name ownership heuristic from `StartGatewayStep`.

`openclaw gateway install --force` can already start/restart the managed gateway service. The subsequent start step should therefore use the idempotent `openclaw gateway start` path and existing health polling instead of rejecting a listener purely because `ss` does not expose a process name.

This avoids false `Port 18789 is already in use by another process` failures when the listener is the gateway service just installed by setup.

## Regression

The first commit intentionally adds a failing regression test only. It asserts that normal startup does not run the `ss -tlnp` ownership probe and still invokes `openclaw gateway start` followed by health checking.

## Intended lifecycle

`install -> gateway start -> health check`

This supersedes the narrower process-name workaround discussed in #547, because `ss` may expose `node`, `openclaw`, or no process identity at all.
