### PR TITLE
Fix Local AI retry recovery

### DIFF
--- a/src/OpenClaw.SetupEngine.UI/Pages/CapabilitiesPage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/CapabilitiesPage.xaml.cs
@@ -74,7 +74,8 @@ public sealed partial class CapabilitiesPage : Page
 
     protected override void OnNavigatedTo(NavigationEventArgs e)
     {
-        _config = e.Parameter as SetupConfig ?? new SetupConfig();
+        var args = e.Parameter as CapabilitiesPageArgs;
+        _config = args?.Config ?? e.Parameter as SetupConfig ?? new SetupConfig();
         // The tray always registers device.info/status with Node Mode. Keep the
         // setup declaration and gateway allowlist aligned with that runtime contract.
         _config.Capabilities.Device = true;
@@ -105,7 +106,9 @@ public sealed partial class CapabilitiesPage : Page
         TailscaleAuthModeSelector.SelectedIndex = _config.Tailscale.AuthMode == TailscaleAuthMode.AuthKey ? 1 : 0;
         UpdateTailscaleOptions();
         var previewPage = SetupPreview.RequestedPage;
-        var localAiReviewPreview = previewPage is "capabilities-review" or "capabilities-review-consent";
+        var localAiReviewPreview =
+            args?.StartAtLocalAiReview == true ||
+            previewPage is "capabilities-review" or "capabilities-review-consent";
         _forceLocalAiNetworkingConsent = previewPage == "capabilities-review-consent";
         if (localAiReviewPreview)
             _config.LocalAi.Enabled = true;

--- a/src/OpenClaw.SetupEngine.UI/Pages/CapabilitiesPageArgs.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/CapabilitiesPageArgs.cs
@@ -1,0 +1,3 @@
+namespace OpenClaw.SetupEngine.UI.Pages;
+
+internal sealed record CapabilitiesPageArgs(SetupConfig Config, bool StartAtLocalAiReview);

--- a/src/OpenClaw.SetupEngine.UI/Pages/ProgressPage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/ProgressPage.xaml.cs
@@ -14,6 +14,7 @@ namespace OpenClaw.SetupEngine.UI.Pages;
 internal sealed record ProgressPageArgs(
     SetupConfig Config,
     bool ShowMilestoneOnly,
+    bool LocalAiRecoveryOnly,
     string DataDir,
     string LocalDataDir);
 
@@ -29,6 +30,8 @@ public sealed partial class ProgressPage : Page
     private string _dataDir = null!;
     private string _localDataDir = null!;
     private Uri? _tailscaleAuthorizationUri;
+    private HashSet<string> _activeStepIds = [];
+    private bool _localAiRecoveryOnly;
     private const int MaxLogLines = 200;
 
     internal bool IsPipelineRunning => _runCts != null && !_pipelineFinished;
@@ -50,7 +53,7 @@ public sealed partial class ProgressPage : Page
         ("local-ai-wsl", "Verify Local AI access", ["verify-local-ai-wsl"]),
         ("tailscale-auth", "Connect Tailscale", ["install-tailscale", "authorize-tailscale"]),
         ("configure", "Configure gateway", ["configure-gateway", "configure-local-ai-gateway", "install-service"]),
-        ("start", "Start gateway", ["start-gateway", "mint-token"]),
+        ("start", "Start gateway", ["start-gateway", "restart-gateway", "mint-token"]),
         ("tailscale-serve", "Publish with Tailscale", ["finalize-tailscale-serve"]),
         ("pairing", "Pair device", ["pair-operator", "pair-node", "verify-e2e"]),
         ("finish", "Finish setup", ["run-wizard", "start-keepalive"]),
@@ -68,6 +71,10 @@ public sealed partial class ProgressPage : Page
         _config = args?.Config ?? e.Parameter as SetupConfig ?? new SetupConfig();
         _dataDir = args?.DataDir ?? SetupContext.ResolveDataDir();
         _localDataDir = args?.LocalDataDir ?? SetupContext.ResolveLocalDataDir();
+        _localAiRecoveryOnly = args?.LocalAiRecoveryOnly == true;
+        _activeStepIds = BuildSteps(_config, _localAiRecoveryOnly)
+            .Select(step => step.Id)
+            .ToHashSet(StringComparer.Ordinal);
         TitleText.Text = _config.LocalAi.Enabled ? "Setting up OpenClaw and Local AI" : "Setting up OpenClaw";
         SubtitleText.Text = _config.LocalAi.Enabled
             ? "Preparing the gateway and Local AI"
@@ -140,7 +147,8 @@ public sealed partial class ProgressPage : Page
                 showDetailProgress: groupId is "local-ai-engine" or "local-ai-model");
             _rows[groupId] = row;
             StepsPanel.Children.Add(row.Element);
-            if (_config?.LocalAi.Enabled != true && IsLocalAiOnlyGroup(stepIds))
+            if (!_activeStepIds.Overlaps(stepIds) ||
+                (_config?.LocalAi.Enabled != true && IsLocalAiOnlyGroup(stepIds)))
                 row.Element.Visibility = Visibility.Collapsed;
         }
     }
@@ -188,7 +196,7 @@ public sealed partial class ProgressPage : Page
             ctx.ExternalAuthorizationPresenter = new ProgressAuthorizationPresenter(DispatcherQueue, ShowTailscaleAuthorization);
             ctx.DetailProgress = new DirectProgress<SetupDetailProgressEvent>(OnDetailProgress);
 
