### PR TITLE
fix(setup): prompt to restart Windows after installing WSL

### DIFF
--- a/src/OpenClaw.SetupEngine.UI/Pages/CompletePage.xaml
+++ b/src/OpenClaw.SetupEngine.UI/Pages/CompletePage.xaml
@@ -42,6 +42,22 @@
                                  AutomationProperties.AccessibilityView="Raw" />
                     </Border>
                 </Grid>
+                <Grid x:Name="RestartIcon" Width="100" Height="100"
+                      HorizontalAlignment="Center" Margin="0,0,0,16"
+                      Visibility="Collapsed">
+                    <Image Source="ms-appx:///OpenClaw.SetupEngine.UI/Assets/Setup/OpenClawMascot.png"
+                           Width="100" Height="100"
+                           AutomationProperties.AccessibilityView="Raw" />
+                    <Border Width="36" Height="36" CornerRadius="18"
+                            HorizontalAlignment="Right" VerticalAlignment="Bottom"
+                            Background="{ThemeResource SystemFillColorCautionBrush}"
+                            BorderBrush="{ThemeResource SolidBackgroundFillColorBaseBrush}" BorderThickness="3">
+                        <FontIcon Glyph="&#xE72C;" FontSize="16" IsTextScaleFactorEnabled="False"
+                                  Foreground="#FFFFFF"
+                                  HorizontalAlignment="Center" VerticalAlignment="Center"
+                                  AutomationProperties.AccessibilityView="Raw" />
+                    </Border>
+                </Grid>
 
                 <TextBlock x:Name="TitleText" Text="All set!"
                            Style="{StaticResource TitleTextBlockStyle}"
@@ -161,7 +177,11 @@
                     Content="Retry with validated fallback"
                     Visibility="Collapsed"
                     Click="FallbackButton_Click" />
-            <StackPanel Grid.ColumnSpan="3" Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center" VerticalAlignment="Center"
+            <Button x:Name="RestartLaterButton" Grid.Column="0"
+                    Content="No, I'm not ready yet"
+                    Visibility="Collapsed"
+                    Click="RestartLaterButton_Click" />
+            <StackPanel x:Name="StepIndicator" Grid.ColumnSpan="3" Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center" VerticalAlignment="Center"
                         IsTabStop="False" AutomationProperties.Name="Step 6 of 6">
                 <Border Width="8" Height="8" CornerRadius="4" VerticalAlignment="Center" Background="{ThemeResource SetupInactiveDotBrush}" />
                 <Border Width="8" Height="8" CornerRadius="4" VerticalAlignment="Center" Background="{ThemeResource SetupInactiveDotBrush}" />
@@ -175,6 +195,12 @@
                     HorizontalAlignment="Right" MinWidth="100"
                     Style="{StaticResource AccentButtonStyle}"
                     Click="LaunchButton_Click" />
+            <Button x:Name="RestartNowButton" Grid.Column="2"
+                    Content="Yes, restart now"
+                    HorizontalAlignment="Right"
+                    Visibility="Collapsed"
+                    Style="{StaticResource AccentButtonStyle}"
+                    Click="RestartNowButton_Click" />
         </Grid>
 
     </Grid>

--- a/src/OpenClaw.SetupEngine.UI/Pages/CompletePage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/CompletePage.xaml.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text.RegularExpressions;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -54,6 +55,31 @@ public sealed partial class CompletePage : Page
             else
             {
                 var errorMessage = args.ErrorMessage ?? "Unknown error";
+
+                if (args.RequiresRestart)
+                {
+                    SuccessIcon.Visibility = Visibility.Collapsed;
+                    FailureIcon.Visibility = Visibility.Collapsed;
+                    RestartIcon.Visibility = Visibility.Visible;
+                    TitleText.Text = "Restart required";
+                    SubtitleText.Text = "OpenClaw needs to restart Windows to continue the installation. Would you like to restart now?";
+                    SubtitleText.TextWrapping = TextWrapping.Wrap;
+                    SubtitleText.TextAlignment = TextAlignment.Center;
+                    SubtitleText.Visibility = Visibility.Visible;
+                    NodeModeBanner.Visibility = Visibility.Collapsed;
+                    StartupRow.Visibility = Visibility.Collapsed;
+                    SummaryPanel.Visibility = Visibility.Collapsed;
+                    LocalAiSummaryCard.Visibility = Visibility.Collapsed;
+                    ErrorCard.Visibility = Visibility.Collapsed;
+                    HelpLink.Visibility = Visibility.Collapsed;
+                    FallbackButton.Visibility = Visibility.Collapsed;
+                    LaunchButton.Visibility = Visibility.Collapsed;
+                    StepIndicator.Visibility = Visibility.Collapsed;
+                    RestartLaterButton.Visibility = Visibility.Visible;
+                    RestartNowButton.Visibility = Visibility.Visible;
+                    return;
+                }
+
                 // Local AI failures (identified by Detail) carry llama-server's own error text in
                 // errorMessage. That text is diagnostic evidence, not a curated OpenClaw message,
                 // so it must never be scanned for a URL to turn into a clickable help link.
@@ -61,6 +87,7 @@ public sealed partial class CompletePage : Page
 
                 SuccessIcon.Visibility = Visibility.Collapsed;
                 FailureIcon.Visibility = Visibility.Visible;
+                RestartIcon.Visibility = Visibility.Collapsed;
                 TitleText.Text = "Setup failed";
                 SubtitleText.Visibility = Visibility.Collapsed;
                 NodeModeBanner.Visibility = Visibility.Collapsed;
@@ -186,6 +213,35 @@ public sealed partial class CompletePage : Page
         FallbackButton.Visibility = Visibility.Collapsed;
         if (!string.IsNullOrWhiteSpace(error))
             ErrorText.Text = $"{ErrorText.Text}{Environment.NewLine}{error}";
+    }
+
+    private void RestartLaterButton_Click(object sender, RoutedEventArgs e)
+    {
+        SetupWindow.Active?.Close();
+    }
+
+    private void RestartNowButton_Click(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = Path.Combine(Environment.SystemDirectory, "shutdown.exe"),
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                ArgumentList = { "/r", "/t", "0" },
+            };
+            Process.Start(startInfo);
+            RestartNowButton.IsEnabled = false;
+            RestartLaterButton.IsEnabled = false;
+            SubtitleText.Text = "Windows is restarting...";
+        }
+        catch (Exception ex)
+        {
+            ErrorText.Text = $"Windows could not be restarted: {ex.Message}";
+            ErrorCard.Visibility = Visibility.Visible;
+            ViewLogLink.Visibility = Visibility.Collapsed;
+        }
     }
 
 }

