### PR TITLE
fix(build): Piper voice preview fails in local builds with "native library could not be loaded"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,6 +248,7 @@ jobs:
             'global.json',
             'NuGet.Config',
             'Directory.Build.props',
+            'Directory.Build.targets',
             'src/Directory.Build.props',
             'src/Directory.Build.targets',
             'tests/Directory.Build.props',

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -873,11 +873,12 @@ gh run download <run-id> --repo shanselman/openclaw-windows-hub
 
 5. **Piper voice preview fails with "Piper TTS native library could not be loaded"**
    - The build copied a Visual C++ runtime that is too old for `onnxruntime`
-     next to the exe. Local x64 builds take the runtime from your Visual Studio
-     install; without the "C++ Redistributable Update" component the build
-     falls back to a 14.29 runtime and warns (`OPENCLAW0001`).
-   - Install that component via the Visual Studio Installer (Individual
-     Components), rebuild, and confirm `msvcp140.dll` beside
+     next to the exe. Local x64 builds take a compatible 14.38-or-newer runtime
+     from your Visual Studio install. If the component is missing, stale, or
+     incomplete for x64, the build falls back to a 14.29 runtime and warns
+     (`OPENCLAW0001`).
+   - Install or update "C++ Redistributable Update" via the Visual Studio
+     Installer (Individual Components), rebuild, and confirm `msvcp140.dll` beside
      `OpenClaw.Tray.WinUI.exe` is 14.38 or newer.
    - The same failure shows up in `%LOCALAPPDATA%\OpenClawTray\openclaw-tray.log`
      as `DllNotFoundException` from `PiperTextToSpeechClient`.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -871,6 +871,17 @@ gh run download <run-id> --repo shanselman/openclaw-windows-hub
    - Verify authentication token is correct
    - Check firewall settings
 