-            var steps = BuildSteps(config);
+            var steps = BuildSteps(config, _localAiRecoveryOnly);
             _pipeline = new SetupPipeline(steps);
             _pipeline.StepProgress += OnStepProgress;
 
@@ -297,7 +305,7 @@ public sealed partial class ProgressPage : Page
                 _completedSteps.Add(e.StepId);
 
                 // If all steps in this group are done, mark group done
-                if (group.StepIds.All(id => _completedSteps.Contains(id)))
+                if (group.StepIds.Where(_activeStepIds.Contains).All(id => _completedSteps.Contains(id)))
                     row.SetStatus(StepStatus.Done);
             }
         });
@@ -378,8 +386,10 @@ public sealed partial class ProgressPage : Page
         MilestoneStatusText.Text = "Another setup task is still active. Wait for it to finish, then start OpenClaw onboard.";
     }
 
-    private static List<SetupStep> BuildSteps(SetupConfig config)
-        => SetupStepFactory.BuildDefaultSteps()
+    private static List<SetupStep> BuildSteps(SetupConfig config, bool localAiRecoveryOnly = false)
+        => (localAiRecoveryOnly
+                ? SetupStepFactory.BuildLocalAiRecoverySteps()
+                : SetupStepFactory.BuildDefaultSteps())
             .Where(step => step is not RunGatewayWizardStep)
             .Where(step => config.SkipWizard || step is not WindowsNodeBootstrapContextStep)
             .ToList();

--- a/src/OpenClaw.SetupEngine.UI/SetupWindow.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/SetupWindow.xaml.cs
@@ -29,6 +29,7 @@ public sealed partial class SetupWindow : Window
     private readonly object _localAiHardwareProbeLock = new();
     private Task<HostHardwareInfo>? _localAiHardwareProbeTask;
     private readonly WslViabilityProbe _wslViabilityProbe = new(InspectWslViabilityAsync);
+    private bool _startAtLocalAiRecoveryReview;
 
     public static SetupWindow? Active { get; private set; }
 
@@ -47,6 +48,7 @@ public sealed partial class SetupWindow : Window
         _setupLock is not null &&
         RootFrame.Content is not ProgressPage { IsPipelineRunning: true } &&
         RootFrame.Content is not WizardPage;
+    public bool CanNavigateToLocalAiRecoveryReview => CanNavigateToGatewayInstalledMilestone;
 
     [DllImport("user32.dll")]
     private static extern uint GetDpiForWindow(IntPtr hwnd);
@@ -54,6 +56,7 @@ public sealed partial class SetupWindow : Window
     public SetupWindow(
         string? configPath = null,
         bool startAtGatewayInstalledMilestone = false,
+        bool startAtLocalAiRecoveryReview = false,
         string? dataDir = null,
         string? localDataDir = null,
         string? distroNameOverride = null,
@@ -62,6 +65,7 @@ public sealed partial class SetupWindow : Window
     {
         _dataDir = dataDir ?? SetupContext.ResolveDataDir();
         _localDataDir = localDataDir ?? SetupContext.ResolveLocalDataDir();
+        _startAtLocalAiRecoveryReview = startAtLocalAiRecoveryReview;
         InitializeComponent();
         Active = this;
 
@@ -189,6 +193,8 @@ public sealed partial class SetupWindow : Window
 
         if (startAtGatewayInstalledMilestone)
             NavigateToGatewayInstalledMilestone();
+        else if (startAtLocalAiRecoveryReview)
+            NavigateToCapabilities();
         else
             NavigateTo(typeof(SecurityNoticePage), _config);
     }
@@ -227,13 +233,16 @@ public sealed partial class SetupWindow : Window
     }
 
     public void NavigateToAdvancedSetup() => NavigateTo(typeof(AdvancedSetupPage), _config);
-    public void NavigateToCapabilities() => NavigateTo(typeof(CapabilitiesPage), _config);
+    public void NavigateToCapabilities() =>
+        NavigateTo(
+            typeof(CapabilitiesPage),
+            new CapabilitiesPageArgs(_config, _startAtLocalAiRecoveryReview));
     public void NavigateToProgress() => NavigateTo(typeof(ProgressPage), CreateProgressPageArgs(showMilestoneOnly: false));
     public void NavigateToGatewayInstalledMilestone() =>
         NavigateTo(typeof(ProgressPage), CreateProgressPageArgs(showMilestoneOnly: true));
 
     private ProgressPageArgs CreateProgressPageArgs(bool showMilestoneOnly) =>
-        new(_config, showMilestoneOnly, _dataDir, _localDataDir);
+        new(_config, showMilestoneOnly, _startAtLocalAiRecoveryReview, _dataDir, _localDataDir);
 
     public bool TryNavigateToGatewayInstalledMilestone()
     {
@@ -243,6 +252,18 @@ public sealed partial class SetupWindow : Window
         _persistStartupPreferenceOnComplete = false;
         _showStartupPreferenceOnComplete = false;
         NavigateToGatewayInstalledMilestone();
+        return true;
+    }
+
+    public bool TryNavigateToLocalAiRecoveryReview()
+    {
+        if (!CanNavigateToLocalAiRecoveryReview)
+            return false;
+
+        _startAtLocalAiRecoveryReview = true;
+        _config.LocalAi.Enabled = true;
+        _config.SkipWizard = true;
+        NavigateToCapabilities();
         return true;
     }
 