--- a/src/OpenClaw.SetupEngine.UI/Pages/CompletePage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/CompletePage.xaml.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Text.RegularExpressions;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -6,6 +5,7 @@ using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
 using OpenClaw.SetupEngine;
 using OpenClaw.SetupEngine.UI;
+using OpenClaw.Shared;
 using Windows.UI;
 
 namespace OpenClaw.SetupEngine.UI.Pages;
@@ -13,6 +13,7 @@ namespace OpenClaw.SetupEngine.UI.Pages;
 public sealed partial class CompletePage : Page
 {
     private static readonly Regex s_urlRegex = new(@"https?://[^\s)]+", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly WindowsRestartLauncher s_windowsRestartLauncher = new();
     private string? _logPath;
     private string? _serverLogDirectory;
 
@@ -222,26 +223,30 @@ public sealed partial class CompletePage : Page
 
     private void RestartNowButton_Click(object sender, RoutedEventArgs e)
     {
-        try
-        {
-            var startInfo = new ProcessStartInfo
-            {
-                FileName = Path.Combine(Environment.SystemDirectory, "shutdown.exe"),
-                UseShellExecute = false,
-                CreateNoWindow = true,
-                ArgumentList = { "/r", "/t", "0" },
-            };
-            Process.Start(startInfo);
-            RestartNowButton.IsEnabled = false;
-            RestartLaterButton.IsEnabled = false;
-            SubtitleText.Text = "Windows is restarting...";
-        }
-        catch (Exception ex)
-        {
-            ErrorText.Text = $"Windows could not be restarted: {ex.Message}";
-            ErrorCard.Visibility = Visibility.Visible;
-            ViewLogLink.Visibility = Visibility.Collapsed;
-        }
+        AsyncEventHandlerGuard.Run(
+            RestartWindowsAsync,
+            NullLogger.Instance,
+            nameof(RestartNowButton_Click),
+            ShowRestartError);
+    }
+
+    private async Task RestartWindowsAsync()
+    {
+        RestartNowButton.IsEnabled = false;
+        RestartLaterButton.IsEnabled = false;
+        SubtitleText.Text = "Windows is restarting...";
+
+        await s_windowsRestartLauncher.RestartAsync();
+    }
+
+    private void ShowRestartError(Exception ex)
+    {
+        ErrorText.Text = $"Windows could not be restarted: {ex.Message}";
+        ErrorCard.Visibility = Visibility.Visible;
+        ViewLogLink.Visibility = Visibility.Collapsed;
+        RestartNowButton.IsEnabled = true;
+        RestartLaterButton.IsEnabled = true;
+        SubtitleText.Text = "OpenClaw needs to restart Windows to continue the installation. Would you like to restart now?";
     }
 
 }

--- a/src/OpenClaw.SetupEngine.UI/Pages/ProgressPage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/ProgressPage.xaml.cs
@@ -226,7 +226,8 @@ public sealed partial class ProgressPage : Page
                     config.LogPath,
                     errorMsg,
                     result.CompatibilityFailure,
-                    result.Detail);
+                    result.Detail,
+                    restartRequired: result.RequiresRestart);
             }
         }
         catch (OperationCanceledException) when (cts.IsCancellationRequested)

--- a/src/OpenClaw.SetupEngine.UI/SetupWindow.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/SetupWindow.xaml.cs
@@ -307,7 +307,8 @@ public sealed partial class SetupWindow : Window
         string? logPath,
         string? errorMessage = null,
         GatewayCompatibilityFailureKind? compatibilityFailure = null,
