### PR TITLE
Make the winnode reference a discoverable agent skill

### DIFF
--- a/.agents/skills/openclaw-proof-validation/SKILL.md
+++ b/.agents/skills/openclaw-proof-validation/SKILL.md
@@ -66,7 +66,7 @@ $token = Get-Content $tokenPath -Raw
 
 1. Register the command in the same `INodeCapability` path used by the gateway node.
 2. Add/update `McpToolBridge.CommandDescriptions`.
-3. Update `src/OpenClaw.WinNode.Cli/skill.md` with input shape, output shape, side effects, permissions, and examples.
+3. Update `.agents/skills/winnode/SKILL.md` with input shape, output shape, side effects, permissions, and examples.
 4. Add/update capability, MCP bridge, `winnode`, and UI/gateway tests as applicable.
 5. Prove discovery and invocation with `winnode` or raw MCP JSON-RPC.
 6. Prove the gateway path when the behavior is gateway-mediated and a gateway is available.

--- a/.agents/skills/windows-app-mcp/SKILL.md
+++ b/.agents/skills/windows-app-mcp/SKILL.md
@@ -49,7 +49,7 @@ winnode --list-tools
 ```
 
 The live `tools/list` response is authoritative. The complete static command
-reference is `src\OpenClaw.WinNode.Cli\skill.md`, and
+reference is `.agents\skills\winnode\SKILL.md`, and
 `McpToolBridge.CommandDescriptions` is the canonical description source.
 
 ## Invoke through winnode
@@ -116,7 +116,7 @@ For a new or changed Windows node command:
 
 1. Register it through the shared `INodeCapability` path.
 2. Update `McpToolBridge.CommandDescriptions`.
-3. Update `src\OpenClaw.WinNode.Cli\skill.md`.
+3. Update `.agents\skills\winnode\SKILL.md`.
 4. Add capability, MCP bridge, and `winnode` tests.
 5. Prove `winnode --list-tools` and `winnode --command ...`.
 6. Prove the gateway path separately when gateway-mediated behavior changed.

--- a/.agents/skills/winnode/SKILL.md
+++ b/.agents/skills/winnode/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: winnode
+description: Invoke and troubleshoot OpenClaw Windows-node commands through the local winnode CLI and MCP endpoint, including command argument schemas and A2UI JSONL calls.
+---
+
 <!--
   REGENERATE-ME-WHEN-CAPABILITIES-CHANGE
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ Every new Windows node call must be exposed, documented, and tested through MCP 
 
 1. Register the capability/command in the tray node capability registry.
 2. Add/update `McpToolBridge.CommandDescriptions`.
-3. Update `src/OpenClaw.WinNode.Cli/skill.md`.
+3. Update `.agents/skills/winnode/SKILL.md`.
 4. Add/update capability, MCP bridge, `winnode`, and UI/gateway tests as appropriate.
 5. Run required validation plus `dotnet test .\tests\OpenClaw.WinNode.Cli.Tests\OpenClaw.WinNode.Cli.Tests.csproj --no-restore` when `winnode`, MCP output, or command docs change.
 

--- a/docs/MCP_MODE.md
+++ b/docs/MCP_MODE.md
@@ -158,7 +158,7 @@ In all cases the user gets a Windows-native agent experience without OpenClaw in
 
 ### Current command surface
 
-The canonical command descriptions live in `OpenClaw.Shared\Mcp\McpToolBridge.CommandDescriptions`; `OpenClaw.WinNode.Cli.Tests\SkillMdDriftTests` keeps `src\OpenClaw.WinNode.Cli\skill.md` in sync with that documented capability surface. The live `tools/list` output may also include newly registered capabilities with fallback descriptions before prose is updated.
+The canonical command descriptions live in `OpenClaw.Shared\Mcp\McpToolBridge.CommandDescriptions`; `OpenClaw.WinNode.Cli.Tests\SkillMdDriftTests` keeps `.agents\skills\winnode\SKILL.md` in sync with that documented capability surface. The live `tools/list` output may also include newly registered capabilities with fallback descriptions before prose is updated.
 
 Gateway/node command groups currently include:
 
@@ -321,7 +321,7 @@ tool discovery plus invocation proof using `winnode` or raw MCP JSON-RPC.
 Every new Windows node command must remain first-class over local MCP. Register
 it in the capability path used by `NodeService`, update
 `McpToolBridge.CommandDescriptions`, update
-`src/OpenClaw.WinNode.Cli/skill.md`, and add focused tests. `SkillMdDriftTests`
+`.agents/skills/winnode/SKILL.md`, and add focused tests. `SkillMdDriftTests`
 guards against drift between capabilities, MCP descriptions, and `winnode` docs.
 
 PR proof for a new command should paste `winnode --list-tools` plus the command

--- a/docs/WINDOWS_NODE_TESTING.md
+++ b/docs/WINDOWS_NODE_TESTING.md
@@ -30,7 +30,7 @@ Short version: run required tests, collect a closeout proof pass with `.\run-app
 
 ### New command MCP contract
 
-Every new Windows node call must be exposed through local MCP and `winnode`: register the capability, update `McpToolBridge.CommandDescriptions`, update `src/OpenClaw.WinNode.Cli/skill.md`, add focused tests, and prove discovery/invocation with `winnode` or raw MCP JSON-RPC.
+Every new Windows node call must be exposed through local MCP and `winnode`: register the capability, update `McpToolBridge.CommandDescriptions`, update `.agents/skills/winnode/SKILL.md`, add focused tests, and prove discovery/invocation with `winnode` or raw MCP JSON-RPC.
 
 ### 1. Settings Toggle
 - Verify the toggle appears in Settings under "ADVANCED"

