### PR TITLE
Bound WebSocket reconnect attempts

### DIFF
--- a/src/OpenClaw.Shared/WebSocketClientBase.cs
+++ b/src/OpenClaw.Shared/WebSocketClientBase.cs
@@ -658,6 +658,11 @@ public abstract class WebSocketClientBase : IDisposable
                     ownerGeneration).ConfigureAwait(false);
                 if (attempt is null)
                 {
+                    if (IsReconnectOwner(ownerSocket, ownerGeneration))
+                    {
+                        continue;
+                    }
+
                     break;
                 }
 

--- a/src/OpenClaw.Shared/WebSocketClientBase.cs
+++ b/src/OpenClaw.Shared/WebSocketClientBase.cs
@@ -96,6 +96,7 @@ internal sealed class HandshakeChallengeGate
 public abstract class WebSocketClientBase : IDisposable
 {
     private ClientWebSocket? _webSocket;
+    private readonly object _connectionStateLock = new();
     private readonly string _gatewayUrl;
     private readonly string? _credentials;
     private CancellationTokenSource _cts;
@@ -107,6 +108,7 @@ public abstract class WebSocketClientBase : IDisposable
     private string? _remoteCloseStatusDescription;
     private readonly SemaphoreSlim _sendLock = new(1, 1);
     private static readonly int[] BackoffMs = { 1000, 2000, 4000, 8000, 15000, 30000, 60000 };
+    private static readonly TimeSpan DefaultConnectAttemptTimeout = TimeSpan.FromSeconds(15);
 
     protected readonly string _token;
     protected readonly IOpenClawLogger _logger;
@@ -208,6 +210,9 @@ public abstract class WebSocketClientBase : IDisposable
     /// </summary>
     protected virtual bool ShouldAutoReconnect() => true;
 
+    /// <summary>Maximum time allowed for one WebSocket HTTP upgrade attempt.</summary>
+    protected virtual TimeSpan ConnectAttemptTimeout => DefaultConnectAttemptTimeout;
+
     protected WebSocketClientBase(string gatewayUrl, string token, IOpenClawLogger? logger = null)
     {
         if (string.IsNullOrEmpty(gatewayUrl))
@@ -225,25 +230,42 @@ public abstract class WebSocketClientBase : IDisposable
 
     public async Task ConnectAsync()
     {
+        _ = await ConnectAsync(
+            expectedSocket: null,
+            expectedGeneration: 0).ConfigureAwait(false);
+    }
+
+    private async Task<(ClientWebSocket Socket, long Generation)?> ConnectAsync(
+        ClientWebSocket? expectedSocket,
+        long expectedGeneration)
+    {
         if (_disposed)
         {
             _logger.Debug($"Skipping {ClientRole} connect: client already disposed");
-            return;
+            return null;
         }
 
-        var connectGeneration = Interlocked.Increment(ref _connectionGeneration);
-        Volatile.Write(ref _remoteCloseStatusCode, -1);
-        Volatile.Write(ref _remoteCloseStatusDescription, null);
+        var connectGeneration = 0L;
         ClientWebSocket? ws = null;
 
         try
         {
+            ws = new ClientWebSocket();
+            if (!TryPublishConnection(
+                    ws,
+                    expectedSocket,
+                    expectedGeneration,
+                    out connectGeneration))
+            {
+                DisposeStaleSocket(ws);
+                _logger.Debug($"{ClientRole} reconnect skipped: connection ownership changed");
+                return null;
+            }
+
             RaiseStatusChanged(ConnectionStatus.Connecting);
             _logger.Info($"Connecting to {ClientRole}: {GatewayUrlForDisplay}");
 
-            ws = new ClientWebSocket();
             ws.Options.KeepAliveInterval = TimeSpan.FromSeconds(30);
-            _webSocket = ws;
 
             // Set Origin header (convert ws/wss to http/https)
             var uri = new Uri(_gatewayUrl);
@@ -259,11 +281,33 @@ public abstract class WebSocketClientBase : IDisposable
                     $"Basic {Convert.ToBase64String(Encoding.UTF8.GetBytes(credentialsToEncode))}");
             }
 
-            await ws.ConnectAsync(uri, _cts.Token);
+            var connectTimeout = ConnectAttemptTimeout;
+            using var connectCancellation =
+                CancellationTokenSource.CreateLinkedTokenSource(_cts.Token);
+            connectCancellation.CancelAfter(connectTimeout);
+            try
+            {
+                await ws.ConnectAsync(uri, connectCancellation.Token);
+            }
+            catch (OperationCanceledException ex) when (
+                !_cts.Token.IsCancellationRequested &&
+                connectCancellation.IsCancellationRequested)
+            {
+                try { ws.Abort(); }
+                catch (Exception abortEx)
+                {
+                    _logger.Debug($"{ClientRole} timed-out WebSocket abort threw: {abortEx.Message}");
+                }
+
+                throw new TimeoutException(
+                    $"{ClientRole} connect timed out after {connectTimeout.TotalSeconds:0.#}s.",
+                    ex);
+            }
+
             if (!IsCurrentConnection(ws, connectGeneration))
             {
                 DisposeStaleSocket(ws);
-                return;
+                return null;
             }
 
             // Don't reset _reconnectAttempts here — TCP connect succeeding doesn't mean
@@ -275,10 +319,11 @@ public abstract class WebSocketClientBase : IDisposable
             if (!IsCurrentConnection(ws, connectGeneration))
             {
                 DisposeStaleSocket(ws);
-                return;
+                return null;
             }
 
             _ = Task.Run(() => ListenForMessagesAsync(ws, connectGeneration), _cts.Token);
+            return (ws, connectGeneration);
         }
         catch (OperationCanceledException)
         {
@@ -287,6 +332,7 @@ public abstract class WebSocketClientBase : IDisposable
                 DisposeStaleSocket(ws);
             }
             _logger.Debug($"{ClientRole} connect canceled (likely shutdown)");
+            return null;
         }
         catch (ObjectDisposedException)
         {
@@ -295,6 +341,7 @@ public abstract class WebSocketClientBase : IDisposable
                 DisposeStaleSocket(ws);
             }
             _logger.Debug($"{ClientRole} connect aborted after dispose");
