### PR TITLE
Avoid repeated WSL check before installation

### DIFF
--- a/src/OpenClaw.SetupEngine/PreflightWslStep.cs
+++ b/src/OpenClaw.SetupEngine/PreflightWslStep.cs
@@ -188,6 +188,7 @@ public sealed class PreflightWslStep : SetupStep
 
     public override async Task<StepResult> ExecuteAsync(SetupContext ctx, CancellationToken ct)
     {
+        ctx.WslViability = null;
         WslViabilityResult viability = await WslViabilityInspector.InspectAsync(
             ctx.Commands,
             ctx.Logger,
@@ -279,15 +280,25 @@ public sealed class PreflightWslStep : SetupStep
 public sealed class EnsureWslPlatformStep : SetupStep
 {
     private readonly Func<SetupContext, CancellationToken, Task<StepResult>> _installer;
+    private readonly bool _reusePreflightResult;
 
     public EnsureWslPlatformStep()
-        : this(PreflightWslStep.InstallWslPlatformAsync)
+        : this(PreflightWslStep.InstallWslPlatformAsync, reusePreflightResult: false)
+    {
+    }
+
+    internal EnsureWslPlatformStep(bool reusePreflightResult)
+        : this(PreflightWslStep.InstallWslPlatformAsync, reusePreflightResult)
     {
     }
 
     internal EnsureWslPlatformStep(
-        Func<SetupContext, CancellationToken, Task<StepResult>> installer) =>
+        Func<SetupContext, CancellationToken, Task<StepResult>> installer,
+        bool reusePreflightResult = false)
+    {
         _installer = installer ?? throw new ArgumentNullException(nameof(installer));
+        _reusePreflightResult = reusePreflightResult;
+    }
 
     public override string Id => "ensure-wsl-platform";
     public override string DisplayName => "Prepare WSL platform";
@@ -295,8 +306,16 @@ public sealed class EnsureWslPlatformStep : SetupStep
 
     public override async Task<StepResult> ExecuteAsync(SetupContext ctx, CancellationToken ct)
     {
-        WslViabilityResult viability = ctx.WslViability
-            ?? await WslViabilityInspector.InspectAsync(ctx.Commands, ctx.Logger, ct);
+        WslViabilityResult viability;
+        if (_reusePreflightResult && ctx.WslViability is { } preflightViability)
+        {
+            viability = preflightViability;
+        }
+        else
+        {
+            ctx.WslViability = null;
+            viability = await WslViabilityInspector.InspectAsync(ctx.Commands, ctx.Logger, ct);
+        }
         ctx.WslViability = viability;
 
         if (viability.Kind == WslViabilityKind.Ready)
@@ -304,6 +323,7 @@ public sealed class EnsureWslPlatformStep : SetupStep
         if (viability.BlocksSetup)
             return StepResult.Terminal(viability.Description);
 
+        ctx.WslViability = null;
         StepResult install = await _installer(ctx, ct);
         if (!install.IsSuccess)
             return install;

--- a/src/OpenClaw.SetupEngine/PreflightWslStep.cs
+++ b/src/OpenClaw.SetupEngine/PreflightWslStep.cs
@@ -295,10 +295,8 @@ public sealed class EnsureWslPlatformStep : SetupStep
 
     public override async Task<StepResult> ExecuteAsync(SetupContext ctx, CancellationToken ct)
     {
-        WslViabilityResult viability = await WslViabilityInspector.InspectAsync(
-            ctx.Commands,
-            ctx.Logger,
-            ct);
+        WslViabilityResult viability = ctx.WslViability
+            ?? await WslViabilityInspector.InspectAsync(ctx.Commands, ctx.Logger, ct);
         ctx.WslViability = viability;
 
         if (viability.Kind == WslViabilityKind.Ready)

--- a/src/OpenClaw.SetupEngine/SetupPipeline.cs
+++ b/src/OpenClaw.SetupEngine/SetupPipeline.cs
@@ -60,7 +60,7 @@ public static class SetupStepFactory
             new PreflightLocalAiHardwareStep(),
             new PreflightWslStep(),
             new PreflightWindowsTailscaleStep(),
-            new EnsureWslPlatformStep(),
+            new EnsureWslPlatformStep(reusePreflightResult: true),
             new ReconcileLocalAiInstallationStep(),
             new AcquireLocalAiRuntimeStep(),
             new AcquireLocalAiModelStep(),

--- a/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
@@ -2121,11 +2121,13 @@ public class SetupStepsTests : IDisposable
             _ => Fail($"unexpected args: {string.Join(' ', args)}"),
         });
         var ctx = CreateContext(commands: commands);
-        var ensure = new EnsureWslPlatformStep((_, _) =>
-        {
-            installed = true;
-            return Task.FromResult(StepResult.Ok("installed"));
-        });
+        var ensure = new EnsureWslPlatformStep(
+            (_, _) =>
+            {
+                installed = true;
+                return Task.FromResult(StepResult.Ok("installed"));
+            },
+            reusePreflightResult: true);
         var pipeline = new SetupPipeline([new PreflightWslStep(), ensure]);
 
         var result = await pipeline.RunAsync(ctx);
@@ -2146,11 +2148,13 @@ public class SetupStepsTests : IDisposable
             _ => Fail($"unexpected args: {string.Join(' ', args)}"),
         });
         var ctx = CreateContext(commands: commands);