-        LocalAiFailureDetail? detail = null)
+        LocalAiFailureDetail? detail = null,
+        bool restartRequired = false)
     {
         var canRetryFallback =
             compatibilityFailure is { } failureKind &&
@@ -326,7 +327,10 @@ public sealed partial class SetupWindow : Window
                 GatewayFallbackVersion: canRetryFallback
                     ? GatewayReleasePolicy.FallbackVersion
                     : null,
-                Detail: detail));
+                Detail: detail)
+            {
+                RequiresRestart = restartRequired,
+            });
     }
 
     public bool TryRetryWithGatewayFallback(out string? error)
@@ -503,5 +507,8 @@ public sealed record CompletePageArgs(
     SetupReviewSummary? ReviewSummary = null,
     bool CanRetryGatewayFallback = false,
     string? GatewayFallbackVersion = null,
-    LocalAiFailureDetail? Detail = null);
+    LocalAiFailureDetail? Detail = null)
+{
+    public bool RequiresRestart { get; init; }
+}
 public sealed record SetupCompletedEventArgs(bool EnableAutoStart);

--- a/src/OpenClaw.SetupEngine.UI/WindowsRestartLauncher.cs
+++ b/src/OpenClaw.SetupEngine.UI/WindowsRestartLauncher.cs
@@ -1,0 +1,39 @@
+using System.Diagnostics;
+
+namespace OpenClaw.SetupEngine.UI;
+
+internal sealed class WindowsRestartLauncher
+{
+    private readonly Func<ProcessStartInfo, Task<int>> _runProcessAsync;
+
+    public WindowsRestartLauncher()
+        : this(RunProcessAsync)
+    {
+    }
+
+    internal WindowsRestartLauncher(Func<ProcessStartInfo, Task<int>> runProcessAsync) =>
+        _runProcessAsync = runProcessAsync ?? throw new ArgumentNullException(nameof(runProcessAsync));
+
+    public async Task RestartAsync()
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = Path.Combine(Environment.SystemDirectory, "shutdown.exe"),
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            ArgumentList = { "/r", "/t", "0" },
+        };
+
+        int exitCode = await _runProcessAsync(startInfo);
+        if (exitCode != 0)
+            throw new InvalidOperationException($"shutdown.exe exited with code {exitCode}.");
+    }
+
+    private static async Task<int> RunProcessAsync(ProcessStartInfo startInfo)
+    {
+        using var process = Process.Start(startInfo) ??
+            throw new InvalidOperationException("Process.Start returned null.");
+        await process.WaitForExitAsync();
+        return process.ExitCode;
+    }
+}

--- a/src/OpenClaw.SetupEngine/PreflightWslStep.cs
+++ b/src/OpenClaw.SetupEngine/PreflightWslStep.cs
@@ -314,7 +314,7 @@ public sealed class EnsureWslPlatformStep : SetupStep
         ctx.WslViability = viability;
         if (viability.Kind == WslViabilityKind.Ready)
             return StepResult.Ok("WSL platform installed and verified.");