+5. **Piper voice preview fails with "Piper TTS native library could not be loaded"**
+   - The build copied a Visual C++ runtime that is too old for `onnxruntime`
+     next to the exe. Local x64 builds take the runtime from your Visual Studio
+     install; without the "C++ Redistributable Update" component the build
+     falls back to a 14.29 runtime and warns (`OPENCLAW0001`).
+   - Install that component via the Visual Studio Installer (Individual
+     Components), rebuild, and confirm `msvcp140.dll` beside
+     `OpenClaw.Tray.WinUI.exe` is 14.38 or newer.
+   - The same failure shows up in `%LOCALAPPDATA%\OpenClawTray\openclaw-tray.log`
+     as `DllNotFoundException` from `PiperTextToSpeechClient`.
+
 ### Getting Help
 
 - **Issues**: [GitHub Issues](https://github.com/shanselman/openclaw-windows-hub/issues)

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -21,6 +21,7 @@
   <PropertyGroup>
     <OpenClawVCRuntimePackageVersion Condition="'$(OpenClawVCRuntimePackageVersion)' == ''">1.0.5</OpenClawVCRuntimePackageVersion>
     <OpenClawVCRuntimePackageRoot Condition="'$(OpenClawVCRuntimePackageRoot)' == ''">$(NuGetPackageRoot)vcruntime.cefsharp.140\$(OpenClawVCRuntimePackageVersion)\vc_redist\</OpenClawVCRuntimePackageRoot>
+    <OpenClawVCRuntimeMinimumVersion Condition="'$(OpenClawVCRuntimeMinimumVersion)' == ''">14.38.33130</OpenClawVCRuntimeMinimumVersion>
     <OpenClawVCRuntimeArch Condition="'$(OpenClawVCRuntimeArch)' == '' and '$(RuntimeIdentifier)' == 'win-x64'">x64</OpenClawVCRuntimeArch>
     <OpenClawVCRuntimeArch Condition="'$(OpenClawVCRuntimeArch)' == '' and '$(RuntimeIdentifier)' == 'win-arm64'">arm64</OpenClawVCRuntimeArch>
     <OpenClawVsWherePath Condition="'$(OpenClawVsWherePath)' == ''">$(MSBuildProgramFiles32)\Microsoft Visual Studio\Installer\vswhere.exe</OpenClawVsWherePath>
@@ -29,7 +30,11 @@
   <Target Name="LocateOpenClawVCRuntimeFromVSInstall"
           Condition="'$(OpenClawVCRuntimeArch)' != '' and '$(OS)' == 'Windows_NT'">
 
-    <Exec Condition="Exists('$(OpenClawVsWherePath)')"
+    <PropertyGroup Condition="'$(OpenClawVsInstallRoot)' != '' and !Exists('$(OpenClawVsInstallRoot)')">
+      <OpenClawVsInstallRoot></OpenClawVsInstallRoot>
+    </PropertyGroup>
+
+    <Exec Condition="'$(OpenClawVsInstallRoot)' == '' and Exists('$(OpenClawVsWherePath)')"
           Command="&quot;$(OpenClawVsWherePath)&quot; -latest -products * -requires Microsoft.VisualStudio.Component.VC.Redist.14.Latest -property installationPath"
           ConsoleToMSBuild="true"
           IgnoreExitCode="true"
@@ -44,13 +49,12 @@
     </PropertyGroup>
 
     <!--
-      VC\Auxiliary\Build\Microsoft.VCRedistVersion.default.txt names the redist
-      version the install treats as current. Using it keeps the glob to one
-      version directory even when an install carries several (for example a
-      14.29 v142 redist beside the current one). The wildcard fallback keeps
-      installs without that file working, and installs whose current version
-      directory lacks this architecture (an ARM64 redist that only exists
-      under an older version, for example).
+      VC\Auxiliary\Build\Microsoft.VCRedistVersion.default.txt names the one
+      redist version the install treats as current. Accept it only when it is
+      at least the 14.38 floor required by onnxruntime and when that exact
+      version contains the requested architecture. Missing, older, or
+      architecture-incomplete installs stay unresolved so local builds use the
+      warned NuGet fallback and publish fails closed.
 
       The Microsoft.VC*.CRT folder name carries the toolset major version
       (Microsoft.VC143.CRT for VS 2022, Microsoft.VC145.CRT for VS 18); there is
@@ -59,12 +63,12 @@
     -->
     <PropertyGroup Condition="'$(OpenClawVsInstallRoot)' != ''">
       <_OpenClawVCRedistVersionFile>$(OpenClawVsInstallRoot)\VC\Auxiliary\Build\Microsoft.VCRedistVersion.default.txt</_OpenClawVCRedistVersionFile>
-      <OpenClawVCRedistVersion Condition="Exists('$(_OpenClawVCRedistVersionFile)')">$([System.IO.File]::ReadAllText('$(_OpenClawVCRedistVersionFile)').Trim())</OpenClawVCRedistVersion>
-      <OpenClawVCRedistVersion Condition="'$(OpenClawVCRedistVersion)' == '' or !Exists('$(OpenClawVsInstallRoot)\VC\Redist\MSVC\$(OpenClawVCRedistVersion)\$(OpenClawVCRuntimeArch)')">*</OpenClawVCRedistVersion>
-      <OpenClawVCRedistCrtDir>$(OpenClawVsInstallRoot)\VC\Redist\MSVC\$(OpenClawVCRedistVersion)\$(OpenClawVCRuntimeArch)\Microsoft.VC*.CRT\</OpenClawVCRedistCrtDir>
+      <OpenClawVCRedistVersion Condition="'$(OpenClawVCRedistVersion)' == '' and Exists('$(_OpenClawVCRedistVersionFile)')">$([System.IO.File]::ReadAllText('$(_OpenClawVCRedistVersionFile)').Trim())</OpenClawVCRedistVersion>
+      <OpenClawVCRuntimeVersionIsSupported Condition="'$(OpenClawVCRedistVersion)' != '' and $([System.Text.RegularExpressions.Regex]::IsMatch('$(OpenClawVCRedistVersion)', '^[0-9]+(\.[0-9]+){1,3}$'))">$([MSBuild]::VersionGreaterThanOrEquals('$(OpenClawVCRedistVersion)', '$(OpenClawVCRuntimeMinimumVersion)'))</OpenClawVCRuntimeVersionIsSupported>
+      <OpenClawVCRedistCrtDir Condition="'$(OpenClawVCRuntimeVersionIsSupported)' == 'true' and Exists('$(OpenClawVsInstallRoot)\VC\Redist\MSVC\$(OpenClawVCRedistVersion)\$(OpenClawVCRuntimeArch)')">$(OpenClawVsInstallRoot)\VC\Redist\MSVC\$(OpenClawVCRedistVersion)\$(OpenClawVCRuntimeArch)\Microsoft.VC*.CRT\</OpenClawVCRedistCrtDir>
     </PropertyGroup>
 
-    <ItemGroup Condition="'$(OpenClawVsInstallRoot)' != ''">
+    <ItemGroup Condition="'$(OpenClawVCRedistCrtDir)' != ''">
       <OpenClawVSVCRuntimeFiles Include="$(OpenClawVCRedistCrtDir)vcruntime140*.dll" />
       <OpenClawVSVCRuntimeFiles Include="$(OpenClawVCRedistCrtDir)msvcp140*.dll" />
     </ItemGroup>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -33,7 +33,9 @@
           Command="&quot;$(OpenClawVsWherePath)&quot; -latest -products * -requires Microsoft.VisualStudio.Component.VC.Redist.14.Latest -property installationPath"
           ConsoleToMSBuild="true"
           IgnoreExitCode="true"
-          StandardOutputImportance="low">
+          IgnoreStandardErrorWarningFormat="true"
+          StandardOutputImportance="low"
+          StandardErrorImportance="low">
       <Output TaskParameter="ConsoleOutput" PropertyName="OpenClawVsInstallRoot" />
     </Exec>
 
@@ -46,7 +48,9 @@
       version the install treats as current. Using it keeps the glob to one
       version directory even when an install carries several (for example a
       14.29 v142 redist beside the current one). The wildcard fallback keeps
-      installs without that file working.
+      installs without that file working, and installs whose current version
+      directory lacks this architecture (an ARM64 redist that only exists
+      under an older version, for example).
 
       The Microsoft.VC*.CRT folder name carries the toolset major version
       (Microsoft.VC143.CRT for VS 2022, Microsoft.VC145.CRT for VS 18); there is
@@ -56,7 +60,7 @@
     <PropertyGroup Condition="'$(OpenClawVsInstallRoot)' != ''">
       <_OpenClawVCRedistVersionFile>$(OpenClawVsInstallRoot)\VC\Auxiliary\Build\Microsoft.VCRedistVersion.default.txt</_OpenClawVCRedistVersionFile>
       <OpenClawVCRedistVersion Condition="Exists('$(_OpenClawVCRedistVersionFile)')">$([System.IO.File]::ReadAllText('$(_OpenClawVCRedistVersionFile)').Trim())</OpenClawVCRedistVersion>
-      <OpenClawVCRedistVersion Condition="'$(OpenClawVCRedistVersion)' == '' or !Exists('$(OpenClawVsInstallRoot)\VC\Redist\MSVC\$(OpenClawVCRedistVersion)')">*</OpenClawVCRedistVersion>
+      <OpenClawVCRedistVersion Condition="'$(OpenClawVCRedistVersion)' == '' or !Exists('$(OpenClawVsInstallRoot)\VC\Redist\MSVC\$(OpenClawVCRedistVersion)\$(OpenClawVCRuntimeArch)')">*</OpenClawVCRedistVersion>
       <OpenClawVCRedistCrtDir>$(OpenClawVsInstallRoot)\VC\Redist\MSVC\$(OpenClawVCRedistVersion)\$(OpenClawVCRuntimeArch)\Microsoft.VC*.CRT\</OpenClawVCRedistCrtDir>
     </PropertyGroup>
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,69 @@
+<Project>
+
+  <!--
+    Shared Visual C++ runtime resolution for every project in the repo.
+
+    The native speech stack (onnxruntime, sherpa-onnx) imports the VC++
+    runtime, and onnxruntime >= 1.20 needs 14.38 or newer. The
+    VCRuntime.CefSharp.140 NuGet package used as the offline fallback ships
+    14.29, which is too old: an app-local 14.29 msvcp140.dll shadows the
+    system runtime and onnxruntime.dll fails to initialize (Win32 error 1114),
+    which the Piper TTS client surfaces as DllNotFoundException.
+
+    LocateOpenClawVCRuntimeFromVSInstall never fails the build. It fills
+    @(OpenClawVSVCRuntimeFiles) with the loose CRT DLLs from the newest Visual
+    Studio install that has the C++ Redistributable component, or leaves the
+    item empty when no such install exists. Consumers decide what an empty
+    result means: src\Directory.Build.targets warns for local builds and errors
+    for publish; tests\Directory.Build.props warns for test hosts.
+  -->
+
+  <PropertyGroup>
+    <OpenClawVCRuntimePackageVersion Condition="'$(OpenClawVCRuntimePackageVersion)' == ''">1.0.5</OpenClawVCRuntimePackageVersion>
+    <OpenClawVCRuntimePackageRoot Condition="'$(OpenClawVCRuntimePackageRoot)' == ''">$(NuGetPackageRoot)vcruntime.cefsharp.140\$(OpenClawVCRuntimePackageVersion)\vc_redist\</OpenClawVCRuntimePackageRoot>
+    <OpenClawVCRuntimeArch Condition="'$(OpenClawVCRuntimeArch)' == '' and '$(RuntimeIdentifier)' == 'win-x64'">x64</OpenClawVCRuntimeArch>
+    <OpenClawVCRuntimeArch Condition="'$(OpenClawVCRuntimeArch)' == '' and '$(RuntimeIdentifier)' == 'win-arm64'">arm64</OpenClawVCRuntimeArch>
+    <OpenClawVsWherePath Condition="'$(OpenClawVsWherePath)' == ''">$(MSBuildProgramFiles32)\Microsoft Visual Studio\Installer\vswhere.exe</OpenClawVsWherePath>
+  </PropertyGroup>
+
+  <Target Name="LocateOpenClawVCRuntimeFromVSInstall"
+          Condition="'$(OpenClawVCRuntimeArch)' != '' and '$(OS)' == 'Windows_NT'">
+
+    <Exec Condition="Exists('$(OpenClawVsWherePath)')"
+          Command="&quot;$(OpenClawVsWherePath)&quot; -latest -products * -requires Microsoft.VisualStudio.Component.VC.Redist.14.Latest -property installationPath"
+          ConsoleToMSBuild="true"
+          IgnoreExitCode="true"
+          StandardOutputImportance="low">
+      <Output TaskParameter="ConsoleOutput" PropertyName="OpenClawVsInstallRoot" />
+    </Exec>
+
+    <PropertyGroup Condition="'$(OpenClawVsInstallRoot)' != '' and !Exists('$(OpenClawVsInstallRoot)')">
+      <OpenClawVsInstallRoot></OpenClawVsInstallRoot>
+    </PropertyGroup>
+
+    <!--
+      VC\Auxiliary\Build\Microsoft.VCRedistVersion.default.txt names the redist
+      version the install treats as current. Using it keeps the glob to one
+      version directory even when an install carries several (for example a
+      14.29 v142 redist beside the current one). The wildcard fallback keeps
+      installs without that file working.
+
+      The Microsoft.VC*.CRT folder name carries the toolset major version
+      (Microsoft.VC143.CRT for VS 2022, Microsoft.VC145.CRT for VS 18); there is
+      one per arch per redist version. Only vcruntime140*.dll and msvcp140*.dll
+      are collected, which is the set the native speech stack imports.
+    -->
+    <PropertyGroup Condition="'$(OpenClawVsInstallRoot)' != ''">
+      <_OpenClawVCRedistVersionFile>$(OpenClawVsInstallRoot)\VC\Auxiliary\Build\Microsoft.VCRedistVersion.default.txt</_OpenClawVCRedistVersionFile>
+      <OpenClawVCRedistVersion Condition="Exists('$(_OpenClawVCRedistVersionFile)')">$([System.IO.File]::ReadAllText('$(_OpenClawVCRedistVersionFile)').Trim())</OpenClawVCRedistVersion>
+      <OpenClawVCRedistVersion Condition="'$(OpenClawVCRedistVersion)' == '' or !Exists('$(OpenClawVsInstallRoot)\VC\Redist\MSVC\$(OpenClawVCRedistVersion)')">*</OpenClawVCRedistVersion>
+      <OpenClawVCRedistCrtDir>$(OpenClawVsInstallRoot)\VC\Redist\MSVC\$(OpenClawVCRedistVersion)\$(OpenClawVCRuntimeArch)\Microsoft.VC*.CRT\</OpenClawVCRedistCrtDir>
+    </PropertyGroup>
+
+    <ItemGroup Condition="'$(OpenClawVsInstallRoot)' != ''">
+      <OpenClawVSVCRuntimeFiles Include="$(OpenClawVCRedistCrtDir)vcruntime140*.dll" />
+      <OpenClawVSVCRuntimeFiles Include="$(OpenClawVCRedistCrtDir)msvcp140*.dll" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -192,10 +192,10 @@ root for the native speech stack. Both build legs source their loose VC runtime
 DLLs from the Visual Studio install on the CI runner (resolved via `vswhere` in
 the repo-root `Directory.Build.targets`, consumed by `src\Directory.Build.targets`).
 This ensures the bundled CRT is new enough for `onnxruntime`. Local x64 builds
-and test hosts use the same resolution whenever a Visual Studio install with the
-C++ Redistributable component is present; the `VCRuntime.CefSharp.140` NuGet
-(14.29) is only a fallback for machines without one, and the build warns because
-that runtime is too old for `onnxruntime`. The release validation
+and test hosts use the same resolution whenever the Visual Studio install's
+current redist is at least 14.38 and contains the requested architecture; the
+`VCRuntime.CefSharp.140` NuGet (14.29) is the warned fallback when that compatible
+runtime is missing, stale, or architecture-incomplete. The release validation
 script enforces a minimum VC++ runtime version floor (currently 14.38) to
 prevent regressions, and the x64 verifier load-probes the native TTS stack
 (`onnxruntime.dll`, `sherpa-onnx.dll`, and `sherpa-onnx-c-api.dll`) from the

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -190,9 +190,12 @@ CI also checks native runtime dependencies before release packaging. Both the
 x64 and ARM64 portable payloads must ship `vcruntime140.dll` in the payload
 root for the native speech stack. Both build legs source their loose VC runtime
 DLLs from the Visual Studio install on the CI runner (resolved via `vswhere` in
-`src\Directory.Build.targets`). This ensures the bundled CRT is new enough for
-`onnxruntime` - the `VCRuntime.CefSharp.140` NuGet is only used as a dev-time
-convenience for local `dotnet build` (not publish). The release validation
+the repo-root `Directory.Build.targets`, consumed by `src\Directory.Build.targets`).
+This ensures the bundled CRT is new enough for `onnxruntime`. Local x64 builds
+and test hosts use the same resolution whenever a Visual Studio install with the
+C++ Redistributable component is present; the `VCRuntime.CefSharp.140` NuGet
+(14.29) is only a fallback for machines without one, and the build warns because
+that runtime is too old for `onnxruntime`. The release validation
 script enforces a minimum VC++ runtime version floor (currently 14.38) to
 prevent regressions, and the x64 verifier load-probes the native TTS stack
 (`onnxruntime.dll`, `sherpa-onnx.dll`, and `sherpa-onnx-c-api.dll`) from the