-        var ensure = new EnsureWslPlatformStep((_, _) =>
-        {
-            installCalls++;
-            return Task.FromResult(StepResult.Ok("installed"));
-        });
+        var ensure = new EnsureWslPlatformStep(
+            (_, _) =>
+            {
+                installCalls++;
+                return Task.FromResult(StepResult.Ok("installed"));
+            },
+            reusePreflightResult: true);
         var pipeline = new SetupPipeline([new PreflightWslStep(), ensure]);
 
         var result = await pipeline.RunAsync(ctx);
@@ -2169,8 +2173,12 @@ public class SetupStepsTests : IDisposable
             : Fail($"unexpected args: {string.Join(' ', args)}"));
         var ctx = CreateContext(commands: commands);
         var pipeline = new SetupPipeline(
-            [new PreflightWslStep(), new EnsureWslPlatformStep((_, _) =>
-                Task.FromResult(StepResult.Ok("installed")))]);
+            [
+                new PreflightWslStep(),
+                new EnsureWslPlatformStep(
+                    (_, _) => Task.FromResult(StepResult.Ok("installed")),
+                    reusePreflightResult: true),
+            ]);
 
         var result = await pipeline.RunAsync(ctx);
 
@@ -2210,6 +2218,162 @@ public class SetupStepsTests : IDisposable
         Assert.Equal(1, installCalls);
         Assert.Equal(WslViabilityKind.Ready, ctx.WslViability?.Kind);
         Assert.Equal(3, commands.Calls.Count);