+            return null;
         }
         catch (Exception ex)
         {
@@ -302,12 +349,16 @@ public abstract class WebSocketClientBase : IDisposable
             {
                 DisposeStaleSocket(ws);
                 _logger.Debug($"{ClientRole} stale connection failure ignored: {ex.Message}");
-                return;
+                return null;
             }
 
             if (ws != null)
             {
                 DisposeStaleSocket(ws);
+            }
+            if (ex is TimeoutException)
+            {
+                _logger.Warn(ex.Message);
             }
             _logger.Error($"{ClientRole} connection failed", ex);
             OnConnectionException(ex);
@@ -315,8 +366,9 @@ public abstract class WebSocketClientBase : IDisposable
 
             if (!_disposed && !_cts.Token.IsCancellationRequested && ShouldAutoReconnect())
             {
-                _ = ReconnectWithBackoffAsync();
+                _ = ReconnectWithBackoffAsync(ws, connectGeneration);
             }
+            return ws is null ? null : (ws, connectGeneration);
         }
     }
 
@@ -333,11 +385,37 @@ public abstract class WebSocketClientBase : IDisposable
         && Interlocked.Read(ref _connectionGeneration) == generation
         && ReferenceEquals(_webSocket, ws);
 
+    private bool TryPublishConnection(
+        ClientWebSocket ws,
+        ClientWebSocket? expectedSocket,
+        long expectedGeneration,
+        out long connectGeneration)
+    {
+        lock (_connectionStateLock)
+        {
+            connectGeneration = 0;
+            if (_disposed ||
+                !IsReconnectOwnerLocked(expectedSocket, expectedGeneration))
+            {
+                return false;
+            }
+
+            connectGeneration = Interlocked.Increment(ref _connectionGeneration);
+            Volatile.Write(ref _remoteCloseStatusCode, -1);
+            Volatile.Write(ref _remoteCloseStatusDescription, null);
+            _webSocket = ws;
+            return true;
+        }
+    }
+
     private void DisposeStaleSocket(ClientWebSocket ws)
     {
-        if (ReferenceEquals(_webSocket, ws))
+        lock (_connectionStateLock)
         {
-            _webSocket = null;
+            if (ReferenceEquals(_webSocket, ws))
+            {
+                _webSocket = null;
+            }
         }
 
         // slopwatch-ignore: SW003 Cleanup is best-effort for superseded sockets.
@@ -509,12 +587,14 @@ public abstract class WebSocketClientBase : IDisposable
             return;
         }
 
+        var ownerSocket = expectedSocket;
+        var ownerGeneration = expectedGeneration;
         try
         {
             while (!_disposed
                 && !_cts.Token.IsCancellationRequested
                 && ShouldAutoReconnect()
-                && IsReconnectOwner(expectedSocket, expectedGeneration))
+                && IsReconnectOwner(ownerSocket, ownerGeneration))
             {
                 var delay = BackoffMs[Math.Min(_reconnectAttempts, BackoffMs.Length - 1)];
                 // Add 0-25% jitter to prevent thundering herd when multiple clients
@@ -530,7 +610,7 @@ public abstract class WebSocketClientBase : IDisposable
                 if (_cts.Token.IsCancellationRequested
                     || _disposed
                     || !ShouldAutoReconnect()
-                    || !IsReconnectOwner(expectedSocket, expectedGeneration))
+                    || !IsReconnectOwner(ownerSocket, ownerGeneration))
                 {
                     break;
                 }