--- a/scripts/test-ci-workflow-contract.ps1
+++ b/scripts/test-ci-workflow-contract.ps1
@@ -436,6 +436,7 @@ foreach ($token in @(
         "'global.json'",
         "'NuGet.Config'",
         "'Directory.Build.props'",
+        "'Directory.Build.targets'",
         "'src/Directory.Build.props'",
         "'src/Directory.Build.targets'",
         "'tests/Directory.Build.props'",

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,87 +1,84 @@
 <Project>
 
-  <PropertyGroup>
-    <OpenClawVCRuntimePackageVersion>1.0.5</OpenClawVCRuntimePackageVersion>
-    <OpenClawVCRuntimePackageRoot>$(NuGetPackageRoot)vcruntime.cefsharp.140\$(OpenClawVCRuntimePackageVersion)\vc_redist\</OpenClawVCRuntimePackageRoot>
-    <OpenClawVCRuntimeArch Condition="'$(RuntimeIdentifier)' == 'win-x64'">x64</OpenClawVCRuntimeArch>
-    <OpenClawVCRuntimeArch Condition="'$(RuntimeIdentifier)' == 'win-arm64'">arm64</OpenClawVCRuntimeArch>
-  </PropertyGroup>
+  <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.targets" />
 
   <!--
-    Both x64 and ARM64 resolve loose VC++ runtime DLLs from the local Visual
-    Studio install at publish time (via ResolveOpenClawVCRuntimeFromVSInstall).
-    This ensures onnxruntime and other native dependencies always get a current
-    CRT — the VCRuntime.CefSharp.140 NuGet ships 14.29 DLLs that are too old
-    for onnxruntime ≥ 1.20.
+    App-local Visual C++ runtime for the tray and the other src projects.
 
-    For local x64 *builds* (not publish), the NuGet DLLs are still copied to
-    the output directory as a convenience so devs without VS can iterate.
-    Local 'dotnet build -r win-arm64' intentionally does NOT require a VS
-    install (so cross-compile sanity checks keep working on x64 dev boxes).
-    The VS-install requirement only kicks in at publish time, which is what
-    the release pipeline actually runs.
+    The native speech stack (onnxruntime, sherpa-onnx) imports the VC++
+    runtime, and onnxruntime >= 1.20 needs 14.38 or newer. Every x64 build and
+    every publish copies loose CRT DLLs next to the executable so the app
+    behaves the same on a clean host as on a dev box.
+
+    The DLLs come from LocateOpenClawVCRuntimeFromVSInstall (repo-root
+    Directory.Build.targets):
+      * Publish (x64 and ARM64): the local Visual Studio install, required.
+        A missing install, component, or DLL set fails the publish.
+      * Local x64 build: the local Visual Studio install when one exists.
+        Without one the build falls back to the VCRuntime.CefSharp.140 NuGet
+        DLLs (14.29) and warns, because that runtime is too old for
+        onnxruntime: the app still builds, but Piper TTS and Silero VAD fail
+        with DllNotFoundException until a current CRT is available.
+      * Local ARM64 build: nothing is copied, so 'dotnet build -r win-arm64'
+        stays a VS-free cross-compile sanity check on x64 dev boxes.
+
+    The 14.29 fallback must never reach a published payload. The release
+    verifier (scripts\Test-ReleaseNativeDependencies.ps1) enforces the 14.38
+    floor and load-probes the native TTS stack; NativeSpeechStackRuntimeTests
+    does the same for local build output and test hosts.
   -->
   <ItemGroup Condition="'$(OpenClawVCRuntimeArch)' == 'x64'">
     <OpenClawVCRuntimeFiles Include="$(OpenClawVCRuntimePackageRoot)x64\*.dll" />
   </ItemGroup>
 
+  <!-- Publish-time resolution: the Visual Studio install is mandatory. -->
   <Target Name="ResolveOpenClawVCRuntimeFromVSInstall"
-          Condition="'$(OpenClawVCRuntimeArch)' != ''">
+          Condition="'$(OpenClawVCRuntimeArch)' != ''"
+          DependsOnTargets="LocateOpenClawVCRuntimeFromVSInstall">
 
-    <PropertyGroup>
-      <_OpenClawVsWherePath>$(MSBuildProgramFiles32)\Microsoft Visual Studio\Installer\vswhere.exe</_OpenClawVsWherePath>
-    </PropertyGroup>
+    <Error Condition="!Exists('$(OpenClawVsWherePath)')"
+           Text="vswhere.exe not found at '$(OpenClawVsWherePath)'. Publishing requires a Visual Studio install with the C++ Redistributable (Microsoft.VisualStudio.Component.VC.Redist.14.Latest) component." />
 
-    <Error Condition="!Exists('$(_OpenClawVsWherePath)')"
-           Text="vswhere.exe not found at '$(_OpenClawVsWherePath)'. Publishing requires a Visual Studio install with the C++ Redistributable (Microsoft.VisualStudio.Component.VC.Redist.14.Latest) component." />
+    <Error Condition="'$(OpenClawVsInstallRoot)' == ''"
+           Text="vswhere did not find a Visual Studio install with the C++ Redistributable (Microsoft.VisualStudio.Component.VC.Redist.14.Latest) component. Install that component via the Visual Studio Installer (Individual Components tab)." />
 
-    <Exec Command="&quot;$(_OpenClawVsWherePath)&quot; -latest -products * -requires Microsoft.VisualStudio.Component.VC.Redist.14.Latest -property installationPath"
-          ConsoleToMSBuild="true"
-          IgnoreExitCode="true">
-      <Output TaskParameter="ConsoleOutput" PropertyName="_OpenClawVsInstallRoot" />
-    </Exec>
+    <Error Condition="'@(OpenClawVSVCRuntimeFiles)' == ''"
+           Text="No $(OpenClawVCRuntimeArch) VC++ Runtime DLLs were found under '$(OpenClawVCRedistCrtDir)'. Install the C++ Redistributable Update Visual Studio component." />
 
-    <Error Condition="'$(_OpenClawVsInstallRoot)' == '' or !Exists('$(_OpenClawVsInstallRoot)')"
-           Text="vswhere did not find a Visual Studio install with the C++ Redistributable (Microsoft.VisualStudio.Component.VC.Redist.14.Latest) component (got '$(_OpenClawVsInstallRoot)'). Install that component via the Visual Studio Installer (Individual Components tab)." />
-
-    <!--
-      Glob the loose CRT DLLs. The Microsoft.VC*.CRT folder name carries the VS
-      major version (Microsoft.VC143.CRT for VS 2022, Microsoft.VC145.CRT for
-      VS 18). There is at most one Microsoft.VC*.CRT subdir per arch per redist
-      version, so the * collapses to a single match. We limit to
-      vcruntime140*.dll + msvcp140*.dll to match the file set required by the
-      native speech stack without carrying unrelated CRT DLLs.
-
-      For x64 this replaces the stale NuGet-sourced items so publish always
-      ships current DLLs from the VS install.
-    -->
-    <ItemGroup Condition="'$(OpenClawVCRuntimeArch)' == 'x64'">
+    <!-- Replace the NuGet-sourced x64 items so publish always ships the VS install's DLLs. -->
+    <ItemGroup>
       <OpenClawVCRuntimeFiles Remove="@(OpenClawVCRuntimeFiles)" />
-      <OpenClawVCRuntimeFiles Include="$(_OpenClawVsInstallRoot)\VC\Redist\MSVC\*\x64\Microsoft.VC*.CRT\vcruntime140*.dll" />
-      <OpenClawVCRuntimeFiles Include="$(_OpenClawVsInstallRoot)\VC\Redist\MSVC\*\x64\Microsoft.VC*.CRT\msvcp140*.dll" />
+      <OpenClawVCRuntimeFiles Include="@(OpenClawVSVCRuntimeFiles)" />
     </ItemGroup>
-
-    <ItemGroup Condition="'$(OpenClawVCRuntimeArch)' == 'arm64'">
-      <OpenClawVCRuntimeFiles Include="$(_OpenClawVsInstallRoot)\VC\Redist\MSVC\*\arm64\Microsoft.VC*.CRT\vcruntime140*.dll" />
-      <OpenClawVCRuntimeFiles Include="$(_OpenClawVsInstallRoot)\VC\Redist\MSVC\*\arm64\Microsoft.VC*.CRT\msvcp140*.dll" />
-    </ItemGroup>
-
-    <Error Condition="'@(OpenClawVCRuntimeFiles)' == ''"
-           Text="No $(OpenClawVCRuntimeArch) VC++ Runtime DLLs were found under '$(_OpenClawVsInstallRoot)\VC\Redist\MSVC\*\$(OpenClawVCRuntimeArch)\Microsoft.VC*.CRT\'. Install the C++ Redistributable Update Visual Studio component." />
   </Target>
 
   <!-- Legacy alias so existing CI log searches and docs still find the target. -->
   <Target Name="ResolveOpenClawVCRuntimeArm64FromVSInstall"
           DependsOnTargets="ResolveOpenClawVCRuntimeFromVSInstall" />
 
+  <!-- Build-time resolution: prefer the Visual Studio install, fall back to NuGet with a warning. -->
+  <Target Name="ResolveOpenClawVCRuntimeForBuild"
+          Condition="'$(OpenClawVCRuntimeArch)' == 'x64'"
+          DependsOnTargets="LocateOpenClawVCRuntimeFromVSInstall">
+
+    <ItemGroup Condition="'@(OpenClawVSVCRuntimeFiles)' != ''">
+      <OpenClawVCRuntimeFiles Remove="@(OpenClawVCRuntimeFiles)" />
+      <OpenClawVCRuntimeFiles Include="@(OpenClawVSVCRuntimeFiles)" />
+    </ItemGroup>
+
+    <Warning Condition="'@(OpenClawVSVCRuntimeFiles)' == ''"
+             Code="OPENCLAW0001"
+             Text="No Visual Studio install with the C++ Redistributable component was found; copying the VCRuntime.CefSharp.140 (14.29) runtime to '$(TargetDir)'. onnxruntime needs 14.38 or newer, so Piper TTS and Silero VAD will fail to load from this output. Install 'C++ Redistributable Update' (Microsoft.VisualStudio.Component.VC.Redist.14.Latest) via the Visual Studio Installer." />
+  </Target>
+
   <Target Name="CopyOpenClawVCRuntimeToOutput"
           AfterTargets="Build"
-          Condition="'$(OpenClawVCRuntimeArch)' == 'x64' and '@(OpenClawVCRuntimeFiles)' != ''">
+          DependsOnTargets="ResolveOpenClawVCRuntimeForBuild"
+          Condition="'$(OpenClawVCRuntimeArch)' == 'x64'">
     <!--
       x64-only on purpose. ARM64 publishes its runtime through the publish-only
       target below so that local 'dotnet build -r win-arm64' does not require
       a Visual Studio install.
-      Uses the NuGet-sourced DLLs (the VS resolution only runs at publish).
     -->
     <Copy SourceFiles="@(OpenClawVCRuntimeFiles)"
           DestinationFolder="$(TargetDir)"

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -43,7 +43,7 @@
            Text="vswhere did not find a Visual Studio install with the C++ Redistributable (Microsoft.VisualStudio.Component.VC.Redist.14.Latest) component. Install that component via the Visual Studio Installer (Individual Components tab)." />
 
     <Error Condition="'@(OpenClawVSVCRuntimeFiles)' == ''"
-           Text="No $(OpenClawVCRuntimeArch) VC++ Runtime DLLs were found under '$(OpenClawVCRedistCrtDir)'. Install the C++ Redistributable Update Visual Studio component." />
+           Text="The Visual Studio VC++ Redistributable could not be used for $(OpenClawVCRuntimeArch). Version file '$(_OpenClawVCRedistVersionFile)' reported '$(OpenClawVCRedistVersion)' (minimum $(OpenClawVCRuntimeMinimumVersion)); resolved CRT directory: '$(OpenClawVCRedistCrtDir)'; expected architecture path: '$(OpenClawVsInstallRoot)\VC\Redist\MSVC\$(OpenClawVCRedistVersion)\$(OpenClawVCRuntimeArch)'. Install or update the C++ Redistributable Update Visual Studio component." />
 
     <!-- Replace the NuGet-sourced x64 items so publish always ships the VS install's DLLs. -->
     <ItemGroup>
@@ -68,7 +68,7 @@
 
     <Warning Condition="'@(OpenClawVSVCRuntimeFiles)' == ''"
              Code="OPENCLAW0001"
-             Text="No Visual Studio install with the C++ Redistributable component was found; copying the VCRuntime.CefSharp.140 (14.29) runtime to '$(TargetDir)'. onnxruntime needs 14.38 or newer, so Piper TTS and Silero VAD will fail to load from this output. Install 'C++ Redistributable Update' (Microsoft.VisualStudio.Component.VC.Redist.14.Latest) via the Visual Studio Installer." />
+             Text="No compatible Visual Studio VC++ Redistributable at or above $(OpenClawVCRuntimeMinimumVersion) was found; copying the VCRuntime.CefSharp.140 (14.29) runtime to '$(TargetDir)'. Piper TTS and Silero VAD will fail to load from this output. Install or update 'C++ Redistributable Update' (Microsoft.VisualStudio.Component.VC.Redist.14.Latest) via the Visual Studio Installer." />
   </Target>
 
   <Target Name="CopyOpenClawVCRuntimeToOutput"

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,6 +1,6 @@
 <Project>
 
-  <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.targets" />
+  <Import Project="..\Directory.Build.targets" />
 
   <!--
     App-local Visual C++ runtime for the tray and the other src projects.

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -15,6 +15,12 @@
     <IsPackable>false</IsPackable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <OpenClawVCRuntimeVersion>1.0.5</OpenClawVCRuntimeVersion>
+    <OpenClawVCRuntimePackageVersion>$(OpenClawVCRuntimeVersion)</OpenClawVCRuntimePackageVersion>
+    <!-- Test hosts load native speech dependencies from their own output, so
+         they get the same app-local VC++ runtime as the tray (see the repo-root
+         Directory.Build.targets): x64 unless the RID or the host is ARM64,
+         because the NuGet fallback ships no ARM64 DLLs. -->
+    <OpenClawVCRuntimeArch Condition="'$(OS)' == 'Windows_NT' and '$(RuntimeIdentifier)' == '' and '$(PROCESSOR_ARCHITECTURE)' != 'ARM64'">x64</OpenClawVCRuntimeArch>
     <!-- Audit direct + transitive dependencies for known CVEs during restore,
          matching the setting in src/Directory.Build.props. -->
     <NuGetAuditMode>all</NuGetAuditMode>
@@ -38,10 +44,23 @@
     <Using Include="Xunit" />
   </ItemGroup>
 
-  <Target Name="CopyWindowsNativeRuntimeForTestHost" AfterTargets="Build" Condition="'$(OS)' == 'Windows_NT'">
+  <!--
+    Copy an app-local VC++ runtime next to the test host. onnxruntime >= 1.20
+    needs 14.38 or newer, so prefer the Visual Studio install's DLLs and only
+    fall back to the VCRuntime.CefSharp.140 (14.29) DLLs, with a warning, when
+    no such install exists. NativeSpeechStackRuntimeTests load-probes the result.
+  -->
+  <Target Name="CopyWindowsNativeRuntimeForTestHost"
+          AfterTargets="Build"
+          DependsOnTargets="LocateOpenClawVCRuntimeFromVSInstall"
+          Condition="'$(OS)' == 'Windows_NT' and '$(OpenClawVCRuntimeArch)' == 'x64'">
     <ItemGroup>
-      <OpenClawNativeRuntime Include="$(NuGetPackageRoot)vcruntime.cefsharp.140\$(OpenClawVCRuntimeVersion)\vc_redist\x64\*.dll" Condition="'$(PROCESSOR_ARCHITECTURE)' != 'ARM64' And Exists('$(NuGetPackageRoot)vcruntime.cefsharp.140\$(OpenClawVCRuntimeVersion)\vc_redist\x64\vcruntime140.dll')" />
+      <OpenClawNativeRuntime Include="@(OpenClawVSVCRuntimeFiles)" />
+      <OpenClawNativeRuntime Include="$(OpenClawVCRuntimePackageRoot)x64\*.dll" Condition="'@(OpenClawVSVCRuntimeFiles)' == ''" />
     </ItemGroup>
+    <Warning Condition="'@(OpenClawVSVCRuntimeFiles)' == ''"
+             Code="OPENCLAW0001"
+             Text="No Visual Studio install with the C++ Redistributable component was found; copying the VCRuntime.CefSharp.140 (14.29) runtime to '$(TargetDir)'. onnxruntime needs 14.38 or newer, so native speech tests will fail to load it. Install 'C++ Redistributable Update' (Microsoft.VisualStudio.Component.VC.Redist.14.Latest) via the Visual Studio Installer." />
     <Copy SourceFiles="@(OpenClawNativeRuntime)" DestinationFolder="$(TargetDir)" SkipUnchangedFiles="true" />
   </Target>
 

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -60,7 +60,7 @@
     </ItemGroup>
     <Warning Condition="'@(OpenClawVSVCRuntimeFiles)' == ''"
              Code="OPENCLAW0001"
-             Text="No Visual Studio install with the C++ Redistributable component was found; copying the VCRuntime.CefSharp.140 (14.29) runtime to '$(TargetDir)'. onnxruntime needs 14.38 or newer, so native speech tests will fail to load it. Install 'C++ Redistributable Update' (Microsoft.VisualStudio.Component.VC.Redist.14.Latest) via the Visual Studio Installer." />
+             Text="No compatible Visual Studio VC++ Redistributable at or above $(OpenClawVCRuntimeMinimumVersion) was found; copying the VCRuntime.CefSharp.140 (14.29) runtime to '$(TargetDir)'. Native speech tests will fail to load it. Install or update 'C++ Redistributable Update' (Microsoft.VisualStudio.Component.VC.Redist.14.Latest) via the Visual Studio Installer." />
     <Copy SourceFiles="@(OpenClawNativeRuntime)" DestinationFolder="$(TargetDir)" SkipUnchangedFiles="true" />
   </Target>
 

--- a/tests/OpenClaw.Tray.Tests/NativeSpeechStackRuntimeTests.cs
+++ b/tests/OpenClaw.Tray.Tests/NativeSpeechStackRuntimeTests.cs
@@ -114,7 +114,7 @@ public sealed class NativeSpeechStackRuntimeTests
         try
         {
             var handle = LoadLibraryExW(library, IntPtr.Zero, LoadLibrarySearchDllLoadDir | LoadLibrarySearchDefaultDirs);
-            var error = Marshal.GetLastWin32Error();
+            var error = Marshal.GetLastPInvokeError();
             if (handle == IntPtr.Zero)
             {
                 var msvcp = Path.Combine(runtimeDirectory, "msvcp140.dll");
@@ -138,10 +138,18 @@ public sealed class NativeSpeechStackRuntimeTests
 
     private static string? FindOnnxRuntime(string baseDirectory)
     {
+        // A RID-specific build places the native asset at the root. A no-RID
+        // build copies every runtimes/<rid>/native folder, so pick the one that
+        // matches this process rather than the first one that exists.
+        var rid = RuntimeInformation.ProcessArchitecture switch
+        {
+            Architecture.Arm64 => "win-arm64",
+            _ => "win-x64",
+        };
         var candidates = new[]
         {
             Path.Combine(baseDirectory, "onnxruntime.dll"),
-            Path.Combine(baseDirectory, "runtimes", "win-x64", "native", "onnxruntime.dll"),
+            Path.Combine(baseDirectory, "runtimes", rid, "native", "onnxruntime.dll"),
         };
         return candidates.FirstOrDefault(File.Exists);
     }

--- a/tests/OpenClaw.Tray.Tests/NativeSpeechStackRuntimeTests.cs
+++ b/tests/OpenClaw.Tray.Tests/NativeSpeechStackRuntimeTests.cs
@@ -1,0 +1,191 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace OpenClaw.Tray.Tests;
+
+/// <summary>
+/// Guards the app-local Visual C++ runtime that local builds and test hosts
+/// copy next to the native speech stack.
+///
+/// onnxruntime &gt;= 1.20 needs VC++ 14.38 or newer. An older app-local
+/// msvcp140.dll shadows the system runtime, onnxruntime.dll then fails to
+/// initialize (Win32 error 1114), and the Piper TTS client surfaces that as
+/// DllNotFoundException. scripts/Test-ReleaseNativeDependencies.ps1 covers
+/// published payloads; these tests cover what developers actually run.
+/// </summary>
+public sealed class NativeSpeechStackRuntimeTests
+{
+    // Same floor as scripts/Test-ReleaseNativeDependencies.ps1: VS 17.8, the first 14.38 release.
+    private static readonly Version VCRuntimeMinVersion = new(14, 38, 33130, 0);
+
+    private const uint LoadLibrarySearchDllLoadDir = 0x00000100;
+    private const uint LoadLibrarySearchDefaultDirs = 0x00001000;
+
+    [Fact]
+    public void TestHost_AppLocalVCRuntime_MeetsOnnxRuntimeFloor()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        var msvcp = Path.Combine(AppContext.BaseDirectory, "msvcp140.dll");
+        if (!File.Exists(msvcp))
+            return; // No app-local runtime: the system runtime is used and nothing can be shadowed.
+
+        AssertMeetsFloor(msvcp);
+    }
+
+    [Fact]
+    public void TestHost_OnnxRuntime_LoadsWithAppLocalVCRuntime()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        var onnxRuntime = FindOnnxRuntime(AppContext.BaseDirectory);
+        Assert.True(onnxRuntime != null, $"onnxruntime.dll was not found under {AppContext.BaseDirectory}.");
+
+        AssertLoads(onnxRuntime!, AppContext.BaseDirectory);
+    }
+
+    [Fact]
+    public void TrayBuildOutput_NativeTtsStack_LoadsWithAppLocalVCRuntime()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        // CI builds src/OpenClaw.Tray.WinUI -r win-x64 before this suite. A local
+        // checkout that has not built the tray has no output to guard yet.
+        var outputDirectory = FindTrayOutputDirectory();
+        if (outputDirectory == null)
+            return;
+
+        var msvcp = Path.Combine(outputDirectory, "msvcp140.dll");
+        Assert.True(File.Exists(msvcp), $"msvcp140.dll was not copied to {outputDirectory}.");
+        AssertMeetsFloor(msvcp);
+
+        AssertLoads(Path.Combine(outputDirectory, "onnxruntime.dll"), outputDirectory);
+        AssertLoads(Path.Combine(outputDirectory, "sherpa-onnx-c-api.dll"), outputDirectory);
+    }
+
+    [Fact]
+    public void BuildTargets_ResolveVCRuntimeFromVSInstallForLocalBuilds()
+    {
+        var root = TestRepositoryPaths.GetRepositoryRoot();
+        var shared = File.ReadAllText(Path.Combine(root, "Directory.Build.targets"));
+        var src = File.ReadAllText(Path.Combine(root, "src", "Directory.Build.targets"));
+        var tests = File.ReadAllText(Path.Combine(root, "tests", "Directory.Build.props"));
+
+        Assert.Contains("Target Name=\"LocateOpenClawVCRuntimeFromVSInstall\"", shared);
+        Assert.Contains("Microsoft.VCRedistVersion.default.txt", shared);
+
+        Assert.Contains("Target Name=\"ResolveOpenClawVCRuntimeForBuild\"", src);
+        Assert.Contains("DependsOnTargets=\"LocateOpenClawVCRuntimeFromVSInstall\"", src);
+        Assert.Matches(
+            "Target Name=\"CopyOpenClawVCRuntimeToOutput\"[^>]*DependsOnTargets=\"ResolveOpenClawVCRuntimeForBuild\"",
+            src);
+
+        Assert.Contains("DependsOnTargets=\"LocateOpenClawVCRuntimeFromVSInstall\"", tests);
+        Assert.Contains("@(OpenClawVSVCRuntimeFiles)", tests);
+    }
+
+    private static void AssertMeetsFloor(string runtimeDll)
+    {
+        var info = FileVersionInfo.GetVersionInfo(runtimeDll);
+        var version = new Version(info.FileMajorPart, info.FileMinorPart, info.FileBuildPart, info.FilePrivatePart);
+        Assert.True(
+            version >= VCRuntimeMinVersion,
+            $"{runtimeDll} is VC++ runtime {version}, older than the {VCRuntimeMinVersion} floor onnxruntime needs. " +
+            "The build copied the VCRuntime.CefSharp.140 fallback instead of the Visual Studio install's runtime; " +
+            "install the 'C++ Redistributable Update' Visual Studio component and rebuild.");
+    }
+
+    /// <summary>
+    /// Load <paramref name="library"/> the way the app's loader would: the
+    /// DLL's own directory first, then <paramref name="runtimeDirectory"/>
+    /// (where the app-local CRT lives), then the default system directories.
+    /// </summary>
+    private static void AssertLoads(string library, string runtimeDirectory)
+    {
+        Assert.True(File.Exists(library), $"{library} does not exist.");
+
+        var cookie = AddDllDirectory(runtimeDirectory);
+        Assert.True(cookie != IntPtr.Zero, $"AddDllDirectory failed for {runtimeDirectory}.");
+        try
+        {
+            var handle = LoadLibraryExW(library, IntPtr.Zero, LoadLibrarySearchDllLoadDir | LoadLibrarySearchDefaultDirs);
+            var error = Marshal.GetLastWin32Error();
+            if (handle == IntPtr.Zero)
+            {
+                var msvcp = Path.Combine(runtimeDirectory, "msvcp140.dll");
+                var msvcpVersion = File.Exists(msvcp)
+                    ? FileVersionInfo.GetVersionInfo(msvcp).FileVersion
+                    : "(none)";
+                Assert.Fail(
+                    $"{Path.GetFileName(library)} failed to load from {Path.GetDirectoryName(library)} " +
+                    $"(Win32 error {error}: {new Win32Exception(error).Message}). " +
+                    $"App-local msvcp140.dll version: {msvcpVersion}. " +
+                    "Error 1114 means the app-local VC++ runtime is older than onnxruntime requires.");
+            }
+
+            FreeLibrary(handle);
+        }
+        finally
+        {
+            RemoveDllDirectory(cookie);
+        }
+    }
+
+    private static string? FindOnnxRuntime(string baseDirectory)
+    {
+        var candidates = new[]
+        {
+            Path.Combine(baseDirectory, "onnxruntime.dll"),
+            Path.Combine(baseDirectory, "runtimes", "win-x64", "native", "onnxruntime.dll"),
+        };
+        return candidates.FirstOrDefault(File.Exists);
+    }
+
+    private static string? FindTrayOutputDirectory()
+    {
+        var configuration = Assembly.GetExecutingAssembly()
+            .GetCustomAttribute<AssemblyConfigurationAttribute>()?
+            .Configuration;
+        if (string.IsNullOrWhiteSpace(configuration))
+            return null;
+
+        var binDirectory = Path.Combine(TestRepositoryPaths.GetRepositoryRoot(), "src", "OpenClaw.Tray.WinUI", "bin");
+        if (!Directory.Exists(binDirectory))
+            return null;
+
+        // dotnet build -r win-x64 writes bin/<Configuration>/<tfm>/win-x64;
+        // Visual Studio's x64 platform writes bin/x64/<Configuration>/<tfm>/win-x64.
+        var configurationDirectories = new[]
+        {
+            Path.Combine(binDirectory, configuration),
+            Path.Combine(binDirectory, "x64", configuration),
+        };
+
+        return configurationDirectories
+            .Where(Directory.Exists)
+            .SelectMany(directory => Directory.EnumerateDirectories(directory, "net10.0-windows*"))
+            .Select(directory => Path.Combine(directory, "win-x64"))
+            .Where(directory => File.Exists(Path.Combine(directory, "OpenClaw.Tray.WinUI.exe")))
+            .OrderByDescending(directory => File.GetLastWriteTimeUtc(Path.Combine(directory, "OpenClaw.Tray.WinUI.exe")))
+            .FirstOrDefault();
+    }
+
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern IntPtr LoadLibraryExW(string lpLibFileName, IntPtr hFile, uint dwFlags);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool FreeLibrary(IntPtr hModule);
+
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern IntPtr AddDllDirectory(string newDirectory);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool RemoveDllDirectory(IntPtr cookie);
+}

--- a/tests/OpenClaw.Tray.Tests/NativeSpeechStackRuntimeTests.cs
+++ b/tests/OpenClaw.Tray.Tests/NativeSpeechStackRuntimeTests.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace OpenClaw.Tray.Tests;
 
@@ -81,9 +82,30 @@ public sealed class NativeSpeechStackRuntimeTests
         var shared = File.ReadAllText(Path.Combine(root, "Directory.Build.targets"));
         var src = File.ReadAllText(Path.Combine(root, "src", "Directory.Build.targets"));
         var tests = File.ReadAllText(Path.Combine(root, "tests", "Directory.Build.props"));
+        var releaseValidation = File.ReadAllText(Path.Combine(
+            root,
+            "scripts",
+            "Test-ReleaseNativeDependencies.ps1"));
 
         Assert.Contains("Target Name=\"LocateOpenClawVCRuntimeFromVSInstall\"", shared);
         Assert.Contains("Microsoft.VCRedistVersion.default.txt", shared);
+        Assert.Contains("OpenClawVCRuntimeMinimumVersion", shared);
+        Assert.Contains("VersionGreaterThanOrEquals", shared);
+        Assert.Contains("Regex]::IsMatch", shared);
+        Assert.Contains(
+            "Condition=\"'$(OpenClawVCRedistVersion)' == '' and Exists",
+            shared);
+        Assert.Contains(
+            $">{VCRuntimeMinVersion.ToString(3)}</OpenClawVCRuntimeMinimumVersion>",
+            shared);
+        Assert.Contains(
+            $"VCRuntimeMinVersion = [version]\"{VCRuntimeMinVersion}\"",
+            releaseValidation);
+        Assert.Contains(
+            "OpenClawVCRuntimeVersionIsSupported)' == 'true'",
+            shared);
+        Assert.DoesNotContain(">*</OpenClawVCRedistVersion>", shared);
+        Assert.DoesNotContain(@"Redist\MSVC\*\", shared);
 
         Assert.Contains("Target Name=\"ResolveOpenClawVCRuntimeForBuild\"", src);
         Assert.Contains("DependsOnTargets=\"LocateOpenClawVCRuntimeFromVSInstall\"", src);
@@ -134,7 +156,22 @@ public sealed class NativeSpeechStackRuntimeTests
                     "Error 1114 means the app-local VC++ runtime is older than onnxruntime requires.");
             }
 
