### PR TITLE
fix(setup): preserve normal command output drains

### DIFF
--- a/src/OpenClaw.SetupEngine/CleanupStaleDistroStep.cs
+++ b/src/OpenClaw.SetupEngine/CleanupStaleDistroStep.cs
@@ -37,7 +37,12 @@ public sealed class CleanupStaleDistroStep : SetupStep
         if (!DistroInstallPathPolicy.TryGetManagedInstallPath(ctx.LocalDataDir, distro, out var wslDir, out var pathError))
             return StepResult.Terminal(pathError);
 
-        var list = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--list", "--quiet"], TimeSpan.FromSeconds(15), ct: ct);
+        var list = await ctx.Commands.RunAsync(
+            WslConstants.WslExePath,
+            ["--list", "--quiet"],
+            TimeSpan.FromSeconds(15),
+            ct: ct,
+            allowInheritedPipeHandleEscape: true);
         if (list.ExitCode != 0)
             return StepResult.Ok("WSL not available or no distros - nothing to clean");
 

--- a/src/OpenClaw.SetupEngine/CommandRunner.cs
+++ b/src/OpenClaw.SetupEngine/CommandRunner.cs
@@ -17,7 +17,8 @@ public interface ICommandRunner
         string? workingDirectory = null,
         string? stdinInput = null,
         CancellationToken ct = default,
-        Stream? stdinStream = null);
+        Stream? stdinStream = null,
+        bool allowInheritedPipeHandleEscape = false);
 
     /// <summary>
     /// Run a command inside a WSL distro.
@@ -73,10 +74,9 @@ public sealed class CommandRunner : ICommandRunner
     private static readonly TimeSpan s_outputDrainGrace = TimeSpan.FromMilliseconds(250);
 
     /// <summary>
-    /// Upper bound on how long an exited process is given to reach EOF on its redirected
-    /// pipes. Large enough that a saturated thread pool cannot make a process that did
-    /// write output look silent, small enough that a descendant holding the pipes open
-    /// cannot stall the caller.
+    /// Upper bound on how long known inherited-pipe callers are given to reach EOF
+    /// after their direct child exits. Normal commands wait for EOF so trailing output
+    /// remains complete.
     /// </summary>
     private static readonly TimeSpan s_outputDrainCap = TimeSpan.FromSeconds(3);
     private const int MaxCapturedStreamChars = 1_048_576;
@@ -94,7 +94,8 @@ public sealed class CommandRunner : ICommandRunner
         string? workingDirectory = null,
         string? stdinInput = null,
         CancellationToken ct = default,
-        Stream? stdinStream = null)
+        Stream? stdinStream = null,
+        bool allowInheritedPipeHandleEscape = false)
     {
         ArgumentNullException.ThrowIfNull(executable);
         ArgumentNullException.ThrowIfNull(arguments);
@@ -200,20 +201,14 @@ public sealed class CommandRunner : ICommandRunner
             throw;
         }
 