-        if (viability.Kind == WslViabilityKind.Installable)
+        if (viability.Kind is WslViabilityKind.Installable or WslViabilityKind.EnvironmentBlocked)
         {
             return StepResult.Terminal(
                 "WSL platform installation completed, but Windows must be restarted before WSL is ready. " +

--- a/src/OpenClaw.SetupEngine/PreflightWslStep.cs
+++ b/src/OpenClaw.SetupEngine/PreflightWslStep.cs
@@ -316,7 +316,7 @@ public sealed class EnsureWslPlatformStep : SetupStep
             return StepResult.Ok("WSL platform installed and verified.");
         if (viability.Kind is WslViabilityKind.Installable or WslViabilityKind.EnvironmentBlocked)
         {
-            return StepResult.Terminal(
+            return StepResult.RestartRequired(
                 "WSL platform installation completed, but Windows must be restarted before WSL is ready. " +
                 "Reboot Windows, then run setup again.");
         }

--- a/src/OpenClaw.SetupEngine/PreflightWslStep.cs
+++ b/src/OpenClaw.SetupEngine/PreflightWslStep.cs
@@ -236,7 +236,7 @@ public sealed class PreflightWslStep : SetupStep
             await process.WaitForExitAsync(ct);
 
             if (process.ExitCode == 3010)
-                return StepResult.Terminal("WSL platform install requires a restart. Reboot Windows, then run setup again.");
+                return StepResult.RestartRequired("WSL platform install requires a restart. Reboot Windows, then run setup again.");
 
             if (process.ExitCode != 0)
             {
@@ -251,7 +251,7 @@ public sealed class PreflightWslStep : SetupStep
                 ct: ct);
             if (probe.ExitCode != 0 || WslViabilityInspector.LooksUnavailable(probe))
             {
-                return StepResult.Terminal(
+                return StepResult.RestartRequired(
                     "WSL platform install completed, but Windows still reports WSL unavailable. Reboot Windows, then run setup again.");
             }
 

--- a/src/OpenClaw.SetupEngine/Program.cs
+++ b/src/OpenClaw.SetupEngine/Program.cs
@@ -346,28 +346,37 @@ public static class Program
             var outputDir = Path.GetDirectoryName(jsonOutput);
             if (outputDir != null) Directory.CreateDirectory(outputDir);
 
-            var jsonResult = new
-            {
-                outcome = result.Outcome.ToString(),
-                exitCode = result.ExitCode,
-                failedStepId = result.FailedStepId,
-                message = result.Message,
-                compatibilityFailure = result.CompatibilityFailure?.ToString(),
-                selectedGatewayVersion = config.Gateway.Version,
-                gatewayProtocolGeneration = GatewayReleasePolicy.ProtocolGeneration,
-                fallbackGatewayVersion =
-                    result.CompatibilityFailure is { } failureKind &&
-                    GatewayReleasePolicy.CanRetryWithFallback(config, failureKind)
-                        ? GatewayReleasePolicy.FallbackVersion
-                        : null,
-                logPath = config.LogPath,
-                journalPath
-            };
-        var json = System.Text.Json.JsonSerializer.Serialize(jsonResult, SetupConfig.JsonWriteOptions);
+            var json = SerializeJsonOutput(result, config, journalPath);
             await AtomicFile.WriteAllTextAsync(jsonOutput, json);
         }
 
         return result.ExitCode;
+    }
+
+    internal static string SerializeJsonOutput(
+        PipelineResult result,
+        SetupConfig config,
+        string journalPath)
+    {
+        var jsonResult = new
+        {
+            outcome = result.Outcome.ToString(),
+            exitCode = result.ExitCode,
+            failedStepId = result.FailedStepId,
+            message = result.Message,
+            requiresRestart = result.RequiresRestart,
+            compatibilityFailure = result.CompatibilityFailure?.ToString(),
+            selectedGatewayVersion = config.Gateway.Version,
+            gatewayProtocolGeneration = GatewayReleasePolicy.ProtocolGeneration,
+            fallbackGatewayVersion =
+                result.CompatibilityFailure is { } failureKind &&
+                GatewayReleasePolicy.CanRetryWithFallback(config, failureKind)
+                    ? GatewayReleasePolicy.FallbackVersion
+                    : null,
+            logPath = config.LogPath,
+            journalPath
+        };
+        return System.Text.Json.JsonSerializer.Serialize(jsonResult, SetupConfig.JsonWriteOptions);
     }
 
     internal static string BuildCompatibilityFallbackMessage(

--- a/src/OpenClaw.SetupEngine/SetupContext.cs
+++ b/src/OpenClaw.SetupEngine/SetupContext.cs
@@ -462,12 +462,16 @@ public sealed record StepResult(
     Exception? Error = null,
     LocalAiFailureDetail? Detail = null)
 {
+    public bool RequiresRestart { get; init; }
+
     public static StepResult Ok(string? message = null) => new(StepOutcome.Success, message);
     public static StepResult Skip(string reason) => new(StepOutcome.Skipped, reason);
     public static StepResult Fail(string message, Exception? ex = null, LocalAiFailureDetail? detail = null) =>
         new(StepOutcome.Failed, message, ex, detail);
     public static StepResult Terminal(string message, Exception? ex = null, LocalAiFailureDetail? detail = null) =>
         new(StepOutcome.FailedTerminal, message, ex, detail);
+    public static StepResult RestartRequired(string message) =>
+        new(StepOutcome.FailedTerminal, message) { RequiresRestart = true };
 
     public bool IsSuccess => Outcome is StepOutcome.Success or StepOutcome.Skipped;
 }

--- a/src/OpenClaw.SetupEngine/SetupPipeline.cs
+++ b/src/OpenClaw.SetupEngine/SetupPipeline.cs
@@ -28,6 +28,8 @@ public sealed record PipelineResult(
     GatewayCompatibilityFailureKind? CompatibilityFailure = null,
     LocalAiFailureDetail? Detail = null)
 {
+    public bool RequiresRestart { get; init; }
+
     public int ExitCode => Outcome switch
     {
         PipelineOutcome.Success => 0,
@@ -222,7 +224,10 @@ public sealed class SetupPipeline
                 step.Id,
                 result.Message,
                 (result.Error as GatewayCompatibilityException)?.Kind,
-                result.Detail);
+                result.Detail)
+            {
+                RequiresRestart = result.RequiresRestart,
+            };
         }
 
         pipelineSw.Stop();

--- a/tests/OpenClaw.SetupEngine.Tests/ProgramArgumentTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/ProgramArgumentTests.cs
@@ -1,4 +1,5 @@
 using System.Runtime.Versioning;
+using System.Text.Json;
 
 namespace OpenClaw.SetupEngine.Tests;
 
@@ -511,6 +512,22 @@ public sealed class ProgramArgumentTests : IDisposable
             ]);
 
         Assert.Equal(2, exitCode);
+    }
+
+    [Fact]
+    public void SerializeJsonOutput_IncludesRequiresRestart()
+    {
+        var config = new SetupConfig();
+        GatewayReleasePolicy.ResolveAndApply(config);
+        var result = new PipelineResult(PipelineOutcome.Failed, "ensure-wsl-platform")
+        {
+            RequiresRestart = true,
+        };
+
+        using var document = JsonDocument.Parse(
+            Program.SerializeJsonOutput(result, config, "journal.jsonl"));
+        Assert.True(document.RootElement.TryGetProperty("requiresRestart", out var requiresRestart));
+        Assert.True(requiresRestart.GetBoolean());
     }
 
     [Fact]