--- a/src/OpenClaw.SetupEngine/CleanupStaleDistroStep.cs
+++ b/src/OpenClaw.SetupEngine/CleanupStaleDistroStep.cs
@@ -37,7 +37,12 @@ public sealed class CleanupStaleDistroStep : SetupStep
         if (!DistroInstallPathPolicy.TryGetManagedInstallPath(ctx.LocalDataDir, distro, out var wslDir, out var pathError))
             return StepResult.Terminal(pathError);
 
-        var list = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--list", "--quiet"], TimeSpan.FromSeconds(15), ct: ct);
+        var list = await ctx.Commands.RunAsync(
+            WslConstants.WslExePath,
+            ["--list", "--quiet"],
+            TimeSpan.FromSeconds(15),
+            ct: ct,
+            allowInheritedPipeHandleEscape: true);
         if (list.ExitCode != 0)
             return StepResult.Ok("WSL not available or no distros - nothing to clean");
 

--- a/src/OpenClaw.SetupEngine/CommandRunner.cs
+++ b/src/OpenClaw.SetupEngine/CommandRunner.cs
@@ -17,7 +17,8 @@ public interface ICommandRunner
         string? workingDirectory = null,
         string? stdinInput = null,
         CancellationToken ct = default,
-        Stream? stdinStream = null);
+        Stream? stdinStream = null,
+        bool allowInheritedPipeHandleEscape = false);
 
     /// <summary>
     /// Run a command inside a WSL distro.
@@ -73,10 +74,9 @@ public sealed class CommandRunner : ICommandRunner
     private static readonly TimeSpan s_outputDrainGrace = TimeSpan.FromMilliseconds(250);
 
     /// <summary>
-    /// Upper bound on how long an exited process is given to reach EOF on its redirected
-    /// pipes. Large enough that a saturated thread pool cannot make a process that did
-    /// write output look silent, small enough that a descendant holding the pipes open
-    /// cannot stall the caller.
+    /// Upper bound on how long known inherited-pipe callers are given to reach EOF
+    /// after their direct child exits. Normal commands wait for EOF so trailing output
+    /// remains complete.
     /// </summary>
     private static readonly TimeSpan s_outputDrainCap = TimeSpan.FromSeconds(3);
     private const int MaxCapturedStreamChars = 1_048_576;
@@ -94,7 +94,8 @@ public sealed class CommandRunner : ICommandRunner
         string? workingDirectory = null,
         string? stdinInput = null,
         CancellationToken ct = default,
-        Stream? stdinStream = null)
+        Stream? stdinStream = null,
+        bool allowInheritedPipeHandleEscape = false)
     {
         ArgumentNullException.ThrowIfNull(executable);
         ArgumentNullException.ThrowIfNull(arguments);
@@ -200,20 +201,14 @@ public sealed class CommandRunner : ICommandRunner
             throw;
         }
 