+    }
+
+    [Fact]
+    public async Task EnsureWslPlatform_StandaloneIgnoresCachedReadyResult()
+    {
+        var installed = false;
+        var installCalls = 0;
+        var commands = new FakeCommandRunner(args => args switch
+        {
+            ["--version"] when !installed => new CommandResult(
+                1,
+                "",
+                "Windows Subsystem for Linux is not installed. See https://aka.ms/wslinstall",
+                TimeSpan.Zero,
+                TimedOut: false),
+            ["--version"] => Ok("WSL version: 2.7.3.0\n"),
+            ["--status"] => Ok("Default Version: 2\n"),
+            _ => Fail($"unexpected args: {string.Join(' ', args)}"),
+        });
+        var ctx = CreateContext(commands: commands);
+        ctx.WslViability = new WslViabilityResult(
+            WslViabilityKind.Ready,
+            "stale ready",
+            string.Empty);
+        var step = new EnsureWslPlatformStep((_, _) =>
+        {
+            installCalls++;
+            installed = true;
+            return Task.FromResult(StepResult.Ok("installed"));
+        });
+
+        var result = await step.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.Success, result.Outcome);
+        Assert.Equal(1, installCalls);
+        Assert.Equal(3, commands.Calls.Count);
+        Assert.Equal(WslViabilityKind.Ready, ctx.WslViability?.Kind);
+    }
+
+    [Fact]
+    public async Task EnsureWslPlatform_StandaloneIgnoresCachedInstallableResult()
+    {
+        var installCalls = 0;
+        var commands = new FakeCommandRunner(args => args switch
+        {
+            ["--version"] => Ok("WSL version: 2.7.3.0\n"),
+            ["--status"] => Ok("Default Version: 2\n"),
+            _ => Fail($"unexpected args: {string.Join(' ', args)}"),
+        });
+        var ctx = CreateContext(commands: commands);
+        ctx.WslViability = new WslViabilityResult(
+            WslViabilityKind.Installable,
+            "stale missing",
+            string.Empty);
+        var step = new EnsureWslPlatformStep((_, _) =>
+        {
+            installCalls++;
+            return Task.FromResult(StepResult.Ok("installed"));
+        });
+
+        var result = await step.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.Success, result.Outcome);
+        Assert.Equal(0, installCalls);
+        Assert.Equal(2, commands.Calls.Count);
+        Assert.Equal(WslViabilityKind.Ready, ctx.WslViability?.Kind);
+    }
+
+    [Fact]
+    public async Task PreflightWsl_ClearsCachedResultBeforeCanceledInspection()
+    {
+        var commands = new FakeCommandRunner(
+            _ => Ok(),
+            runWithCancellation: (_, _, _, cancellationToken) =>
+                throw new OperationCanceledException(cancellationToken));
+        var ctx = CreateContext(commands: commands);
+        ctx.WslViability = new WslViabilityResult(
+            WslViabilityKind.Ready,
+            "stale ready",
+            string.Empty);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => new PreflightWslStep().ExecuteAsync(ctx, CancellationToken.None));
+
+        Assert.Null(ctx.WslViability);
+    }
+
+    [Fact]
+    public async Task EnsureWslPlatform_StandaloneClearsCachedResultBeforeCanceledInspection()
+    {
+        var commands = new FakeCommandRunner(
+            _ => Ok(),
+            runWithCancellation: (_, _, _, cancellationToken) =>
+                throw new OperationCanceledException(cancellationToken));
+        var ctx = CreateContext(commands: commands);
+        ctx.WslViability = new WslViabilityResult(
+            WslViabilityKind.Ready,
+            "stale ready",
+            string.Empty);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => new EnsureWslPlatformStep().ExecuteAsync(ctx, CancellationToken.None));
+
+        Assert.Null(ctx.WslViability);
+    }
+
+    [Fact]
+    public async Task EnsureWslPlatform_ClearsPreflightResultBeforeCanceledInstallation()
+    {
+        var commands = new FakeCommandRunner(_ =>
+            Fail("The cached same-run preflight result should be reused."));
+        var ctx = CreateContext(commands: commands);
+        ctx.WslViability = new WslViabilityResult(
+            WslViabilityKind.Installable,
+            "current-run missing",
+            string.Empty);
+        using var cts = new CancellationTokenSource();
+        var step = new EnsureWslPlatformStep(
+            (_, cancellationToken) =>
+            {
+                cts.Cancel();
+                throw new OperationCanceledException(cancellationToken);
+            },
+            reusePreflightResult: true);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => step.ExecuteAsync(ctx, cts.Token));
+        Assert.Null(ctx.WslViability);
+    }
+
+    [Fact]
+    public async Task EnsureWslPlatform_ClearsPreflightResultBeforeCanceledPostInstallInspection()
+    {
+        var commands = new FakeCommandRunner(
+            _ => Ok(),
+            runWithCancellation: (_, _, _, cancellationToken) =>
+            {
+                throw new OperationCanceledException(cancellationToken);
+            });
+        var ctx = CreateContext(commands: commands);
+        ctx.WslViability = new WslViabilityResult(
+            WslViabilityKind.Installable,
+            "current-run missing",
+            string.Empty);
+        using var cts = new CancellationTokenSource();
+        var step = new EnsureWslPlatformStep(
+            (_, _) =>
+            {
+                cts.Cancel();
+                return Task.FromResult(StepResult.Ok("installed"));
+            },
+            reusePreflightResult: true);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => step.ExecuteAsync(ctx, cts.Token));
+        Assert.Null(ctx.WslViability);
     }
 
     [Fact]