--- a/tests/OpenClaw.SetupEngine.Tests/SetupConfigTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupConfigTests.cs
@@ -654,6 +654,20 @@ public class SetupConfigTests : IDisposable
     }
 
     [Fact]
+    public void StepResult_RestartRequired_IsTypedTerminal()
+    {
+        var result = StepResult.RestartRequired("restart Windows");
+        var (outcome, message, error, detail) = result;
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(StepOutcome.FailedTerminal, outcome);
+        Assert.Equal("restart Windows", message);
+        Assert.Null(error);
+        Assert.Null(detail);
+        Assert.True(result.RequiresRestart);
+    }
+
+    [Fact]
     public void PipelineResult_ExitCodes()
     {
         Assert.Equal(0, new PipelineResult(PipelineOutcome.Success).ExitCode);

--- a/tests/OpenClaw.SetupEngine.Tests/SetupPipelineTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupPipelineTests.cs
@@ -75,6 +75,26 @@ public class SetupPipelineTests
     }
 
     [Fact]
+    public async Task RunAsync_RestartRequired_PreservesTypedTerminalReason()
+    {
+        var pipeline = new SetupPipeline([
+            new MockStep(
+                "restart",
+                (_, _) => Task.FromResult(StepResult.RestartRequired("restart Windows"))),
+        ]);
+
+        var result = await pipeline.RunAsync(CreateContext());
+        var (outcome, failedStepId, message, compatibilityFailure, detail) = result;
+
+        Assert.Equal(PipelineOutcome.Failed, outcome);
+        Assert.Equal("restart", failedStepId);
+        Assert.Equal("restart Windows", message);
+        Assert.Null(compatibilityFailure);
+        Assert.Null(detail);
+        Assert.True(result.RequiresRestart);
+    }
+
+    [Fact]
     public void BuildDefaultSteps_IncludesCurrentSetupFlow()
     {
         var steps = SetupStepFactory.BuildDefaultSteps();

--- a/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
@@ -2257,6 +2257,33 @@ public class SetupStepsTests : IDisposable
     }
 
     [Fact]
+    public async Task EnsureWslPlatform_PreservesRestartRequiredFromInstaller()
+    {
+        var commands = new FakeCommandRunner(args => args switch
+        {
+            ["--version"] => Ok("WSL version: 2.7.3.0\n"),
+            ["--status"] => new CommandResult(
+                1,
+                "",
+                "Error code: Wsl/WSL_E_WSL_OPTIONAL_COMPONENT_REQUIRED",
+                TimeSpan.Zero,
+                TimedOut: false),
+            _ => Fail($"unexpected args: {string.Join(' ', args)}"),
+        });
+        var ctx = CreateContext(commands: commands);
+        var installerResult = StepResult.RestartRequired("installer requires restart");
+        var step = new EnsureWslPlatformStep((_, _) => Task.FromResult(installerResult));
+
+        var result = await step.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Same(installerResult, result);
+        Assert.Equal(StepOutcome.FailedTerminal, result.Outcome);
+        Assert.True(result.RequiresRestart);
+        Assert.Equal("installer requires restart", result.Message);
+        Assert.Equal(2, commands.Calls.Count);
+    }
+
+    [Fact]
     public async Task EnsureWslPlatform_RequiresRestartWhenPostInstallStatusLooksLikeFirmwareFailure()
     {
         var installed = false;

--- a/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
@@ -2256,6 +2256,41 @@ public class SetupStepsTests : IDisposable
     }
 
     [Fact]
