### PR TITLE
fix(setup): avoid repeated WSL check before installation

### DIFF
--- a/src/OpenClaw.SetupEngine/PreflightWslStep.cs
+++ b/src/OpenClaw.SetupEngine/PreflightWslStep.cs
@@ -295,10 +295,8 @@ public sealed class EnsureWslPlatformStep : SetupStep
 
     public override async Task<StepResult> ExecuteAsync(SetupContext ctx, CancellationToken ct)
     {
-        WslViabilityResult viability = await WslViabilityInspector.InspectAsync(
-            ctx.Commands,
-            ctx.Logger,
-            ct);
+        WslViabilityResult viability = ctx.WslViability
+            ?? await WslViabilityInspector.InspectAsync(ctx.Commands, ctx.Logger, ct);
         ctx.WslViability = viability;
 
         if (viability.Kind == WslViabilityKind.Ready)

--- a/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
@@ -2105,6 +2105,81 @@ public class SetupStepsTests : IDisposable
     }
 
     [Fact]
+    public async Task WslPipeline_ReusesPreflightResultBeforeInstallingMissingPlatform()
+    {
+        var installed = false;
+        var commands = new FakeCommandRunner(args => args switch
+        {
+            ["--version"] when !installed => new CommandResult(
+                1,
+                "",
+                "Windows Subsystem for Linux is not installed. See https://aka.ms/wslinstall",
+                TimeSpan.Zero,
+                TimedOut: false),
+            ["--version"] => Ok("WSL version: 2.7.3.0\n"),
+            ["--status"] => Ok("Default Version: 2\n"),
+            _ => Fail($"unexpected args: {string.Join(' ', args)}"),
+        });
+        var ctx = CreateContext(commands: commands);
+        var ensure = new EnsureWslPlatformStep((_, _) =>
+        {
+            installed = true;
+            return Task.FromResult(StepResult.Ok("installed"));
+        });
+        var pipeline = new SetupPipeline([new PreflightWslStep(), ensure]);
+
+        var result = await pipeline.RunAsync(ctx);
+
+        Assert.Equal(PipelineOutcome.Success, result.Outcome);
+        Assert.Equal(2, commands.Calls.Count(call => call.Arguments is ["--version"]));
+        Assert.Single(commands.Calls, call => call.Arguments is ["--status"]);
+    }
+
+    [Fact]
+    public async Task WslPipeline_ReusesReadyPreflightResultWithoutReinspection()
+    {
+        var installCalls = 0;
+        var commands = new FakeCommandRunner(args => args switch
+        {
+            ["--version"] => Ok("WSL version: 2.7.3.0\n"),
+            ["--status"] => Ok("Default Version: 2\n"),
+            _ => Fail($"unexpected args: {string.Join(' ', args)}"),
+        });
+        var ctx = CreateContext(commands: commands);
+        var ensure = new EnsureWslPlatformStep((_, _) =>
+        {
+            installCalls++;
+            return Task.FromResult(StepResult.Ok("installed"));
+        });
+        var pipeline = new SetupPipeline([new PreflightWslStep(), ensure]);
+
+        var result = await pipeline.RunAsync(ctx);
+
+        Assert.Equal(PipelineOutcome.Success, result.Outcome);
+        Assert.Equal(0, installCalls);
+        Assert.Single(commands.Calls, call => call.Arguments is ["--version"]);
+        Assert.Single(commands.Calls, call => call.Arguments is ["--status"]);
+    }
+
+    [Fact]
+    public async Task WslPipeline_BoundsHungVersionInspectionToOneProbe()
+    {
+        var commands = new FakeCommandRunner(args => args is ["--version"]
+            ? new CommandResult(-1, "", "", TimeSpan.FromSeconds(5), TimedOut: true)
+            : Fail($"unexpected args: {string.Join(' ', args)}"));
+        var ctx = CreateContext(commands: commands);
+        var pipeline = new SetupPipeline(
+            [new PreflightWslStep(), new EnsureWslPlatformStep((_, _) =>
+                Task.FromResult(StepResult.Ok("installed")))]);
+
+        var result = await pipeline.RunAsync(ctx);
+
+        Assert.Equal(PipelineOutcome.Failed, result.Outcome);
+        Assert.Equal("preflight-wsl", result.FailedStepId);
+        Assert.Single(commands.Calls, call => call.Arguments is ["--version"]);
+    }
+
+    [Fact]
     public async Task EnsureWslPlatform_InstallsOnlyAfterReadOnlyPreflight()
     {
         var installed = false;


### PR DESCRIPTION
Closes #1335

## What Problem This Solves

Fixes an issue where fresh Windows setup checked the absent WSL platform twice before requesting elevation.
Each check could consume the full five-second timeout, adding approximately ten seconds and duplicate warning noise before the WSL installation prompt.

## Why This Change Was Made

The WSL preparation step now reuses the typed viability result already collected by the read-only preflight step in the same setup run.
It still performs its own inspection when executed without a prior result, and it still reinspects WSL after installation before allowing setup to continue.

The command runner, timeout policy, WSL output classification, installation behavior, and post-install verification are unchanged.

## User Impact

Fresh setup no longer repeats the known five-second WSL version probe before elevation.
An absent WSL platform proceeds directly from preflight to the disclosed installation step, while genuine hangs remain bounded and installed WSL environments are not rechecked unnecessarily.

## Evidence

On unmodified `main`, the new missing-platform pipeline regression failed because setup issued three `wsl.exe --version` calls: the preflight probe, the redundant pre-install probe, and the required post-install verification probe.
The expected count was two.

```text
Failed WslPipeline_ReusesPreflightResultBeforeInstallingMissingPlatform
Expected: 2
Actual:   3
```

At commit `5ac88ea50dac1ad55ac95b0e011ff682c4b4569a`, all three focused pipeline cases pass:

```text
Passed! - Failed: 0, Passed: 3, Skipped: 0, Total: 3
```

The focused cases verify:

- Missing WSL uses one preflight version probe, installs, then performs the required version and status verification.
- Ready WSL uses one version and one status probe across both pipeline steps, without invoking installation.
- A genuinely timed-out version probe fails closed in preflight and is not repeated by the preparation step.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs or instructions
- [x] Tests or validation
- [ ] Security hardening
- [ ] Chore or infrastructure

## Scope

- [ ] Tray or WinUI UX
- [ ] Windows node capability
- [ ] Local MCP or `winnode`
- [ ] Gateway, connection, or pairing
- [x] Setup or onboarding
- [ ] Permissions, privacy, or security
- [x] Tests, CI, or docs

## Required proof pools

- `windows-wsl-gateway-e2e`: The changed behavior is part of fresh Windows WSL setup and should be confirmed on a clean WSL-disabled VM before merge.

## Validation

- `./build.ps1`: passed; all five projects built successfully.
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore`: passed, 3,937 passed and 32 skipped.
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore`: passed, 2,858 passed.
- `dotnet test ./tests/OpenClaw.SetupEngine.Tests/OpenClaw.SetupEngine.Tests.csproj --no-restore`: passed, 1,058 passed.
- `dotnet test ./tests/OpenClaw.SetupEngine.Tests/OpenClaw.SetupEngine.Tests.csproj --no-restore --filter "FullyQualifiedName~WslPipeline_"`: passed, 3 passed.
- `./scripts/validate-mxc-e2e.ps1 -NoBuild`: not accepted as complete proof on this host; 11 tests passed and 6 MXC tests skipped because the host reports `appcontainer-dacl` instead of the required MXC BaseContainer configuration.

## Real Behavior Proof

- Environment tested: Windows x64 development host with deterministic pipeline-level WSL command responses.
- PR head or commit tested: `5ac88ea50dac1ad55ac95b0e011ff682c4b4569a`.
- Exact steps or command run: `dotnet test ./tests/OpenClaw.SetupEngine.Tests/OpenClaw.SetupEngine.Tests.csproj --no-restore --filter "FullyQualifiedName~WslPipeline_"`.
- Evidence after fix: all 3 absent, ready, and hung pipeline cases passed.
- Observed result: setup reuses the preflight result before any WSL mutation, preserves standalone inspection, and performs a fresh verification after successful installation.
- Screenshot or artifact links verified? `N/A`.
- Not verified or blocked: current-head interactive setup on a clean WSL-disabled VM is not yet captured.
  The repository-declared `windows-wsl-gateway-e2e` pool remains required.
  Formal MXC proof was also unavailable on this host, although this change does not touch MXC, `system.run`, Windows node execution, or Gateway connection behavior.

## Security Impact

- New permissions or capabilities? `No`.
- Secrets or tokens handling changed? `No`.
- New or changed network calls? `No`.
- Command or tool execution surface changed? `No`.
- Data access scope changed? `No`.
- If any answer is `Yes`, explain the risk and mitigation: `N/A`.

## Compatibility and Migration

- Backward compatible? `Yes`.
- Config or environment changes? `No`.
- Migration needed? `No`.
- If yes, list the exact upgrade steps: `N/A`.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation addressed by this PR.
- [ ] I left unresolved only conversations that still need maintainer judgment.
