### PR TITLE
fix(setup): keep WSL diagnostics readable with deterministic UTF-8

### DIFF
--- a/src/OpenClaw.SetupEngine/CommandRunner.cs
+++ b/src/OpenClaw.SetupEngine/CommandRunner.cs
@@ -115,6 +115,12 @@ public sealed class CommandRunner : ICommandRunner
             WorkingDirectory = workingDirectory ?? ""
         };
 
+        if (UsesUtf16OutputEncoding(executable, arguments))
+        {
+            psi.StandardOutputEncoding = Encoding.Unicode;
+            psi.StandardErrorEncoding = Encoding.Unicode;
+        }
+
         foreach (var arg in arguments)
             psi.ArgumentList.Add(arg);
 
@@ -240,6 +246,24 @@ public sealed class CommandRunner : ICommandRunner
             return TimeSpan.Zero;
 
         return remaining < s_outputDrainCap ? remaining : s_outputDrainCap;
+    }
+
+    internal static bool UsesUtf16OutputEncoding(string executable, string[] arguments)
+    {
+        if (!string.Equals(Path.GetFileName(executable), "wsl.exe", StringComparison.OrdinalIgnoreCase) ||
+            arguments.Length == 0)
+        {
+            return false;
+        }
+
+        return arguments[0] is
+            "--version" or
+            "--status" or
+            "--list" or
+            "--install" or
+            "--terminate" or
+            "--unregister" or
+            "--shutdown";
     }
 
     /// <summary>

--- a/src/OpenClaw.SetupEngine/CommandRunner.cs
+++ b/src/OpenClaw.SetupEngine/CommandRunner.cs
@@ -126,9 +126,9 @@ public sealed class CommandRunner : ICommandRunner
 
         if (IsWslExecutable(executable))
         {
-            // wsl.exe management commands default to UTF-16LE, while distro
-            // commands emit UTF-8. Force the documented UTF-8 mode so every WSL
-            // invocation has one deterministic redirected-output encoding.
+            // Redirected wsl.exe output defaults to UTF-16LE unless WSL_UTF8=1.
+            // Force the documented UTF-8 mode so every WSL invocation has one
+            // deterministic redirected-output encoding.
             psi.Environment["WSL_UTF8"] = "1";
             psi.StandardOutputEncoding = Encoding.UTF8;
             psi.StandardErrorEncoding = Encoding.UTF8;

--- a/src/OpenClaw.SetupEngine/CommandRunner.cs
+++ b/src/OpenClaw.SetupEngine/CommandRunner.cs
@@ -115,12 +115,6 @@ public sealed class CommandRunner : ICommandRunner
             WorkingDirectory = workingDirectory ?? ""
         };
 
-        if (UsesUtf16OutputEncoding(executable, arguments))
-        {
-            psi.StandardOutputEncoding = Encoding.Unicode;
-            psi.StandardErrorEncoding = Encoding.Unicode;
-        }
-
         foreach (var arg in arguments)
             psi.ArgumentList.Add(arg);
 
@@ -128,6 +122,16 @@ public sealed class CommandRunner : ICommandRunner
         {
             foreach (var (key, value) in environment)
                 psi.Environment[key] = value;
+        }
+
+        if (IsWslExecutable(executable))
+        {
+            // wsl.exe management commands default to UTF-16LE, while distro
+            // commands emit UTF-8. Force the documented UTF-8 mode so every WSL
+            // invocation has one deterministic redirected-output encoding.
+            psi.Environment["WSL_UTF8"] = "1";
+            psi.StandardOutputEncoding = Encoding.UTF8;
+            psi.StandardErrorEncoding = Encoding.UTF8;
         }
 
         using var process = new Process { StartInfo = psi };
@@ -248,23 +252,8 @@ public sealed class CommandRunner : ICommandRunner
         return remaining < s_outputDrainCap ? remaining : s_outputDrainCap;
     }
 