+    public async Task EnsureWslPlatform_RequiresRestartWhenPostInstallStatusLooksLikeFirmwareFailure()
+    {
+        var installed = false;
+        var commands = new FakeCommandRunner(args => args switch
+        {
+            ["--version"] => Ok("WSL version: 2.7.13.0\n"),
+            ["--status"] when !installed => new CommandResult(
+                1,
+                "",
+                "Error code: Wsl/WSL_E_WSL_OPTIONAL_COMPONENT_REQUIRED",
+                TimeSpan.Zero,
+                TimedOut: false),
+            ["--status"] => Ok(
+                "WSL2 is unable to start since virtualization is not enabled on this machine. "
+                + "Please ensure the 'Virtual Machine Platform' optional component is enabled "
+                + "and virtualization is turned on in your computer's firmware settings."),
+            _ => Fail($"unexpected args: {string.Join(' ', args)}"),
+        });
+        var ctx = CreateContext(commands: commands);
+        var step = new EnsureWslPlatformStep((_, _) =>
+        {
+            installed = true;
+            return Task.FromResult(StepResult.Ok("installed"));
+        });
+
+        var result = await step.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.FailedTerminal, result.Outcome);
+        Assert.Contains("Reboot Windows", result.Message);
+        Assert.DoesNotContain("firmware", result.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("BIOS", result.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(4, commands.Calls.Count);
+    }
+
+    [Fact]
     public async Task EnsureWslPlatform_PropagatesElevationCancellationWithoutReinspection()
     {
         var commands = new FakeCommandRunner(args => args switch

--- a/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
@@ -2248,6 +2248,7 @@ public class SetupStepsTests : IDisposable
         var result = await step.ExecuteAsync(ctx, CancellationToken.None);
 
         Assert.Equal(StepOutcome.FailedTerminal, result.Outcome);
+        Assert.True(result.RequiresRestart);
         Assert.Contains("restarted", result.Message, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("Reboot Windows", result.Message);
         Assert.Equal(1, installCalls);
@@ -2284,6 +2285,7 @@ public class SetupStepsTests : IDisposable
         var result = await step.ExecuteAsync(ctx, CancellationToken.None);
 
         Assert.Equal(StepOutcome.FailedTerminal, result.Outcome);
+        Assert.True(result.RequiresRestart);
         Assert.Contains("Reboot Windows", result.Message);
         Assert.DoesNotContain("firmware", result.Message, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("BIOS", result.Message, StringComparison.OrdinalIgnoreCase);

--- a/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
@@ -1326,6 +1326,30 @@ public sealed class AppRefactorContractTests
     }
 
     [Fact]
+    public void CompletePage_OffersTypedRestartChoiceWithoutForcingApplicationsClosed()
+    {
+        var root = TestRepositoryPaths.GetRepositoryRoot();
+        var xaml = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.SetupEngine.UI", "Pages", "CompletePage.xaml"));
+        var complete = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.SetupEngine.UI", "Pages", "CompletePage.xaml.cs"));
+        var progress = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.SetupEngine.UI", "Pages", "ProgressPage.xaml.cs"));
+        var setupWindow = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.SetupEngine.UI", "SetupWindow.xaml.cs"));
+        var deferRestart = ExtractMethod(complete, "RestartLaterButton_Click");
+
+        Assert.Contains("restartRequired: result.RequiresRestart", progress);
+        Assert.Contains("if (args.RequiresRestart)", complete);
+        Assert.Contains("OpenClaw needs to restart Windows to continue the installation. Would you like to restart now?", complete);
+        Assert.Contains("Content=\"Yes, restart now\"", xaml);
+        Assert.Contains("Content=\"No, I'm not ready yet\"", xaml);
+        Assert.Contains("Path.Combine(Environment.SystemDirectory, \"shutdown.exe\")", complete);
+        Assert.Contains("ArgumentList = { \"/r\", \"/t\", \"0\" }", complete);
+        Assert.DoesNotContain("\"/f\"", complete);
+        Assert.Contains("SetupWindow.Active?.Close()", deferRestart);
+        Assert.DoesNotContain("Process.", deferRestart);
+        Assert.Contains("public bool RequiresRestart { get; init; }", setupWindow);
+        Assert.DoesNotContain("LocalAiFailureDetail? Detail = null,\n    bool RequiresRestart", setupWindow.Replace("\r\n", "\n"));
+    }
+
+    [Fact]
     public void CapabilitiesPage_PersistsSelectedProfileIntoRuntimeNodeSettings()
     {
         var root = TestRepositoryPaths.GetRepositoryRoot();

--- a/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
@@ -1331,6 +1331,7 @@ public sealed class AppRefactorContractTests
         var root = TestRepositoryPaths.GetRepositoryRoot();
         var xaml = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.SetupEngine.UI", "Pages", "CompletePage.xaml"));
         var complete = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.SetupEngine.UI", "Pages", "CompletePage.xaml.cs"));
+        var restartLauncher = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.SetupEngine.UI", "WindowsRestartLauncher.cs"));
         var progress = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.SetupEngine.UI", "Pages", "ProgressPage.xaml.cs"));
         var setupWindow = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.SetupEngine.UI", "SetupWindow.xaml.cs"));
         var deferRestart = ExtractMethod(complete, "RestartLaterButton_Click");
@@ -1340,11 +1341,20 @@ public sealed class AppRefactorContractTests
         Assert.Contains("OpenClaw needs to restart Windows to continue the installation. Would you like to restart now?", complete);
         Assert.Contains("Content=\"Yes, restart now\"", xaml);
         Assert.Contains("Content=\"No, I'm not ready yet\"", xaml);
-        Assert.Contains("Path.Combine(Environment.SystemDirectory, \"shutdown.exe\")", complete);
-        Assert.Contains("ArgumentList = { \"/r\", \"/t\", \"0\" }", complete);
-        Assert.DoesNotContain("\"/f\"", complete);
+        Assert.Contains("Path.Combine(Environment.SystemDirectory, \"shutdown.exe\")", restartLauncher);
+        Assert.Contains("ArgumentList = { \"/r\", \"/t\", \"0\" }", restartLauncher);
+        Assert.DoesNotContain("\"/f\"", restartLauncher);
         Assert.Contains("SetupWindow.Active?.Close()", deferRestart);
         Assert.DoesNotContain("Process.", deferRestart);
+        var restartNow = ExtractMethod(complete, "RestartNowButton_Click");
+        var restartWindows = ExtractMethod(complete, "RestartWindowsAsync");
+        var restartError = ExtractMethod(complete, "ShowRestartError");
+        Assert.Contains("AsyncEventHandlerGuard.Run(", restartNow);
+        Assert.Contains("RestartWindowsAsync", restartNow);
+        Assert.Contains("ShowRestartError", restartNow);
+        Assert.Contains("await s_windowsRestartLauncher.RestartAsync()", restartWindows);
+        Assert.Contains("RestartNowButton.IsEnabled = true", restartError);
+        Assert.Contains("RestartLaterButton.IsEnabled = true", restartError);
         Assert.Contains("public bool RequiresRestart { get; init; }", setupWindow);
         Assert.DoesNotContain("LocalAiFailureDetail? Detail = null,\n    bool RequiresRestart", setupWindow.Replace("\r\n", "\n"));
     }

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -186,6 +186,7 @@
     <!-- Pulled in for console-log tail tests. Pure logic, no WinUI deps. -->
     <Compile Include="..\..\src\OpenClaw.SetupEngine.UI\WizardConsoleTail.cs" Link="WizardConsoleTail.cs" />
     <Compile Include="..\..\src\OpenClaw.SetupEngine.UI\WizardPayloadHelpers.cs" Link="WizardPayloadHelpers.cs" />
+    <Compile Include="..\..\src\OpenClaw.SetupEngine.UI\WindowsRestartLauncher.cs" Link="WindowsRestartLauncher.cs" />
     <Compile Include="..\..\src\OpenClaw.SetupEngine.UI\Pages\LocalAiSetupAvailabilityCoordinator.cs" Link="Pages\LocalAiSetupAvailabilityCoordinator.cs" />
   </ItemGroup>
 

--- a/tests/OpenClaw.Tray.Tests/WindowsRestartLauncherTests.cs
+++ b/tests/OpenClaw.Tray.Tests/WindowsRestartLauncherTests.cs
@@ -1,0 +1,27 @@
+using System.Diagnostics;
+using OpenClaw.SetupEngine.UI;
+
+namespace OpenClaw.Tray.Tests;
+
+public sealed class WindowsRestartLauncherTests
+{
+    [Fact]
+    public async Task RestartAsync_NonzeroExitCodeIsRejected()
+    {
+        ProcessStartInfo? observedStartInfo = null;
+        var launcher = new WindowsRestartLauncher(startInfo =>
+        {
+            observedStartInfo = startInfo;
+            return Task.FromResult(5);
+        });
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(launcher.RestartAsync);
+
+        var startInfo = Assert.IsType<ProcessStartInfo>(observedStartInfo);
+        Assert.Equal(Path.Combine(Environment.SystemDirectory, "shutdown.exe"), startInfo.FileName);
+        Assert.Equal(["/r", "/t", "0"], startInfo.ArgumentList);
+        Assert.False(startInfo.UseShellExecute);
+        Assert.True(startInfo.CreateNoWindow);
+        Assert.Contains("code 5", exception.Message);
+    }
+}


### PR DESCRIPTION
Closes #1244

## What Problem This Solves

Fixes fresh Windows setup incorrectly reporting that firmware virtualization is disabled after OpenClaw successfully enables the Windows components needed by WSL and Windows actually requires a restart.

## Why This Change Was Made

The native WSL installer can indicate a required restart in two ways: exit code `3010`, or a successful install followed by `wsl.exe --version` remaining unavailable until reboot.
Both paths now return the existing typed `RestartRequired` result, and `EnsureWslPlatformStep` preserves that result for the setup UI and headless JSON output.

The completion page gives the user two explicit choices:

- `Yes, restart now` invokes the fixed, app-owned `%SystemRoot%\System32\shutdown.exe /r /t 0` command without a shell or forced application shutdown.
- `No, I'm not ready yet` closes only the setup wizard, leaves the tray running, schedules no restart or countdown, and lets the user restart Windows manually when ready.

The restart launcher checks that the process was created, waits for it to exit, and treats any nonzero exit code as a failure.
If restart initiation fails, the page shows the error and restores both restart controls so the user can retry or defer.

## User Impact

Fresh-system WSL setup now explains the actual next step instead of presenting misleading virtualization guidance.
Users can restart immediately or safely defer without OpenClaw forcing other applications to close.

## Evidence

The screenshots below show the complete VMConnect window and guest viewport for each tested state.

### Native WSL installation reaches the restart prompt

The OpenClaw completion page explains that Windows must restart before installation can continue and offers explicit Restart Now and Restart Later choices.

<img width="2732" height="1730" alt="Native WSL installation reaches the OpenClaw restart prompt inside the complete VMConnect window" src="https://github.com/user-attachments/assets/d30c1072-8064-4154-9719-924e228406a4" />

### Restart Later closes only setup and leaves the tray active

The setup wizard is closed, the OpenClaw tray icon remains visible in the expanded notification area, no `shutdown.exe` process exists, and the VM remains running with a pending reboot.

The setup wizard is gone while the OpenClaw tray icon remains active in the guest notification area, confirming that deferral closes only setup.

<img width="2732" height="1730" alt="Restart Later closes only setup while the OpenClaw tray remains active inside the complete VMConnect window" src="https://github.com/user-attachments/assets/9f8d20b6-b9a3-4b50-966e-cbd7e6626678" />

### Restart Now initiates a normal Windows restart

Hyper-V uptime reset and the guest boot timestamp changed from `2026-09-05T17:06:07.5000000-07:00` to `2026-09-05T17:21:28.5000000-07:00`.

Windows displays its normal Restarting screen after the user selects Restart Now.

<img width="2732" height="1730" alt="Windows restart initiated from the OpenClaw restart prompt inside the complete VMConnect window" src="https://github.com/user-attachments/assets/cc7e28f6-efb8-4009-83a8-1edd07dfb578" />

### Setup continues after reboot and completes

After reboot, the same setup build resumes successfully and reaches the completed gateway installation state.

<img width="2732" height="1730" alt="OpenClaw setup completes gateway installation after reboot inside the complete VMConnect window" src="https://github.com/user-attachments/assets/3a700cb1-7be4-4ca9-a0b9-87ab87f666d0" />

### An already-ready WSL installation continues normally

`wsl.exe --version` returned exit code `0`, `VirtualMachinePlatform` was enabled, and no reboot was pending.
The setup run marked `Prepare WSL` complete and continued into `Install WSL gateway` without displaying the restart prompt again.

With WSL already ready, setup proceeds through Prepare WSL and into gateway installation without showing the restart prompt.

<img width="2732" height="1730" alt="Already-ready WSL setup continues normally inside the complete VMConnect window" src="https://github.com/user-attachments/assets/e63cb7b3-218d-4227-8a20-0466534b6c2d" />

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs or instructions
- [x] Tests or validation
- [ ] Security hardening
- [ ] Chore or infrastructure

## Scope

- [x] Tray or WinUI UX
- [ ] Windows node capability
- [ ] Local MCP or `winnode`
- [ ] Gateway, connection, or pairing
- [x] Setup or onboarding
- [ ] Permissions, privacy, or security
- [x] Tests, CI, or docs

## Required proof pools

- `windows-winui-interactive`: verified the restart-required completion state, both button paths, wizard-only close behavior, and retry controls for restart-launch rejection.
- `windows-wsl-gateway-e2e`: verified native WSL platform installation reaches the restart prompt, Windows restarts, ready WSL continues normally, and gateway setup completes after reboot.

## Validation

Current refreshed head: `bb276e9c23740b02988f9ec6bd6b9aaf429a106c`.

- `.\build.ps1`: passed.
- `$env:OPENCLAW_REPO_ROOT=(Get-Location).Path; dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore`: passed, 3,937 tests; 32 skipped.
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore`: passed, 2,860 tests.
- `dotnet test .\tests\OpenClaw.SetupEngine.Tests\OpenClaw.SetupEngine.Tests.csproj --no-restore`: passed, 1,060 tests.
- Focused `ProgramArgumentTests.SerializeJsonOutput_IncludesRequiresRestart`: passed.
- Focused restart-result, restart-launcher, completion-page contract, and async-event-handler tests: passed.
- The first full Shared run hit an unrelated `McpHttpServerTests.Dispose_DuringInFlightHandler_DoesNotSurfaceObjectDisposedException` race. The focused test passed three consecutive reruns and the required full rerun passed.
- `git diff --check`: passed.
- Independent rubber-duck review: the headless JSON completeness gap was fixed. The post-install reboot-first behavior was re-evaluated as intentional and non-blocking because a persistent firmware block is diagnosed with full BIOS/UEFI remediation on the next preflight.

## Real Behavior Proof

- Environment tested: Windows 11 Pro x64 build 26200 in a nested Hyper-V VM, exercised through native `wsl.exe` and the unpackaged WinUI tray application.
- Behavior-proof commit: `3792741a37c8e5238448af1a8d4f8d941d768432`.
- Current head proof continuity: every setup/UI production and test file covered by the VM proof is byte-for-byte unchanged after merging current `main`; the only current-head functional addition exposes the existing typed result as `requiresRestart` in headless JSON.
- Tested artifact SHA-256: `13F772CC37EB7D1E157343D353B7D5E68F252D7BD5C847C8F05E799EB1225F0C`.
- Exact flow: began with WSL and Virtual Machine Platform disabled, approved the native WSL install, exercised Restart Later, restored the same pre-install checkpoint, exercised Restart Now, and reran setup after reboot.
- Observed result: Restart Later closed only the wizard and preserved the tray; Restart Now initiated a Windows restart; after reboot WSL was ready and the same build completed gateway setup.
- Screenshot or artifact links verified? Previously verified in the contributor proof and reviewed at the proofed head. Maintainer unauthenticated HEAD requests returned HTTP 403, so no new link-availability claim is made.
- Not verified or blocked: no new VM run was performed after the conflict-free `main` merge because all behavior-proof files were unchanged.

## Security Impact

- New permissions or capabilities? (`Yes`/`No`): No.
- Secrets or tokens handling changed? (`Yes`/`No`): No.
- New or changed network calls? (`Yes`/`No`): No.
- Command or tool execution surface changed? (`Yes`/`No`): Yes.
- Data access scope changed? (`Yes`/`No`): No.
- If any answer is `Yes`, explain the risk and mitigation: setup can invoke Windows restart only after an explicit user click. The executable path and arguments are fixed and app-owned, user-controlled input is not included, shell execution is disabled, the process result is checked, and `/f` is omitted so Windows can protect unsaved work.

## Compatibility and Migration

- Backward compatible? (`Yes`/`No`): Yes.
- Config or environment changes? (`Yes`/`No`): No.
- Migration needed? (`Yes`/`No`): No.
- If yes, list the exact upgrade steps: N/A.

## Review Conversations

- [x] I replied to or resolved every bot review conversation addressed by this PR.
- [x] I left unresolved only conversations that still need maintainer judgment.