-        // A surviving descendant can keep inherited pipe handles open after the child
-        // exits, so the EOF wait must stay bounded and cannot simply run to the command
-        // timeout. It also cannot be as tight as a few hundred milliseconds: the
-        // OutputDataReceived callbacks are queued to the thread pool, and on a saturated
-        // pool they can miss that window even though the process already exited and
-        // wrote its output. That surfaced as an exited process being reported with empty
-        // stdout and stderr, which every caller that classifies command output then
-        // misreads as silence. Wait up to a short cap instead, clamped by whatever
-        // remains of the caller's own deadline so the accepted timeout is never exceeded.
-        TimeSpan drainBudget = GetOutputDrainBudget(timeout, sw.Elapsed, timedOut);
-
-        await Task.WhenAny(
-            Task.WhenAll(stdoutClosed.Task, stderrClosed.Task),
-            Task.Delay(drainBudget));
+        var outputClosed = Task.WhenAll(stdoutClosed.Task, stderrClosed.Task);
+        await WaitForOutputDrainAsync(
+            outputClosed,
+            timeout,
+            sw.Elapsed,
+            timedOut,
+            allowInheritedPipeHandleEscape,
+            ct).ConfigureAwait(false);
 
         sw.Stop();
         var result = new CommandResult(
@@ -240,6 +235,31 @@ public sealed class CommandRunner : ICommandRunner
             return TimeSpan.Zero;
 
         return remaining < s_outputDrainCap ? remaining : s_outputDrainCap;
+    }
+
+    internal static async Task WaitForOutputDrainAsync(
+        Task outputClosed,
+        TimeSpan timeout,
+        TimeSpan elapsed,
+        bool timedOut,
+        bool allowInheritedPipeHandleEscape,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(outputClosed);
+
+        if (timedOut || allowInheritedPipeHandleEscape)
+        {
+            // A surviving descendant can keep inherited pipe handles open after the
+            // child exits. Bound only known inherited-pipe callers and timeout cleanup.
+            TimeSpan drainBudget = GetOutputDrainBudget(timeout, elapsed, timedOut);
+            var delay = Task.Delay(drainBudget, cancellationToken);
+            var completed = await Task.WhenAny(outputClosed, delay).ConfigureAwait(false);
+            if (ReferenceEquals(completed, delay))
+                await delay.ConfigureAwait(false);
+            return;
+        }
+
+        await outputClosed.WaitAsync(cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/OpenClaw.SetupEngine/CreateWslInstanceStep.cs
+++ b/src/OpenClaw.SetupEngine/CreateWslInstanceStep.cs
@@ -41,7 +41,12 @@ public sealed class CreateWslInstanceStep : SetupStep
 
         ctx.Logger.Info($"Creating clean app-owned WSL distro '{distro}' from '{baseDistro}' at '{installPath}'");
 
-        var existing = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--list", "--quiet"], TimeSpan.FromSeconds(15), ct: ct);
+        var existing = await ctx.Commands.RunAsync(
+            WslConstants.WslExePath,
+            ["--list", "--quiet"],
+            TimeSpan.FromSeconds(15),
+            ct: ct,
+            allowInheritedPipeHandleEscape: true);
         if (existing.ExitCode != 0)
             return StepResult.Fail($"Failed to list WSL distros before creating '{distro}': {existing.Stderr}");
 
@@ -126,7 +131,12 @@ public sealed class CreateWslInstanceStep : SetupStep
 
     private static async Task<StepResult> VerifyFreshDistro(SetupContext ctx, string distro, string installPath, CancellationToken ct)
     {
-        var list = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--list", "--quiet"], TimeSpan.FromSeconds(15), ct: ct);
+        var list = await ctx.Commands.RunAsync(
+            WslConstants.WslExePath,
+            ["--list", "--quiet"],
+            TimeSpan.FromSeconds(15),
+            ct: ct,
+            allowInheritedPipeHandleEscape: true);
         if (list.ExitCode != 0 || !WslInstallSupport.ContainsDistro(list.Stdout, distro))
         {
             var environmentIssue = await PreflightWslStep.DetectEnvironmentIssueAsync(ctx, ct);
@@ -138,7 +148,8 @@ public sealed class CreateWslInstanceStep : SetupStep
             WslConstants.WslExePath,
             ["--list", "--verbose"],
             DistroVersionVerificationTimeout,
-            ct: ct);
+            ct: ct,
+            allowInheritedPipeHandleEscape: true);
         if (verbose.ExitCode != 0 || !WslInstallSupport.TryGetDistroVersion(verbose.Stdout, distro, out var version))
             return StepResult.Fail($"Fresh WSL install registered '{distro}', but setup could not verify it is WSL2.");
 
@@ -182,7 +193,12 @@ public sealed class CreateWslInstanceStep : SetupStep
     {
         var cleanupErrors = new List<string>();
         var installPathExists = Directory.Exists(installPath) || File.Exists(installPath);
-        var list = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--list", "--quiet"], TimeSpan.FromSeconds(15), ct: ct);
+        var list = await ctx.Commands.RunAsync(
+            WslConstants.WslExePath,
+            ["--list", "--quiet"],
+            TimeSpan.FromSeconds(15),
+            ct: ct,
+            allowInheritedPipeHandleEscape: true);
         var registrationStateKnown = list.ExitCode == 0;
         var distroExists = registrationStateKnown && WslInstallSupport.ContainsDistro(list.Stdout, distro);
         var canDeleteInstallPath = registrationStateKnown && !distroExists;

--- a/src/OpenClaw.SetupEngine/ExistingConfigDetector.cs
+++ b/src/OpenClaw.SetupEngine/ExistingConfigDetector.cs
@@ -37,7 +37,11 @@ public sealed class ExistingConfigDetector
 
         var logger = new SetupLogger(filePath: null, LogLevel.Warn);
         var result = new CommandRunner(logger)
-            .RunAsync(WslConstants.WslExePath, ["--list", "--quiet"], TimeSpan.FromSeconds(5))
+            .RunAsync(
+                WslConstants.WslExePath,
+                ["--list", "--quiet"],
+                TimeSpan.FromSeconds(5),
+                allowInheritedPipeHandleEscape: true)
             .GetAwaiter()
             .GetResult();
         var hasDistro = InterpretDistroList(result, targetDistroName);

--- a/src/OpenClaw.SetupEngine/PreflightWslStep.cs
+++ b/src/OpenClaw.SetupEngine/PreflightWslStep.cs
@@ -48,7 +48,8 @@ internal static class WslViabilityInspector
                 WslConstants.WslExePath,
                 ["--version"],
                 TimeSpan.FromSeconds(5),
-                ct: ct);
+                ct: ct,
+                allowInheritedPipeHandleEscape: true);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -106,7 +107,8 @@ internal static class WslViabilityInspector
                 WslConstants.WslExePath,
                 ["--status"],
                 TimeSpan.FromSeconds(10),
-                ct: ct);
+                ct: ct,
+                allowInheritedPipeHandleEscape: true);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -204,7 +206,8 @@ public sealed class PreflightWslStep : SetupStep
             WslConstants.WslExePath,
             ["--status"],
             TimeSpan.FromSeconds(10),