-    internal static bool UsesUtf16OutputEncoding(string executable, string[] arguments)
-    {
-        if (!string.Equals(Path.GetFileName(executable), "wsl.exe", StringComparison.OrdinalIgnoreCase) ||
-            arguments.Length == 0)
-        {
-            return false;
-        }
-
-        return arguments[0] is
-            "--version" or
-            "--status" or
-            "--list" or
-            "--install" or
-            "--terminate" or
-            "--unregister" or
-            "--shutdown";
-    }
+    internal static bool IsWslExecutable(string executable) =>
+        string.Equals(Path.GetFileName(executable), "wsl.exe", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// Run a command inside a WSL distro.

--- a/tests/OpenClaw.SetupEngine.Tests/CommandRunnerTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/CommandRunnerTests.cs
@@ -28,6 +28,7 @@ public class CommandRunnerTests
 
             var output = result.Stdout + result.Stderr;
             Assert.NotEmpty(output);
+            Assert.Contains("WSL version", output, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain('\0', output);
 
             var jsonl = await File.ReadAllTextAsync(logPath);
@@ -40,33 +41,20 @@ public class CommandRunnerTests
     }
 
     [Theory]
-    [InlineData("--version")]
-    [InlineData("--status")]
-    [InlineData("--list")]
-    [InlineData("--install")]
-    [InlineData("--terminate")]
-    [InlineData("--unregister")]
-    [InlineData("--shutdown")]
-    public void UsesUtf16OutputEncoding_WslManagementVerb_ReturnsTrue(string verb)
+    [InlineData("wsl.exe")]
+    [InlineData(@"C:\Windows\System32\WSL.EXE")]
+    public void IsWslExecutable_WslPath_ReturnsTrue(string executable)
     {
-        Assert.True(CommandRunner.UsesUtf16OutputEncoding("wsl.exe", [verb]));
-        Assert.True(CommandRunner.UsesUtf16OutputEncoding(@"C:\Windows\System32\WSL.EXE", [verb]));
+        Assert.True(CommandRunner.IsWslExecutable(executable));
     }
 
     [Theory]
-    [InlineData("wsl.exe", "-d")]
-    [InlineData("wsl.exe", "--distribution")]
-    [InlineData("wsl.exe", "--exec")]
-    [InlineData("powershell.exe", "--version")]
-    public void UsesUtf16OutputEncoding_OtherCommand_ReturnsFalse(string executable, string argument)
+    [InlineData("wsl")]
+    [InlineData("powershell.exe")]
+    [InlineData("")]
+    public void IsWslExecutable_OtherPath_ReturnsFalse(string executable)
     {
-        Assert.False(CommandRunner.UsesUtf16OutputEncoding(executable, [argument]));
-    }
-
-    [Fact]
-    public void UsesUtf16OutputEncoding_EmptyArguments_ReturnsFalse()
-    {
-        Assert.False(CommandRunner.UsesUtf16OutputEncoding("wsl.exe", []));
+        Assert.False(CommandRunner.IsWslExecutable(executable));
     }
 
     [Fact]

--- a/tests/OpenClaw.SetupEngine.Tests/CommandRunnerTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/CommandRunnerTests.cs
@@ -7,6 +7,69 @@ public class CommandRunnerTests
     private static readonly string s_largeStdin = new('x', 8 * 1024 * 1024);
 
     [Fact]
+    public async Task RunAsync_WslVersion_DecodesOutputBeforeLogging()
+    {
+        if (!OperatingSystem.IsWindows() || !File.Exists(WslConstants.WslExePath))
+            return;
+
+        var logPath = Path.Combine(Path.GetTempPath(), $"openclaw-wsl-output-{Guid.NewGuid():N}.jsonl");
+
+        try
+        {
+            CommandResult result;
+            using (var logger = new SetupLogger(logPath, LogLevel.Trace))
+            {
+                var runner = new CommandRunner(logger);
+                result = await runner.RunAsync(
+                    WslConstants.WslExePath,
+                    ["--version"],
+                    TimeSpan.FromSeconds(15));
+            }
+
+            var output = result.Stdout + result.Stderr;
+            Assert.NotEmpty(output);
+            Assert.DoesNotContain('\0', output);
+
+            var jsonl = await File.ReadAllTextAsync(logPath);
+            Assert.DoesNotContain("\\u0000", jsonl, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            File.Delete(logPath);
+        }
+    }
+
+    [Theory]
+    [InlineData("--version")]
+    [InlineData("--status")]
+    [InlineData("--list")]
+    [InlineData("--install")]
+    [InlineData("--terminate")]
+    [InlineData("--unregister")]
+    [InlineData("--shutdown")]
+    public void UsesUtf16OutputEncoding_WslManagementVerb_ReturnsTrue(string verb)
+    {
+        Assert.True(CommandRunner.UsesUtf16OutputEncoding("wsl.exe", [verb]));
+        Assert.True(CommandRunner.UsesUtf16OutputEncoding(@"C:\Windows\System32\WSL.EXE", [verb]));
+    }
+
+    [Theory]
+    [InlineData("wsl.exe", "-d")]
+    [InlineData("wsl.exe", "--distribution")]
+    [InlineData("wsl.exe", "--exec")]
+    [InlineData("powershell.exe", "--version")]
+    public void UsesUtf16OutputEncoding_OtherCommand_ReturnsFalse(string executable, string argument)
+    {
+        Assert.False(CommandRunner.UsesUtf16OutputEncoding(executable, [argument]));
+    }
+
+    [Fact]
+    public void UsesUtf16OutputEncoding_EmptyArguments_ReturnsFalse()
+    {
+        Assert.False(CommandRunner.UsesUtf16OutputEncoding("wsl.exe", []));
+    }
+
+    [Fact]
     public async Task RunAsync_LargeStdinWriteObeysTimeout()
     {
         var runner = CreateRunner();

--- a/tests/OpenClaw.SetupEngine.Tests/CommandRunnerTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/CommandRunnerTests.cs
@@ -23,7 +23,11 @@ public class CommandRunnerTests
                 result = await runner.RunAsync(
                     WslConstants.WslExePath,
                     ["--version"],
-                    TimeSpan.FromSeconds(15));
+                    TimeSpan.FromSeconds(15),
+                    environment: new Dictionary<string, string>
+                    {
+                        ["WSL_UTF8"] = "0",
+                    });
             }
 
             var output = result.Stdout + result.Stderr;


### PR DESCRIPTION
Supersedes #1338. The contributor commit is preserved as `cc0c2ad1`; the follow-up replaces its verb-specific UTF-16LE decoder with one deterministic WSL output contract.

Closes #1336.

## Summary

- set `WSL_UTF8=1` for every `wsl.exe` process launched by SetupEngine
- explicitly decode redirected WSL stdout and stderr as UTF-8
- keep caller-provided environment values, but override `WSL_UTF8` so setup output is deterministic
- cover the real local `wsl.exe --version` path and ensure ambient `WSL_UTF8=0` cannot mask a production regression
- remove the management-verb allowlist so new WSL commands cannot silently regress to UTF-16LE/NUL-filled diagnostics

## Required proof pools

- `windows-wsl-gateway-e2e`: setup WSL command output changed. The prior contributor proof covered fresh Windows management output and distro execution. Current-head local proof exercised the production `CommandRunner` against real `wsl.exe --version`; full Gateway setup was not rerun for this replacement.

## Validation

- focused repaired encoding tests: 6 passed
- `.\build.ps1`: passed
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore`: 3,937 passed, 32 skipped
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore`: 2,860 passed
- `dotnet test .\tests\OpenClaw.SetupEngine.Tests\OpenClaw.SetupEngine.Tests.csproj --no-restore`: 1,072 passed
- independent rubber-duck review: no blocking issues
- `git diff --check`: passed

Two unrelated baseline races appeared during repeated full validation: Local AI staging directory access and Piper PID-file sharing. Each focused test passed three consecutive reruns, followed by a clean full closeout.

## Real behavior proof

- On this Windows host, redirected `wsl.exe --version` output was UTF-16LE with NUL bytes by default.
- With `WSL_UTF8=1`, the same command emitted readable UTF-8 with no NUL bytes.
- Current-head `CommandRunnerTests.RunAsync_WslVersion_DecodesOutputBeforeLogging` invoked the real `wsl.exe` through production code while supplying ambient `WSL_UTF8=0`; production overrode it, returned readable `WSL version` output, and wrote JSONL containing no `\u0000` escapes.
- Not verified / blocked: the full current-head `windows-wsl-gateway-e2e` setup flow was not rerun. The implementation applies the same deterministic encoding to both management and distro invocations.

## Rubber-duck review

The reviewer independently reproduced the default UTF-16LE output and confirmed the uniform `WSL_UTF8=1` approach is sound. Follow-up review suggestions were applied by correcting the code comment and ensuring the test does not depend on ambient developer-machine state.
