### PR TITLE
fix: keep WSL setup diagnostics readable

### DIFF
--- a/src/OpenClaw.SetupEngine/CommandRunner.cs
+++ b/src/OpenClaw.SetupEngine/CommandRunner.cs
@@ -115,6 +115,12 @@ public sealed class CommandRunner : ICommandRunner
             WorkingDirectory = workingDirectory ?? ""
         };
 
+        if (UsesUtf16OutputEncoding(executable, arguments))
+        {
+            psi.StandardOutputEncoding = Encoding.Unicode;
+            psi.StandardErrorEncoding = Encoding.Unicode;
+        }
+
         foreach (var arg in arguments)
             psi.ArgumentList.Add(arg);
 
@@ -240,6 +246,24 @@ public sealed class CommandRunner : ICommandRunner
             return TimeSpan.Zero;
 
         return remaining < s_outputDrainCap ? remaining : s_outputDrainCap;
+    }
+
+    internal static bool UsesUtf16OutputEncoding(string executable, string[] arguments)
+    {
+        if (!string.Equals(Path.GetFileName(executable), "wsl.exe", StringComparison.OrdinalIgnoreCase) ||
+            arguments.Length == 0)
+        {
+            return false;
+        }
+
+        return arguments[0] is
+            "--version" or
+            "--status" or
+            "--list" or
+            "--install" or
+            "--terminate" or
+            "--unregister" or
+            "--shutdown";
     }
 
     /// <summary>

--- a/tests/OpenClaw.SetupEngine.Tests/CommandRunnerTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/CommandRunnerTests.cs
@@ -7,6 +7,69 @@ public class CommandRunnerTests
     private static readonly string s_largeStdin = new('x', 8 * 1024 * 1024);
 
     [Fact]