-            FreeLibrary(handle);
+            try
+            {
+                var loadedPath = new StringBuilder(32_768);
+                var length = GetModuleFileNameW(handle, loadedPath, loadedPath.Capacity);
+                Assert.True(length > 0, $"GetModuleFileNameW failed for {library}.");
+                Assert.True(
+                    string.Equals(
+                        Path.GetFullPath(library),
+                        Path.GetFullPath(loadedPath.ToString()),
+                        StringComparison.OrdinalIgnoreCase),
+                    $"Requested {library}, but Windows reused {loadedPath}.");
+            }
+            finally
+            {
+                FreeLibrary(handle);
+            }
         }
         finally
         {
@@ -195,6 +232,12 @@ public sealed class NativeSpeechStackRuntimeTests
     [DllImport("kernel32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     private static extern bool FreeLibrary(IntPtr hModule);
+
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern int GetModuleFileNameW(
+        IntPtr hModule,
+        StringBuilder lpFilename,
+        int nSize);
 
     [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
     private static extern IntPtr AddDllDirectory(string newDirectory);

--- a/tests/OpenClaw.Tray.Tests/NativeSpeechStackRuntimeTests.cs
+++ b/tests/OpenClaw.Tray.Tests/NativeSpeechStackRuntimeTests.cs
@@ -54,6 +54,12 @@ public sealed class NativeSpeechStackRuntimeTests
         if (!OperatingSystem.IsWindows())
             return;
 
+        // FindTrayOutputDirectory only discovers win-x64 output, and this probe
+        // loads that output into the test process. A native ARM64 test host
+        // cannot load x64 DLLs, so only an x64 process can exercise it.
+        if (RuntimeInformation.ProcessArchitecture != Architecture.X64)
+            return;
+
         // CI builds src/OpenClaw.Tray.WinUI -r win-x64 before this suite. A local
         // checkout that has not built the tray has no output to guard yet.
         var outputDirectory = FindTrayOutputDirectory();


### PR DESCRIPTION
## Problem

Local `dotnet build` and `run-app-local.ps1` outputs copied the `VCRuntime.CefSharp.140` NuGet runtime (VC++ 14.29) next to the tray and test hosts. `onnxruntime` 1.29 requires VC++ 14.38 or newer, so the app-local `msvcp140.dll` shadowed the system runtime, `onnxruntime.dll` failed initialization with Win32 error 1114, and every Piper voice preview failed with `DllNotFoundException`.

Published release builds already sourced a current runtime from Visual Studio. Local builds and test hosts did not.

## Fix

- add one repo-root VC++ runtime resolver shared by source projects and test hosts
- use the Visual Studio install's current redist only when its version is valid, at least 14.38.33130, and contains the requested architecture
- copy one deterministic redist version instead of wildcard-copying multiple installed versions
- preserve a non-failing local-build fallback to the NuGet 14.29 runtime with warning `OPENCLAW0001`
- keep publish fail-closed when a compatible runtime is unavailable
- preserve an explicit `OpenClawVsInstallRoot` or `OpenClawVCRedistVersion` override when valid
- treat missing, malformed, stale, and architecture-incomplete Visual Studio redist state as unresolved instead of crashing MSBuild
- verify native load probes use the DLL from the requested build output, not an already-loaded module with the same base name
- hash the new root `Directory.Build.targets` in the CI NuGet cache key
- update developer and release documentation

## Required proof pools

- `windows-winui-interactive`: contributor proof on the original implementation exercised Settings > Voice & Audio > Piper Preview with isolated tray data and confirmed synthesis plus playback. The current head changes only harden build-time runtime selection and regression checks. Current-head native load probes directly exercise the original failure boundary from the produced tray output.

## Validation

Current head: `920078a6`.

Local current-head validation:

- `.\build.ps1`: passed
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore`: 3,937 passed, 32 skipped
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore`: 2,862 passed
- `NativeSpeechStackRuntimeTests`: 4 passed
- `scripts\test-ci-workflow-contract.ps1`: passed
- fake VC++ 14.29 Visual Studio layout: local fallback emitted `OPENCLAW0001`; publish rejected it
- malformed `Microsoft.VCRedistVersion.default.txt`: local fallback emitted `OPENCLAW0001`; publish rejected it with the exact version file and architecture path
- x64-host cross-publish for `win-arm64`: passed
- ARM64 release native dependency policy: passed
- final structured autoreview: clean, no accepted/actionable findings
- independent rubber-duck review: all accepted resolver, wildcard, version-floor, diagnostic, module-origin, and ARM64 proof findings addressed

Current-head PR workflow [34313774261](https://github.com/openclaw/openclaw-windows-node/actions/runs/34313774261):

- Core and CLI tests: passed
- Tray, setup, and integration tests: passed
- UI, functional, and accessibility tests: passed
- Setup and connect E2E: passed
- Network recovery E2E: passed
- Revocation recovery E2E: passed
- x64 release publish smoke: passed
- proof contracts, release metadata, and CI Gate: passed

Real `windows-11-arm` proof:

- workflow run [34313909091](https://github.com/openclaw/openclaw-windows-node/actions/runs/34313909091), job [ARM64 release publish](https://github.com/openclaw/openclaw-windows-node/actions/runs/34313909091/job/102346210480): passed
- that job restored and published the self-contained `win-arm64` tray payload and passed `Test-ReleaseNativeDependencies.ps1 -RequireAppLocalVCRuntime -SkipNativeLoadProbe`
- the temporary proof run's overall conclusion was failure only because its token-safe branch intentionally omitted the workflow cache-key edit, causing the cache contract test to fail, plus the known unrelated Piper extractor cleanup flake. The ARM64 release job itself passed.

## Real behavior proof

Current-head automated proof establishes:

- `msvcp140.dll` beside the local tray and test hosts meets the 14.38 floor
- `onnxruntime.dll` loads successfully from the current-head local tray output
- `sherpa-onnx-c-api.dll` loads successfully from the current-head local tray output
- `GetModuleFileNameW` confirms Windows loaded the requested output DLL instead of reusing another module with the same base name
- the current machine copied VC++ 14.51.36247.0 beside the tray and test hosts
- publish fails before packaging when the selected Visual Studio runtime is missing, malformed, below the floor, or missing the requested architecture
- local builds remain available on machines without a compatible Visual Studio redist, but emit the explicit `OPENCLAW0001` warning and preserve the previous 14.29 fallback behavior

Contributor visible playback proof:

- isolated tray data contained only the `en_GB-alan-low` voice and minimal settings
- Settings > Voice & Audio > Piper > Preview synthesized and played the preview sentence
- the isolated log recorded `Piper voice 'en_GB-alan-low' loaded (sample rate 16000 Hz, 16 threads)`
- before the fix, the same path consistently logged `Piper voice preview failed: System.DllNotFoundException: Piper TTS native library could not be loaded`

Not verified / blocked:

- a new current-head screenshot or video was not captured because the background-safe Computer Use host could not deliver the focus-dependent Settings hotkey even after the user made the desktop available
- the no-Visual-Studio fallback was exercised with missing, old, and malformed resolver inputs rather than by uninstalling Visual Studio

## Security impact

No new permissions, capabilities, secrets, network calls, command surfaces, or data access. The build copies Microsoft-signed runtime DLLs from the local Visual Studio installation, with a version floor and fail-closed publish behavior.