-            ct: ct);
+            ct: ct,
+            allowInheritedPipeHandleEscape: true);
         var combined = $"{status.Stdout}\n{status.Stderr}";
         if (!WslInstallSupport.TryGetEnvironmentIssue(combined, out var message))
             return null;
@@ -248,7 +251,8 @@ public sealed class PreflightWslStep : SetupStep
                 WslConstants.WslExePath,
                 ["--version"],
                 TimeSpan.FromSeconds(5),
-                ct: ct);
+                ct: ct,
+                allowInheritedPipeHandleEscape: true);
             if (probe.ExitCode != 0 || WslViabilityInspector.LooksUnavailable(probe))
             {
                 return StepResult.Terminal(

--- a/src/OpenClaw.SetupEngine/StartGatewayStep.cs
+++ b/src/OpenClaw.SetupEngine/StartGatewayStep.cs
@@ -148,7 +148,12 @@ public sealed class StartGatewayStep : SetupStep
         var distro = ctx.DistroName!;
 
         // Check if distro is running before trying systemctl stop
-        var list = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--list", "--quiet"], TimeSpan.FromSeconds(15), ct: ct);
+        var list = await ctx.Commands.RunAsync(
+            WslConstants.WslExePath,
+            ["--list", "--quiet"],
+            TimeSpan.FromSeconds(15),
+            ct: ct,
+            allowInheritedPipeHandleEscape: true);
         if (!WslInstallSupport.ContainsDistro(list.Stdout, distro))
         {
             ctx.Logger.Info("[Uninstall] Distro not registered — skipping gateway stop");
@@ -156,7 +161,12 @@ public sealed class StartGatewayStep : SetupStep
         }
 
         // Check distro state — only stop if Running
-        var verbose = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--list", "--verbose"], TimeSpan.FromSeconds(15), ct: ct);
+        var verbose = await ctx.Commands.RunAsync(
+            WslConstants.WslExePath,
+            ["--list", "--verbose"],
+            TimeSpan.FromSeconds(15),
+            ct: ct,
+            allowInheritedPipeHandleEscape: true);
         var isRunning = WslInstallSupport.Normalize(verbose.Stdout)
             .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)
             .Any(line => line.Contains(distro, StringComparison.OrdinalIgnoreCase)

--- a/tests/OpenClaw.SetupEngine.Tests/CommandRunnerTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/CommandRunnerTests.cs
@@ -87,11 +87,68 @@ public class CommandRunnerTests
         var (executable, arguments) = ExitsLeavingPipeHolderCommand();
         var stopwatch = Stopwatch.StartNew();
 
-        var result = await runner.RunAsync(executable, arguments, TimeSpan.FromSeconds(30));
+        var result = await runner.RunAsync(
+            executable,
+            arguments,
+            TimeSpan.FromSeconds(30),
+            allowInheritedPipeHandleEscape: true);
 
         Assert.False(result.TimedOut);
         Assert.Equal(0, result.ExitCode);
         Assert.InRange(stopwatch.Elapsed, TimeSpan.Zero, TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task WaitForOutputDrainAsync_WaitsPastCommandDeadlineOnNormalExit()
+    {
+        var outputClosed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var wait = CommandRunner.WaitForOutputDrainAsync(
+            outputClosed.Task,
+            TimeSpan.FromMilliseconds(100),
+            TimeSpan.Zero,
+            timedOut: false,
+            allowInheritedPipeHandleEscape: false);
+
+        var completed = await Task.WhenAny(wait, Task.Delay(TimeSpan.FromMilliseconds(250)));
+        Assert.NotSame(wait, completed);
+
+        outputClosed.SetResult();
+        await wait;
+    }
+
+    [Fact]
+    public async Task WaitForOutputDrainAsync_CancellationInterruptsNormalPostExitDrain()
+    {
+        var outputClosed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            CommandRunner.WaitForOutputDrainAsync(
+                outputClosed.Task,
+                TimeSpan.FromSeconds(30),
+                TimeSpan.Zero,
+                timedOut: false,
+                allowInheritedPipeHandleEscape: false,
+                cancellation.Token));
+    }
+
+    [Fact]
+    public async Task RunAsync_DrainsHighVolumeStdoutAndStderrThroughTrailingMarkers()
+    {
+        const int lineCount = 8_000;
+        var (executable, arguments) = HighVolumeOutputCommand(lineCount);
+
+        var result = await CreateRunner().RunAsync(
+            executable,
+            arguments,
+            TimeSpan.FromSeconds(30));
+
+        Assert.False(result.TimedOut);
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(lineCount, CountLinesStartingWith(result.Stdout, "stdout-"));
+        Assert.Equal(lineCount, CountLinesStartingWith(result.Stderr, "stderr-"));
+        Assert.EndsWith($"STDOUT_MARKER{Environment.NewLine}", result.Stdout, StringComparison.Ordinal);
+        Assert.EndsWith($"STDERR_MARKER{Environment.NewLine}", result.Stderr, StringComparison.Ordinal);
     }
 
     [Theory]
@@ -125,6 +182,32 @@ public class CommandRunnerTests
         => OperatingSystem.IsWindows()
             ? ("cmd.exe", ["/d", "/s", "/c", "ping 127.0.0.1 -n 30 >nul"])
             : ("/bin/sh", ["-c", "sleep 30"]);
+
+    private static (string Executable, string[] Arguments) HighVolumeOutputCommand(int lineCount)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return ("/bin/sh",
+            [
+                "-c",
+                "i=0; while [ $i -lt " + lineCount + " ]; do printf 'stdout-%s\\n' \"$i\"; i=$((i+1)); done; " +
+                "printf 'STDOUT_MARKER\\n'; " +
+                "i=0; while [ $i -lt " + lineCount + " ]; do printf 'stderr-%s\\n' \"$i\" >&2; i=$((i+1)); done; " +
+                "printf 'STDERR_MARKER\\n' >&2"
+            ]);
+        }
+
+        var script =
+            $"for ($i = 0; $i -lt {lineCount}; $i++) {{ [Console]::Out.WriteLine(\"stdout-$i\") }}; " +
+            "[Console]::Out.WriteLine(\"STDOUT_MARKER\"); " +
+            $"for ($i = 0; $i -lt {lineCount}; $i++) {{ [Console]::Error.WriteLine(\"stderr-$i\") }}; " +
+            "[Console]::Error.WriteLine(\"STDERR_MARKER\")";
+        return ("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", script]);
+    }
+
+    private static int CountLinesStartingWith(string value, string prefix) =>
+        value.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)
+            .Count(line => line.StartsWith(prefix, StringComparison.Ordinal));
 
     private static (string Executable, string[] Arguments) CopyStdinCommand(string path)
     {

--- a/tests/OpenClaw.SetupEngine.Tests/LocalAiGatewayUninstallTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/LocalAiGatewayUninstallTests.cs
@@ -194,7 +194,8 @@ public sealed class LocalAiGatewayUninstallTests
             string? workingDirectory = null,
             string? stdinInput = null,
             CancellationToken ct = default,
-            Stream? stdinStream = null) => throw new NotSupportedException();
+            Stream? stdinStream = null,
+            bool allowInheritedPipeHandleEscape = false) => throw new NotSupportedException();
 
         public Task<CommandResult> RunInWslAsync(
             string distroName,

--- a/tests/OpenClaw.SetupEngine.Tests/LocalAiWslNetworkingConsentTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/LocalAiWslNetworkingConsentTests.cs
@@ -99,7 +99,8 @@ public sealed class LocalAiWslNetworkingConsentTests
             string? workingDirectory = null,
             string? stdinInput = null,
             CancellationToken ct = default,
-            Stream? stdinStream = null)
+            Stream? stdinStream = null,
+            bool allowInheritedPipeHandleEscape = false)
         {
             Invocations.Add($"{executable} {string.Join(' ', arguments)}");
             throw new InvalidOperationException(

--- a/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
@@ -5822,7 +5822,8 @@ public class SetupStepsTests : IDisposable
             string? workingDirectory = null,
             string? stdinInput = null,
             CancellationToken ct = default,
-            Stream? stdinStream = null)
+            Stream? stdinStream = null,
+            bool allowInheritedPipeHandleEscape = false)
         {
             Calls.Add((executable, arguments));
             TimedCalls.Add((executable, arguments, timeout));


### PR DESCRIPTION
## Summary

Fixes #1194

`CommandRunner` still applied a universal post-exit drain cap, so a cleanly exited command could return before queued stdout or stderr callbacks delivered trailing JSON or success markers. This PR waits for both redirected streams to close on normal exits, preserves caller cancellation while waiting, and keeps bounded waits only for timeout cleanup or explicit WSL inspection calls that can inherit pipe handles.

Closed PR #1207 had the right shape, but it was closed as an obsolete conflicting branch. This reapplies the narrow fix against current `main`, including the current three-second inherited-pipe cap.

## Required proof pools

- `windows-wsl-gateway-e2e`: setup WSL inspection command behavior changed; maintainer-scheduled real gateway setup proof should verify the product path before merge.

## Validation

- `$env:OPENCLAW_REPO_ROOT=(Get-Location).Path; .\build.ps1` - passed, all builds succeeded.
- `$env:OPENCLAW_REPO_ROOT=(Get-Location).Path; dotnet test .\tests\OpenClaw.SetupEngine.Tests\OpenClaw.SetupEngine.Tests.csproj --no-restore --filter FullyQualifiedName~CommandRunnerTests` - passed, 12/12.
- `$env:OPENCLAW_REPO_ROOT=(Get-Location).Path; dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore` - passed, 3937 passed, 32 skipped.
- `$env:OPENCLAW_REPO_ROOT=(Get-Location).Path; $env:OPENCLAW_TRAY_DATA_DIR=Join-Path (Get-Location).Path '.tray-test-data'; dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore` - passed, 2858/2858.
- Rubber-duck code review - no significant issues found after fixing cancellation during normal post-exit drain.

## Real behavior proof

- `RunAsync_DrainsHighVolumeStdoutAndStderrThroughTrailingMarkers` emits 8,000 stdout lines and 8,000 stderr lines plus final `STDOUT_MARKER` and `STDERR_MARKER`; current head captures all lines and both trailing markers.
- `WaitForOutputDrainAsync_WaitsPastCommandDeadlineOnNormalExit` proves normal exits no longer return just because the old drain cap or remaining command deadline elapsed.
- `WaitForOutputDrainAsync_CancellationInterruptsNormalPostExitDrain` proves caller cancellation remains honored while waiting for normal stream closure.
- `RunAsync_ReturnsWhenDescendantKeepsOutputPipesOpen` now uses `allowInheritedPipeHandleEscape: true` and still returns within the bounded inherited-pipe wait.
- `windows-wsl-gateway-e2e` is not run locally; it is a maintainer-scheduled proof pool.

MXC and `system.run` were not touched, so `.\scripts\validate-mxc-e2e.ps1` was not required.