--- a/scripts/Get-CiChangeClassification.ps1
+++ b/scripts/Get-CiChangeClassification.ps1
@@ -302,6 +302,13 @@ foreach ($changedPath in $paths) {
         Complete-Impact (New-FullImpact)
         return
     }
+    if ($normalizedPath.Equals(
+            ".agents/skills/winnode/SKILL.md",
+            [StringComparison]::OrdinalIgnoreCase)) {
+        $hasProductChange = $true
+        Add-Lanes -Impact $impact -Core
+        continue
+    }
     if (Test-IsSafeDocumentationPath $normalizedPath) {
         continue
     }

--- a/scripts/test-ci-change-classifier.ps1
+++ b/scripts/test-ci-change-classifier.ps1
@@ -86,6 +86,12 @@ $cases = @(
         Classification = "docs_only"
     },
     @{
+        Scenario = "WinNode skill reference"
+        Paths = @(".agents/skills/winnode/SKILL.md")
+        Classification = "targeted"
+        Required = @("core_tests")
+    },
+    @{
         Scenario = "CLI-only product change"
         Paths = @("src/OpenClaw.Cli/Program.cs")
         Classification = "targeted"

--- a/src/OpenClaw.WinNode.Cli/OpenClaw.WinNode.Cli.csproj
+++ b/src/OpenClaw.WinNode.Cli/OpenClaw.WinNode.Cli.csproj
@@ -9,9 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Ship the agent skill reference next to winnode.exe. -->
-    <Content Include="skill.md">
+    <!-- Ship the discoverable repository skill next to winnode.exe under the
+         legacy sidecar name referenced by CLI help. -->
+    <Content Include="..\..\.agents\skills\winnode\SKILL.md">
+      <Link>skill.md</Link>
+      <TargetPath>skill.md</TargetPath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
   </ItemGroup>
 

--- a/tests/OpenClaw.WinNode.Cli.Tests/SkillMdDriftTests.cs
+++ b/tests/OpenClaw.WinNode.Cli.Tests/SkillMdDriftTests.cs
@@ -46,7 +46,7 @@ public class SkillMdDriftTests
         {
             var msg = "skill.md drifted from the capability registry " +
                       "(McpToolBridge.CommandDescriptions). Update " +
-                      $"src/OpenClaw.WinNode.Cli/skill.md.\n  Missing from doc: " +
+                      $".agents/skills/winnode/SKILL.md.\n  Missing from doc: " +
                       $"[{string.Join(", ", missingFromDoc)}]\n  Extras in doc: " +
                       $"[{string.Join(", ", extrasInDoc)}]";
             Assert.Fail(msg);
@@ -134,8 +134,8 @@ public class SkillMdDriftTests
     }
 
     /// <summary>
-    /// skill.md ships next to winnode.exe. From the test's working directory
-    /// (the test bin folder), walk up to the repo root and resolve the source
+    /// SKILL.md ships next to winnode.exe as skill.md. From the test bin
+    /// working directory, walk up to the repo root and resolve the source
     /// copy — that's the canonical input the build copies to output. Falls
     /// back to the test bin's own copy if the source can't be located.
     /// </summary>
@@ -144,12 +144,12 @@ public class SkillMdDriftTests
         var dir = AppContext.BaseDirectory;
         for (var i = 0; i < 8 && dir is not null; i++)
         {
-            var candidate = Path.Combine(dir, "src", "OpenClaw.WinNode.Cli", "skill.md");
+            var candidate = Path.Combine(dir, ".agents", "skills", "winnode", "SKILL.md");
             if (File.Exists(candidate)) return candidate;
             dir = Path.GetDirectoryName(dir);
         }
         var nextTo = Path.Combine(AppContext.BaseDirectory, "skill.md");
         if (File.Exists(nextTo)) return nextTo;
-        throw new FileNotFoundException("Could not locate src/OpenClaw.WinNode.Cli/skill.md from the test working directory.");
+        throw new FileNotFoundException("Could not locate .agents/skills/winnode/SKILL.md from the test working directory.");
     }
 }


### PR DESCRIPTION
## Summary

- move the canonical winnode command reference to `.agents/skills/winnode/SKILL.md`
- add skill discovery frontmatter
- keep copying it beside `winnode.exe` as `skill.md` during build and publish
- update drift tests and repository guidance to use the canonical skill path
- keep reference-only edits in the core-test lane so command drift remains CI-enforced

## Required proof pools

- `none`: repository skill packaging, documentation, and CI classification do not require a custom Windows host class.

## Validation

- `.\scripts\test-ci-change-classifier.ps1` passed
- `.\scripts\test-ci-workflow-contract.ps1` passed
- `.\scripts\validate-agent-skills.ps1` passed: 6 skills and 13 Markdown files
- `.\scripts\test-agent-skills-validator.ps1` passed
- `.\build.ps1` passed
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore` passed: 3,937 passed, 32 skipped
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore` passed: 2,858 passed
- `dotnet test .\tests\OpenClaw.WinNode.Cli.Tests\OpenClaw.WinNode.Cli.Tests.csproj --no-restore` passed: 127 passed
- `git diff --check` passed

## Real behavior proof

- Classifying only `.agents/skills/winnode/SKILL.md` returns `classification=targeted` and `core_tests=true`.
- Classifying an ordinary `.agents/skills/example/SKILL.md` path still returns `classification=docs_only` and `core_tests=false`.
- The locally built `src\OpenClaw.WinNode.Cli\bin\Debug\net10.0\skill.md` SHA-256 matches the canonical `.agents\skills\winnode\SKILL.md` SHA-256 exactly.
- The project links the canonical skill with target path `skill.md` and copies it to build and publish output with `PreserveNewest`.

## Rubber-duck review

An independent final code review found no significant issues in the relocation, packaging link, drift tests, or exact-path CI classification exception.