+    public async Task RunAsync_WslVersion_DecodesOutputBeforeLogging()
+    {
+        if (!OperatingSystem.IsWindows() || !File.Exists(WslConstants.WslExePath))
+            return;
+
+        var logPath = Path.Combine(Path.GetTempPath(), $"openclaw-wsl-output-{Guid.NewGuid():N}.jsonl");
+
+        try
+        {
+            CommandResult result;
+            using (var logger = new SetupLogger(logPath, LogLevel.Trace))
+            {
+                var runner = new CommandRunner(logger);
+                result = await runner.RunAsync(
+                    WslConstants.WslExePath,
+                    ["--version"],
+                    TimeSpan.FromSeconds(15));
+            }
+
+            var output = result.Stdout + result.Stderr;
+            Assert.NotEmpty(output);
+            Assert.DoesNotContain('\0', output);
+
+            var jsonl = await File.ReadAllTextAsync(logPath);
+            Assert.DoesNotContain("\\u0000", jsonl, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            File.Delete(logPath);
+        }
+    }
+
+    [Theory]
+    [InlineData("--version")]
+    [InlineData("--status")]
+    [InlineData("--list")]
+    [InlineData("--install")]
+    [InlineData("--terminate")]
+    [InlineData("--unregister")]
+    [InlineData("--shutdown")]
+    public void UsesUtf16OutputEncoding_WslManagementVerb_ReturnsTrue(string verb)
+    {
+        Assert.True(CommandRunner.UsesUtf16OutputEncoding("wsl.exe", [verb]));
+        Assert.True(CommandRunner.UsesUtf16OutputEncoding(@"C:\Windows\System32\WSL.EXE", [verb]));
+    }
+
+    [Theory]
+    [InlineData("wsl.exe", "-d")]
+    [InlineData("wsl.exe", "--distribution")]
+    [InlineData("wsl.exe", "--exec")]
+    [InlineData("powershell.exe", "--version")]
+    public void UsesUtf16OutputEncoding_OtherCommand_ReturnsFalse(string executable, string argument)
+    {
+        Assert.False(CommandRunner.UsesUtf16OutputEncoding(executable, [argument]));
+    }
+
+    [Fact]
+    public void UsesUtf16OutputEncoding_EmptyArguments_ReturnsFalse()
+    {
+        Assert.False(CommandRunner.UsesUtf16OutputEncoding("wsl.exe", []));
+    }
+
+    [Fact]
     public async Task RunAsync_LargeStdinWriteObeysTimeout()
     {
         var runner = CreateRunner();


### PR DESCRIPTION
Closes #1336

## What Problem This Solves

Fixes an issue where users inspecting Windows setup diagnostics would find `wsl.exe` output serialized with an interleaved NUL character after nearly every visible character.
The malformed fields were difficult to read or search and inflated setup JSONL logs.

## Why This Change Was Made

Windows-side WSL management commands emit UTF-16LE, so the setup command runner now selects UTF-16LE for a small allowlist of management verbs before redirected output is read.
WSL distro execution through `-d`, `--distribution`, or `--exec` remains on the existing default decoding path.

## User Impact

WSL version, status, listing, installation, termination, unregister, and shutdown diagnostics are now readable in setup results and JSONL logs.
Existing command execution, parsing, sanitization, timeout, output-drain, and distro-output behavior remain unchanged.

## Evidence

- Current-main baseline at `305bb4ef5334ded9f8541aca19c66ba2c4b08754`: `wsl.exe --version` produced 464 captured characters, including 224 NUL characters in `CommandResult` and 224 escaped NULs in JSONL.
- Current PR head `5388cfbc`: the same host command produced 224 readable characters with 0 NUL characters, and `wsl.exe --status` produced 165 readable characters with 0 NUL characters.
- Fresh Windows 11 VM with WSL absent: both `--version` and `--status` exercised stderr, each producing 164 readable characters with 0 NUL characters.
- The fresh-VM JSONL contained 0 escaped NUL characters.
- A controlled `wsl.exe --exec` negative control remained outside the UTF-16LE path and preserved exact stdout and stderr sentinels.
- A pre-fix regression test failed on the first interleaved NUL and passed after the capture-boundary repair.
- Local rubber-duck review rechecked the principal risk identified on #1336: blanket decoding could damage Linux payload output.
  The executable check, explicit management-verb allowlist, and negative tests confine the change to Windows-side WSL management output.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs or instructions
- [x] Tests or validation
- [ ] Security hardening
- [ ] Chore or infrastructure

## Scope

- [ ] Tray or WinUI UX
- [ ] Windows node capability
- [ ] Local MCP or `winnode`
- [ ] Gateway, connection, or pairing
- [x] Setup or onboarding
- [ ] Permissions, privacy, or security
- [x] Tests, CI, or docs

## Required proof pools

- `none`: this changes only setup diagnostic decoding, not WSL Gateway installation, bootstrap, pairing, recovery, protocol, or Gateway-mediated behavior.
  Focused current-head proof was completed on both the Windows host and a clean disposable Windows VM.

## Validation

- `.\build.ps1`: passed, all five projects built successfully.
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore`: 3,937 passed, 32 environment-gated skips, 0 failed.
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore`: 2,858 passed, 0 skipped, 0 failed.
- `dotnet test .\tests\OpenClaw.SetupEngine.Tests\OpenClaw.SetupEngine.Tests.csproj --no-restore`: 1,068 passed, 0 skipped, 0 failed.
- `git diff --check`: passed.

## Real Behavior Proof

- Environment tested: Windows 11 Pro x64 build 26200 on the host, plus a fresh disposable Windows 11 Pro x64 VM with WSL absent.
- PR head or commit tested: `5388cfbc`.
- Exact steps or command run: invoked setup-engine `CommandRunner.RunAsync` with the system `wsl.exe --version` and `wsl.exe --status`, then inspected both `CommandResult` and emitted JSONL.
- Evidence after fix: host output contained 0 NULs for both commands; clean-VM stderr contained 0 NULs for both commands; both JSONL probes contained 0 escaped NULs.
- Observed result: WSL management output was readable before logging, including the clean-VM nonzero exit paths.
- Screenshot or artifact links verified? (`Yes`/`No`/`N/A`): N/A. This is a non-visual diagnostics change and the proof is copied above.
- Not verified or blocked: localized Windows display-language output was not exercised in a separate localized VM.
  UTF-16LE decoding and existing localized parser tests remain covered, but this PR does not claim localized live-runtime proof.

## Security Impact

- New permissions or capabilities? (`Yes`/`No`): No
- Secrets or tokens handling changed? (`Yes`/`No`): No
- New or changed network calls? (`Yes`/`No`): No
- Command or tool execution surface changed? (`Yes`/`No`): No
- Data access scope changed? (`Yes`/`No`): No
- If any answer is `Yes`, explain the risk and mitigation: N/A

## Compatibility and Migration

- Backward compatible? (`Yes`/`No`): Yes
- Config or environment changes? (`Yes`/`No`): No
- Migration needed? (`Yes`/`No`): No
- If yes, list the exact upgrade steps: N/A

## Review Conversations

- [ ] I replied to or resolved every bot review conversation addressed by this PR.
- [ ] I left unresolved only conversations that still need maintainer judgment.