@@ -539,6 +619,14 @@ public abstract class WebSocketClientBase : IDisposable
                 {
                     var authorization =
                         await ReconnectAuthorizationAsync(_cts.Token).ConfigureAwait(false);
+                    if (_cts.Token.IsCancellationRequested
+                        || _disposed
+                        || !ShouldAutoReconnect()
+                        || !IsReconnectOwner(ownerSocket, ownerGeneration))
+                    {
+                        break;
+                    }
+
                     if (!authorization.Allowed)
                     {
                         _logger.Warn(
@@ -551,7 +639,7 @@ public abstract class WebSocketClientBase : IDisposable
                 }
 
                 // Safely dispose old socket
-                var oldSocket = expectedSocket ?? _webSocket;
+                var oldSocket = ownerSocket ?? _webSocket;
                 if (oldSocket != null)
                 {
                     DisposeStaleSocket(oldSocket);
@@ -565,7 +653,16 @@ public abstract class WebSocketClientBase : IDisposable
                     DisposeStaleSocket(currentSocket);
                 }
 
-                await ConnectAsync();
+                var attempt = await ConnectAsync(
+                    ownerSocket,
+                    ownerGeneration).ConfigureAwait(false);
+                if (attempt is null)
+                {
+                    break;
+                }
+
+                ownerSocket = attempt.Value.Socket;
+                ownerGeneration = attempt.Value.Generation;
 
                 if (IsConnected)
                 {
@@ -593,11 +690,29 @@ public abstract class WebSocketClientBase : IDisposable
 
     private bool IsReconnectOwner(ClientWebSocket? expectedSocket, long expectedGeneration)
     {
-        if (expectedSocket is null || IsCurrentConnection(expectedSocket, expectedGeneration))
+        lock (_connectionStateLock)
+        {
+            return IsReconnectOwnerLocked(expectedSocket, expectedGeneration);
+        }
+    }
+
+    private bool IsReconnectOwnerLocked(
+        ClientWebSocket? expectedSocket,
+        long expectedGeneration)
+    {
+        if (expectedSocket is null && expectedGeneration == 0)
+            return true;
+
+        if (Interlocked.Read(ref _connectionGeneration) == expectedGeneration &&
+            (expectedSocket is null ||
+             _webSocket is null ||
+             ReferenceEquals(_webSocket, expectedSocket)))
         {
             return true;
         }
 
+        // A newer open socket owns recovery. A null or closing socket can be adopted because its
+        // listener cannot start another reconnect loop while this loop holds the single-flight gate.
         var currentSocket = _webSocket;
         return currentSocket is null || IsSocketClosingOrClosed(currentSocket);
     }
@@ -787,18 +902,25 @@ public abstract class WebSocketClientBase : IDisposable
 
     public void Dispose()
     {
-        if (_disposed) return;
-        _disposed = true;
+        lock (_connectionStateLock)
+        {
+            if (_disposed) return;
+            _disposed = true;
+        }
 
         OnDisposing();
 
-        Interlocked.Increment(ref _connectionGeneration);
+        ClientWebSocket? ws;
+        lock (_connectionStateLock)
+        {
+            Interlocked.Increment(ref _connectionGeneration);
+            ws = _webSocket;
+            _webSocket = null;
+        }
 
         try { _cts.Cancel(); }
         catch (Exception ex) { _logger.Debug($"{ClientRole} cts.Cancel during Dispose threw: {ex.Message}"); }
 
-        var ws = _webSocket;
-        _webSocket = null;
         try { ws?.Dispose(); }
         catch (Exception ex) { _logger.Debug($"{ClientRole} WebSocket Dispose threw: {ex.Message}"); }
 

--- a/tests/OpenClaw.Shared.Tests/WebSocketClientBaseTests.cs
+++ b/tests/OpenClaw.Shared.Tests/WebSocketClientBaseTests.cs
@@ -519,6 +519,40 @@ public class WebSocketClientBaseTests
     }
 
     [Fact]
+    public async Task ConnectAsync_NewerFailedAttempt_DoesNotAbandonActiveReconnectLoop()
+    {
+        using var server = new ControlledUpgradeWebSocketServer(
+            ControlledUpgradeBehavior.Stall,
+            ControlledUpgradeBehavior.Stall,
+            ControlledUpgradeBehavior.Close,
+            ControlledUpgradeBehavior.Upgrade);
+        using var client = new TestWebSocketClient(server.WebSocketUrl, "token", _logger)
+        {
+            TestConnectAttemptTimeout = TimeSpan.FromMilliseconds(250),
+        };
+
+        await client.ConnectAsync().WaitAsync(TimeSpan.FromSeconds(2));
+        await WaitForConditionAsync(
+            () => server.RequestCount >= 2,
+            TimeSpan.FromSeconds(3));
+
+        await client.ConnectAsync().WaitAsync(TimeSpan.FromSeconds(2));
+
+        await server.UpgradeCompleted.WaitAsync(TimeSpan.FromSeconds(5));
+        await WaitForConditionAsync(
+            () => client.TestIsConnected,
+            TimeSpan.FromSeconds(2));
+
+        Assert.Equal(1, client.OnConnectedCallCount);
+        Assert.Equal(4, server.RequestCount);
+
+        await server.SendTextAsync("recovered-after-newer-failure");
+        await WaitForConditionAsync(
+            () => client.ProcessedMessages.Contains("recovered-after-newer-failure"),
+            TimeSpan.FromSeconds(2));
+    }
+
+    [Fact]
     public async Task ConnectAsync_WhenAutoReconnectDisabled_DoesNotStartReconnectLoop()
     {
         var client = new TestWebSocketClient("ws://127.0.0.1:1", "token", _logger)
@@ -1059,11 +1093,18 @@ internal sealed class LoopbackWebSocketServer : IDisposable
     }
 }
 
+internal enum ControlledUpgradeBehavior
+{
+    Stall,
+    Close,
+    Upgrade,
+}
+
 internal sealed class ControlledUpgradeWebSocketServer : IDisposable
 {
     private readonly TcpListener _listener;
     private readonly CancellationTokenSource _cts = new();
-    private readonly int _stalledUpgradeCount;
+    private readonly Func<int, ControlledUpgradeBehavior> _behaviorForRequest;
     private readonly object _connectionsLock = new();
     private readonly List<TcpClient> _clients = new();
     private readonly List<WebSocket> _webSockets = new();
@@ -1083,8 +1124,35 @@ internal sealed class ControlledUpgradeWebSocketServer : IDisposable
     public Task UpgradeCompleted => _upgradeCompleted.Task;
 
     public ControlledUpgradeWebSocketServer(int stalledUpgradeCount)
+        : this(requestNumber =>
+            requestNumber <= stalledUpgradeCount
+                ? ControlledUpgradeBehavior.Stall
+                : ControlledUpgradeBehavior.Upgrade)
     {
-        _stalledUpgradeCount = stalledUpgradeCount;
+    }
+
+    public ControlledUpgradeWebSocketServer(
+        params ControlledUpgradeBehavior[] behaviors)
+        : this(CreateBehaviorSelector(behaviors))
+    {
+    }
+
+    private static Func<int, ControlledUpgradeBehavior> CreateBehaviorSelector(
+        ControlledUpgradeBehavior[] behaviors)
+    {
+        if (behaviors.Length == 0)
+            throw new ArgumentException("At least one upgrade behavior is required.", nameof(behaviors));
+
+        return requestNumber =>
+            requestNumber <= behaviors.Length
+                ? behaviors[requestNumber - 1]
+                : behaviors[^1];
+    }
+
+    private ControlledUpgradeWebSocketServer(
+        Func<int, ControlledUpgradeBehavior> behaviorForRequest)
+    {
+        _behaviorForRequest = behaviorForRequest;
         _listener = new TcpListener(IPAddress.Loopback, 0);
         _listener.Start();
         var port = ((IPEndPoint)_listener.LocalEndpoint).Port;
@@ -1122,6 +1190,7 @@ internal sealed class ControlledUpgradeWebSocketServer : IDisposable
     {
         WebSocket? webSocket = null;
         var requestNumber = 0;
+        var stalled = false;
         try
         {
             var stream = client.GetStream();
@@ -1132,8 +1201,15 @@ internal sealed class ControlledUpgradeWebSocketServer : IDisposable
                 _firstRequestReceived.TrySetResult();
             }
 
-            if (requestNumber <= _stalledUpgradeCount)
+            var behavior = _behaviorForRequest(requestNumber);
+            if (behavior == ControlledUpgradeBehavior.Close)
             {
+                return;
+            }
+
+            if (behavior == ControlledUpgradeBehavior.Stall)
+            {
+                stalled = true;
                 var buffer = new byte[1];
                 while (await stream.ReadAsync(buffer, _cts.Token) > 0)
                 {
@@ -1185,7 +1261,7 @@ internal sealed class ControlledUpgradeWebSocketServer : IDisposable
         }
         finally
         {
-            if (requestNumber == 1 && requestNumber <= _stalledUpgradeCount)
+            if (requestNumber == 1 && stalled)
             {
                 _firstStalledClientClosed.TrySetResult();
             }

--- a/tests/OpenClaw.Shared.Tests/WebSocketClientBaseTests.cs
+++ b/tests/OpenClaw.Shared.Tests/WebSocketClientBaseTests.cs
@@ -26,9 +26,12 @@ public class TestWebSocketClient : WebSocketClientBase
     public Exception? LastError { get; private set; }
     public int OnDisposingCallCount { get; private set; }
     public bool AutoReconnectEnabled { get; set; } = true;
+    public TimeSpan? TestConnectAttemptTimeout { get; set; }
 
     protected override int ReceiveBufferSize => 8192;
     protected override string ClientRole => "test";
+    protected override TimeSpan ConnectAttemptTimeout =>
+        TestConnectAttemptTimeout ?? base.ConnectAttemptTimeout;
 
     public TestWebSocketClient(string gatewayUrl, string token, IOpenClawLogger? logger = null)
         : base(gatewayUrl, token, logger) { }
@@ -68,6 +71,7 @@ public class TestWebSocketClient : WebSocketClientBase
         => RaiseStatusChanged(status);
 
     public bool TestIsDisposed => IsDisposed;
+    public bool TestIsConnected => IsConnected;
     public string TestGatewayUrlForDisplay => GatewayUrlForDisplay;
     public string TestToken => _token;
     public IOpenClawLogger TestLogger => _logger;
@@ -327,6 +331,191 @@ public class WebSocketClientBaseTests
         Assert.Contains(_logger.Logs, line => line.Contains("reconnecting in 1", StringComparison.OrdinalIgnoreCase) && line.Contains("ms (attempt 1)", StringComparison.OrdinalIgnoreCase));
 
         client.Dispose();
+    }
+
+    [Fact]
+    public async Task ConnectAsync_WhenUpgradeResponseStalls_TimesOutAndRetries()
+    {
+        using var server = new ControlledUpgradeWebSocketServer(int.MaxValue);
+        using var client = new TestWebSocketClient(server.WebSocketUrl, "token", _logger)
+        {
+            TestConnectAttemptTimeout = TimeSpan.FromMilliseconds(250),
+        };
+        var statuses = new ConcurrentQueue<ConnectionStatus>();
+        client.StatusChanged += (_, status) => statuses.Enqueue(status);
+
+        await client.ConnectAsync().WaitAsync(TimeSpan.FromSeconds(2));
+        await server.FirstStalledClientClosed.WaitAsync(TimeSpan.FromSeconds(2));
+        await WaitForConditionAsync(
+            () => server.RequestCount >= 2,
+            TimeSpan.FromSeconds(3));
+
+        Assert.Equal(0, client.OnConnectedCallCount);
+        Assert.Contains(ConnectionStatus.Error, statuses);
+        Assert.True(statuses.Count(status => status == ConnectionStatus.Connecting) >= 2);
+        Assert.Contains(
+            _logger.Logs,
+            line => line.Contains(
+                "test connect timed out after",
+                StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task ConnectAsync_DisposeDuringStalledUpgrade_IsShutdownNotTimeout()
+    {
+        using var server = new ControlledUpgradeWebSocketServer(int.MaxValue);
+        var client = new TestWebSocketClient(server.WebSocketUrl, "token", _logger)
+        {
+            TestConnectAttemptTimeout = TimeSpan.FromSeconds(10),
+        };
+        var statuses = new ConcurrentQueue<ConnectionStatus>();
+        client.StatusChanged += (_, status) => statuses.Enqueue(status);
+
+        var connect = client.ConnectAsync();
+        await server.FirstRequestReceived.WaitAsync(TimeSpan.FromSeconds(2));
+
+        client.Dispose();
+        await connect.WaitAsync(TimeSpan.FromSeconds(2));
+        await server.FirstStalledClientClosed.WaitAsync(TimeSpan.FromSeconds(2));
+        await Task.Delay(250);
+
+        Assert.DoesNotContain(ConnectionStatus.Error, statuses);
+        Assert.Equal(1, server.RequestCount);
+        Assert.DoesNotContain(
+            _logger.Logs,
+            line => line.Contains("connect timed out", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(
+            _logger.Logs,
+            line => line.Contains("reconnecting in", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task ConnectAsync_TimedOutRetry_DoesNotDisposeNewerConnectionDuringBackoff()
+    {
+        using var server = new ControlledUpgradeWebSocketServer(stalledUpgradeCount: 1);
+        using var client = new TestWebSocketClient(server.WebSocketUrl, "token", _logger)
+        {
+            TestConnectAttemptTimeout = TimeSpan.FromMilliseconds(250),
+        };
+        var statuses = new ConcurrentQueue<ConnectionStatus>();
+        client.StatusChanged += (_, status) => statuses.Enqueue(status);
+
+        var timedOutConnect = client.ConnectAsync();
+        await server.FirstRequestReceived.WaitAsync(TimeSpan.FromSeconds(2));
+        await timedOutConnect.WaitAsync(TimeSpan.FromSeconds(2));
+        var errorStatusesAfterTimeout =
+            statuses.Count(status => status == ConnectionStatus.Error);
+        Assert.True(errorStatusesAfterTimeout >= 1);
+
+        var currentConnect = client.ConnectAsync();
+        await server.UpgradeCompleted.WaitAsync(TimeSpan.FromSeconds(2));
+        await currentConnect.WaitAsync(TimeSpan.FromSeconds(2));
+        await Task.Delay(TimeSpan.FromMilliseconds(1500));
+
+        Assert.True(client.TestIsConnected);
+        Assert.Equal(1, client.OnConnectedCallCount);
+        Assert.Equal(2, server.RequestCount);
+        Assert.Equal(
+            errorStatusesAfterTimeout,
+            statuses.Count(status => status == ConnectionStatus.Error));
+
+        await server.SendTextAsync("current-socket-message");
+        await WaitForConditionAsync(
+            () => client.ProcessedMessages.Contains("current-socket-message"),
+            TimeSpan.FromSeconds(2));
+    }
+
+    [Fact]
+    public async Task ConnectAsync_TimedOutRetry_DoesNotReplaceNewerConnectionAfterAuthorization()
+    {
+        using var server = new ControlledUpgradeWebSocketServer(stalledUpgradeCount: 1);
+        using var client = new TestWebSocketClient(server.WebSocketUrl, "token", _logger)
+        {
+            TestConnectAttemptTimeout = TimeSpan.FromMilliseconds(250),
+        };
+        var authorizationEntered =
+            new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseAuthorization =
+            new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        client.ReconnectAuthorizationAsync = async cancellationToken =>
+        {
+            authorizationEntered.TrySetResult();
+            await releaseAuthorization.Task.WaitAsync(cancellationToken);
+            return ReconnectAuthorizationResult.AllowedResult;
+        };
+
+        await client.ConnectAsync().WaitAsync(TimeSpan.FromSeconds(2));
+        await authorizationEntered.Task.WaitAsync(TimeSpan.FromSeconds(3));
+
+        var currentConnect = client.ConnectAsync();
+        await server.UpgradeCompleted.WaitAsync(TimeSpan.FromSeconds(2));
+        await currentConnect.WaitAsync(TimeSpan.FromSeconds(2));
+
+        releaseAuthorization.TrySetResult();
+        await Task.Delay(TimeSpan.FromMilliseconds(500));
+
+        Assert.True(client.TestIsConnected);
+        Assert.Equal(1, client.OnConnectedCallCount);
+        Assert.Equal(2, server.RequestCount);
+
+        await server.SendTextAsync("authorized-current-socket-message");
+        await WaitForConditionAsync(
+            () => client.ProcessedMessages.Contains("authorized-current-socket-message"),
+            TimeSpan.FromSeconds(2));
+    }
+
+    [Fact]
+    public async Task ConnectAsync_StaleAuthorizationDenial_DoesNotFailNewerConnection()
+    {
+        using var server = new ControlledUpgradeWebSocketServer(stalledUpgradeCount: 1);
+        using var client = new TestWebSocketClient(server.WebSocketUrl, "token", _logger)
+        {
+            TestConnectAttemptTimeout = TimeSpan.FromMilliseconds(250),
+        };
+        var statuses = new ConcurrentQueue<ConnectionStatus>();
+        client.StatusChanged += (_, status) => statuses.Enqueue(status);
+        var authorizationEntered =
+            new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var authorizationResult =
+            new TaskCompletionSource<ReconnectAuthorizationResult>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+        client.ReconnectAuthorizationAsync = async cancellationToken =>
+        {
+            authorizationEntered.TrySetResult();
+            return await authorizationResult.Task.WaitAsync(cancellationToken);
+        };
+
+        await client.ConnectAsync().WaitAsync(TimeSpan.FromSeconds(2));
+        await authorizationEntered.Task.WaitAsync(TimeSpan.FromSeconds(3));
+        var errorsAfterTimeout =
+            statuses.Count(status => status == ConnectionStatus.Error);
+
+        var currentConnect = client.ConnectAsync();
+        await server.UpgradeCompleted.WaitAsync(TimeSpan.FromSeconds(2));
+        await currentConnect.WaitAsync(TimeSpan.FromSeconds(2));
+
+        authorizationResult.TrySetResult(new ReconnectAuthorizationResult(
+            false,
+            GatewayErrorKind.LocalPortConflict,
+            "stale denial"));
+        await Task.Delay(TimeSpan.FromMilliseconds(500));
+
+        Assert.True(client.TestIsConnected);
+        Assert.Equal(1, client.OnConnectedCallCount);
+        Assert.Equal(2, server.RequestCount);
+        Assert.Equal(
+            errorsAfterTimeout,
+            statuses.Count(status => status == ConnectionStatus.Error));
+        Assert.DoesNotContain(
+            _logger.Logs,
+            line => line.Contains(
+                "reconnect blocked by endpoint authorization policy",
+                StringComparison.OrdinalIgnoreCase));
+
+        await server.SendTextAsync("denied-current-socket-message");
+        await WaitForConditionAsync(
+            () => client.ProcessedMessages.Contains("denied-current-socket-message"),
+            TimeSpan.FromSeconds(2));
     }
 
     [Fact]
@@ -867,6 +1056,202 @@ internal sealed class LoopbackWebSocketServer : IDisposable
         {
             listener.Stop();
         }
+    }
+}
+
+internal sealed class ControlledUpgradeWebSocketServer : IDisposable
+{
+    private readonly TcpListener _listener;
+    private readonly CancellationTokenSource _cts = new();
+    private readonly int _stalledUpgradeCount;
+    private readonly object _connectionsLock = new();
+    private readonly List<TcpClient> _clients = new();
+    private readonly List<WebSocket> _webSockets = new();
+    private readonly TaskCompletionSource _firstRequestReceived =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource _firstStalledClientClosed =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource<WebSocket> _upgradeCompleted =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly Task _acceptLoop;
+    private int _requestCount;
+
+    public string WebSocketUrl { get; }
+    public int RequestCount => Volatile.Read(ref _requestCount);
+    public Task FirstRequestReceived => _firstRequestReceived.Task;
+    public Task FirstStalledClientClosed => _firstStalledClientClosed.Task;
+    public Task UpgradeCompleted => _upgradeCompleted.Task;
+
+    public ControlledUpgradeWebSocketServer(int stalledUpgradeCount)
+    {
+        _stalledUpgradeCount = stalledUpgradeCount;
+        _listener = new TcpListener(IPAddress.Loopback, 0);
+        _listener.Start();
+        var port = ((IPEndPoint)_listener.LocalEndpoint).Port;
+        WebSocketUrl = $"ws://127.0.0.1:{port}/";
+        _acceptLoop = Task.Run(AcceptLoopAsync);
+    }
+
+    private async Task AcceptLoopAsync()
+    {
+        while (!_cts.Token.IsCancellationRequested)
+        {
+            TcpClient client;
+            try
+            {
+                client = await _listener.AcceptTcpClientAsync(_cts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+            catch (SocketException) when (_cts.Token.IsCancellationRequested)
+            {
+                return;
+            }
+
+            lock (_connectionsLock)
+            {
+                _clients.Add(client);
+            }
+            _ = HandleClientAsync(client);
+        }
+    }
+
+    private async Task HandleClientAsync(TcpClient client)
+    {
+        WebSocket? webSocket = null;
+        var requestNumber = 0;
+        try
+        {
+            var stream = client.GetStream();
+            var request = await ReadHttpHeadersAsync(stream, _cts.Token);
+            requestNumber = Interlocked.Increment(ref _requestCount);
+            if (requestNumber == 1)
+            {
+                _firstRequestReceived.TrySetResult();
+            }
+
+            if (requestNumber <= _stalledUpgradeCount)
+            {
+                var buffer = new byte[1];
+                while (await stream.ReadAsync(buffer, _cts.Token) > 0)
+                {
+                }
+                return;
+            }
+
+            var key = request
+                .Split("\r\n", StringSplitOptions.RemoveEmptyEntries)
+                .First(line => line.StartsWith(
+                    "Sec-WebSocket-Key:",
+                    StringComparison.OrdinalIgnoreCase))
+                .Split(':', 2)[1]
+                .Trim();
+            var accept = Convert.ToBase64String(
+                SHA1.HashData(
+                    Encoding.ASCII.GetBytes(
+                        $"{key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11")));
+            var response = Encoding.ASCII.GetBytes(
+                "HTTP/1.1 101 Switching Protocols\r\n" +
+                "Upgrade: websocket\r\n" +
+                "Connection: Upgrade\r\n" +
+                $"Sec-WebSocket-Accept: {accept}\r\n\r\n");
+            await stream.WriteAsync(response, _cts.Token);
+
+            webSocket = WebSocket.CreateFromStream(
+                stream,
+                isServer: true,
+                subProtocol: null,
+                keepAliveInterval: TimeSpan.FromSeconds(30));
+            lock (_connectionsLock)
+            {
+                _webSockets.Add(webSocket);
+            }
+            _upgradeCompleted.TrySetResult(webSocket);
+            await Task.Delay(Timeout.InfiniteTimeSpan, _cts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (IOException)
+        {
+        }
+        catch (SocketException)
+        {
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+        finally
+        {
+            if (requestNumber == 1 && requestNumber <= _stalledUpgradeCount)
+            {
+                _firstStalledClientClosed.TrySetResult();
+            }
+
+            try { webSocket?.Dispose(); } catch { }
+            try { client.Dispose(); } catch { }
+        }
+    }
+
+    private static async Task<string> ReadHttpHeadersAsync(
+        NetworkStream stream,
+        CancellationToken cancellationToken)
+    {
+        const int maxHeaderBytes = 16 * 1024;
+        var bytes = new List<byte>();
+        var next = new byte[1];
+        while (bytes.Count < maxHeaderBytes)
+        {
+            var read = await stream.ReadAsync(next, cancellationToken);
+            if (read == 0)
+                throw new EndOfStreamException("WebSocket handshake ended before the HTTP headers.");
+
+            bytes.Add(next[0]);
+            var count = bytes.Count;
+            if (count >= 4 &&
+                bytes[count - 4] == '\r' &&
+                bytes[count - 3] == '\n' &&
+                bytes[count - 2] == '\r' &&
+                bytes[count - 1] == '\n')
+            {
+                return Encoding.ASCII.GetString(bytes.ToArray());
+            }
+        }
+
+        throw new InvalidOperationException("WebSocket handshake headers exceeded the test limit.");
+    }
+
+    public async Task SendTextAsync(
+        string message,
+        CancellationToken cancellationToken = default)
+    {
+        var socket = await _upgradeCompleted.Task.WaitAsync(cancellationToken);
+        await socket.SendAsync(
+            Encoding.UTF8.GetBytes(message),
+            WebSocketMessageType.Text,
+            endOfMessage: true,
+            cancellationToken);
+    }
+
+    public void Dispose()
+    {
+        _cts.Cancel();
+        try { _listener.Stop(); } catch { }
+        lock (_connectionsLock)
+        {
+            foreach (var socket in _webSockets)
+            {
+                try { socket.Dispose(); } catch { }
+            }
+            foreach (var client in _clients)
+            {
+                try { client.Dispose(); } catch { }
+            }
+        }
+        try { _acceptLoop.Wait(TimeSpan.FromSeconds(1)); } catch { }
+        _cts.Dispose();
     }
 }
 


### PR DESCRIPTION
## Problem

Fixes #1344.

A gateway peer can accept TCP but never complete the WebSocket HTTP upgrade. `WebSocketClientBase.ConnectAsync` previously awaited `ClientWebSocket.ConnectAsync` with only the client lifetime token, so one stalled attempt could block the single reconnect loop forever and leave node mode stuck at Connecting until the tray process was force-killed.

## Fix

- bound each WebSocket HTTP upgrade attempt to 15 seconds using a token linked to the client lifetime
- abort and dispose a timed-out socket, classify it as a network timeout, raise the existing Error status, and continue the existing backoff loop
- keep shutdown cancellation distinct from an attempt timeout, so disposal does not surface a false error or schedule reconnect
- bind reconnect work to its socket and generation instead of starting an ownerless retry
- atomically validate reconnect ownership when publishing a replacement socket
- re-check ownership after asynchronous endpoint authorization, including denied results, so stale authorization cannot overwrite a newer healthy connection
- preserve the existing single-flight handoff where the active loop may adopt a newer null or closing transport, while a newer open socket remains authoritative
- continue the active reconnect loop when a newer manual attempt supersedes an in-flight retry but also fails and cannot acquire the single-flight gate itself

## Required proof pools

- `windows-wsl-gateway-e2e`: verified on current head by real Gateway stop/start recovery and three repeated Gateway restart recoveries.

## Validation

Current head: `8134a76e`.

- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore --filter "FullyQualifiedName~WebSocketClientBaseTests"`: 35 passed per run, repeated 5 consecutive times
- `.\build.ps1`: passed
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore`: 3,943 passed, 32 skipped
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore`: 2,860 passed
- `dotnet test .\tests\OpenClaw.Connection.Tests\OpenClaw.Connection.Tests.csproj --no-restore`: 718 passed
- `git diff --check`: passed
- GitHub run `34133976203`: CI Gate, setup/connect E2E, network recovery E2E, revocation recovery E2E, core/CLI, tray/setup/integration, UI/accessibility, CodeQL, and security checks passed
- the initial broad tray/setup run hit the unrelated `CommandRunnerTests.RunAsync_ReturnsWhenDescendantKeepsOutputPipesOpen` timing flake at 5.81 seconds against a 5-second assertion; the failed job rerun passed
- required rubber-duck review completed; concrete reconnect-ownership races were accepted and fixed
- final `python .agents\skills\autoreview\scripts\autoreview --mode local --stream-engine-output`: clean, no accepted/actionable findings
- ClawSweeper current-head review: ready for maintainer review, no findings, proof sufficient

## Real behavior proof

The focused suite uses a real loopback TCP peer, not a mocked `ClientWebSocket`:

- the peer accepts the TCP connection and reads the complete WebSocket upgrade request, but deliberately sends no HTTP response
- the client reaches its test-scoped attempt deadline, aborts the socket, and the peer observes that first client close
- the reconnect loop advances through backoff and the peer receives a second complete upgrade request
- disposing during the same stalled upgrade produces no timeout, Error status, or reconnect
- a manual connection that succeeds while the timed-out retry is in backoff remains open and receives a message after the stale retry wakes
- the same newer-socket protection is proven while reconnect authorization is blocked, for both allowed and denied authorization results
- a four-attempt sequence proves recovery is not abandoned when retry A stalls, newer manual attempt B supersedes it and fails, B cannot acquire the occupied single-flight gate, and A must continue to a final successful upgrade
- all 35 transport tests passed in five consecutive runs

Current-head GitHub `Network recovery E2E` passed both real WSL Gateway scenarios:

- `GatewayStopAndStart_TrayLeavesReadyThenRecovers`: passed in 25 seconds
- `RepeatedGatewayRestart_TrayAndNodeRecoverEachTime`: passed in 55 seconds, covering three consecutive Gateway restarts
- complete network recovery shard: 2 passed

The original intermittent remote-LAN incident and reporter dump were not independently reproduced. The deterministic peer directly reproduces the source-level failure mode shown by the dump: TCP is accepted while `ClientWebSocket` waits indefinitely for the HTTP upgrade response.

## Review notes

ClawSweeper identified a lost-recovery handoff when a newer manual attempt superseded an in-flight retry and also failed. That finding was accepted and fixed with the four-attempt real-loopback regression above. Its current-head review reports no findings and marks the PR ready for maintainer review.

An earlier autoreview TOCTOU finding was rejected after tracing the locked state transition. It assumed disposing a newer closing socket would make atomic publication reject the retry and leave the client disconnected. The implementation intentionally permits the active single-flight loop to adopt a null or closing transport; only a newer open or connecting socket blocks publication. Existing and new tests prove both the closing-socket handoff and newer-open-socket preservation. The final structured autoreview is clean.

## Security impact

No credential or endpoint-authorization policy changes. Authorization still runs before every client-owned reconnect. The change only bounds transport establishment and prevents stale retry or authorization work from replacing a newer healthy socket.