### PR TITLE
fix(setup): recognize the gateway service on its own port after install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,0 @@
-# Changelog
-
-## Unreleased
-
-- Fix local gateway setup rejecting its own newly started service as a port conflict. Verify the service PID and include available process names for genuine conflicts. Related context: #547 from @ranjeshj.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+
+- Fix local gateway setup rejecting its own newly started service as a port conflict. Verify the service PID and include available process names for genuine conflicts. Related context: #547 from @ranjeshj.

--- a/docs/SETUP_ENGINE_REDESIGN.md
+++ b/docs/SETUP_ENGINE_REDESIGN.md
@@ -200,6 +200,14 @@ Executed sequentially. Each step is a small class (30–120 lines) in its own fi
 | 23 | `WindowsNodeBootstrapContextStep` | Inject Windows-node context into the WSL workspace `AGENTS.md` |
 | 24 | `StartKeepaliveStep` | Background WSL keepalive to prevent VM shutdown |
 
+The Windows port preflight requires a free port before installation. Installing
+the gateway service can start it immediately, so the subsequent WSL port check
+accepts listeners only when every reported owner PID matches the installed
+`openclaw-gateway.service` systemd `MainPID` in the configured distro. A process
+name such as `node` or `openclaw` alone is insufficient. Conflicts retain the
+port-in-use error and include owning process names when available. Missing
+listener ownership or a failed listener inspection does not bypass the check.
+
 ### Step Base Class
 
 ```csharp

--- a/src/OpenClaw.SetupEngine/PreflightPortStep.cs
+++ b/src/OpenClaw.SetupEngine/PreflightPortStep.cs
@@ -1,12 +1,6 @@
-using System.Diagnostics;
 using System.Net;
-using System.Net.Http;
 using System.Net.Sockets;
-using System.Runtime.InteropServices;
-using System.Security.Cryptography;
-using System.Text.Json;
 using OpenClaw.Connection;
-using OpenClaw.Shared;
 
 namespace OpenClaw.SetupEngine;
 
@@ -30,7 +24,13 @@ public sealed class PreflightPortStep : SetupStep
         foreach (var address in addresses)
         {
             if (!CanBind(address, port, out var error))
-                return StepResult.Fail($"Port {port} is already in use for {DescribeBind(address)} ({error.SocketErrorCode})");
+            {
+                var owners = string.Join(", ", WindowsTcpListenerSnapshot.Capture().Listeners
+                    .Where(listener => listener.Port == port && listener.Address.AddressFamily == address.AddressFamily)
+                    .Select(listener => listener.ProcessName).Where(name => !string.IsNullOrWhiteSpace(name)).Distinct());
+                return StepResult.Fail($"Port {port} is already in use for {DescribeBind(address)} ({error.SocketErrorCode})" +
+                    (owners.Length > 0 ? $". Owning process: {owners}." : ""));
+            }
         }
 
         return StepResult.Ok($"Port {port} is available");

--- a/src/OpenClaw.SetupEngine/StartGatewayStep.cs
+++ b/src/OpenClaw.SetupEngine/StartGatewayStep.cs
@@ -1,12 +1,4 @@
-using System.Diagnostics;
-using System.Net;
-using System.Net.Http;
-using System.Net.Sockets;
-using System.Runtime.InteropServices;
-using System.Security.Cryptography;
-using System.Text.Json;
-using OpenClaw.Connection;
-using OpenClaw.Shared;
+using System.Text.RegularExpressions;
 
 namespace OpenClaw.SetupEngine;
 
@@ -36,19 +28,32 @@ public sealed class StartGatewayStep : SetupStep
         if (!restart)
         {
             var portCheck = await ctx.Commands.RunInWslAsync(
-                distro, $"ss -tlnp 2>/dev/null | grep ':{ctx.Config.GatewayPort}\\b' || true",
+                distro, $"ss -H -ltnp 'sport = :{ctx.Config.GatewayPort}'",
                 TimeSpan.FromSeconds(10), ct: ct);
 
-            if (!string.IsNullOrWhiteSpace(portCheck.Stdout) && portCheck.Stdout.Contains($":{ctx.Config.GatewayPort}"))
+            if (portCheck.ExitCode != 0)
+                return StepResult.Fail($"Could not inspect gateway port {ctx.Config.GatewayPort} (exit {portCheck.ExitCode}).");
+
+            if (!string.IsNullOrWhiteSpace(portCheck.Stdout))
             {
-                if (!portCheck.Stdout.Contains("openclaw", StringComparison.OrdinalIgnoreCase))
+                // Installation may already start the service. Process names (including node) are not ownership proof.
+                var service = await ctx.Commands.RunInWslAsync(
+                    distro, "systemctl --user show openclaw-gateway.service -p MainPID --value",
+                    TimeSpan.FromSeconds(10), ct: ct);
+                var listeners = portCheck.Stdout.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                if (service.ExitCode != 0 || !int.TryParse(service.Stdout.Trim(), out var pid) || pid <= 0 ||
+                    listeners.Any(line => Regex.Matches(line, @"pid=(\d+),") is var owners &&
+                        (owners.Count == 0 || owners.Any(owner => owner.Groups[1].Value != pid.ToString()))))
                 {
-                    ctx.Logger.Warn($"Port {ctx.Config.GatewayPort} is in use by another process:\n{portCheck.Stdout.Trim()}");
+                    var names = string.Join(", ", Regex.Matches(portCheck.Stdout, "\\(\\\"([^\\\"]+)\\\",")
+                        .Select(owner => owner.Groups[1].Value).Distinct());
+                    var ownerDetail = names.Length > 0 ? $" Owning process: {names}." : "";
+                    ctx.Logger.Warn($"Port {ctx.Config.GatewayPort} is in use by another process.{ownerDetail}");
                     return StepResult.Fail(
-                        $"Port {ctx.Config.GatewayPort} is already in use by another process. Either stop the conflicting process or change GatewayPort in the setup config.");
+                        $"Port {ctx.Config.GatewayPort} is already in use by another process.{ownerDetail} Either stop the conflicting process or change GatewayPort in the setup config.");
                 }
 
-                ctx.Logger.Info($"Port {ctx.Config.GatewayPort} appears to be in use by openclaw — proceeding");
+                ctx.Logger.Info($"Port {ctx.Config.GatewayPort} is owned by openclaw-gateway.service (PID {pid}). Post-install port check succeeded.");
             }
         }
 

--- a/tests/OpenClaw.E2ETests/Setup/SetupAndConnectTests.cs
+++ b/tests/OpenClaw.E2ETests/Setup/SetupAndConnectTests.cs
@@ -1,5 +1,3 @@
-using System.Net;
-using System.Net.Sockets;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using OpenClaw.E2ETests;
@@ -193,21 +191,23 @@ public class SetupAndConnectTests
 
         var proofLogPath = Path.Combine(_fixture.ArtifactDir, "service-owned-gateway-start.jsonl");
         var config = SetupConfig.LoadFromFile(_fixture.ConfigPath);
-        using var logger = new SetupLogger(proofLogPath, LogLevel.Trace);
-        using var journal = new TransactionJournal(filePath: null, logger);
-        var context = new SetupContext(
-            config,
-            logger,
-            journal,
-            new CommandRunner(logger),
-            CancellationToken.None,
-            _fixture.DataDir,
-            _fixture.LocalAppDataRoot)
+        StepResult result;
+        using (var logger = new SetupLogger(proofLogPath, LogLevel.Trace))
+        using (var journal = new TransactionJournal(filePath: null, logger))
         {
-            DistroName = _fixture.DistroName,
-        };
-
-        var result = await new StartGatewayStep().ExecuteAsync(context, CancellationToken.None);
+            var context = new SetupContext(
+                config,
+                logger,
+                journal,
+                new CommandRunner(logger),
+                CancellationToken.None,
+                _fixture.DataDir,
+                _fixture.LocalAppDataRoot)
+            {
+                DistroName = _fixture.DistroName,
+            };
+            result = await new StartGatewayStep().ExecuteAsync(context, CancellationToken.None);
+        }
 
         Assert.True(result.IsSuccess, result.Message);
         var proofLog = await File.ReadAllTextAsync(proofLogPath);
@@ -221,12 +221,17 @@ public class SetupAndConnectTests
     public async Task FullSetup_ForeignWslListener_IsRejectedBeforeGatewayStart()
     {
         var config = SetupConfig.LoadFromFile(_fixture.ConfigPath);
-        var port = GetFreeTcpPort();
         var nodePath = $"/home/{config.Wsl.User}/.openclaw/tools/node/bin/node";
+        var proofId = Guid.NewGuid().ToString("N");
+        var portPath = $"/tmp/openclaw-foreign-listener-{proofId}.port";
+        var logPath = $"/tmp/openclaw-foreign-listener-{proofId}.log";
+        var nodeScript =
+            $"const fs=require(\"fs\"),net=require(\"net\");const server=net.createServer();" +
+            $"server.listen(0,\"127.0.0.1\",()=>fs.writeFileSync(\"{portPath}\",String(server.address().port)))";
         var start = await _fixture.RunInWslAsync(
             $"""
-            nohup '{nodePath}' -e 'require("net").createServer().listen({port}, "127.0.0.1")' \
-              >/tmp/openclaw-foreign-listener-{port}.log 2>&1 </dev/null &
+            rm -f '{portPath}' '{logPath}'
+            nohup '{nodePath}' -e '{nodeScript}' >'{logPath}' 2>&1 </dev/null &
             echo $!
             """,
             TimeSpan.FromSeconds(15),
@@ -236,6 +241,28 @@ public class SetupAndConnectTests
 
         try
         {
+            string? publishedPort = null;
+            for (var attempt = 0; attempt < 50; attempt++)
+            {
+                var portResult = await _fixture.RunInWslAsync(
+                    $"cat '{portPath}' 2>/dev/null || true",
+                    TimeSpan.FromSeconds(15));
+                if (int.TryParse(portResult.Stdout.Trim(), out _))
+                {
+                    publishedPort = portResult.Stdout.Trim();
+                    break;
+                }
+                await Task.Delay(100);
+            }
+            if (!int.TryParse(publishedPort, out var port))
+            {
+                var startupLog = await _fixture.RunInWslAsync(
+                    $"cat '{logPath}' 2>/dev/null || true",
+                    TimeSpan.FromSeconds(15));
+                Assert.Fail($"Foreign listener did not publish a port. Log: {startupLog.Stdout} {startupLog.Stderr}");
+                return;
+            }
+
             OpenClaw.SetupEngine.CommandResult? listeners = null;
             for (var attempt = 0; attempt < 20; attempt++)
             {
@@ -279,16 +306,9 @@ public class SetupAndConnectTests
         finally
         {
             _ = await _fixture.RunInWslAsync(
-                $"kill {foreignPid} 2>/dev/null || true",
+                $"kill {foreignPid} 2>/dev/null || true; rm -f '{portPath}' '{logPath}'",
                 TimeSpan.FromSeconds(15));
         }
-    }
-
-    private static int GetFreeTcpPort()
-    {
-        using var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        return ((IPEndPoint)listener.LocalEndpoint).Port;
     }
 
     private static string ResolveNodeCommandsAllowKey()

--- a/tests/OpenClaw.E2ETests/Setup/SetupAndConnectTests.cs
+++ b/tests/OpenClaw.E2ETests/Setup/SetupAndConnectTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using OpenClaw.E2ETests;
@@ -223,45 +224,41 @@ public class SetupAndConnectTests
         var config = SetupConfig.LoadFromFile(_fixture.ConfigPath);
         var nodePath = $"/home/{config.Wsl.User}/.openclaw/tools/node/bin/node";
         var proofId = Guid.NewGuid().ToString("N");
-        var portPath = $"/tmp/openclaw-foreign-listener-{proofId}.port";
-        var logPath = $"/tmp/openclaw-foreign-listener-{proofId}.log";
+        var statePath = $"/tmp/openclaw-foreign-listener-{proofId}.state";
         var nodeScript =
             $"const fs=require(\"fs\"),net=require(\"net\");const server=net.createServer();" +
-            $"server.listen(0,\"127.0.0.1\",()=>fs.writeFileSync(\"{portPath}\",String(server.address().port)))";
-        var start = await _fixture.RunInWslAsync(
-            $"""
-            rm -f '{portPath}' '{logPath}'
-            nohup '{nodePath}' -e '{nodeScript}' >'{logPath}' 2>&1 </dev/null &
-            echo $!
-            """,
-            TimeSpan.FromSeconds(15),
-            inputViaStdin: true);
-        AssertCommandSucceeded(start, "start foreign WSL listener");
-        Assert.True(int.TryParse(start.Stdout.Trim(), out var foreignPid) && foreignPid > 0);
+            $"server.listen(0,\"127.0.0.1\",()=>fs.writeFileSync(\"{statePath}\",process.pid+\" \"+server.address().port))";
+        _ = await _fixture.RunInWslAsync($"rm -f '{statePath}'", TimeSpan.FromSeconds(15));
+        using var foreignProcess = StartWslProcess(_fixture.DistroName, nodePath, nodeScript);
+        var foreignPid = 0;
 
         try
         {
-            string? publishedPort = null;
+            var port = 0;
             for (var attempt = 0; attempt < 50; attempt++)
             {
-                var portResult = await _fixture.RunInWslAsync(
-                    $"cat '{portPath}' 2>/dev/null || true",
+                var stateResult = await _fixture.RunInWslAsync(
+                    $"cat '{statePath}' 2>/dev/null || true",
                     TimeSpan.FromSeconds(15));
-                if (int.TryParse(portResult.Stdout.Trim(), out _))
+                var values = stateResult.Stdout.Split(
+                    ' ',
+                    StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                if (values.Length == 2 &&
+                    int.TryParse(values[0], out foreignPid) &&
+                    int.TryParse(values[1], out port) &&
+                    foreignPid > 0 &&
+                    port > 0)
                 {
-                    publishedPort = portResult.Stdout.Trim();
                     break;
+                }
+                if (foreignProcess.HasExited)
+                {
+                    var stderr = await foreignProcess.StandardError.ReadToEndAsync();
+                    Assert.Fail($"Foreign listener exited before publishing its state: {stderr}");
                 }
                 await Task.Delay(100);
             }
-            if (!int.TryParse(publishedPort, out var port))
-            {
-                var startupLog = await _fixture.RunInWslAsync(
-                    $"cat '{logPath}' 2>/dev/null || true",
-                    TimeSpan.FromSeconds(15));
-                Assert.Fail($"Foreign listener did not publish a port. Log: {startupLog.Stdout} {startupLog.Stderr}");
-                return;
-            }
+            Assert.True(foreignPid > 0 && port > 0, "Foreign listener did not publish a PID and port.");
 
             OpenClaw.SetupEngine.CommandResult? listeners = null;
             for (var attempt = 0; attempt < 20; attempt++)
@@ -305,10 +302,41 @@ public class SetupAndConnectTests
         }
         finally
         {
-            _ = await _fixture.RunInWslAsync(
-                $"kill {foreignPid} 2>/dev/null || true; rm -f '{portPath}' '{logPath}'",
-                TimeSpan.FromSeconds(15));
+            if (foreignPid > 0)
+            {
+                _ = await _fixture.RunInWslAsync(
+                    $"kill {foreignPid} 2>/dev/null || true; rm -f '{statePath}'",
+                    TimeSpan.FromSeconds(15));
+            }
+            try
+            {
+                await foreignProcess.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(5));
+            }
+            catch (TimeoutException)
+            {
+                foreignProcess.Kill(entireProcessTree: true);
+            }
         }
+    }
+
+    private static Process StartWslProcess(string distroName, string executable, string argument)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "wsl.exe",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        startInfo.Environment["WSL_UTF8"] = "1";
+        startInfo.ArgumentList.Add("-d");
+        startInfo.ArgumentList.Add(distroName);
+        startInfo.ArgumentList.Add("--");
+        startInfo.ArgumentList.Add(executable);
+        startInfo.ArgumentList.Add("-e");
+        startInfo.ArgumentList.Add(argument);
+        return Process.Start(startInfo) ?? throw new InvalidOperationException("Could not start the foreign WSL listener.");
     }
 
     private static string ResolveNodeCommandsAllowKey()

--- a/tests/OpenClaw.E2ETests/Setup/SetupAndConnectTests.cs
+++ b/tests/OpenClaw.E2ETests/Setup/SetupAndConnectTests.cs
@@ -279,21 +279,23 @@ public class SetupAndConnectTests
 
             config.GatewayPort = port;
             var proofLogPath = Path.Combine(_fixture.ArtifactDir, "foreign-gateway-listener.jsonl");
-            using var logger = new SetupLogger(proofLogPath, LogLevel.Trace);
-            using var journal = new TransactionJournal(filePath: null, logger);
-            var context = new SetupContext(
-                config,
-                logger,
-                journal,
-                new CommandRunner(logger),
-                CancellationToken.None,
-                _fixture.DataDir,
-                _fixture.LocalAppDataRoot)
+            StepResult result;
+            using (var logger = new SetupLogger(proofLogPath, LogLevel.Trace))
+            using (var journal = new TransactionJournal(filePath: null, logger))
             {
-                DistroName = _fixture.DistroName,
-            };
-
-            var result = await new StartGatewayStep().ExecuteAsync(context, CancellationToken.None);
+                var context = new SetupContext(
+                    config,
+                    logger,
+                    journal,
+                    new CommandRunner(logger),
+                    CancellationToken.None,
+                    _fixture.DataDir,
+                    _fixture.LocalAppDataRoot)
+                {
+                    DistroName = _fixture.DistroName,
+                };
+                result = await new StartGatewayStep().ExecuteAsync(context, CancellationToken.None);
+            }
 
             Assert.False(result.IsSuccess);
             Assert.Contains($"Port {port} is already in use by another process.", result.Message);

--- a/tests/OpenClaw.E2ETests/Setup/SetupAndConnectTests.cs
+++ b/tests/OpenClaw.E2ETests/Setup/SetupAndConnectTests.cs
@@ -1,4 +1,7 @@
+using System.Net;
+using System.Net.Sockets;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using OpenClaw.E2ETests;
 using OpenClaw.SetupEngine;
 using OpenClaw.Shared;
@@ -165,6 +168,127 @@ public class SetupAndConnectTests
         var identityDir = Path.Combine(_fixture.DataDir, "gateways", gateway.ActiveId);
         Assert.True(Directory.Exists(identityDir), $"Expected identity directory: {identityDir}");
         Assert.Contains(Directory.EnumerateFiles(identityDir), path => Path.GetFileName(path).Contains("device-key", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [E2EFact]
+    public async Task FullSetup_AlreadyRunningGateway_IsRecognizedAsServiceOwned()
+    {
+        var listeners = await _fixture.RunInWslAsync(
+            $"ss -H -ltnp 'sport = :{_fixture.GatewayPort}'",
+            TimeSpan.FromSeconds(15));
+        AssertCommandSucceeded(listeners, "inspect running gateway listeners");
+
+        var mainPid = await _fixture.RunInWslAsync(
+            "systemctl --user show openclaw-gateway.service -p MainPID --value",
+            TimeSpan.FromSeconds(15));
+        AssertCommandSucceeded(mainPid, "read gateway service MainPID");
+
+        var parsedMainPid = mainPid.Stdout.Trim();
+        Assert.True(int.TryParse(parsedMainPid, out var pid) && pid > 0, $"Invalid gateway MainPID: {parsedMainPid}");
+        var listenerPids = Regex.Matches(listeners.Stdout, @"pid=(\d+),")
+            .Select(match => int.Parse(match.Groups[1].Value))
+            .ToArray();
+        Assert.NotEmpty(listenerPids);
+        Assert.All(listenerPids, listenerPid => Assert.Equal(pid, listenerPid));
+
+        var proofLogPath = Path.Combine(_fixture.ArtifactDir, "service-owned-gateway-start.jsonl");
+        var config = SetupConfig.LoadFromFile(_fixture.ConfigPath);
+        using var logger = new SetupLogger(proofLogPath, LogLevel.Trace);
+        using var journal = new TransactionJournal(filePath: null, logger);
+        var context = new SetupContext(
+            config,
+            logger,
+            journal,
+            new CommandRunner(logger),
+            CancellationToken.None,
+            _fixture.DataDir,
+            _fixture.LocalAppDataRoot)
+        {
+            DistroName = _fixture.DistroName,
+        };
+
+        var result = await new StartGatewayStep().ExecuteAsync(context, CancellationToken.None);
+
+        Assert.True(result.IsSuccess, result.Message);
+        var proofLog = await File.ReadAllTextAsync(proofLogPath);
+        Assert.Contains(
+            $"Port {_fixture.GatewayPort} is owned by openclaw-gateway.service (PID {pid}).",
+            proofLog,
+            StringComparison.Ordinal);
+    }
+
+    [E2EFact]
+    public async Task FullSetup_ForeignWslListener_IsRejectedBeforeGatewayStart()
+    {
+        var config = SetupConfig.LoadFromFile(_fixture.ConfigPath);
+        var port = GetFreeTcpPort();
+        var nodePath = $"/home/{config.Wsl.User}/.openclaw/tools/node/bin/node";
+        var start = await _fixture.RunInWslAsync(
+            $"""
+            nohup '{nodePath}' -e 'require("net").createServer().listen({port}, "127.0.0.1")' \
+              >/tmp/openclaw-foreign-listener-{port}.log 2>&1 </dev/null &
+            echo $!
+            """,
+            TimeSpan.FromSeconds(15),
+            inputViaStdin: true);
+        AssertCommandSucceeded(start, "start foreign WSL listener");
+        Assert.True(int.TryParse(start.Stdout.Trim(), out var foreignPid) && foreignPid > 0);
+
+        try
+        {
+            OpenClaw.SetupEngine.CommandResult? listeners = null;
+            for (var attempt = 0; attempt < 20; attempt++)
+            {
+                listeners = await _fixture.RunInWslAsync(
+                    $"ss -H -ltnp 'sport = :{port}'",
+                    TimeSpan.FromSeconds(15));
+                if (listeners.ExitCode == 0 &&
+                    listeners.Stdout.Contains($"pid={foreignPid},", StringComparison.Ordinal))
+                {
+                    break;
+                }
+                await Task.Delay(100);
+            }
+            var verifiedListeners = Assert.IsType<OpenClaw.SetupEngine.CommandResult>(listeners);
+            AssertCommandSucceeded(verifiedListeners, "inspect foreign WSL listener");
+            Assert.Contains($"pid={foreignPid},", verifiedListeners.Stdout, StringComparison.Ordinal);
+
+            config.GatewayPort = port;
+            var proofLogPath = Path.Combine(_fixture.ArtifactDir, "foreign-gateway-listener.jsonl");
+            using var logger = new SetupLogger(proofLogPath, LogLevel.Trace);
+            using var journal = new TransactionJournal(filePath: null, logger);
+            var context = new SetupContext(
+                config,
+                logger,
+                journal,
+                new CommandRunner(logger),
+                CancellationToken.None,
+                _fixture.DataDir,
+                _fixture.LocalAppDataRoot)
+            {
+                DistroName = _fixture.DistroName,
+            };
+
+            var result = await new StartGatewayStep().ExecuteAsync(context, CancellationToken.None);
+
+            Assert.False(result.IsSuccess);
+            Assert.Contains($"Port {port} is already in use by another process.", result.Message);
+            var proofLog = await File.ReadAllTextAsync(proofLogPath);
+            Assert.DoesNotContain("openclaw gateway start", proofLog, StringComparison.Ordinal);
+        }
+        finally
+        {
+            _ = await _fixture.RunInWslAsync(
+                $"kill {foreignPid} 2>/dev/null || true",
+                TimeSpan.FromSeconds(15));
+        }
+    }
+
+    private static int GetFreeTcpPort()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        return ((IPEndPoint)listener.LocalEndpoint).Port;
     }
 
     private static string ResolveNodeCommandsAllowKey()

--- a/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
@@ -3337,6 +3337,100 @@ public class SetupStepsTests : IDisposable
             decision.Result.Message);
     }
 
+    [Theory]
+    [InlineData("node", "321", true)]
+    [InlineData("openclaw-gateway", "321", true)]
+    [InlineData("node", "999", false)]
+    [InlineData("other-openclaw", "999", false)]
+    [InlineData("python3", "0", false)]
+    [InlineData("node", "", false)]
+    public async Task StartGateway_AfterFreePortAndInstall_RequiresServiceOwnedListener(
+        string processName, string mainPid, bool expectedSuccess)
+    {
+        var port = GetFreeTcpPort();
+        var installed = false;
+        var commands = new FakeCommandRunner(
+            _ => throw new InvalidOperationException("Unexpected Windows command"),
+            (_, command, _) =>
+            {
+                if (command.Contains("openclaw gateway install --force"))
+                {
+                    installed = true;
+                    return Ok();
+                }
+                Assert.True(installed);
+                return command switch
+                {
+                    var value when value == $"ss -H -ltnp 'sport = :{port}'" =>
+                        Ok($"LISTEN 0 511 127.0.0.1:{port} 0.0.0.0:* users:((\"{processName}\",pid=321,fd=22))"),
+                    "systemctl --user show openclaw-gateway.service -p MainPID --value" => Ok(mainPid),
+                    var value when value.Contains("openclaw gateway start") => Ok(),
+                    var value when value.Contains("curl -s") => Ok("200"),
+                    _ => throw new InvalidOperationException($"Unexpected command: {command}"),
+                };
+            });
+        var ctx = CreateContext(new SetupConfig { GatewayPort = port }, commands);
+        ctx.DistroName = "test-distro";
+
+        Assert.True((await new PreflightPortStep().ExecuteAsync(ctx, CancellationToken.None)).IsSuccess);
+        Assert.True((await new InstallGatewayServiceStep().ExecuteAsync(ctx, CancellationToken.None)).IsSuccess);
+        var result = await new StartGatewayStep().ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(expectedSuccess, result.IsSuccess);
+        Assert.All(commands.WslCalls, call => Assert.Equal(ctx.DistroName, call.DistroName));
+        if (!expectedSuccess)
+        {
+            Assert.Contains($"Port {port} is already in use by another process.", result.Message);
+            Assert.Contains($"Owning process: {processName}.", result.Message);
+            Assert.DoesNotContain(commands.WslCalls, call => call.Command.Contains("openclaw gateway start") || call.Command.Contains("curl -s"));
+        }
+    }
+
+    [Theory]
+    [InlineData("", "0", 0, true)]
+    [InlineData("LISTEN 0 511 127.0.0.1:18789 *:*", "321", 0, false)]
+    [InlineData("LISTEN 0 511 127.0.0.1:18789 *:* users:((\"node\",pid=321,fd=22))\nLISTEN 0 511 [::1]:18789 *:* users:((\"python3\",pid=999,fd=23))", "321", 0, false)]
+    [InlineData("LISTEN 0 511 127.0.0.1:18789 *:* users:((\"node\",pid=321,fd=22),(\"python3\",pid=999,fd=23))", "321", 0, false)]
+    [InlineData("", "321", 1, false)]
+    public async Task StartGateway_PortInspection_RejectsUnownedOrUnreadableListeners(
+        string listeners, string mainPid, int inspectionExitCode, bool expectedSuccess)
+    {
+        var commands = new FakeCommandRunner(_ => Ok(), (_, command, _) => command switch
+        {
+            var value when value.StartsWith("ss -H") => new CommandResult(inspectionExitCode, listeners, "", TimeSpan.Zero, false),
+            var value when value.StartsWith("systemctl --user show") => Ok(mainPid),
+            var value when value.Contains("openclaw gateway start") => Ok(),
+            var value when value.Contains("curl -s") => Ok("200"),
+            _ => throw new InvalidOperationException($"Unexpected command: {command}"),
+        });
+        var ctx = CreateContext(commands: commands);
+        ctx.DistroName = "test-distro";
+
+        var result = await new StartGatewayStep().ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(expectedSuccess, result.IsSuccess);
+    }
+
+    [Fact]
+    public async Task PreflightPort_ForeignListener_BlocksBeforeServiceInstall()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0) { ExclusiveAddressUse = true };
+        listener.Start();
+        var commands = new FakeCommandRunner(_ => throw new InvalidOperationException("Must not install"));
+        var ctx = CreateContext(new SetupConfig { GatewayPort = ((IPEndPoint)listener.LocalEndpoint).Port }, commands);
+
+        var result = await new PreflightPortStep().ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains("already in use", result.Message);
+        if (OperatingSystem.IsWindows())
+        {
+            using var process = System.Diagnostics.Process.GetCurrentProcess();
+            Assert.Contains(process.ProcessName, result.Message);
+        }
+        Assert.Empty(commands.WslCalls);
+    }
+
     [Fact]
     public async Task StartGateway_RestartUsesRestartCommandAndWaitsForHealth()
     {
@@ -3359,7 +3453,7 @@ public class SetupStepsTests : IDisposable
         Assert.True(result.IsSuccess, result.Message);
         Assert.DoesNotContain(
             commands.WslCalls,
-            call => call.Command.Contains("ss -tlnp"));
+            call => call.Command.StartsWith("ss "));
         Assert.Contains(
             commands.WslCalls,
             call => call.Command.Contains("openclaw gateway restart"));


### PR DESCRIPTION
## Problem and root cause

Local Windows gateway setup can reject the gateway it just installed. The initial Windows port preflight succeeds, `openclaw gateway install --force` starts the WSL user service, and the later WSL check sees the now-occupied port. Main accepts that listener only when `ss` output contains `openclaw`; the real gateway process can be named `node`, so setup reports a foreign listener and may roll back.

This preserves the core diagnosis from Peter Steinberger and supersedes #1334 by @Elliot-Construct. #1334 correctly reproduced the bug but removed the post-install ownership check entirely. Closed #547 identified the `node` process-name case, but a blanket process-name exemption would also accept unrelated Node.js servers.

## Fix

- query the exact configured listener with `ss -H -ltnp 'sport = :<port>'`
- compare every reported listener PID with the positive systemd user-service `MainPID`
- accept the listener only when ownership is proven, not from a process name substring
- fail closed for missing ownership, mixed owners, invalid MainPID, or inspection failure
- include available process names in genuine conflict diagnostics
- preserve the existing start and health-wait flow after ownership succeeds

The root `CHANGELOG.md` added by the original patch was removed because this repository has no owned changelog convention. The existing setup architecture documentation remains updated.

## Relationship to #1344

#1344 is an independent runtime reconnect P0. It concerns an unbounded `ClientWebSocket.ConnectAsync` HTTP-upgrade wait after a Gateway restart. #1349 concerns setup-time WSL listener ownership after service installation. They can produce adjacent “Gateway did not come back” symptoms, but #1349 does not fix or close #1344.

## Required proof pools

- `windows-wsl-gateway-e2e`: verified on current head by real managed WSL service ownership and foreign-listener rejection tests in GitHub CI.
- `windows-wsl-mxc`: required setup/connect closeout. Attempted locally and through Azure Crabbox without `-AllowSkip`; blocked because no available host combined working WSL setup with OpenClaw's required unaugmented MXC BaseContainer tier.

`windows-clean-installer-upgrade` is not selected. This patch changes no installer layout, packaged payload selection, persisted schema, migration, repair, or uninstall behavior. The current-head real WSL test performs a clean managed setup and then reruns production `StartGatewayStep` against the already-installed, already-running service, which is the compatibility boundary affected by this ownership check. Exact signed-installer execution would invoke the same setup code without adding ownership coverage.

## Validation

Current head: `a813f775`.

- focused `StartGateway` and `PreflightPort` tests: 16 passed
- `dotnet build .\tests\OpenClaw.E2ETests\OpenClaw.E2ETests.csproj -c Debug -r win-x64`: passed
- `.\build.ps1`: passed
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore`: 3,937 passed, 32 skipped
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore`: 2,860 passed
- `dotnet test .\tests\OpenClaw.SetupEngine.Tests\OpenClaw.SetupEngine.Tests.csproj --no-restore`: 1,084 passed
- GitHub `Setup and connect E2E`: 43 passed
- GitHub `Tray, setup, and integration tests`: passed
- GitHub CI Gate and CodeQL: passed
- `git diff --check`: passed
- `python .agents\skills\autoreview\scripts\autoreview --mode branch --base origin/main --stream-engine-output`: clean, no accepted/actionable findings

Repeated validation exposed unrelated baseline timing/file-sharing races in `CommandRunnerTests`, `BoundedProcessOutputTests`, `PiperVoiceExtractionTests`, and `McpHttpServerTests`. Their focused reruns passed and the final full local closeout is green.

## Real behavior proof

GitHub run `34099646730`, setup/connect job `101671061479`, executed the production setup path against a real app-owned WSL distribution on current head:

- `FullSetup_ForeignWslListener_IsRejectedBeforeGatewayStart`: passed. A directly owned foreign Node listener was visible in `ss`; production `StartGatewayStep` reported `Port 44121 is in use by another process. Owning process: node.` and the test proved `openclaw gateway start` was not invoked.
- `FullSetup_AlreadyRunningGateway_IsRecognizedAsServiceOwned`: passed. After full setup, the test required every real `ss` listener PID to match the systemd user service `MainPID`, reran production `StartGatewayStep`, and required the service-owned success result.
- Complete setup/connect shard: 43 passed; CI Gate passed.

Additional evidence and boundaries:

- Pinned upstream `v2026.6.34` uses a systemd user service whose `ExecStart` launches the Node Gateway process; the generated unit has `Restart=always` and `KillMode=control-group`.
- Local `.\scripts\validate-mxc-e2e.ps1` ran without `-AllowSkip`, but WSL could not attach its temporary `swap.vhdx` (`E_ACCESSDENIED`) before distro creation.
- Crabbox v0.51.0 was installed from its stable Windows release with SHA-256 verification. Azure direct-mode runs returned no portal URL (`portal=-`, `logs=-`).
- Azure Windows Server lease `cbx_14f4b42c0be4`, run `run_c3162c2e444e`: exact head built; formal MXC command reported 11 passed and 6 skipped because Windows Server does not support OpenClaw MXC containment. Lease stopped.
- Azure Windows 11 24H2 lease `cbx_718fc34376bd`, run `run_ed82af3dff46`: exact head built; formal MXC command reported 11 passed and 6 skipped because build 26100 exposed only `appcontainer-dacl`, not the required unaugmented BaseContainer tier. Lease stopped.
- Azure Windows 11 26H2 preview lease `cbx_e6fa429c1b02`, probe run `run_dd8d06761d50`: build 26300 still reported `appcontainer-dacl`, `baseContainerSupportsDenyPaths=false`, and `isolationSessionAvailable=false`. The policy was not weakened to admit DACL augmentation. Lease stopped.
- The local Windows 26340 host reports `base-container`, `baseContainerSupportsDenyPaths=true`, and `isolationSessionAvailable=true`, but its independent WSL install failure prevents the combined proof.
- All task-owned Azure resources were deleted; `crabbox list --provider azure` is empty.

## Adversarial review

Both reviewers agreed the PID-based direction is safer than #1334’s removal or #547’s process-name exemption. Both identified runtime compatibility proof as the primary merge risk and noted a sampling race between listener and MainPID reads. The existing three-attempt step retry limits that race; the current-head real E2E asserts all observed listener PIDs match the service MainPID and proves both positive and negative production paths. One reviewer recommended warning and proceeding on ambiguity, but that was rejected because later setup steps could contact a foreign listener and trigger bootstrap or pairing operations. Fail-closed ownership remains intentional.

ClawSweeper's current-head review reports no actionable patch defect, marks direct real behavior proof sufficient, and rates the PR 4/6. The remaining block is the repository-required non-skipping MXC host proof described above.

## Security impact

No credential authority changes. This check occurs before bootstrap minting and pairing. Unknown or conflicting listeners remain blocked; `PairOperatorStep` and managed endpoint provenance remain the authoritative credential boundary.