-        // A surviving descendant can keep inherited pipe handles open after the child
-        // exits, so the EOF wait must stay bounded and cannot simply run to the command
-        // timeout. It also cannot be as tight as a few hundred milliseconds: the
-        // OutputDataReceived callbacks are queued to the thread pool, and on a saturated
-        // pool they can miss that window even though the process already exited and
-        // wrote its output. That surfaced as an exited process being reported with empty
-        // stdout and stderr, which every caller that classifies command output then
-        // misreads as silence. Wait up to a short cap instead, clamped by whatever
-        // remains of the caller's own deadline so the accepted timeout is never exceeded.
-        TimeSpan drainBudget = GetOutputDrainBudget(timeout, sw.Elapsed, timedOut);
-
-        await Task.WhenAny(
-            Task.WhenAll(stdoutClosed.Task, stderrClosed.Task),
-            Task.Delay(drainBudget));
+        var outputClosed = Task.WhenAll(stdoutClosed.Task, stderrClosed.Task);
+        await WaitForOutputDrainAsync(
+            outputClosed,
+            timeout,
+            sw.Elapsed,
+            timedOut,
+            allowInheritedPipeHandleEscape,
+            ct).ConfigureAwait(false);
 
         sw.Stop();
         var result = new CommandResult(
@@ -240,6 +235,31 @@ public sealed class CommandRunner : ICommandRunner
             return TimeSpan.Zero;
 
         return remaining < s_outputDrainCap ? remaining : s_outputDrainCap;
+    }
+
+    internal static async Task WaitForOutputDrainAsync(
+        Task outputClosed,
+        TimeSpan timeout,
+        TimeSpan elapsed,
+        bool timedOut,
+        bool allowInheritedPipeHandleEscape,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(outputClosed);
+
+        if (timedOut || allowInheritedPipeHandleEscape)
+        {
+            // A surviving descendant can keep inherited pipe handles open after the
+            // child exits. Bound only known inherited-pipe callers and timeout cleanup.
+            TimeSpan drainBudget = GetOutputDrainBudget(timeout, elapsed, timedOut);
+            var delay = Task.Delay(drainBudget, cancellationToken);
+            var completed = await Task.WhenAny(outputClosed, delay).ConfigureAwait(false);
+            if (ReferenceEquals(completed, delay))
+                await delay.ConfigureAwait(false);
+            return;
+        }
+
+        await outputClosed.WaitAsync(cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/OpenClaw.SetupEngine/CreateWslInstanceStep.cs
+++ b/src/OpenClaw.SetupEngine/CreateWslInstanceStep.cs
@@ -41,7 +41,12 @@ public sealed class CreateWslInstanceStep : SetupStep
 
         ctx.Logger.Info($"Creating clean app-owned WSL distro '{distro}' from '{baseDistro}' at '{installPath}'");
 
-        var existing = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--list", "--quiet"], TimeSpan.FromSeconds(15), ct: ct);
+        var existing = await ctx.Commands.RunAsync(
+            WslConstants.WslExePath,
+            ["--list", "--quiet"],
+            TimeSpan.FromSeconds(15),
+            ct: ct,
+            allowInheritedPipeHandleEscape: true);
         if (existing.ExitCode != 0)
             return StepResult.Fail($"Failed to list WSL distros before creating '{distro}': {existing.Stderr}");
 
@@ -126,7 +131,12 @@ public sealed class CreateWslInstanceStep : SetupStep
 
     private static async Task<StepResult> VerifyFreshDistro(SetupContext ctx, string distro, string installPath, CancellationToken ct)
     {
-        var list = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--list", "--quiet"], TimeSpan.FromSeconds(15), ct: ct);
+        var list = await ctx.Commands.RunAsync(
+            WslConstants.WslExePath,
+            ["--list", "--quiet"],
+            TimeSpan.FromSeconds(15),
+            ct: ct,
+            allowInheritedPipeHandleEscape: true);
         if (list.ExitCode != 0 || !WslInstallSupport.ContainsDistro(list.Stdout, distro))
         {
             var environmentIssue = await PreflightWslStep.DetectEnvironmentIssueAsync(ctx, ct);
@@ -138,7 +148,8 @@ public sealed class CreateWslInstanceStep : SetupStep
             WslConstants.WslExePath,
             ["--list", "--verbose"],
             DistroVersionVerificationTimeout,
-            ct: ct);
+            ct: ct,
+            allowInheritedPipeHandleEscape: true);
         if (verbose.ExitCode != 0 || !WslInstallSupport.TryGetDistroVersion(verbose.Stdout, distro, out var version))
             return StepResult.Fail($"Fresh WSL install registered '{distro}', but setup could not verify it is WSL2.");
 
@@ -182,7 +193,12 @@ public sealed class CreateWslInstanceStep : SetupStep
     {
         var cleanupErrors = new List<string>();
         var installPathExists = Directory.Exists(installPath) || File.Exists(installPath);
-        var list = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--list", "--quiet"], TimeSpan.FromSeconds(15), ct: ct);
+        var list = await ctx.Commands.RunAsync(
+            WslConstants.WslExePath,
+            ["--list", "--quiet"],
+            TimeSpan.FromSeconds(15),
+            ct: ct,
+            allowInheritedPipeHandleEscape: true);
         var registrationStateKnown = list.ExitCode == 0;
         var distroExists = registrationStateKnown && WslInstallSupport.ContainsDistro(list.Stdout, distro);
         var canDeleteInstallPath = registrationStateKnown && !distroExists;

--- a/src/OpenClaw.SetupEngine/ExistingConfigDetector.cs
+++ b/src/OpenClaw.SetupEngine/ExistingConfigDetector.cs
@@ -37,7 +37,11 @@ public sealed class ExistingConfigDetector
 
         var logger = new SetupLogger(filePath: null, LogLevel.Warn);
         var result = new CommandRunner(logger)
-            .RunAsync(WslConstants.WslExePath, ["--list", "--quiet"], TimeSpan.FromSeconds(5))
+            .RunAsync(
+                WslConstants.WslExePath,
+                ["--list", "--quiet"],
+                TimeSpan.FromSeconds(5),
+                allowInheritedPipeHandleEscape: true)
             .GetAwaiter()
             .GetResult();
         var hasDistro = InterpretDistroList(result, targetDistroName);

--- a/src/OpenClaw.SetupEngine/PreflightWslStep.cs
+++ b/src/OpenClaw.SetupEngine/PreflightWslStep.cs
@@ -48,7 +48,8 @@ internal static class WslViabilityInspector
                 WslConstants.WslExePath,
                 ["--version"],
                 TimeSpan.FromSeconds(5),
-                ct: ct);
+                ct: ct,
+                allowInheritedPipeHandleEscape: true);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -106,7 +107,8 @@ internal static class WslViabilityInspector
                 WslConstants.WslExePath,
                 ["--status"],
                 TimeSpan.FromSeconds(10),
-                ct: ct);
+                ct: ct,
+                allowInheritedPipeHandleEscape: true);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -204,7 +206,8 @@ public sealed class PreflightWslStep : SetupStep
             WslConstants.WslExePath,
             ["--status"],
             TimeSpan.FromSeconds(10),
-            ct: ct);
+            ct: ct,
+            allowInheritedPipeHandleEscape: true);
         var combined = $"{status.Stdout}\n{status.Stderr}";
         if (!WslInstallSupport.TryGetEnvironmentIssue(combined, out var message))
             return null;
@@ -248,7 +251,8 @@ public sealed class PreflightWslStep : SetupStep
                 WslConstants.WslExePath,
                 ["--version"],
                 TimeSpan.FromSeconds(5),