--- a/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
@@ -2105,6 +2105,81 @@ public class SetupStepsTests : IDisposable
     }
 
     [Fact]
+    public async Task WslPipeline_ReusesPreflightResultBeforeInstallingMissingPlatform()
+    {
+        var installed = false;
+        var commands = new FakeCommandRunner(args => args switch
+        {
+            ["--version"] when !installed => new CommandResult(
+                1,
+                "",
+                "Windows Subsystem for Linux is not installed. See https://aka.ms/wslinstall",
+                TimeSpan.Zero,
+                TimedOut: false),
+            ["--version"] => Ok("WSL version: 2.7.3.0\n"),
+            ["--status"] => Ok("Default Version: 2\n"),
+            _ => Fail($"unexpected args: {string.Join(' ', args)}"),
+        });
+        var ctx = CreateContext(commands: commands);
+        var ensure = new EnsureWslPlatformStep((_, _) =>
+        {
+            installed = true;
+            return Task.FromResult(StepResult.Ok("installed"));
+        });
+        var pipeline = new SetupPipeline([new PreflightWslStep(), ensure]);
+
+        var result = await pipeline.RunAsync(ctx);
+
+        Assert.Equal(PipelineOutcome.Success, result.Outcome);
+        Assert.Equal(2, commands.Calls.Count(call => call.Arguments is ["--version"]));
+        Assert.Single(commands.Calls, call => call.Arguments is ["--status"]);
+    }
+
+    [Fact]
+    public async Task WslPipeline_ReusesReadyPreflightResultWithoutReinspection()
+    {
+        var installCalls = 0;
+        var commands = new FakeCommandRunner(args => args switch
+        {
+            ["--version"] => Ok("WSL version: 2.7.3.0\n"),
+            ["--status"] => Ok("Default Version: 2\n"),
+            _ => Fail($"unexpected args: {string.Join(' ', args)}"),
+        });
+        var ctx = CreateContext(commands: commands);
+        var ensure = new EnsureWslPlatformStep((_, _) =>
+        {
+            installCalls++;
+            return Task.FromResult(StepResult.Ok("installed"));
+        });
+        var pipeline = new SetupPipeline([new PreflightWslStep(), ensure]);
+
+        var result = await pipeline.RunAsync(ctx);
+
+        Assert.Equal(PipelineOutcome.Success, result.Outcome);
+        Assert.Equal(0, installCalls);
+        Assert.Single(commands.Calls, call => call.Arguments is ["--version"]);
+        Assert.Single(commands.Calls, call => call.Arguments is ["--status"]);
+    }
+
+    [Fact]
+    public async Task WslPipeline_BoundsHungVersionInspectionToOneProbe()
+    {
+        var commands = new FakeCommandRunner(args => args is ["--version"]
+            ? new CommandResult(-1, "", "", TimeSpan.FromSeconds(5), TimedOut: true)
+            : Fail($"unexpected args: {string.Join(' ', args)}"));
+        var ctx = CreateContext(commands: commands);
+        var pipeline = new SetupPipeline(
+            [new PreflightWslStep(), new EnsureWslPlatformStep((_, _) =>
+                Task.FromResult(StepResult.Ok("installed")))]);
+
+        var result = await pipeline.RunAsync(ctx);
+
+        Assert.Equal(PipelineOutcome.Failed, result.Outcome);
+        Assert.Equal("preflight-wsl", result.FailedStepId);
+        Assert.Single(commands.Calls, call => call.Arguments is ["--version"]);
+    }
+
+    [Fact]
     public async Task EnsureWslPlatform_InstallsOnlyAfterReadOnlyPreflight()
     {
         var installed = false;


### PR DESCRIPTION
## Problem

Supersedes #1340 and closes #1335 while preserving @nerclid's focused fix and regression coverage.

On a fresh Windows installation, the default setup pipeline inspected WSL in `PreflightWslStep`, stored the typed result, then immediately repeated the same inspection in `EnsureWslPlatformStep` before requesting elevation. On systems where `wsl.exe --version` reaches its five-second bound, that duplicated a known pre-install delay and warning.

## Fix

- reuse the typed WSL viability result only when the default setup pipeline explicitly opts in
- keep public and standalone `EnsureWslPlatformStep` execution on a fresh inspection
- invalidate stale viability before preflight, standalone inspection, installation, and post-install verification
- preserve the existing elevated installer, restart-required behavior, timeout handling, and fresh post-install version/status verification
- cover stale Ready/Installable state and cancellation during preflight, standalone inspection, installation, and post-install inspection

## Required proof pools

- `windows-wsl-gateway-e2e`: verified through exact-head production SetupEngine runs on a clean Windows VM and the hosted setup/connect E2E shard.

## Validation

Current head: `dddd1528`.

- `dotnet test .\tests\OpenClaw.SetupEngine.Tests\OpenClaw.SetupEngine.Tests.csproj --no-restore --filter "FullyQualifiedName~WslPipeline_|FullyQualifiedName~EnsureWslPlatform_|FullyQualifiedName~PreflightWsl_"`: 28 passed
- `.\build.ps1`: passed
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore`: 3,943 passed, 32 skipped
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore`: 2,860 passed
- `dotnet test .\tests\OpenClaw.SetupEngine.Tests\OpenClaw.SetupEngine.Tests.csproj --no-restore`: 1,081 passed
- GitHub run `34142382387`: setup/connect E2E 41 passed; tray/setup/integration, CI Gate, CodeQL, and security checks passed
- `git diff --check`: passed
- required rubber-duck review completed; the stale-context finding was accepted and fixed
- `python .agents\skills\autoreview\scripts\autoreview --mode local --stream-engine-output`: clean, no accepted/actionable findings
- ClawSweeper current-head review: ready for maintainer review, no findings, proof sufficient

## Real behavior proof

Crabbox v0.51.0 ran the exact committed head on Azure Windows 11 24H2. Direct Azure runs returned no portal URL (`portal=-`, `logs=-`). The task-owned lease was stopped after proof.

Provider and host:

- provider: `azure`
- target: `windows`
- Windows mode: `normal`
- lease: `cbx_329a8b65bb0a` (`pearl-shrimp`)
- source SHA: `dddd1528c3b39f29479da19c3d7b7f432430a8e3`

Clean WSL-disabled production run, Crabbox run `run_725978431b8a`:

- Microsoft WSL package absent; WSL and Virtual Machine Platform features disabled
- production `Program.Main` and the default 37-step setup pipeline ran through a temporary console host outside the repository
- exactly one `wsl.exe --version` started before `WSL platform appears to be missing; launching elevated WSL platform install`
- no second pre-install version probe occurred
- the real elevated `wsl.exe --install --no-distribution` completed
- the unchanged post-install path ran its immediate version probe, then the full version/status viability verification
- SetupEngine returned `requiresRestart: true` with the expected restart guidance

Ready WSL production rerun after reboot, Crabbox run `run_86161b451756`:

- `PreflightWslStep` ran one real `wsl.exe --version` and one real `wsl.exe --status`
- `EnsureWslPlatformStep` completed in 0.0 seconds without another version/status probe
- no elevated installation marker appeared
- the pipeline continued beyond WSL preparation and was intentionally stopped by an invalid proof-only distro name at `wsl-create`

Hosted GitHub setup/connect E2E then passed all 41 tests on the same head, including full managed WSL setup and `FullSetup_GatewayRestart_ReconnectsTrayAndNode`.

This directly proves the user-visible optimization and the preserved post-install/restart recovery path. No credentials, gateway endpoints, or user data were collected.

## Review notes

The original contributor patch correctly reused `ctx.WslViability`, but reviewers identified that trusting any non-null context value could admit stale state during standalone execution or after cancellation. The replacement keeps reuse explicitly scoped to the default pipeline run and invalidates state at every inspection and mutation boundary. Final review found no remaining issues.

## Security impact

No credential, permission, network, or command-execution policy changes. The same WSL commands and elevated installer are used; only duplicate same-run inspection is removed.