-                ct: ct);
+                ct: ct,
+                allowInheritedPipeHandleEscape: true);
             if (probe.ExitCode != 0 || WslViabilityInspector.LooksUnavailable(probe))
             {
                 return StepResult.Terminal(

--- a/src/OpenClaw.SetupEngine/RestartGatewayStep.cs
+++ b/src/OpenClaw.SetupEngine/RestartGatewayStep.cs
@@ -1,0 +1,11 @@
+namespace OpenClaw.SetupEngine;
+
+public sealed class RestartGatewayStep : SetupStep
+{
+    public override string Id => "restart-gateway";
+    public override string DisplayName => "Restart gateway";
+    public override RetryPolicy Retry => new(MaxAttempts: 3, InitialDelay: TimeSpan.FromSeconds(3));
+
+    public override Task<StepResult> ExecuteAsync(SetupContext ctx, CancellationToken ct) =>
+        StartGatewayStep.RestartAndWaitForHealthAsync(ctx, ct);
+}

--- a/src/OpenClaw.SetupEngine/SetupPipeline.cs
+++ b/src/OpenClaw.SetupEngine/SetupPipeline.cs
@@ -49,6 +49,27 @@ public static class SetupStepFactory
         new WindowsNodeBootstrapContextStep(),
     ];
 
+    public static List<SetupStep> BuildLocalAiRecoverySteps() =>
+    [
+        new ValidateDistroInstallPathStep(),
+        new PreflightOsStep(),
+        new PreflightLocalAiHardwareStep(),
+        new PreflightWslStep(),
+        new EnsureWslPlatformStep(),
+        new ReconcileLocalAiInstallationStep(),
+        new AcquireLocalAiRuntimeStep(),
+        new AcquireLocalAiModelStep(),
+        new PersistLocalAiManifestStep(),
+        new StartLocalAiRuntimeStep(),
+        new CaptureLocalAiGpuBaselineStep(),
+        new VerifyLocalAiInferenceStep(),
+        new VerifyLocalAiGpuLoadStep(),
+        new ConfigureLocalAiWslNetworkingStep(),
+        new VerifyLocalAiWslStep(),
+        new ConfigureLocalAiGatewayStep(),
+        new RestartGatewayStep(),
+    ];
+
     public static List<SetupStep> BuildDefaultSteps()
     {
         return

--- a/src/OpenClaw.SetupEngine/StartGatewayStep.cs
+++ b/src/OpenClaw.SetupEngine/StartGatewayStep.cs
@@ -148,7 +148,12 @@ public sealed class StartGatewayStep : SetupStep
         var distro = ctx.DistroName!;
 
         // Check if distro is running before trying systemctl stop
-        var list = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--list", "--quiet"], TimeSpan.FromSeconds(15), ct: ct);
+        var list = await ctx.Commands.RunAsync(
+            WslConstants.WslExePath,
+            ["--list", "--quiet"],
+            TimeSpan.FromSeconds(15),
+            ct: ct,
+            allowInheritedPipeHandleEscape: true);
         if (!WslInstallSupport.ContainsDistro(list.Stdout, distro))
         {
             ctx.Logger.Info("[Uninstall] Distro not registered — skipping gateway stop");
@@ -156,7 +161,12 @@ public sealed class StartGatewayStep : SetupStep
         }
 
         // Check distro state — only stop if Running
-        var verbose = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--list", "--verbose"], TimeSpan.FromSeconds(15), ct: ct);
+        var verbose = await ctx.Commands.RunAsync(
+            WslConstants.WslExePath,
+            ["--list", "--verbose"],
+            TimeSpan.FromSeconds(15),
+            ct: ct,
+            allowInheritedPipeHandleEscape: true);
         var isRunning = WslInstallSupport.Normalize(verbose.Stdout)
             .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)
             .Any(line => line.Contains(distro, StringComparison.OrdinalIgnoreCase)

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -3916,6 +3916,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands, IPer
     void IAppCommands.ShowChat() => ShowChatWindow();
     void IAppCommands.CheckForUpdates() => _ = _updateCoordinator!.CheckForUpdatesUserInitiatedAsync();
     void IAppCommands.ShowOnboarding() => _ = ShowOnboardingAsync();
+    void IAppCommands.ShowLocalAiSetupRecovery() => _ = _windowManager?.ShowLocalAiSetupRecoveryAsync();
     void IAppCommands.OpenLocalAiLogs() =>
         OpenFolder(new LocalAiPaths(AppIdentity.ResolveSetupLocalDataDirectory()).LogsDirectory, "Local AI logs");
     void IAppCommands.ShowGatewayWizard() => _ = ShowGatewayWizardAsync();

--- a/src/OpenClaw.Tray.WinUI/Presentation/LocalAiPageViewModel.cs
+++ b/src/OpenClaw.Tray.WinUI/Presentation/LocalAiPageViewModel.cs
@@ -188,7 +188,7 @@ internal sealed class LocalAiPageViewModel : INavigationAware, IDisposable, INot
     public Task<bool> StopAsync() => RunRuntimeActionAsync(CanStop, _runtime.StopAsync);
     public Task<bool> RestartAsync() => RunRuntimeActionAsync(CanRestart, _runtime.RestartAsync);
     public bool OpenLogs() => RunCommand(CanOpenLogs, _appCommands.OpenLocalAiLogs);
-    public bool RetrySetup() => RunCommand(CanRetrySetup, _appCommands.ShowOnboarding);
+    public bool RetrySetup() => RunCommand(CanRetrySetup, _appCommands.ShowLocalAiSetupRecovery);
     public bool ChangeModel() => RunCommand(CanChangeModel, _appCommands.ShowOnboarding);
     public bool RepairConnection() => RunCommand(CanRepairConnection, _appCommands.Reconnect);
     public bool OpenChat() => RunCommand(CanOpenChat, _appCommands.ShowChat);

--- a/src/OpenClaw.Tray.WinUI/Services/IAppCommands.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/IAppCommands.cs
@@ -17,6 +17,7 @@ internal interface IAppCommands
     void ShowChat();
     void CheckForUpdates();
     void ShowOnboarding();
+    void ShowLocalAiSetupRecovery();
     void OpenLocalAiLogs() { }
     void ShowGatewayWizard();
     void ShowConnectionStatus();

--- a/src/OpenClaw.Tray.WinUI/Services/IWindowManager.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/IWindowManager.cs
@@ -26,6 +26,7 @@ internal interface IWindowManager
     void ShowHub(string? navigateTo = null, bool activate = true);
     void ShowConnectionStatus();
     Task ShowOnboardingAsync();
+    Task ShowLocalAiSetupRecoveryAsync();
     Task ShowGatewayWizardAsync();
     void CloseSetup();
     void ApplyThemeToOpenWindows();

--- a/src/OpenClaw.Tray.WinUI/Services/WindowManager.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/WindowManager.cs
@@ -341,13 +341,34 @@ internal sealed class WindowManager : IWindowManager
 
     public async Task ShowOnboardingAsync()
     {
-        await EnsureSetupWindowAsync(startAtGatewayInstalledMilestone: false);
+        await EnsureSetupWindowAsync(
+            startAtGatewayInstalledMilestone: false,
+            startAtLocalAiRecoveryReview: false);
+    }
+
+    public async Task ShowLocalAiSetupRecoveryAsync()
+    {
+        var (setupWindow, created) = await EnsureSetupWindowAsync(
+            startAtGatewayInstalledMilestone: false,
+            startAtLocalAiRecoveryReview: true);
+        if (!_isShuttingDown && !created && setupWindow is { IsClosed: false })
+        {
+            if (setupWindow.TryNavigateToLocalAiRecoveryReview())
+            {
+                Logger.Info("Setup window already open; switched to Local AI recovery review");
+            }
+            else
+            {
+                Logger.Info("Setup window already open; leaving current setup page visible to avoid interrupting active setup");
+            }
+        }
     }
 
     public async Task ShowGatewayWizardAsync()
     {
         var (setupWindow, created) = await EnsureSetupWindowAsync(
-            startAtGatewayInstalledMilestone: true);
+            startAtGatewayInstalledMilestone: true,
+            startAtLocalAiRecoveryReview: false);
         if (!_isShuttingDown && !created && setupWindow is { IsClosed: false })
         {
             if (setupWindow.TryNavigateToGatewayInstalledMilestone())
@@ -362,7 +383,8 @@ internal sealed class WindowManager : IWindowManager
     }
 
     private async Task<(SetupWindow? Window, bool Created)> EnsureSetupWindowAsync(
-        bool startAtGatewayInstalledMilestone)
+        bool startAtGatewayInstalledMilestone,
+        bool startAtLocalAiRecoveryReview)
     {
         if (_isShuttingDown || _callbacks.GetSettings() is null)
         {
@@ -409,6 +431,7 @@ internal sealed class WindowManager : IWindowManager
         {
             setupWindow = new SetupWindow(
                 startAtGatewayInstalledMilestone: startAtGatewayInstalledMilestone,
+                startAtLocalAiRecoveryReview: startAtLocalAiRecoveryReview,
                 dataDir: AppIdentity.ResolveRoamingDataDirectory(),
                 localDataDir: AppIdentity.ResolveSetupLocalDataDirectory(),
                 distroNameOverride: AppIdentity.SetupDistroName,

--- a/tests/OpenClaw.SetupEngine.Tests/CommandRunnerTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/CommandRunnerTests.cs
@@ -87,11 +87,52 @@ public class CommandRunnerTests
         var (executable, arguments) = ExitsLeavingPipeHolderCommand();
         var stopwatch = Stopwatch.StartNew();
 
-        var result = await runner.RunAsync(executable, arguments, TimeSpan.FromSeconds(30));
+        var result = await runner.RunAsync(
+            executable,
+            arguments,
+            TimeSpan.FromSeconds(30),
+            allowInheritedPipeHandleEscape: true);
 
         Assert.False(result.TimedOut);
         Assert.Equal(0, result.ExitCode);
         Assert.InRange(stopwatch.Elapsed, TimeSpan.Zero, TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task WaitForOutputDrainAsync_WaitsPastCommandDeadlineOnNormalExit()
+    {
+        var outputClosed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var wait = CommandRunner.WaitForOutputDrainAsync(
+            outputClosed.Task,
+            TimeSpan.FromMilliseconds(100),
+            TimeSpan.Zero,
+            timedOut: false,
+            allowInheritedPipeHandleEscape: false);
+
+        var completed = await Task.WhenAny(wait, Task.Delay(TimeSpan.FromMilliseconds(250)));
+        Assert.NotSame(wait, completed);
+
+        outputClosed.SetResult();
+        await wait;
+    }
+
+    [Fact]
+    public async Task RunAsync_DrainsHighVolumeStdoutAndStderrThroughTrailingMarkers()
+    {
+        const int lineCount = 8_000;
+        var (executable, arguments) = HighVolumeOutputCommand(lineCount);
+
+        var result = await CreateRunner().RunAsync(
+            executable,
+            arguments,
+            TimeSpan.FromSeconds(30));
+
+        Assert.False(result.TimedOut);
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(lineCount, CountLinesStartingWith(result.Stdout, "stdout-"));
+        Assert.Equal(lineCount, CountLinesStartingWith(result.Stderr, "stderr-"));
+        Assert.EndsWith($"STDOUT_MARKER{Environment.NewLine}", result.Stdout, StringComparison.Ordinal);
+        Assert.EndsWith($"STDERR_MARKER{Environment.NewLine}", result.Stderr, StringComparison.Ordinal);
     }
 
     [Theory]
@@ -125,6 +166,32 @@ public class CommandRunnerTests
         => OperatingSystem.IsWindows()
             ? ("cmd.exe", ["/d", "/s", "/c", "ping 127.0.0.1 -n 30 >nul"])
             : ("/bin/sh", ["-c", "sleep 30"]);
+
+    private static (string Executable, string[] Arguments) HighVolumeOutputCommand(int lineCount)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return ("/bin/sh",
+            [
+                "-c",
+                "i=0; while [ $i -lt " + lineCount + " ]; do printf 'stdout-%s\\n' \"$i\"; i=$((i+1)); done; " +
+                "printf 'STDOUT_MARKER\\n'; " +
+                "i=0; while [ $i -lt " + lineCount + " ]; do printf 'stderr-%s\\n' \"$i\" >&2; i=$((i+1)); done; " +
+                "printf 'STDERR_MARKER\\n' >&2"
+            ]);
+        }
+
+        var script =
+            $"for ($i = 0; $i -lt {lineCount}; $i++) {{ [Console]::Out.WriteLine(\"stdout-$i\") }}; " +
+            "[Console]::Out.WriteLine(\"STDOUT_MARKER\"); " +
+            $"for ($i = 0; $i -lt {lineCount}; $i++) {{ [Console]::Error.WriteLine(\"stderr-$i\") }}; " +
+            "[Console]::Error.WriteLine(\"STDERR_MARKER\")";
+        return ("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", script]);
+    }
+
+    private static int CountLinesStartingWith(string value, string prefix) =>
+        value.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)
+            .Count(line => line.StartsWith(prefix, StringComparison.Ordinal));
 
     private static (string Executable, string[] Arguments) CopyStdinCommand(string path)
     {

--- a/tests/OpenClaw.SetupEngine.Tests/LocalAiGatewayUninstallTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/LocalAiGatewayUninstallTests.cs
@@ -194,7 +194,8 @@ public sealed class LocalAiGatewayUninstallTests
             string? workingDirectory = null,
             string? stdinInput = null,
             CancellationToken ct = default,
-            Stream? stdinStream = null) => throw new NotSupportedException();
+            Stream? stdinStream = null,
+            bool allowInheritedPipeHandleEscape = false) => throw new NotSupportedException();
 
         public Task<CommandResult> RunInWslAsync(
             string distroName,

--- a/tests/OpenClaw.SetupEngine.Tests/LocalAiWslNetworkingConsentTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/LocalAiWslNetworkingConsentTests.cs
@@ -99,7 +99,8 @@ public sealed class LocalAiWslNetworkingConsentTests
             string? workingDirectory = null,
             string? stdinInput = null,
             CancellationToken ct = default,
-            Stream? stdinStream = null)
+            Stream? stdinStream = null,
+            bool allowInheritedPipeHandleEscape = false)
         {
             Invocations.Add($"{executable} {string.Join(' ', arguments)}");
             throw new InvalidOperationException(

--- a/tests/OpenClaw.SetupEngine.Tests/SetupPipelineTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupPipelineTests.cs
@@ -127,6 +127,23 @@ public class SetupPipelineTests
     }
 
     [Fact]
+    public void BuildLocalAiRecoverySteps_PreservesExistingWslGateway()
+    {
+        var steps = SetupStepFactory.BuildLocalAiRecoverySteps();
+
+        Assert.DoesNotContain(steps, step => step is CleanupStaleDistroStep);
+        Assert.DoesNotContain(steps, step => step is CleanupStaleGatewayStep);
+        Assert.DoesNotContain(steps, step => step is CreateWslInstanceStep);
+        Assert.DoesNotContain(steps, step => step is ConfigureWslInstanceStep);
+        Assert.DoesNotContain(steps, step => step is InstallCliStep);
+        Assert.Contains(steps, step => step is AcquireLocalAiRuntimeStep);
+        Assert.Contains(steps, step => step is AcquireLocalAiModelStep);
+        Assert.Contains(steps, step => step is VerifyLocalAiWslStep);
+        Assert.IsType<ConfigureLocalAiGatewayStep>(steps[^2]);
+        Assert.IsType<RestartGatewayStep>(steps[^1]);
+    }
+
+    [Fact]
     public void LocalAiDisabled_SkipsEveryLocalAiMutation()
     {
         var ctx = CreateContext(new SetupConfig

--- a/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
@@ -5822,7 +5822,8 @@ public class SetupStepsTests : IDisposable
             string? workingDirectory = null,
             string? stdinInput = null,
             CancellationToken ct = default,
-            Stream? stdinStream = null)
+            Stream? stdinStream = null,
+            bool allowInheritedPipeHandleEscape = false)
         {
             Calls.Add((executable, arguments));
             TimedCalls.Add((executable, arguments, timeout));

--- a/tests/OpenClaw.Tray.Tests/Presentation/LocalAiPageViewModelTests.cs
+++ b/tests/OpenClaw.Tray.Tests/Presentation/LocalAiPageViewModelTests.cs
@@ -563,7 +563,7 @@ public sealed class LocalAiPageViewModelTests
     [Theory]
     [InlineData(LocalAiModelAvailabilityState.Unknown)]
     [InlineData(LocalAiModelAvailabilityState.NotInstalled)]
-    public void MissingModel_KeepsRetrySetupAndDoesNotOfferChangeModel(
+    public void MissingModel_UsesLocalAiRecoveryAndDoesNotOfferChangeModel(
         LocalAiModelAvailabilityState modelState)
     {
         using var harness = new LocalAiHarness(modelState);
@@ -576,7 +576,8 @@ public sealed class LocalAiPageViewModelTests
         Assert.True(harness.ViewModel.RetrySetup());
 
         Assert.Equal(0, harness.Commands.ShowGatewayWizardCount);
-        Assert.Equal(1, harness.Commands.ShowOnboardingCount);
+        Assert.Equal(0, harness.Commands.ShowOnboardingCount);
+        Assert.Equal(1, harness.Commands.ShowLocalAiSetupRecoveryCount);
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/Presentation/PresentationTestDoubles.cs
+++ b/tests/OpenClaw.Tray.Tests/Presentation/PresentationTestDoubles.cs
@@ -67,6 +67,7 @@ internal sealed class FakeAppCommands : IAppCommands, IDisposable
     public int ReconnectCount { get; private set; }
     public int ShowChatCount { get; private set; }
     public int ShowOnboardingCount { get; private set; }
+    public int ShowLocalAiSetupRecoveryCount { get; private set; }
     public int OpenLocalAiLogsCount { get; private set; }
 
     public void ClearOperationLog() => _operationLog.Clear();
@@ -79,6 +80,7 @@ internal sealed class FakeAppCommands : IAppCommands, IDisposable
     public void ShowChat() => ShowChatCount++;
     public void CheckForUpdates() { }
     public void ShowOnboarding() => ShowOnboardingCount++;
+    public void ShowLocalAiSetupRecovery() => ShowLocalAiSetupRecoveryCount++;
     public void ShowGatewayWizard() => ShowGatewayWizardCount++;
     public void OpenLocalAiLogs() => OpenLocalAiLogsCount++;
     public void ShowConnectionStatus() { }
@@ -148,6 +150,7 @@ internal sealed class SelfWritingAppCommands : IAppCommands
     public void ShowChat() { }
     public void CheckForUpdates() { }
     public void ShowOnboarding() { }
+    public void ShowLocalAiSetupRecovery() { }
     public void ShowGatewayWizard() { }
     public void ShowConnectionStatus() { }
     public void NotifySettingsSaved() { }


### PR DESCRIPTION
Fixes #1307

## Summary
- Route Local AI Retry setup or download through a Local AI recovery command instead of full onboarding.
- Add a recovery-only setup pipeline that preserves the existing WSL distro and gateway install, repairs Local AI assets/configuration, verifies WSL reachability, and restarts the gateway.
- Start the setup UI directly at the Local AI review page so Install & setup is recomputed from current capability/setup state instead of staying stale-disabled.

## Required proof pools
- `windows-wsl-dgx-blackwell`: Local AI WSL-visible NVIDIA setup/restart/inference proof is required for hardware-backed behavior.
- `windows-wsl-gateway-e2e`: Local AI recovery must preserve product WSL/gateway state and prove gateway invocation.
- `windows-winui-interactive`: current-head visual proof is required for the Local AI retry and Install & setup recovery path.

## Validation
- `.\build.ps1`: passed, all builds succeeded.
- `$env:OPENCLAW_REPO_ROOT=(Get-Location).Path; dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore`: passed, 3937 passed, 32 skipped, 0 failed.
- `$env:OPENCLAW_REPO_ROOT=(Get-Location).Path; dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore`: passed, 2858 passed, 0 skipped, 0 failed.
- `$env:OPENCLAW_REPO_ROOT=(Get-Location).Path; dotnet test .\tests\OpenClaw.SetupEngine.Tests\OpenClaw.SetupEngine.Tests.csproj --no-restore`: passed, 1058 passed, 0 skipped, 0 failed.
- `$env:OPENCLAW_REPO_ROOT=(Get-Location).Path; dotnet test .\tests\OpenClaw.SetupEngine.Tests\OpenClaw.SetupEngine.Tests.csproj --no-restore --filter "FullyQualifiedName~SetupPipelineTests"`: passed, 29 passed, 0 skipped, 0 failed.
- `$env:OPENCLAW_REPO_ROOT=(Get-Location).Path; dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore --filter "FullyQualifiedName~LocalAiPageViewModelTests"`: passed, 3 passed, 0 skipped, 0 failed.
- `python .agents\skills\autoreview\scripts\autoreview --mode local`: no significant issues reported by rubber-duck closeout; helper failed closed on one path because the diff bundle exceeded the local safety limit.

## Real behavior proof
- Focused regression proof: `LocalAiPageViewModelTests` verifies Retry setup or download now invokes `ShowLocalAiSetupRecovery` and does not invoke full onboarding.
- Focused recovery-pipeline proof: `SetupPipelineTests.BuildLocalAiRecoverySteps_PreservesExistingWslGateway` verifies the retry pipeline excludes WSL/gateway destructive steps such as `cleanup-stale-distro`, `cleanup-stale-gateway`, `create-wsl`, `configure-wsl`, and `install-cli`, while still including Local AI repair, WSL verification, gateway configuration, and gateway restart.
- Not verified / blocked: no interactive WinUI plus WSL-visible NVIDIA/Gateway proof was captured on this host. The required proof pools above remain declared for maintainer-scheduled validation.

## Ownership notes
- Old owner: Local AI settings retried via the general onboarding command and default setup pipeline.
- New owner: `WindowManager.ShowLocalAiSetupRecoveryAsync` opens setup in Local AI recovery mode, and `SetupStepFactory.BuildLocalAiRecoverySteps` owns the non-destructive retry step list.
- Preserved invariant: `App.xaml.cs` remains only the composition-root command forwarder; setup window orchestration stays in `WindowManager`, and full onboarding behavior is unchanged for normal setup.