### PR TITLE
Add non-destructive Local AI recovery

### DIFF
--- a/src/OpenClaw.Connection/GatewayRecord.cs
+++ b/src/OpenClaw.Connection/GatewayRecord.cs
@@ -113,7 +113,7 @@ public static class GatewayRecordEditing
         return result;
     }
 
-    internal static bool AreEquivalentLoopbackEndpoints(string? left, string? right)
+    public static bool AreEquivalentLoopbackEndpoints(string? left, string? right)
     {
         if (!Uri.TryCreate(left, UriKind.Absolute, out var leftUri) ||
             !Uri.TryCreate(right, UriKind.Absolute, out var rightUri) ||
@@ -179,6 +179,16 @@ public static class GatewayRecordEditing
         }
 
         return distro;
+    }
+
+    public static bool IsSetupManagedLocalRecord(GatewayRecord record)
+    {
+        if (record.SshTunnel is not null)
+            return false;
+
+        return ResolveManagedDistroName(record) is not null &&
+            (record.IsLocal ||
+             OpenClaw.Shared.LocalGatewayUrlClassifier.IsLocalGatewayUrl(record.Url));
     }
 
     private static string? ParseLegacyManagedDistroName(string? friendlyName)

--- a/src/OpenClaw.SetupEngine.UI/Pages/CapabilitiesPage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/CapabilitiesPage.xaml.cs
@@ -36,6 +36,7 @@ public sealed partial class CapabilitiesPage : Page
     private readonly LocalAiSetupAvailabilityCoordinator _localAiAvailability = new();
     private bool _treatBundledAllOnAsPlaceholder;
     private bool _forceLocalAiNetworkingConsent;
+    private bool _localAiRecoveryOnly;
     private CancellationTokenSource? _tailscaleStatusCancellation;
     private int _tailscaleStatusGeneration;
     private int _step = 1;
@@ -74,7 +75,8 @@ public sealed partial class CapabilitiesPage : Page
 
     protected override void OnNavigatedTo(NavigationEventArgs e)
     {
-        _config = e.Parameter as SetupConfig ?? new SetupConfig();
+        var args = e.Parameter as CapabilitiesPageArgs;
+        _config = args?.Config ?? e.Parameter as SetupConfig ?? new SetupConfig();
         // The tray always registers device.info/status with Node Mode. Keep the
         // setup declaration and gateway allowlist aligned with that runtime contract.
         _config.Capabilities.Device = true;
@@ -105,7 +107,10 @@ public sealed partial class CapabilitiesPage : Page
         TailscaleAuthModeSelector.SelectedIndex = _config.Tailscale.AuthMode == TailscaleAuthMode.AuthKey ? 1 : 0;
         UpdateTailscaleOptions();
         var previewPage = SetupPreview.RequestedPage;
-        var localAiReviewPreview = previewPage is "capabilities-review" or "capabilities-review-consent";
+        var localAiReviewPreview =
+            args?.StartAtLocalAiReview == true ||
+            previewPage is "capabilities-review" or "capabilities-review-consent";
+        _localAiRecoveryOnly = args?.StartAtLocalAiReview == true;
         _forceLocalAiNetworkingConsent = previewPage == "capabilities-review-consent";
         if (localAiReviewPreview)
             _config.LocalAi.Enabled = true;
@@ -214,6 +219,12 @@ public sealed partial class CapabilitiesPage : Page
 
     private void Back_Click(object sender, RoutedEventArgs e)
     {
+        if (_localAiRecoveryOnly)
+        {
+            SetupWindow.Active?.NavigateToWelcome(back: true);
+            return;
+        }
+
         if (_step <= 1)
         {
             // First capability step — step back to the Welcome screen.
@@ -781,8 +792,9 @@ public sealed partial class CapabilitiesPage : Page
         // below immediately, without needing Continue to advance on incomplete information.
         PrimaryButton.IsEnabled =
             _step != 3 ||
-            LocalAiToggle.IsOn != true ||
-            (_localAiSelectionEligible &&
+            (!_localAiRecoveryOnly && LocalAiToggle.IsOn != true) ||
+            (LocalAiToggle.IsOn == true &&
+             _localAiSelectionEligible &&
              (!_localAiNetworkingConsentRequired || LocalAiNetworkingConsentCheckBox.IsChecked == true));
     }
 

--- a/src/OpenClaw.SetupEngine.UI/Pages/CapabilitiesPageArgs.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/CapabilitiesPageArgs.cs
@@ -1,0 +1,3 @@
+namespace OpenClaw.SetupEngine.UI.Pages;
+
+internal sealed record CapabilitiesPageArgs(SetupConfig Config, bool StartAtLocalAiReview);

--- a/src/OpenClaw.SetupEngine.UI/Pages/ProgressPage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/ProgressPage.xaml.cs
@@ -14,6 +14,7 @@ namespace OpenClaw.SetupEngine.UI.Pages;
 internal sealed record ProgressPageArgs(
     SetupConfig Config,
     bool ShowMilestoneOnly,
+    bool LocalAiRecoveryOnly,
     string DataDir,
     string LocalDataDir);
 
@@ -29,6 +30,8 @@ public sealed partial class ProgressPage : Page
     private string _dataDir = null!;
     private string _localDataDir = null!;
     private Uri? _tailscaleAuthorizationUri;
+    private HashSet<string> _activeStepIds = [];
+    private bool _localAiRecoveryOnly;
     private const int MaxLogLines = 200;
 
     internal bool IsPipelineRunning => _runCts != null && !_pipelineFinished;
@@ -50,7 +53,7 @@ public sealed partial class ProgressPage : Page
         ("local-ai-wsl", "Verify Local AI access", ["verify-local-ai-wsl"]),
         ("tailscale-auth", "Connect Tailscale", ["install-tailscale", "authorize-tailscale"]),
         ("configure", "Configure gateway", ["configure-gateway", "configure-local-ai-gateway", "install-service"]),
-        ("start", "Start gateway", ["start-gateway", "mint-token"]),
+        ("start", "Start gateway", ["start-gateway", "restart-gateway", "mint-token"]),
         ("tailscale-serve", "Publish with Tailscale", ["finalize-tailscale-serve"]),
         ("pairing", "Pair device", ["pair-operator", "pair-node", "verify-e2e"]),
         ("finish", "Finish setup", ["run-wizard", "start-keepalive"]),
@@ -68,6 +71,10 @@ public sealed partial class ProgressPage : Page
         _config = args?.Config ?? e.Parameter as SetupConfig ?? new SetupConfig();
         _dataDir = args?.DataDir ?? SetupContext.ResolveDataDir();
         _localDataDir = args?.LocalDataDir ?? SetupContext.ResolveLocalDataDir();
+        _localAiRecoveryOnly = args?.LocalAiRecoveryOnly == true;
+        _activeStepIds = BuildSteps(_config, _localAiRecoveryOnly)
+            .Select(step => step.Id)
+            .ToHashSet(StringComparer.Ordinal);
         TitleText.Text = _config.LocalAi.Enabled ? "Setting up OpenClaw and Local AI" : "Setting up OpenClaw";
         SubtitleText.Text = _config.LocalAi.Enabled
             ? "Preparing the gateway and Local AI"
@@ -140,7 +147,8 @@ public sealed partial class ProgressPage : Page
                 showDetailProgress: groupId is "local-ai-engine" or "local-ai-model");
             _rows[groupId] = row;
             StepsPanel.Children.Add(row.Element);
-            if (_config?.LocalAi.Enabled != true && IsLocalAiOnlyGroup(stepIds))
+            if (!_activeStepIds.Overlaps(stepIds) ||
+                (_config?.LocalAi.Enabled != true && IsLocalAiOnlyGroup(stepIds)))
                 row.Element.Visibility = Visibility.Collapsed;
         }
     }
@@ -188,7 +196,7 @@ public sealed partial class ProgressPage : Page
             ctx.ExternalAuthorizationPresenter = new ProgressAuthorizationPresenter(DispatcherQueue, ShowTailscaleAuthorization);
             ctx.DetailProgress = new DirectProgress<SetupDetailProgressEvent>(OnDetailProgress);
 
-            var steps = BuildSteps(config);
+            var steps = BuildSteps(config, _localAiRecoveryOnly);
             _pipeline = new SetupPipeline(steps);
             _pipeline.StepProgress += OnStepProgress;
 
@@ -298,7 +306,7 @@ public sealed partial class ProgressPage : Page
                 _completedSteps.Add(e.StepId);
 
                 // If all steps in this group are done, mark group done
-                if (group.StepIds.All(id => _completedSteps.Contains(id)))
+                if (group.StepIds.Where(_activeStepIds.Contains).All(id => _completedSteps.Contains(id)))
                     row.SetStatus(StepStatus.Done);
             }
         });
@@ -379,8 +387,10 @@ public sealed partial class ProgressPage : Page
         MilestoneStatusText.Text = "Another setup task is still active. Wait for it to finish, then start OpenClaw onboard.";
     }
 
-    private static List<SetupStep> BuildSteps(SetupConfig config)
-        => SetupStepFactory.BuildDefaultSteps()
+    private static List<SetupStep> BuildSteps(SetupConfig config, bool localAiRecoveryOnly = false)
+        => (localAiRecoveryOnly
+                ? SetupStepFactory.BuildLocalAiRecoverySteps()
+                : SetupStepFactory.BuildDefaultSteps())
             .Where(step => step is not RunGatewayWizardStep)
             .Where(step => config.SkipWizard || step is not WindowsNodeBootstrapContextStep)
             .ToList();

--- a/src/OpenClaw.SetupEngine.UI/SetupWindow.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/SetupWindow.xaml.cs
@@ -29,6 +29,12 @@ public sealed partial class SetupWindow : Window
     private readonly object _localAiHardwareProbeLock = new();
     private Task<HostHardwareInfo>? _localAiHardwareProbeTask;
     private readonly WslViabilityProbe _wslViabilityProbe = new(InspectWslViabilityAsync);
+    private bool _startAtLocalAiRecoveryReview;
+    private bool _defaultLocalAiEnabled;
+    private bool _defaultSkipWizard;
+    private string _defaultDistroName = null!;
+    private int _defaultGatewayPort;
+    private string? _defaultGatewayUrl;
 
     public static SetupWindow? Active { get; private set; }
 
@@ -47,21 +53,25 @@ public sealed partial class SetupWindow : Window
         _setupLock is not null &&
         RootFrame.Content is not ProgressPage { IsPipelineRunning: true } &&
         RootFrame.Content is not WizardPage;
-
     [DllImport("user32.dll")]
     private static extern uint GetDpiForWindow(IntPtr hwnd);
 
     public SetupWindow(
         string? configPath = null,
         bool startAtGatewayInstalledMilestone = false,
+        bool startAtLocalAiRecoveryReview = false,
         string? dataDir = null,
         string? localDataDir = null,
         string? distroNameOverride = null,
         int? gatewayPortOverride = null,
+        string? localAiRecoveryGatewayId = null,
+        string? localAiRecoveryDistroName = null,
+        int? localAiRecoveryGatewayPort = null,
         string[]? commandLineArgs = null)
     {
         _dataDir = dataDir ?? SetupContext.ResolveDataDir();
         _localDataDir = localDataDir ?? SetupContext.ResolveLocalDataDir();
+        _startAtLocalAiRecoveryReview = startAtLocalAiRecoveryReview;
         InitializeComponent();
         Active = this;
 
@@ -168,7 +178,25 @@ public sealed partial class SetupWindow : Window
             return;
         }
         _config.ApplyUiDefaults(rollbackOnFailure: setupArguments.RollbackOnFailure);
-        if (startAtGatewayInstalledMilestone)
+        _defaultLocalAiEnabled = _config.LocalAi.Enabled;
+        _defaultSkipWizard = _config.SkipWizard;
+        _defaultDistroName = _config.DistroName;
+        _defaultGatewayPort = _config.GatewayPort;
+        _defaultGatewayUrl = _config.GatewayUrl;
+        if (startAtLocalAiRecoveryReview)
+        {
+            _config.LocalAiRecoveryGatewayId = localAiRecoveryGatewayId;
+            if (!string.IsNullOrWhiteSpace(localAiRecoveryDistroName))
+                _config.DistroName = localAiRecoveryDistroName;
+            if (localAiRecoveryGatewayPort is > 0 and <= 65535)
+            {
+                _config.GatewayPort = localAiRecoveryGatewayPort.Value;
+                _config.GatewayUrl = null;
+            }
+            _config.LocalAi.Enabled = true;
+            _config.SkipWizard = true;
+        }
+        if (startAtGatewayInstalledMilestone || startAtLocalAiRecoveryReview)
         {
             _persistStartupPreferenceOnComplete = false;
             _showStartupPreferenceOnComplete = false;
@@ -189,12 +217,18 @@ public sealed partial class SetupWindow : Window
 
         if (startAtGatewayInstalledMilestone)
             NavigateToGatewayInstalledMilestone();
+        else if (startAtLocalAiRecoveryReview)
+            NavigateToCapabilities();
         else
             NavigateTo(typeof(SecurityNoticePage), _config);
     }
 
     public void NavigateToSecurityNotice(bool back = false) => NavigateTo(typeof(SecurityNoticePage), _config, back);
-    public void NavigateToWelcome(bool back = false) => NavigateTo(typeof(WelcomePage), _config, back);
+    public void NavigateToWelcome(bool back = false)
+    {
+        ResetLocalAiRecoveryMode();
+        NavigateTo(typeof(WelcomePage), _config, back);
+    }
     public bool IsWelcomeInstallSelected => _isWelcomeInstallSelected;
     public void SetWelcomeInstallSelected(bool installSelected) => _isWelcomeInstallSelected = installSelected;
 
@@ -227,13 +261,16 @@ public sealed partial class SetupWindow : Window
     }
 
     public void NavigateToAdvancedSetup() => NavigateTo(typeof(AdvancedSetupPage), _config);
-    public void NavigateToCapabilities() => NavigateTo(typeof(CapabilitiesPage), _config);
+    public void NavigateToCapabilities() =>
+        NavigateTo(
+            typeof(CapabilitiesPage),
+            new CapabilitiesPageArgs(_config, _startAtLocalAiRecoveryReview));
     public void NavigateToProgress() => NavigateTo(typeof(ProgressPage), CreateProgressPageArgs(showMilestoneOnly: false));
     public void NavigateToGatewayInstalledMilestone() =>
         NavigateTo(typeof(ProgressPage), CreateProgressPageArgs(showMilestoneOnly: true));
 
     private ProgressPageArgs CreateProgressPageArgs(bool showMilestoneOnly) =>
-        new(_config, showMilestoneOnly, _dataDir, _localDataDir);
+        new(_config, showMilestoneOnly, _startAtLocalAiRecoveryReview, _dataDir, _localDataDir);
 
     public bool TryNavigateToGatewayInstalledMilestone()
     {
@@ -244,6 +281,22 @@ public sealed partial class SetupWindow : Window
         _showStartupPreferenceOnComplete = false;
         NavigateToGatewayInstalledMilestone();
         return true;
+    }
+
+    private void ResetLocalAiRecoveryMode()
+    {
+        if (!_startAtLocalAiRecoveryReview)
+            return;
+
+        _startAtLocalAiRecoveryReview = false;
+        _config.LocalAiRecoveryGatewayId = null;
+        _config.DistroName = _defaultDistroName;
+        _config.GatewayPort = _defaultGatewayPort;
+        _config.GatewayUrl = _defaultGatewayUrl;
+        _config.LocalAi.Enabled = _defaultLocalAiEnabled;
+        _config.SkipWizard = _defaultSkipWizard;
+        _persistStartupPreferenceOnComplete = true;
+        _showStartupPreferenceOnComplete = true;
     }
 
     public bool TryNavigateToWizard(bool back = false)

--- a/src/OpenClaw.SetupEngine/ExistingConfigDetector.cs
+++ b/src/OpenClaw.SetupEngine/ExistingConfigDetector.cs
@@ -25,14 +25,19 @@ public sealed class ExistingConfigDetector
     public static ExistingConfig Detect(
         string dataDir,
         string targetDistroName,
-        string? localDataDir = null)
+        string? localDataDir = null,
+        string? expectedLocalGatewayId = null)
     {
         localDataDir ??= SetupContext.ResolveLocalDataDir();
         var registry = new GatewayRegistry(dataDir);
         registry.Load();
         var all = registry.GetAll();
 
-        var localRecord = all.FirstOrDefault(r => r.IsLocal && r.SshTunnel == null);
+        var localRecord = string.IsNullOrWhiteSpace(expectedLocalGatewayId)
+            ? all.FirstOrDefault(r => r.IsLocal && r.SshTunnel == null)
+            : all.FirstOrDefault(r =>
+                string.Equals(r.Id, expectedLocalGatewayId, StringComparison.Ordinal) &&
+                GatewayRecordEditing.IsSetupManagedLocalRecord(r));
         var preserved = all.Where(r => !r.IsLocal || r.SshTunnel != null).ToList();
 
         var logger = new SetupLogger(filePath: null, LogLevel.Warn);

--- a/src/OpenClaw.SetupEngine/LocalAiGatewayConfiguration.cs
+++ b/src/OpenClaw.SetupEngine/LocalAiGatewayConfiguration.cs
@@ -195,6 +195,9 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
         if (ctx.LocalAiGatewayPriorState is not { } prior)
             return;
 
+        if (ctx.LocalAiRecoveryProviderTransition)
+            ctx.LocalAiRecoveryReceiptRollbackAllowed = false;
+
         CommandResult currentResult = await CaptureStateAsync(ctx, ct);
         if (currentResult.ExitCode != 0 || currentResult.TimedOut)
         {
@@ -230,6 +233,7 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
             (!current.PrimaryModelExisted ||
                 JsonEquals(current.PrimaryModelJson!, prior.PrimaryModelJson!)))
         {
+            ctx.LocalAiRecoveryReceiptRollbackAllowed = true;
             return;
         }
 
@@ -273,6 +277,8 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
                 ctx.Logger.Warn("Restoring the previous Local AI gateway settings failed.");
                 return;
             }
+            if (recoveryOriginal is not null)
+                ctx.LocalAiRecoveryReceiptRollbackAllowed = true;
         }
 
         var unset = new List<string>(2);

--- a/src/OpenClaw.SetupEngine/LocalAiGatewayConfiguration.cs
+++ b/src/OpenClaw.SetupEngine/LocalAiGatewayConfiguration.cs
@@ -198,6 +198,8 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
         CommandResult currentResult = await CaptureStateAsync(ctx, ct);
         if (currentResult.ExitCode != 0 || currentResult.TimedOut)
         {
+            if (ctx.LocalAiRecoveryProviderTransition)
+                ctx.LocalAiRecoveryReceiptRollbackAllowed = false;
             ctx.Logger.Warn("Could not inspect the Local AI gateway configuration during rollback; preserving it.");
             return;
         }
@@ -209,6 +211,8 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
         }
         catch (Exception ex) when (ex is FormatException or JsonException or InvalidDataException)
         {
+            if (ctx.LocalAiRecoveryProviderTransition)
+                ctx.LocalAiRecoveryReceiptRollbackAllowed = false;
             ctx.Logger.Warn($"Could not validate Local AI gateway rollback state; preserving it ({ex.GetType().Name}).");
             return;
         }
@@ -236,6 +240,8 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
                 ctx.LocalAiResolvedInstall!) ||
             !JsonEquals(current.PrimaryModelJson!, expectedPrimary))
         {
+            if (ctx.LocalAiRecoveryProviderTransition)
+                ctx.LocalAiRecoveryReceiptRollbackAllowed = false;
             ctx.Logger.Warn("Local AI gateway settings changed after setup; preserving the newer values.");
             return;
         }
@@ -256,6 +262,14 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
             CommandResult restore = await ApplyBatchAsync(ctx, restoreBatch, "LOCAL_AI_GATEWAY_RESTORED", ct);
             if (restore.ExitCode != 0 || restore.TimedOut)
             {
+                if (recoveryOriginal is not null)
+                {
+                    await ReconcileFailedRecoveryRestoreAsync(
+                        ctx,
+                        prior,
+                        recoveryOriginal,
+                        ct).ConfigureAwait(false);
+                }
                 ctx.Logger.Warn("Restoring the previous Local AI gateway settings failed.");
                 return;
             }
@@ -275,6 +289,66 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
             if (result.ExitCode != 0 || result.TimedOut)
                 ctx.Logger.Warn("Removing setup-created Local AI gateway settings failed.");
         }
+    }
+
+    private static async Task ReconcileFailedRecoveryRestoreAsync(
+        SetupContext ctx,
+        LocalAiGatewayPriorState prior,
+        LocalAiResolvedInstall recoveryOriginal,
+        CancellationToken ct)
+    {
+        CommandResult observedResult = await CaptureStateAsync(ctx, ct).ConfigureAwait(false);
+        if (observedResult.ExitCode != 0 || observedResult.TimedOut)
+        {
+            ctx.LocalAiRecoveryReceiptRollbackAllowed = false;
+            ctx.Logger.Warn(
+                "The Local AI provider rollback outcome could not be inspected; preserving the replacement receipt.");
+            return;
+        }
+
+        LocalAiGatewayPriorState observed;
+        try
+        {
+            observed = ParseSnapshot(observedResult.Stdout);
+        }
+        catch (Exception ex) when (ex is FormatException or JsonException or InvalidDataException)
+        {
+            ctx.LocalAiRecoveryReceiptRollbackAllowed = false;
+            ctx.Logger.Warn(
+                $"The Local AI provider rollback outcome was invalid; preserving the replacement receipt ({ex.GetType().Name}).");
+            return;
+        }
+
+        bool originalRestored =
+            observed.ProviderExisted &&
+            prior.ProviderExisted &&
+            LocalAiGatewayProviderDefinition.MatchesProviderJson(
+                observed.ProviderJson!,
+                recoveryOriginal) &&
+            observed.PrimaryModelExisted == prior.PrimaryModelExisted &&
+            (!observed.PrimaryModelExisted ||
+                JsonEquals(observed.PrimaryModelJson!, prior.PrimaryModelJson!));
+        if (originalRestored)
+        {
+            ctx.LocalAiRecoveryReceiptRollbackAllowed = true;
+            return;
+        }
+
+        bool replacementRetained =
+            observed.ProviderExisted &&
+            observed.PrimaryModelExisted &&
+            ctx.LocalAiResolvedInstall is { } replacement &&
+            LocalAiGatewayProviderDefinition.MatchesProviderJson(
+                observed.ProviderJson!,
+                replacement) &&
+            JsonEquals(
+                observed.PrimaryModelJson!,
+                JsonSerializer.Serialize(
+                    LocalAiGatewayProviderDefinition.BuildPrimaryModel(replacement)));
+        ctx.LocalAiRecoveryReceiptRollbackAllowed = false;
+        ctx.Logger.Warn(replacementRetained
+            ? "The replacement Local AI gateway route remains active; preserving its endpoint receipt."
+            : "The Local AI provider rollback was incomplete; preserving the replacement receipt for manual recovery.");
     }
 
     private static async Task RemoveManagedStateForUninstallAsync(

--- a/src/OpenClaw.SetupEngine/LocalAiGatewayConfiguration.cs
+++ b/src/OpenClaw.SetupEngine/LocalAiGatewayConfiguration.cs
@@ -86,7 +86,6 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
     {
         if (ctx.LocalAiResolvedInstall is null || ctx.LocalAiEligibility?.Plan is null)
             return StepResult.Terminal("Local AI gateway configuration requires a qualified install receipt.");
-        ctx.LocalAiRecoveryProviderTransition = false;
 
         CommandResult snapshotResult = await CaptureStateAsync(ctx, ct);
         if (snapshotResult.ExitCode != 0 || snapshotResult.TimedOut)
@@ -96,7 +95,6 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
         try
         {
             prior = ParseSnapshot(snapshotResult.Stdout);
-            ctx.LocalAiGatewayPriorState = prior;
         }
         catch (Exception ex) when (ex is FormatException or JsonException or InvalidDataException)
         {
@@ -131,7 +129,8 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
                 return StepResult.Fail(
                     "The existing llamacpp gateway route is not the exact companion-managed configuration; preserving it.");
             }
-            ctx.LocalAiRecoveryProviderTransition = matchesRecoveryInstall;
+            if (matchesRecoveryInstall)
+                ctx.LocalAiRecoveryProviderTransition = true;
             fallbackModel = install.Manifest.GatewayFallbackModel;
         }
         else if (prior.PrimaryModelExisted)
@@ -148,6 +147,7 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
         {
             fallbackModel = null;
         }
+        ctx.LocalAiGatewayPriorState ??= prior;
 
         if (!string.Equals(
                 install.Manifest.GatewayFallbackModel,
@@ -226,8 +226,6 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
             (!current.PrimaryModelExisted ||
                 JsonEquals(current.PrimaryModelJson!, prior.PrimaryModelJson!)))
         {
-            if (await RestoreRecoveryManifestAsync(ctx, recoveryOriginal, ct).ConfigureAwait(false))
-                ctx.LocalAiRecoveryProviderTransition = false;
             return;
         }
 
@@ -263,12 +261,6 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
             }
         }
 
-        if (recoveryOriginal is not null)
-        {
-            if (await RestoreRecoveryManifestAsync(ctx, recoveryOriginal, ct).ConfigureAwait(false))
-                ctx.LocalAiRecoveryProviderTransition = false;
-        }
-
         var unset = new List<string>(2);
         if (!prior.PrimaryModelExisted)
             unset.Add($"openclaw config unset {LocalAiGatewayConfigBuilder.PrimaryModelPath}");
@@ -282,26 +274,6 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
                 user: ctx.Config.Wsl.User, inputViaStdin: true);
             if (result.ExitCode != 0 || result.TimedOut)
                 ctx.Logger.Warn("Removing setup-created Local AI gateway settings failed.");
-        }
-    }
-
-    private static async Task<bool> RestoreRecoveryManifestAsync(
-        SetupContext ctx,
-        LocalAiResolvedInstall recoveryOriginal,
-        CancellationToken ct)
-    {
-        try
-        {
-            var store = new LocalAiManifestStore(new LocalAiPaths(ctx.LocalDataDir));
-            await store.SaveAsync(recoveryOriginal.Manifest, ct).ConfigureAwait(false);
-            ctx.LocalAiResolvedInstall = store.ResolveAndValidate(recoveryOriginal.Manifest);
-            return true;
-        }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidDataException)
-        {
-            ctx.Logger.Warn(
-                $"Restoring the previous Local AI endpoint receipt failed ({ex.GetType().Name}).");
-            return false;
         }
     }
 

--- a/src/OpenClaw.SetupEngine/LocalAiGatewayConfiguration.cs
+++ b/src/OpenClaw.SetupEngine/LocalAiGatewayConfiguration.cs
@@ -105,6 +105,7 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
         string expectedPrimary = JsonSerializer.Serialize(
             LocalAiGatewayProviderDefinition.BuildPrimaryModel(install));
         string? fallbackModel;
+        bool recoveryProviderTransition = false;
         if (prior.ProviderExisted)
         {
             bool matchesCurrentInstall = install.Endpoint is not null &&
@@ -129,8 +130,7 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
                 return StepResult.Fail(
                     "The existing llamacpp gateway route is not the exact companion-managed configuration; preserving it.");
             }
-            if (matchesRecoveryInstall)
-                ctx.LocalAiRecoveryProviderTransition = true;
+            recoveryProviderTransition = matchesRecoveryInstall;
             fallbackModel = install.Manifest.GatewayFallbackModel;
         }
         else if (prior.PrimaryModelExisted)
@@ -146,6 +146,11 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
         else
         {
             fallbackModel = null;
+        }
+        if (ctx.LocalAiRecoveryOriginalInstall is not null &&
+            (recoveryProviderTransition || !prior.ProviderExisted))
+        {
+            ctx.LocalAiRecoveryProviderTransition = true;
         }
         ctx.LocalAiGatewayPriorState ??= prior;
 
@@ -224,11 +229,11 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
             ? ctx.LocalAiRecoveryOriginalInstall
             : null;
         if (recoveryOriginal is not null &&
-            current.ProviderExisted &&
-            prior.ProviderExisted &&
-            LocalAiGatewayProviderDefinition.MatchesProviderJson(
-                current.ProviderJson!,
-                recoveryOriginal) &&
+            current.ProviderExisted == prior.ProviderExisted &&
+            (!current.ProviderExisted ||
+                LocalAiGatewayProviderDefinition.MatchesProviderJson(
+                    current.ProviderJson!,
+                    recoveryOriginal)) &&
             current.PrimaryModelExisted == prior.PrimaryModelExisted &&
             (!current.PrimaryModelExisted ||
                 JsonEquals(current.PrimaryModelJson!, prior.PrimaryModelJson!)))
@@ -251,7 +256,7 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
         }
 
         string restoreBatch;
-        if (recoveryOriginal is not null)
+        if (recoveryOriginal is not null && prior.ProviderExisted)
         {
             restoreBatch = LocalAiGatewayConfigBuilder.BuildRecoveryRestoreBatchJson(
                 prior,
@@ -277,8 +282,6 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
                 ctx.Logger.Warn("Restoring the previous Local AI gateway settings failed.");
                 return;
             }
-            if (recoveryOriginal is not null)
-                ctx.LocalAiRecoveryReceiptRollbackAllowed = true;
         }
 
         var unset = new List<string>(2);
@@ -293,8 +296,21 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
                 ctx.DistroName!, script, TimeSpan.FromMinutes(2), ct: ct,
                 user: ctx.Config.Wsl.User, inputViaStdin: true);
             if (result.ExitCode != 0 || result.TimedOut)
+            {
+                if (recoveryOriginal is not null)
+                {
+                    await ReconcileFailedRecoveryRestoreAsync(
+                        ctx,
+                        prior,
+                        recoveryOriginal,
+                        ct).ConfigureAwait(false);
+                }
                 ctx.Logger.Warn("Removing setup-created Local AI gateway settings failed.");
+                return;
+            }
         }
+        if (recoveryOriginal is not null)
+            ctx.LocalAiRecoveryReceiptRollbackAllowed = true;
     }
 
     private static async Task ReconcileFailedRecoveryRestoreAsync(
@@ -326,11 +342,11 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
         }
 
         bool originalRestored =
-            observed.ProviderExisted &&
-            prior.ProviderExisted &&
-            LocalAiGatewayProviderDefinition.MatchesProviderJson(
-                observed.ProviderJson!,
-                recoveryOriginal) &&
+            observed.ProviderExisted == prior.ProviderExisted &&
+            (!observed.ProviderExisted ||
+                LocalAiGatewayProviderDefinition.MatchesProviderJson(
+                    observed.ProviderJson!,
+                    recoveryOriginal)) &&
             observed.PrimaryModelExisted == prior.PrimaryModelExisted &&
             (!observed.PrimaryModelExisted ||
                 JsonEquals(observed.PrimaryModelJson!, prior.PrimaryModelJson!));

--- a/src/OpenClaw.SetupEngine/LocalAiGatewayConfiguration.cs
+++ b/src/OpenClaw.SetupEngine/LocalAiGatewayConfiguration.cs
@@ -51,6 +51,23 @@ internal static class LocalAiGatewayConfigBuilder
         LocalAiGatewayProviderDefinition.BuildPrimaryModel(
             context.LocalAiResolvedInstall
                 ?? throw new InvalidOperationException("The Local AI install receipt is required."));
+
+    public static string BuildRecoveryRestoreBatchJson(
+        LocalAiGatewayPriorState prior,
+        LocalAiResolvedInstall originalInstall)
+    {
+        ArgumentNullException.ThrowIfNull(prior);
+        ArgumentNullException.ThrowIfNull(originalInstall);
+        using JsonDocument provider = JsonDocument.Parse(
+            LocalAiGatewayProviderDefinition.BuildProviderJson(originalInstall));
+        using JsonDocument primary = JsonDocument.Parse(prior.PrimaryModelJson!);
+        object[] operations =
+        [
+            new { path = ProviderPath, value = (object)provider.RootElement.Clone() },
+            new { path = PrimaryModelPath, value = (object)primary.RootElement.Clone() },
+        ];
+        return JsonSerializer.Serialize(operations);
+    }
 }
 
 public sealed class ConfigureLocalAiGatewayStep : SetupStep
@@ -69,6 +86,7 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
     {
         if (ctx.LocalAiResolvedInstall is null || ctx.LocalAiEligibility?.Plan is null)
             return StepResult.Terminal("Local AI gateway configuration requires a qualified install receipt.");
+        ctx.LocalAiRecoveryProviderTransition = false;
 
         CommandResult snapshotResult = await CaptureStateAsync(ctx, ct);
         if (snapshotResult.ExitCode != 0 || snapshotResult.TimedOut)
@@ -91,14 +109,29 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
         string? fallbackModel;
         if (prior.ProviderExisted)
         {
-            if (install.Endpoint is null ||
-                !LocalAiGatewayProviderDefinition.MatchesProviderJson(prior.ProviderJson!, install) ||
+            bool matchesCurrentInstall = install.Endpoint is not null &&
+                LocalAiGatewayProviderDefinition.MatchesProviderJson(prior.ProviderJson!, install);
+            bool matchesRecoveryInstall = false;
+            if (!matchesCurrentInstall &&
+                ctx.LocalAiRecoveryOriginalInstall is { Endpoint: not null } originalInstall)
+            {
+                string originalPrimary = JsonSerializer.Serialize(
+                    LocalAiGatewayProviderDefinition.BuildPrimaryModel(originalInstall));
+                matchesRecoveryInstall =
+                    LocalAiGatewayProviderDefinition.MatchesProviderJson(
+                        prior.ProviderJson!,
+                        originalInstall) &&
+                    JsonEquals(originalPrimary, expectedPrimary);
+            }
+
+            if ((!matchesCurrentInstall && !matchesRecoveryInstall) ||
                 !prior.PrimaryModelExisted ||
                 !JsonEquals(prior.PrimaryModelJson!, expectedPrimary))
             {
                 return StepResult.Fail(
                     "The existing llamacpp gateway route is not the exact companion-managed configuration; preserving it.");
             }
+            ctx.LocalAiRecoveryProviderTransition = matchesRecoveryInstall;
             fallbackModel = install.Manifest.GatewayFallbackModel;
         }
         else if (prior.PrimaryModelExisted)
@@ -180,6 +213,24 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
             return;
         }
 
+        LocalAiResolvedInstall? recoveryOriginal = ctx.LocalAiRecoveryProviderTransition
+            ? ctx.LocalAiRecoveryOriginalInstall
+            : null;
+        if (recoveryOriginal is not null &&
+            current.ProviderExisted &&
+            prior.ProviderExisted &&
+            LocalAiGatewayProviderDefinition.MatchesProviderJson(
+                current.ProviderJson!,
+                recoveryOriginal) &&
+            current.PrimaryModelExisted == prior.PrimaryModelExisted &&
+            (!current.PrimaryModelExisted ||
+                JsonEquals(current.PrimaryModelJson!, prior.PrimaryModelJson!)))
+        {
+            if (await RestoreRecoveryManifestAsync(ctx, recoveryOriginal, ct).ConfigureAwait(false))
+                ctx.LocalAiRecoveryProviderTransition = false;
+            return;
+        }
+
         string expectedPrimary = JsonSerializer.Serialize(LocalAiGatewayConfigBuilder.ExpectedPrimaryModel(ctx));
         if (!current.ProviderExisted || !current.PrimaryModelExisted ||
             !LocalAiGatewayProviderDefinition.MatchesProviderJson(
@@ -191,12 +242,31 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
             return;
         }
 
-        string restoreBatch = LocalAiGatewayConfigBuilder.BuildRestoreBatchJson(prior);
+        string restoreBatch;
+        if (recoveryOriginal is not null)
+        {
+            restoreBatch = LocalAiGatewayConfigBuilder.BuildRecoveryRestoreBatchJson(
+                prior,
+                recoveryOriginal);
+        }
+        else
+        {
+            restoreBatch = LocalAiGatewayConfigBuilder.BuildRestoreBatchJson(prior);
+        }
         if (restoreBatch != "[]")
         {
             CommandResult restore = await ApplyBatchAsync(ctx, restoreBatch, "LOCAL_AI_GATEWAY_RESTORED", ct);
             if (restore.ExitCode != 0 || restore.TimedOut)
+            {
                 ctx.Logger.Warn("Restoring the previous Local AI gateway settings failed.");
+                return;
+            }
+        }
+
+        if (recoveryOriginal is not null)
+        {
+            if (await RestoreRecoveryManifestAsync(ctx, recoveryOriginal, ct).ConfigureAwait(false))
+                ctx.LocalAiRecoveryProviderTransition = false;
         }
 
         var unset = new List<string>(2);
@@ -212,6 +282,26 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
                 user: ctx.Config.Wsl.User, inputViaStdin: true);
             if (result.ExitCode != 0 || result.TimedOut)
                 ctx.Logger.Warn("Removing setup-created Local AI gateway settings failed.");
+        }
+    }
+
+    private static async Task<bool> RestoreRecoveryManifestAsync(
+        SetupContext ctx,
+        LocalAiResolvedInstall recoveryOriginal,
+        CancellationToken ct)
+    {
+        try
+        {
+            var store = new LocalAiManifestStore(new LocalAiPaths(ctx.LocalDataDir));
+            await store.SaveAsync(recoveryOriginal.Manifest, ct).ConfigureAwait(false);
+            ctx.LocalAiResolvedInstall = store.ResolveAndValidate(recoveryOriginal.Manifest);
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidDataException)
+        {
+            ctx.Logger.Warn(
+                $"Restoring the previous Local AI endpoint receipt failed ({ex.GetType().Name}).");
+            return false;
         }
     }
 

--- a/src/OpenClaw.SetupEngine/LocalAiRecoveryPolicy.cs
+++ b/src/OpenClaw.SetupEngine/LocalAiRecoveryPolicy.cs
@@ -148,20 +148,29 @@ public sealed class PreserveLocalAiRecoveryGatewayStep : SetupStep
         Exception? receiptError = null;
         if (ctx.LocalAiRecoveryOriginalInstall is { } originalInstall)
         {
-            try
+            if (!ctx.LocalAiRecoveryReceiptRollbackAllowed)
             {
-                var store = new LocalAiManifestStore(new LocalAiPaths(ctx.LocalDataDir));
-                await store.SaveAsync(originalInstall.Manifest, ct).ConfigureAwait(false);
-                ctx.LocalAiResolvedInstall = store.ResolveAndValidate(originalInstall.Manifest);
-                ctx.LocalAiRecoveryProviderTransition = false;
-                ctx.LocalAiGatewayPriorState = null;
-            }
-            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidDataException)
-            {
-                receiptError = ex;
                 ctx.Logger.Warn(
-                    $"Restoring the previous Local AI endpoint receipt failed ({ex.GetType().Name}).");
+                    "The previous Local AI endpoint receipt was not restored because gateway provider rollback did not complete.");
             }
+            else
+            {
+                try
+                {
+                    var store = new LocalAiManifestStore(new LocalAiPaths(ctx.LocalDataDir));
+                    await store.SaveAsync(originalInstall.Manifest, ct).ConfigureAwait(false);
+                    ctx.LocalAiResolvedInstall = store.ResolveAndValidate(originalInstall.Manifest);
+                }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidDataException)
+                {
+                    receiptError = ex;
+                    ctx.Logger.Warn(
+                        $"Restoring the previous Local AI endpoint receipt failed ({ex.GetType().Name}).");
+                }
+            }
+            ctx.LocalAiRecoveryProviderTransition = false;
+            ctx.LocalAiRecoveryReceiptRollbackAllowed = false;
+            ctx.LocalAiGatewayPriorState = null;
         }
 
         if (ctx.LocalAiRecoveryStoppedWsl)

--- a/src/OpenClaw.SetupEngine/LocalAiRecoveryPolicy.cs
+++ b/src/OpenClaw.SetupEngine/LocalAiRecoveryPolicy.cs
@@ -1,0 +1,156 @@
+using OpenClaw.Connection;
+
+namespace OpenClaw.SetupEngine;
+
+public static class LocalAiRecoveryPolicy
+{
+    public static bool CanRecoverExistingGateway(
+        ExistingConfigDetector.ExistingConfig existing,
+        string expectedGatewayId,
+        string targetDistroName,
+        string expectedGatewayUrl) =>
+        existing.HasLocalGateway &&
+        string.Equals(
+            existing.LocalGatewayId,
+            expectedGatewayId,
+            StringComparison.Ordinal) &&
+        existing.HasDistro &&
+        existing.DistroIsAppOwned &&
+        string.Equals(
+            existing.DistroName,
+            targetDistroName,
+            StringComparison.OrdinalIgnoreCase) &&
+        GatewayRecordEditing.AreEquivalentLoopbackEndpoints(
+            existing.LocalGatewayUrl,
+            expectedGatewayUrl);
+}
+
+public sealed class ValidateLocalAiRecoveryGatewayStep : SetupStep
+{
+    private readonly Func<string, string, string?, string?, ExistingConfigDetector.ExistingConfig> _detect;
+    private readonly Func<string, IReadOnlyList<GatewayRecord>> _loadGatewayRecords;
+    private readonly bool _finalCheck;
+
+    public ValidateLocalAiRecoveryGatewayStep(bool finalCheck = false)
+        : this(ExistingConfigDetector.Detect, LoadGatewayRecords, finalCheck)
+    {
+    }
+
+    internal ValidateLocalAiRecoveryGatewayStep(
+        Func<string, string, string?, string?, ExistingConfigDetector.ExistingConfig> detect,
+        Func<string, IReadOnlyList<GatewayRecord>> loadGatewayRecords,
+        bool finalCheck = false)
+    {
+        _detect = detect ?? throw new ArgumentNullException(nameof(detect));
+        _loadGatewayRecords =
+            loadGatewayRecords ?? throw new ArgumentNullException(nameof(loadGatewayRecords));
+        _finalCheck = finalCheck;
+    }
+
+    public override string Id => _finalCheck
+        ? "revalidate-local-ai-recovery-gateway"
+        : "validate-local-ai-recovery-gateway";
+    public override string DisplayName => _finalCheck
+        ? "Recheck gateway before Local AI recovery changes"
+        : "Verify existing gateway for Local AI recovery";
+    public override bool CanRetry => false;
+
+    public override Task<StepResult> ExecuteAsync(SetupContext ctx, CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+
+        var expectedGatewayId = ctx.Config.LocalAiRecoveryGatewayId;
+        if (string.IsNullOrWhiteSpace(expectedGatewayId))
+        {
+            return Task.FromResult(StepResult.Terminal(
+                "Local AI recovery is missing its managed gateway identity. Close recovery and retry."));
+        }
+
+        var owners = _loadGatewayRecords(ctx.DataDir)
+            .Where(record =>
+                GatewayRecordEditing.IsSetupManagedLocalRecord(record) &&
+                !string.IsNullOrWhiteSpace(record.Id) &&
+                !string.IsNullOrWhiteSpace(
+                    GatewayRecordEditing.ResolveManagedDistroName(record)))
+            .ToArray();
+        if (owners.Length != 1 ||
+            !string.Equals(owners[0].Id, expectedGatewayId, StringComparison.Ordinal) ||
+            !string.Equals(
+                GatewayRecordEditing.ResolveManagedDistroName(owners[0]),
+                ctx.Config.DistroName,
+                StringComparison.OrdinalIgnoreCase) ||
+            !GatewayRecordEditing.AreEquivalentLoopbackEndpoints(
+                owners[0].Url,
+                ctx.Config.EffectiveGatewayUrl))
+        {
+            return Task.FromResult(StepResult.Terminal(
+                "The managed gateway owner changed before Local AI recovery. Close recovery and review Connection settings."));
+        }
+
+        ExistingConfigDetector.ExistingConfig existing;
+        try
+        {
+            existing = _detect(
+                ctx.DataDir,
+                ctx.Config.DistroName,
+                ctx.LocalDataDir,
+                expectedGatewayId);
+        }
+        catch (Exception ex)
+        {
+            ctx.Logger.Warn($"Local AI recovery gateway inspection failed: {ex.Message}");
+            return Task.FromResult(StepResult.Terminal(
+                "OpenClaw could not safely verify the existing managed gateway. Close recovery and run full setup."));
+        }
+
+        return Task.FromResult(
+            LocalAiRecoveryPolicy.CanRecoverExistingGateway(
+                existing,
+                expectedGatewayId,
+                ctx.Config.DistroName,
+                ctx.Config.EffectiveGatewayUrl)
+                ? StepResult.Ok("Existing app-managed gateway verified for Local AI recovery.")
+                : StepResult.Terminal(
+                    "The existing app-managed gateway is unavailable. Close recovery and run full setup."));
+    }
+
+    private static IReadOnlyList<GatewayRecord> LoadGatewayRecords(string dataDir)
+    {
+        var registry = new GatewayRegistry(dataDir);
+        registry.Load();
+        return registry.GetAll();
+    }
+}
+
+public sealed class PreserveLocalAiRecoveryGatewayStep : SetupStep
+{
+    private readonly Func<SetupContext, CancellationToken, Task<StepResult>> _restart;
+
+    public PreserveLocalAiRecoveryGatewayStep()
+        : this(StartGatewayStep.RestartAndWaitForHealthAsync)
+    {
+    }
+
+    internal PreserveLocalAiRecoveryGatewayStep(
+        Func<SetupContext, CancellationToken, Task<StepResult>> restart) =>
+        _restart = restart ?? throw new ArgumentNullException(nameof(restart));
+
+    public override string Id => "preserve-local-ai-recovery-gateway";
+    public override string DisplayName => "Preserve gateway during Local AI recovery";
+    public override bool CanRetry => false;
+
+    public override Task<StepResult> ExecuteAsync(SetupContext ctx, CancellationToken ct) =>
+        Task.FromResult(StepResult.Ok("Gateway recovery guard armed."));
+
+    public override async Task RollbackAsync(SetupContext ctx, CancellationToken ct)
+    {
+        if (!ctx.LocalAiRecoveryStoppedWsl)
+            return;
+
+        StepResult restart = await _restart(ctx, ct);
+        if (!restart.IsSuccess)
+            throw new InvalidOperationException(restart.Message);
+
+        ctx.LocalAiRecoveryStoppedWsl = false;
+    }
+}

--- a/src/OpenClaw.SetupEngine/LocalAiRecoveryPolicy.cs
+++ b/src/OpenClaw.SetupEngine/LocalAiRecoveryPolicy.cs
@@ -1,4 +1,5 @@
 using OpenClaw.Connection;
+using OpenClaw.Connection.LocalAi;
 
 namespace OpenClaw.SetupEngine;
 
@@ -144,13 +145,39 @@ public sealed class PreserveLocalAiRecoveryGatewayStep : SetupStep
 
     public override async Task RollbackAsync(SetupContext ctx, CancellationToken ct)
     {
-        if (!ctx.LocalAiRecoveryStoppedWsl)
-            return;
+        Exception? receiptError = null;
+        if (ctx.LocalAiRecoveryOriginalInstall is { } originalInstall)
+        {
+            try
+            {
+                var store = new LocalAiManifestStore(new LocalAiPaths(ctx.LocalDataDir));
+                await store.SaveAsync(originalInstall.Manifest, ct).ConfigureAwait(false);
+                ctx.LocalAiResolvedInstall = store.ResolveAndValidate(originalInstall.Manifest);
+                ctx.LocalAiRecoveryProviderTransition = false;
+                ctx.LocalAiGatewayPriorState = null;
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidDataException)
+            {
+                receiptError = ex;
+                ctx.Logger.Warn(
+                    $"Restoring the previous Local AI endpoint receipt failed ({ex.GetType().Name}).");
+            }
+        }
 
-        StepResult restart = await _restart(ctx, ct);
-        if (!restart.IsSuccess)
-            throw new InvalidOperationException(restart.Message);
+        if (ctx.LocalAiRecoveryStoppedWsl)
+        {
+            StepResult restart = await _restart(ctx, ct);
+            if (!restart.IsSuccess)
+                throw new InvalidOperationException(restart.Message);
 
-        ctx.LocalAiRecoveryStoppedWsl = false;
+            ctx.LocalAiRecoveryStoppedWsl = false;
+        }
+
+        if (receiptError is not null)
+        {
+            throw new InvalidOperationException(
+                "The previous Local AI endpoint receipt could not be restored.",
+                receiptError);
+        }
     }
 }

--- a/src/OpenClaw.SetupEngine/LocalAiSetupSteps.cs
+++ b/src/OpenClaw.SetupEngine/LocalAiSetupSteps.cs
@@ -161,6 +161,8 @@ public sealed class ConfigureLocalAiWslNetworkingStep : SetupStep
 
         try
         {
+            if (!string.IsNullOrWhiteSpace(ctx.Config.LocalAiRecoveryGatewayId))
+                ctx.LocalAiRecoveryStoppedWsl = true;
             CommandResult shutdown = await ShutdownWslAsync(ctx, ct);
             if (shutdown.ExitCode != 0 || shutdown.TimedOut)
             {
@@ -196,6 +198,8 @@ public sealed class ConfigureLocalAiWslNetworkingStep : SetupStep
                 CommandResult shutdown = await ShutdownWslAsync(ctx, ct);
                 if (shutdown.ExitCode != 0 || shutdown.TimedOut)
                     throw new InvalidOperationException("WSL could not be stopped to apply the restored configuration.");
+                if (!string.IsNullOrWhiteSpace(ctx.Config.LocalAiRecoveryGatewayId))
+                    ctx.LocalAiRecoveryStoppedWsl = true;
                 return;
             default:
                 throw new InvalidOperationException($"Unknown WSL configuration restore result: {restore}.");

--- a/src/OpenClaw.SetupEngine/LocalAiSetupSteps.cs
+++ b/src/OpenClaw.SetupEngine/LocalAiSetupSteps.cs
@@ -274,6 +274,8 @@ public sealed class ReconcileLocalAiInstallationStep : SetupStep
             ctx.LocalAiRuntimeInstall = result.RuntimeInstall;
             ctx.LocalAiModelInstall = result.ModelInstall;
             ctx.LocalAiPort = result.ResolvedInstall!.Manifest.RequestedPort;
+            if (!string.IsNullOrWhiteSpace(ctx.Config.LocalAiRecoveryGatewayId))
+                ctx.LocalAiRecoveryOriginalInstall = result.ResolvedInstall;
             return StepResult.Ok("Reused the verified managed Local AI installation.");
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)

--- a/src/OpenClaw.SetupEngine/LocalAiSetupSteps.cs
+++ b/src/OpenClaw.SetupEngine/LocalAiSetupSteps.cs
@@ -275,7 +275,10 @@ public sealed class ReconcileLocalAiInstallationStep : SetupStep
             ctx.LocalAiModelInstall = result.ModelInstall;
             ctx.LocalAiPort = result.ResolvedInstall!.Manifest.RequestedPort;
             if (!string.IsNullOrWhiteSpace(ctx.Config.LocalAiRecoveryGatewayId))
+            {
                 ctx.LocalAiRecoveryOriginalInstall = result.ResolvedInstall;
+                ctx.LocalAiRecoveryReceiptRollbackAllowed = true;
+            }
             return StepResult.Ok("Reused the verified managed Local AI installation.");
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)

--- a/src/OpenClaw.SetupEngine/RestartGatewayStep.cs
+++ b/src/OpenClaw.SetupEngine/RestartGatewayStep.cs
@@ -1,0 +1,30 @@
+namespace OpenClaw.SetupEngine;
+
+public sealed class RestartGatewayStep : SetupStep
+{
+    private readonly Func<SetupContext, CancellationToken, Task<StepResult>> _restart;
+
+    public RestartGatewayStep()
+        : this(StartGatewayStep.RestartAndWaitForHealthAsync)
+    {
+    }
+
+    internal RestartGatewayStep(
+        Func<SetupContext, CancellationToken, Task<StepResult>> restart) =>
+        _restart = restart ?? throw new ArgumentNullException(nameof(restart));
+
+    public override string Id => "restart-gateway";
+    public override string DisplayName => "Restart gateway";
+    public override RetryPolicy Retry => new(MaxAttempts: 3, InitialDelay: TimeSpan.FromSeconds(3));
+
+    public override async Task<StepResult> ExecuteAsync(SetupContext ctx, CancellationToken ct)
+    {
+        if (!string.IsNullOrWhiteSpace(ctx.Config.LocalAiRecoveryGatewayId))
+            ctx.LocalAiRecoveryStoppedWsl = true;
+
+        StepResult result = await _restart(ctx, ct);
+        if (result.IsSuccess)
+            ctx.LocalAiRecoveryStoppedWsl = false;
+        return result;
+    }
+}

--- a/src/OpenClaw.SetupEngine/SetupContext.cs
+++ b/src/OpenClaw.SetupEngine/SetupContext.cs
@@ -511,6 +511,8 @@ public sealed class SetupContext
     internal LlamaRuntimeInstallResult? LocalAiRuntimeInstall { get; set; }
     internal HuggingFaceModelInstallResult? LocalAiModelInstall { get; set; }
     internal LocalAiResolvedInstall? LocalAiResolvedInstall { get; set; }
+    internal LocalAiResolvedInstall? LocalAiRecoveryOriginalInstall { get; set; }
+    internal bool LocalAiRecoveryProviderTransition { get; set; }
     internal bool LocalAiManifestCreatedThisRun { get; set; }
     internal ILocalAiRuntime? LocalAiRuntime { get; set; }
     internal HostHardwareInfo? LocalAiGpuBaseline { get; set; }

--- a/src/OpenClaw.SetupEngine/SetupContext.cs
+++ b/src/OpenClaw.SetupEngine/SetupContext.cs
@@ -513,6 +513,7 @@ public sealed class SetupContext
     internal LocalAiResolvedInstall? LocalAiResolvedInstall { get; set; }
     internal LocalAiResolvedInstall? LocalAiRecoveryOriginalInstall { get; set; }
     internal bool LocalAiRecoveryProviderTransition { get; set; }
+    internal bool LocalAiRecoveryReceiptRollbackAllowed { get; set; }
     internal bool LocalAiManifestCreatedThisRun { get; set; }
     internal ILocalAiRuntime? LocalAiRuntime { get; set; }
     internal HostHardwareInfo? LocalAiGpuBaseline { get; set; }

--- a/src/OpenClaw.SetupEngine/SetupContext.cs
+++ b/src/OpenClaw.SetupEngine/SetupContext.cs
@@ -34,6 +34,8 @@ public sealed class SetupConfig
     public Dictionary<string, string>? WizardAnswers { get; set; }
     [JsonIgnore]
     public bool UsesBundledDefaultConfig { get; set; }
+    [JsonIgnore]
+    public string? LocalAiRecoveryGatewayId { get; set; }
 
     // Nested config sections — everything is configurable
     public WslConfig Wsl { get; set; } = new();
@@ -516,6 +518,7 @@ public sealed class SetupContext
     internal LocalAiGpuLoadEvidence? LocalAiGpuLoadEvidence { get; set; }
     internal LocalAiGatewayPriorState? LocalAiGatewayPriorState { get; set; }
     internal bool IsUninstalling { get; set; }
+    internal bool LocalAiRecoveryStoppedWsl { get; set; }
 
     // Data directory for gateway registry and identity files
     public string DataDir { get; }

--- a/src/OpenClaw.SetupEngine/SetupPipeline.cs
+++ b/src/OpenClaw.SetupEngine/SetupPipeline.cs
@@ -51,6 +51,29 @@ public static class SetupStepFactory
         new WindowsNodeBootstrapContextStep(),
     ];
 
+    public static List<SetupStep> BuildLocalAiRecoverySteps() =>
+    [
+        new PreflightOsStep(),
+        new ValidateLocalAiRecoveryGatewayStep(),
+        new PreserveLocalAiRecoveryGatewayStep(),
+        new PreflightLocalAiHardwareStep(),
+        new PreflightWslStep(),
+        new EnsureWslPlatformStep(reusePreflightResult: true),
+        new ReconcileLocalAiInstallationStep(),
+        new AcquireLocalAiRuntimeStep(),
+        new AcquireLocalAiModelStep(),
+        new PersistLocalAiManifestStep(),
+        new StartLocalAiRuntimeStep(),
+        new CaptureLocalAiGpuBaselineStep(),
+        new VerifyLocalAiInferenceStep(),
+        new VerifyLocalAiGpuLoadStep(),
+        new ValidateLocalAiRecoveryGatewayStep(finalCheck: true),
+        new ConfigureLocalAiWslNetworkingStep(),
+        new VerifyLocalAiWslStep(),
+        new ConfigureLocalAiGatewayStep(),
+        new RestartGatewayStep(),
+    ];
+
     public static List<SetupStep> BuildDefaultSteps()
     {
         return

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -3916,6 +3916,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands, IPer
     void IAppCommands.ShowChat() => ShowChatWindow();
     void IAppCommands.CheckForUpdates() => _ = _updateCoordinator!.CheckForUpdatesUserInitiatedAsync();
     void IAppCommands.ShowOnboarding() => _ = ShowOnboardingAsync();
+    void IAppCommands.ShowLocalAiSetup() => _ = _windowManager?.ShowLocalAiSetupAsync();
     void IAppCommands.OpenLocalAiLogs() =>
         OpenFolder(new LocalAiPaths(AppIdentity.ResolveSetupLocalDataDirectory()).LogsDirectory, "Local AI logs");
     void IAppCommands.ShowGatewayWizard() => _ = ShowGatewayWizardAsync();

--- a/src/OpenClaw.Tray.WinUI/Presentation/LocalAiPageViewModel.cs
+++ b/src/OpenClaw.Tray.WinUI/Presentation/LocalAiPageViewModel.cs
@@ -188,7 +188,7 @@ internal sealed class LocalAiPageViewModel : INavigationAware, IDisposable, INot
     public Task<bool> StopAsync() => RunRuntimeActionAsync(CanStop, _runtime.StopAsync);
     public Task<bool> RestartAsync() => RunRuntimeActionAsync(CanRestart, _runtime.RestartAsync);
     public bool OpenLogs() => RunCommand(CanOpenLogs, _appCommands.OpenLocalAiLogs);
-    public bool RetrySetup() => RunCommand(CanRetrySetup, _appCommands.ShowOnboarding);
+    public bool RetrySetup() => RunCommand(CanRetrySetup, _appCommands.ShowLocalAiSetup);
     public bool ChangeModel() => RunCommand(CanChangeModel, _appCommands.ShowOnboarding);
     public bool RepairConnection() => RunCommand(CanRepairConnection, _appCommands.Reconnect);
     public bool OpenChat() => RunCommand(CanOpenChat, _appCommands.ShowChat);

--- a/src/OpenClaw.Tray.WinUI/Services/IAppCommands.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/IAppCommands.cs
@@ -17,6 +17,7 @@ internal interface IAppCommands
     void ShowChat();
     void CheckForUpdates();
     void ShowOnboarding();
+    void ShowLocalAiSetup();
     void OpenLocalAiLogs() { }
     void ShowGatewayWizard();
     void ShowConnectionStatus();

--- a/src/OpenClaw.Tray.WinUI/Services/IWindowManager.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/IWindowManager.cs
@@ -26,6 +26,7 @@ internal interface IWindowManager
     void ShowHub(string? navigateTo = null, bool activate = true);
     void ShowConnectionStatus();
     Task ShowOnboardingAsync();
+    Task ShowLocalAiSetupAsync();
     Task ShowGatewayWizardAsync();
     void CloseSetup();
     void ApplyThemeToOpenWindows();

--- a/src/OpenClaw.Tray.WinUI/Services/LocalAiGatewayDistroResolver.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/LocalAiGatewayDistroResolver.cs
@@ -115,7 +115,7 @@ internal sealed class LocalAiGatewayDistroResolver : ILocalAiGatewayDistroResolv
 
         GatewayRecord owner = owners[0];
         _gatewayId = owner.Id;
-        _distroName = owner.SetupManagedDistroName!.Trim();
+        _distroName = GatewayRecordEditing.ResolveManagedDistroName(owner)!.Trim();
     }
 
     public LocalAiGatewayDistroResolution Resolve()
@@ -132,7 +132,7 @@ internal sealed class LocalAiGatewayDistroResolver : ILocalAiGatewayDistroResolv
         if (owners.Count != 1 ||
             !string.Equals(owners[0].Id, _gatewayId, StringComparison.Ordinal) ||
             !string.Equals(
-                owners[0].SetupManagedDistroName?.Trim(),
+                GatewayRecordEditing.ResolveManagedDistroName(owners[0])?.Trim(),
                 _distroName,
                 StringComparison.Ordinal))
         {

--- a/src/OpenClaw.Tray.WinUI/Services/LocalAiGatewayDistroResolver.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/LocalAiGatewayDistroResolver.cs
@@ -19,6 +19,62 @@ internal interface ILocalAiGatewayDistroResolver
     LocalAiGatewayDistroResolution Resolve();
 }
 
+internal enum LocalAiSetupRoute
+{
+    Recovery,
+    Provision,
+    Blocked,
+}
+
+internal sealed record LocalAiRecoveryTarget(
+    string GatewayId,
+    string DistroName,
+    int GatewayPort);
+
+internal sealed record LocalAiSetupResolution(
+    LocalAiSetupRoute Route,
+    LocalAiRecoveryTarget? RecoveryTarget = null);
+
+internal static class LocalAiSetupRoutePolicy
+{
+    public static LocalAiSetupResolution Decide(
+        IReadOnlyList<GatewayRecord> owners,
+        bool hasLocalGateway,
+        string? localGatewayId,
+        bool hasDistro,
+        bool hasDistroDataDirectory,
+        bool distroIsAppOwned)
+    {
+        if (owners.Count == 1)
+        {
+            var owner = owners[0];
+            if (hasLocalGateway &&
+                string.Equals(localGatewayId, owners[0].Id, StringComparison.Ordinal) &&
+                hasDistro &&
+                distroIsAppOwned &&
+                Uri.TryCreate(owner.Url, UriKind.Absolute, out var uri) &&
+                uri.Port is > 0 and <= 65535)
+            {
+                return new(
+                    LocalAiSetupRoute.Recovery,
+                    new LocalAiRecoveryTarget(
+                        owner.Id,
+                        GatewayRecordEditing.ResolveManagedDistroName(owner)!.Trim(),
+                        uri.Port));
+            }
+
+            return new(LocalAiSetupRoute.Blocked);
+        }
+
+        return new(owners.Count == 0 &&
+            !hasLocalGateway &&
+            !hasDistro &&
+            !hasDistroDataDirectory
+                ? LocalAiSetupRoute.Provision
+                : LocalAiSetupRoute.Blocked);
+    }
+}
+
 /// <summary>
 /// Pins the singleton Local AI installation to the one explicitly setup-managed
 /// local WSL gateway in the loaded registry. Every resolution revalidates the
@@ -87,11 +143,12 @@ internal sealed class LocalAiGatewayDistroResolver : ILocalAiGatewayDistroResolv
         return LocalAiGatewayDistroResolution.Resolved(_distroName);
     }
 
-    private static IReadOnlyList<GatewayRecord> FindOwners(IEnumerable<GatewayRecord> records) =>
+    internal static IReadOnlyList<GatewayRecord> FindOwners(IEnumerable<GatewayRecord> records) =>
         records
             .Where(record =>
-                WslKeepAlivePolicy.IsSetupManagedLocalRecord(record) &&
+                GatewayRecordEditing.IsSetupManagedLocalRecord(record) &&
                 !string.IsNullOrWhiteSpace(record.Id) &&
-                !string.IsNullOrWhiteSpace(record.SetupManagedDistroName))
+                !string.IsNullOrWhiteSpace(
+                    GatewayRecordEditing.ResolveManagedDistroName(record)))
             .ToArray();
 }

--- a/src/OpenClaw.Tray.WinUI/Services/WindowManager.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/WindowManager.cs
@@ -2,6 +2,7 @@ using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using OpenClaw.Connection;
+using OpenClaw.SetupEngine;
 using OpenClaw.Shared;
 using OpenClawTray.Helpers;
 using OpenClawTray.Presentation;
@@ -341,13 +342,89 @@ internal sealed class WindowManager : IWindowManager
 
     public async Task ShowOnboardingAsync()
     {
-        await EnsureSetupWindowAsync(startAtGatewayInstalledMilestone: false);
+        await EnsureSetupWindowAsync(
+            startAtGatewayInstalledMilestone: false,
+            localAiRecoveryTarget: null);
+    }
+
+    public async Task ShowLocalAiSetupAsync()
+    {
+        var resolution = await ResolveLocalAiSetupRouteAsync();
+        if (resolution.Route == LocalAiSetupRoute.Provision)
+        {
+            Logger.Info("Local AI recovery requires an existing app-managed gateway; opening full setup");
+            await ShowOnboardingAsync();
+            return;
+        }
+        if (resolution.Route == LocalAiSetupRoute.Blocked ||
+            resolution.RecoveryTarget is null)
+        {
+            Logger.Warn("Local AI setup could not safely identify one existing app-managed gateway");
+            _callbacks.GetAppNotificationService()?.Show(new AppNotification
+            {
+                Id = $"local-ai-setup-owner-{Guid.NewGuid():N}",
+                Title = "Local AI setup needs attention",
+                Message = "OpenClaw could not safely identify the managed WSL gateway. Review Connection settings before retrying setup.",
+                Severity = AppNotificationSeverity.Warning,
+                Source = "local-ai",
+                DedupeKey = "local-ai-setup-owner",
+                CreatedAt = DateTimeOffset.UtcNow,
+            });
+            ShowHub("connection");
+            return;
+        }
+
+        await ShowLocalAiSetupRecoveryAsync(resolution.RecoveryTarget);
+    }
+
+    private async Task<LocalAiSetupResolution> ResolveLocalAiSetupRouteAsync()
+    {
+        var registry = _callbacks.GetGatewayRegistry();
+        if (registry is null)
+            return new(LocalAiSetupRoute.Blocked);
+
+        try
+        {
+            var owners = LocalAiGatewayDistroResolver.FindOwners(registry.GetAll());
+            var distroName = owners.Count == 1
+                ? GatewayRecordEditing.ResolveManagedDistroName(owners[0])!.Trim()
+                : AppIdentity.SetupDistroName;
+            var existing = await Task.Run(() => ExistingConfigDetector.Detect(
+                AppIdentity.ResolveRoamingDataDirectory(),
+                distroName,
+                AppIdentity.ResolveSetupLocalDataDirectory(),
+                owners.Count == 1 ? owners[0].Id : null));
+            return LocalAiSetupRoutePolicy.Decide(
+                owners,
+                existing.HasLocalGateway,
+                existing.LocalGatewayId,
+                existing.HasDistro,
+                existing.HasDistroDataDirectory,
+                existing.DistroIsAppOwned);
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn($"Local AI recovery gateway inspection failed: {ex.Message}");
+            return new(LocalAiSetupRoute.Blocked);
+        }
+    }
+
+    private async Task ShowLocalAiSetupRecoveryAsync(LocalAiRecoveryTarget target)
+    {
+        var (setupWindow, created) = await EnsureSetupWindowAsync(
+            startAtGatewayInstalledMilestone: false,
+            localAiRecoveryTarget: target);
+        if (!_isShuttingDown && !created && setupWindow is { IsClosed: false })
+        {
+            Logger.Info("Setup window already open; leaving current setup page visible to avoid interrupting active setup");
+        }
     }
 
     public async Task ShowGatewayWizardAsync()
     {
         var (setupWindow, created) = await EnsureSetupWindowAsync(
-            startAtGatewayInstalledMilestone: true);
+            startAtGatewayInstalledMilestone: true,
+            localAiRecoveryTarget: null);
         if (!_isShuttingDown && !created && setupWindow is { IsClosed: false })
         {
             if (setupWindow.TryNavigateToGatewayInstalledMilestone())
@@ -362,7 +439,8 @@ internal sealed class WindowManager : IWindowManager
     }
 
     private async Task<(SetupWindow? Window, bool Created)> EnsureSetupWindowAsync(
-        bool startAtGatewayInstalledMilestone)
+        bool startAtGatewayInstalledMilestone,
+        LocalAiRecoveryTarget? localAiRecoveryTarget)
     {
         if (_isShuttingDown || _callbacks.GetSettings() is null)
         {
@@ -409,10 +487,14 @@ internal sealed class WindowManager : IWindowManager
         {
             setupWindow = new SetupWindow(
                 startAtGatewayInstalledMilestone: startAtGatewayInstalledMilestone,
+                startAtLocalAiRecoveryReview: localAiRecoveryTarget is not null,
                 dataDir: AppIdentity.ResolveRoamingDataDirectory(),
                 localDataDir: AppIdentity.ResolveSetupLocalDataDirectory(),
                 distroNameOverride: AppIdentity.SetupDistroName,
                 gatewayPortOverride: AppIdentity.SetupGatewayPort,
+                localAiRecoveryGatewayId: localAiRecoveryTarget?.GatewayId,
+                localAiRecoveryDistroName: localAiRecoveryTarget?.DistroName,
+                localAiRecoveryGatewayPort: localAiRecoveryTarget?.GatewayPort,
                 commandLineArgs: SetupWindowArgumentProjection.Project(
                     _callbacks.GetStartupArgs(),
                     _callbacks.IsDeepLinkArg,

--- a/src/OpenClaw.Tray.WinUI/Services/WslKeepAlivePolicy.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/WslKeepAlivePolicy.cs
@@ -107,15 +107,9 @@ internal static class WslKeepAlivePolicy
     }
 
     public static bool IsSetupManagedLocalRecord(GatewayRecord record)
-    {
-        if (record.SshTunnel is not null)
-            return false;
-
-        if (GatewayRecordEditing.ResolveManagedDistroName(record) is not null)
-            return record.IsLocal || LocalGatewayUrlClassifier.IsLocalGatewayUrl(record.Url);
-
-        return IsLegacyDefaultSetupManagedLocalRecord(record);
-    }
+        => GatewayRecordEditing.IsSetupManagedLocalRecord(record) ||
+           (record.SshTunnel is null &&
+            IsLegacyDefaultSetupManagedLocalRecord(record));
 
     public static bool IsSameSetupManagedGateway(
         GatewayRecord expected,

--- a/tests/OpenClaw.SetupEngine.Tests/LocalAiGatewayUninstallTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/LocalAiGatewayUninstallTests.cs
@@ -427,6 +427,52 @@ public sealed class LocalAiGatewayUninstallTests
         Assert.False(context.LocalAiRecoveryReceiptRollbackAllowed);
     }
 
+    [Fact]
+    public async Task Recovery_RollbackCancellationKeepsReplacementReceipt()
+    {
+        using var temp = new TempDirectory("local-ai-gateway-recovery-");
+        LocalAiResolvedInstall original = await SaveManifestAsync(temp.Path, "openai/gpt-5");
+        string originalProvider = LocalAiGatewayProviderDefinition.BuildProviderJson(original);
+        string primary = JsonSerializer.Serialize(
+            LocalAiGatewayProviderDefinition.BuildPrimaryModel(original));
+        var commands = new GatewayStateCommandRunner(originalProvider, primary);
+        SetupContext context = CreateRecoveryContext(temp.Path, commands);
+        context.Config.RollbackOnFailure = true;
+        context.LocalAiRecoveryOriginalInstall = original;
+        context.LocalAiRecoveryReceiptRollbackAllowed = true;
+        LocalAiInstallManifest replacementManifest = original.Manifest with
+        {
+            Endpoint = "http://127.0.0.1:39876/v1",
+        };
+        var store = new LocalAiManifestStore(new LocalAiPaths(temp.Path));
+        await store.SaveAsync(replacementManifest);
+        context.LocalAiResolvedInstall = store.ResolveAndValidate(replacementManifest);
+        var configure = new ConfigureLocalAiGatewayStep();
+        StepResult configured = await configure.ExecuteAsync(context, CancellationToken.None);
+        commands.ThrowOnNextCapture = true;
+        var pipeline = new SetupPipeline(
+        [
+            new PreserveLocalAiRecoveryGatewayStep((_, _) =>
+                Task.FromResult(StepResult.Ok("not needed"))),
+            new DelegatingRollbackStep("configured", configure.RollbackAsync),
+            new DelegatingRollbackStep(
+                "fail",
+                (_, _) => Task.CompletedTask,
+                (_, _) => Task.FromResult(StepResult.Fail("forced failure"))),
+        ]);
+
+        PipelineResult result = await pipeline.RunAsync(context);
+
+        Assert.Equal(StepOutcome.Success, configured.Outcome);
+        Assert.Equal(PipelineOutcome.Failed, result.Outcome);
+        Assert.True(LocalAiGatewayProviderDefinition.MatchesProviderJson(
+            commands.ProviderJson!,
+            context.LocalAiResolvedInstall));
+        Assert.Equal(new Uri(replacementManifest.Endpoint!), (await store.LoadAsync())!.Endpoint);
+        Assert.False(context.LocalAiRecoveryProviderTransition);
+        Assert.False(context.LocalAiRecoveryReceiptRollbackAllowed);
+    }
+
     private static SetupContext CreateContext(string localDataDirectory, ICommandRunner commands)
     {
         var config = new SetupConfig();
@@ -527,6 +573,7 @@ public sealed class LocalAiGatewayUninstallTests
         public bool LoseConfiguredAcknowledgementOnce { get; set; }
         public bool FailRestoreBatchOnce { get; set; }
         public bool LoseRestoreAcknowledgementOnce { get; set; }
+        public bool ThrowOnNextCapture { get; set; }
         public List<string> WslCalls { get; } = [];
 
         public Task<CommandResult> RunAsync(
@@ -632,6 +679,11 @@ public sealed class LocalAiGatewayUninstallTests
                     "",
                     TimeSpan.Zero,
                     TimedOut: false));
+            }
+            if (ThrowOnNextCapture)
+            {
+                ThrowOnNextCapture = false;
+                throw new OperationCanceledException(ct);
             }
             if (FailCapture)
             {

--- a/tests/OpenClaw.SetupEngine.Tests/LocalAiGatewayUninstallTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/LocalAiGatewayUninstallTests.cs
@@ -1,6 +1,8 @@
 using OpenClaw.Connection.LocalAi;
+using OpenClaw.Shared.Inference;
 using OpenClaw.Shared.Inference.Catalog;
 using OpenClaw.TestSupport;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
 
@@ -116,6 +118,136 @@ public sealed class LocalAiGatewayUninstallTests
             command.Contains("LOCAL_AI_GATEWAY_UNSET", StringComparison.Ordinal));
     }
 
+    [Fact]
+    public async Task Recovery_ReplacesExactManagedProviderAfterAutomaticPortChanges()
+    {
+        using var temp = new TempDirectory("local-ai-gateway-recovery-");
+        LocalAiResolvedInstall original = await SaveManifestAsync(temp.Path, "openai/gpt-5");
+        string originalProvider = LocalAiGatewayProviderDefinition.BuildProviderJson(original);
+        string primary = JsonSerializer.Serialize(
+            LocalAiGatewayProviderDefinition.BuildPrimaryModel(original));
+        var commands = new GatewayStateCommandRunner(originalProvider, primary);
+        SetupContext context = CreateRecoveryContext(temp.Path, commands);
+        context.LocalAiRecoveryOriginalInstall = original;
+        LocalAiInstallManifest replacementManifest = original.Manifest with
+        {
+            Endpoint = "http://127.0.0.1:39876/v1",
+        };
+        var store = new LocalAiManifestStore(new LocalAiPaths(temp.Path));
+        await store.SaveAsync(replacementManifest);
+        context.LocalAiResolvedInstall = store.ResolveAndValidate(replacementManifest);
+        var step = new ConfigureLocalAiGatewayStep();
+
+        StepResult result = await step.ExecuteAsync(context, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.Success, result.Outcome);
+        Assert.True(context.LocalAiRecoveryProviderTransition);
+        Assert.True(LocalAiGatewayProviderDefinition.MatchesProviderJson(
+            commands.ProviderJson!,
+            context.LocalAiResolvedInstall));
+        Assert.Equal(primary, commands.PrimaryJson);
+    }
+
+    [Fact]
+    public async Task Recovery_PreservesProviderThatMatchesNeitherEndpoint()
+    {
+        using var temp = new TempDirectory("local-ai-gateway-recovery-");
+        LocalAiResolvedInstall original = await SaveManifestAsync(temp.Path);
+        string driftedProvider = LocalAiGatewayProviderDefinition.BuildProviderJson(original)
+            .Replace(
+                "http://127.0.0.1:28765/v1",
+                "http://127.0.0.1:45555/v1",
+                StringComparison.Ordinal);
+        string primary = JsonSerializer.Serialize(
+            LocalAiGatewayProviderDefinition.BuildPrimaryModel(original));
+        var commands = new GatewayStateCommandRunner(driftedProvider, primary);
+        SetupContext context = CreateRecoveryContext(temp.Path, commands);
+        context.LocalAiRecoveryOriginalInstall = original;
+        LocalAiInstallManifest replacementManifest = original.Manifest with
+        {
+            Endpoint = "http://127.0.0.1:39876/v1",
+        };
+        context.LocalAiResolvedInstall = new LocalAiResolvedInstall(
+            replacementManifest,
+            original.ExecutablePath,
+            original.ModelPath,
+            new Uri(replacementManifest.Endpoint!));
+
+        StepResult result = await new ConfigureLocalAiGatewayStep()
+            .ExecuteAsync(context, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.Failed, result.Outcome);
+        Assert.Equal(driftedProvider, commands.ProviderJson);
+        Assert.Equal(primary, commands.PrimaryJson);
+    }
+
+    [Fact]
+    public async Task Recovery_RollbackRestoresOriginalProviderAndReceipt()
+    {
+        using var temp = new TempDirectory("local-ai-gateway-recovery-");
+        LocalAiResolvedInstall original = await SaveManifestAsync(temp.Path, "openai/gpt-5");
+        string originalProvider = LocalAiGatewayProviderDefinition.BuildProviderJson(original);
+        string primary = JsonSerializer.Serialize(
+            LocalAiGatewayProviderDefinition.BuildPrimaryModel(original));
+        var commands = new GatewayStateCommandRunner(originalProvider, primary);
+        SetupContext context = CreateRecoveryContext(temp.Path, commands);
+        context.LocalAiRecoveryOriginalInstall = original;
+        LocalAiInstallManifest replacementManifest = original.Manifest with
+        {
+            Endpoint = "http://127.0.0.1:39876/v1",
+        };
+        var store = new LocalAiManifestStore(new LocalAiPaths(temp.Path));
+        await store.SaveAsync(replacementManifest);
+        context.LocalAiResolvedInstall = store.ResolveAndValidate(replacementManifest);
+        var step = new ConfigureLocalAiGatewayStep();
+
+        StepResult result = await step.ExecuteAsync(context, CancellationToken.None);
+        await step.RollbackAsync(context, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.Success, result.Outcome);
+        Assert.True(LocalAiGatewayProviderDefinition.MatchesProviderJson(
+            commands.ProviderJson!,
+            original));
+        Assert.Equal(primary, commands.PrimaryJson);
+        Assert.Equal(original.Endpoint, (await store.LoadAsync())!.Endpoint);
+        Assert.False(context.LocalAiRecoveryProviderTransition);
+    }
+
+    [Fact]
+    public async Task Recovery_FailedProviderSwitchRestoresOriginalReceipt()
+    {
+        using var temp = new TempDirectory("local-ai-gateway-recovery-");
+        LocalAiResolvedInstall original = await SaveManifestAsync(temp.Path, "openai/gpt-5");
+        string originalProvider = LocalAiGatewayProviderDefinition.BuildProviderJson(original);
+        string primary = JsonSerializer.Serialize(
+            LocalAiGatewayProviderDefinition.BuildPrimaryModel(original));
+        var commands = new GatewayStateCommandRunner(originalProvider, primary)
+        {
+            FailConfiguredBatchOnce = true,
+        };
+        SetupContext context = CreateRecoveryContext(temp.Path, commands);
+        context.LocalAiRecoveryOriginalInstall = original;
+        LocalAiInstallManifest replacementManifest = original.Manifest with
+        {
+            Endpoint = "http://127.0.0.1:39876/v1",
+        };
+        var store = new LocalAiManifestStore(new LocalAiPaths(temp.Path));
+        await store.SaveAsync(replacementManifest);
+        context.LocalAiResolvedInstall = store.ResolveAndValidate(replacementManifest);
+        var step = new ConfigureLocalAiGatewayStep();
+
+        StepResult result = await step.ExecuteAsync(context, CancellationToken.None);
+        await step.RollbackAsync(context, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.Failed, result.Outcome);
+        Assert.True(LocalAiGatewayProviderDefinition.MatchesProviderJson(
+            commands.ProviderJson!,
+            original));
+        Assert.Equal(primary, commands.PrimaryJson);
+        Assert.Equal(original.Endpoint, (await store.LoadAsync())!.Endpoint);
+        Assert.False(context.LocalAiRecoveryProviderTransition);
+    }
+
     private static SetupContext CreateContext(string localDataDirectory, ICommandRunner commands)
     {
         var config = new SetupConfig();
@@ -128,6 +260,34 @@ public sealed class LocalAiGatewayUninstallTests
             CancellationToken.None,
             localDataDir: localDataDirectory);
     }
+
+    private static SetupContext CreateRecoveryContext(
+        string localDataDirectory,
+        ICommandRunner commands)
+    {
+        SetupContext context = CreateContext(localDataDirectory, commands);
+        context.Config.LocalAi.Enabled = true;
+        context.Config.LocalAiRecoveryGatewayId = "gateway-id";
+        context.DistroName = "OpenClawGateway";
+        context.LocalAiEligibility = LocalInferenceEligibility.Evaluate(CreateSparkHardware());
+        return context;
+    }
+
+    private static HostHardwareInfo CreateSparkHardware() => new(
+        Architecture.Arm64,
+        128L * 1024 * 1024 * 1024,
+        100L * 1024 * 1024 * 1024,
+        [
+            new GpuInfo(
+                GpuVendor.Nvidia,
+                "NVIDIA RTX Spark N1X (6144-core Blackwell RTX GPU)",
+                GpuVisibleMemoryBytes: 48L * 1024 * 1024 * 1024,
+                FreeGpuVisibleMemoryBytes: 40L * 1024 * 1024 * 1024,
+                DriverVersion: "616.00",
+                CudaMajorVersion: 13,
+                StableId: "GPU-SPARK"),
+        ],
+        VulkanAvailable: false);
 
     private static async Task<LocalAiResolvedInstall> SaveManifestAsync(
         string localDataDirectory,
@@ -184,6 +344,7 @@ public sealed class LocalAiGatewayUninstallTests
         public string? ProviderJson { get; private set; } = providerJson;
         public string? PrimaryJson { get; private set; } = primaryJson;
         public bool FailCapture { get; init; }
+        public bool FailConfiguredBatchOnce { get; set; }
         public List<string> WslCalls { get; } = [];
 
         public Task<CommandResult> RunAsync(
@@ -207,20 +368,44 @@ public sealed class LocalAiGatewayUninstallTests
         {
             ct.ThrowIfCancellationRequested();
             WslCalls.Add(command);
-            if (command.Contains("LOCAL_AI_PRIMARY_RESTORED", StringComparison.Ordinal))
+            if (environment is not null && environment.Count == 1)
             {
-                string encoded = Assert.Single(environment!).Value;
+                if (FailConfiguredBatchOnce &&
+                    command.Contains("LOCAL_AI_GATEWAY_CONFIGURED", StringComparison.Ordinal))
+                {
+                    FailConfiguredBatchOnce = false;
+                    return Task.FromResult(new CommandResult(
+                        1,
+                        "",
+                        "gateway configuration failed",
+                        TimeSpan.Zero,
+                        TimedOut: false));
+                }
+                string encoded = Assert.Single(environment).Value;
                 string batch = Encoding.UTF8.GetString(Convert.FromBase64String(encoded));
                 using JsonDocument document = JsonDocument.Parse(batch);
-                PrimaryJson = document.RootElement[0].GetProperty("value").GetRawText();
+                foreach (JsonElement operation in document.RootElement.EnumerateArray())
+                {
+                    string path = operation.GetProperty("path").GetString()!;
+                    string value = operation.GetProperty("value").GetRawText();
+                    if (path == LocalAiGatewayProviderDefinition.ProviderPath)
+                        ProviderJson = value;
+                    else if (path == LocalAiGatewayProviderDefinition.PrimaryModelPath)
+                        PrimaryJson = value;
+                }
+                string marker = command.Contains(
+                    "LOCAL_AI_GATEWAY_CONFIGURED",
+                    StringComparison.Ordinal)
+                    ? "LOCAL_AI_GATEWAY_CONFIGURED"
+                    : "LOCAL_AI_PRIMARY_RESTORED";
                 return Task.FromResult(new CommandResult(
                     0,
-                    "LOCAL_AI_PRIMARY_RESTORED",
+                    marker,
                     "",
                     TimeSpan.Zero,
                     TimedOut: false));
             }
-            if (command.Contains("LOCAL_AI_GATEWAY_UNSET", StringComparison.Ordinal))
+            if (command.Contains("openclaw config unset", StringComparison.Ordinal))
             {
                 if (command.Contains(LocalAiGatewayProviderDefinition.PrimaryModelPath, StringComparison.Ordinal))
                     PrimaryJson = null;

--- a/tests/OpenClaw.SetupEngine.Tests/LocalAiGatewayUninstallTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/LocalAiGatewayUninstallTests.cs
@@ -473,6 +473,50 @@ public sealed class LocalAiGatewayUninstallTests
         Assert.False(context.LocalAiRecoveryReceiptRollbackAllowed);
     }
 
+    [Fact]
+    public async Task Recovery_ProviderCreationRollbackCancellationKeepsReplacementReceipt()
+    {
+        using var temp = new TempDirectory("local-ai-gateway-recovery-");
+        LocalAiResolvedInstall original = await SaveManifestAsync(temp.Path, "openai/gpt-5");
+        string fallback = JsonSerializer.Serialize("openai/gpt-5");
+        var commands = new GatewayStateCommandRunner(providerJson: null, primaryJson: fallback);
+        SetupContext context = CreateRecoveryContext(temp.Path, commands);
+        context.Config.RollbackOnFailure = true;
+        context.LocalAiRecoveryOriginalInstall = original;
+        context.LocalAiRecoveryReceiptRollbackAllowed = true;
+        LocalAiInstallManifest replacementManifest = original.Manifest with
+        {
+            Endpoint = "http://127.0.0.1:39876/v1",
+        };
+        var store = new LocalAiManifestStore(new LocalAiPaths(temp.Path));
+        await store.SaveAsync(replacementManifest);
+        context.LocalAiResolvedInstall = store.ResolveAndValidate(replacementManifest);
+        var configure = new ConfigureLocalAiGatewayStep();
+        StepResult configured = await configure.ExecuteAsync(context, CancellationToken.None);
+        commands.ThrowOnNextCapture = true;
+        var pipeline = new SetupPipeline(
+        [
+            new PreserveLocalAiRecoveryGatewayStep((_, _) =>
+                Task.FromResult(StepResult.Ok("not needed"))),
+            new DelegatingRollbackStep("configured", configure.RollbackAsync),
+            new DelegatingRollbackStep(
+                "fail",
+                (_, _) => Task.CompletedTask,
+                (_, _) => Task.FromResult(StepResult.Fail("forced failure"))),
+        ]);
+
+        PipelineResult result = await pipeline.RunAsync(context);
+
+        Assert.Equal(StepOutcome.Success, configured.Outcome);
+        Assert.Equal(PipelineOutcome.Failed, result.Outcome);
+        Assert.True(LocalAiGatewayProviderDefinition.MatchesProviderJson(
+            commands.ProviderJson!,
+            context.LocalAiResolvedInstall));
+        Assert.Equal(new Uri(replacementManifest.Endpoint!), (await store.LoadAsync())!.Endpoint);
+        Assert.False(context.LocalAiRecoveryProviderTransition);
+        Assert.False(context.LocalAiRecoveryReceiptRollbackAllowed);
+    }
+
     private static SetupContext CreateContext(string localDataDirectory, ICommandRunner commands)
     {
         var config = new SetupConfig();

--- a/tests/OpenClaw.SetupEngine.Tests/LocalAiGatewayUninstallTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/LocalAiGatewayUninstallTests.cs
@@ -203,6 +203,9 @@ public sealed class LocalAiGatewayUninstallTests
 
         StepResult result = await step.ExecuteAsync(context, CancellationToken.None);
         await step.RollbackAsync(context, CancellationToken.None);
+        await new PreserveLocalAiRecoveryGatewayStep((_, _) =>
+                Task.FromResult(StepResult.Ok("not needed")))
+            .RollbackAsync(context, CancellationToken.None);
 
         Assert.Equal(StepOutcome.Success, result.Outcome);
         Assert.True(LocalAiGatewayProviderDefinition.MatchesProviderJson(
@@ -238,8 +241,85 @@ public sealed class LocalAiGatewayUninstallTests
 
         StepResult result = await step.ExecuteAsync(context, CancellationToken.None);
         await step.RollbackAsync(context, CancellationToken.None);
+        await new PreserveLocalAiRecoveryGatewayStep((_, _) =>
+                Task.FromResult(StepResult.Ok("not needed")))
+            .RollbackAsync(context, CancellationToken.None);
 
         Assert.Equal(StepOutcome.Failed, result.Outcome);
+        Assert.True(LocalAiGatewayProviderDefinition.MatchesProviderJson(
+            commands.ProviderJson!,
+            original));
+        Assert.Equal(primary, commands.PrimaryJson);
+        Assert.Equal(original.Endpoint, (await store.LoadAsync())!.Endpoint);
+        Assert.False(context.LocalAiRecoveryProviderTransition);
+    }
+
+    [Fact]
+    public async Task Recovery_FailureBeforeProviderConfigurationRestoresOriginalReceipt()
+    {
+        using var temp = new TempDirectory("local-ai-gateway-recovery-");
+        LocalAiResolvedInstall original = await SaveManifestAsync(temp.Path, "openai/gpt-5");
+        var commands = new GatewayStateCommandRunner(
+            providerJson: null,
+            primaryJson: JsonSerializer.Serialize("openai/gpt-5"));
+        SetupContext context = CreateRecoveryContext(temp.Path, commands);
+        context.LocalAiRecoveryOriginalInstall = original;
+        LocalAiInstallManifest replacementManifest = original.Manifest with
+        {
+            Endpoint = "http://127.0.0.1:39876/v1",
+        };
+        var store = new LocalAiManifestStore(new LocalAiPaths(temp.Path));
+        await store.SaveAsync(replacementManifest);
+        context.LocalAiResolvedInstall = store.ResolveAndValidate(replacementManifest);
+        context.LocalAiRecoveryProviderTransition = true;
+        context.LocalAiGatewayPriorState = new(
+            ProviderExisted: false,
+            ProviderJson: null,
+            PrimaryModelExisted: true,
+            PrimaryModelJson: JsonSerializer.Serialize("openai/gpt-5"));
+        var step = new PreserveLocalAiRecoveryGatewayStep((_, _) =>
+            Task.FromResult(StepResult.Ok("not needed")));
+
+        await step.RollbackAsync(context, CancellationToken.None);
+
+        Assert.Equal(original.Endpoint, (await store.LoadAsync())!.Endpoint);
+        Assert.Equal(original.Endpoint, context.LocalAiResolvedInstall!.Endpoint);
+        Assert.False(context.LocalAiRecoveryProviderTransition);
+        Assert.Null(context.LocalAiGatewayPriorState);
+    }
+
+    [Fact]
+    public async Task Recovery_RetryPreservesOriginalProviderRollbackBaseline()
+    {
+        using var temp = new TempDirectory("local-ai-gateway-recovery-");
+        LocalAiResolvedInstall original = await SaveManifestAsync(temp.Path, "openai/gpt-5");
+        string originalProvider = LocalAiGatewayProviderDefinition.BuildProviderJson(original);
+        string primary = JsonSerializer.Serialize(
+            LocalAiGatewayProviderDefinition.BuildPrimaryModel(original));
+        var commands = new GatewayStateCommandRunner(originalProvider, primary)
+        {
+            LoseConfiguredAcknowledgementOnce = true,
+        };
+        SetupContext context = CreateRecoveryContext(temp.Path, commands);
+        context.LocalAiRecoveryOriginalInstall = original;
+        LocalAiInstallManifest replacementManifest = original.Manifest with
+        {
+            Endpoint = "http://127.0.0.1:39876/v1",
+        };
+        var store = new LocalAiManifestStore(new LocalAiPaths(temp.Path));
+        await store.SaveAsync(replacementManifest);
+        context.LocalAiResolvedInstall = store.ResolveAndValidate(replacementManifest);
+        var step = new ConfigureLocalAiGatewayStep();
+
+        StepResult first = await step.ExecuteAsync(context, CancellationToken.None);
+        StepResult second = await step.ExecuteAsync(context, CancellationToken.None);
+        await step.RollbackAsync(context, CancellationToken.None);
+        await new PreserveLocalAiRecoveryGatewayStep((_, _) =>
+                Task.FromResult(StepResult.Ok("not needed")))
+            .RollbackAsync(context, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.Failed, first.Outcome);
+        Assert.Equal(StepOutcome.Success, second.Outcome);
         Assert.True(LocalAiGatewayProviderDefinition.MatchesProviderJson(
             commands.ProviderJson!,
             original));
@@ -345,6 +425,7 @@ public sealed class LocalAiGatewayUninstallTests
         public string? PrimaryJson { get; private set; } = primaryJson;
         public bool FailCapture { get; init; }
         public bool FailConfiguredBatchOnce { get; set; }
+        public bool LoseConfiguredAcknowledgementOnce { get; set; }
         public List<string> WslCalls { get; } = [];
 
         public Task<CommandResult> RunAsync(
@@ -392,6 +473,17 @@ public sealed class LocalAiGatewayUninstallTests
                         ProviderJson = value;
                     else if (path == LocalAiGatewayProviderDefinition.PrimaryModelPath)
                         PrimaryJson = value;
+                }
+                if (LoseConfiguredAcknowledgementOnce &&
+                    command.Contains("LOCAL_AI_GATEWAY_CONFIGURED", StringComparison.Ordinal))
+                {
+                    LoseConfiguredAcknowledgementOnce = false;
+                    return Task.FromResult(new CommandResult(
+                        1,
+                        "",
+                        "gateway configuration acknowledgement lost",
+                        TimeSpan.Zero,
+                        TimedOut: false));
                 }
                 string marker = command.Contains(
                     "LOCAL_AI_GATEWAY_CONFIGURED",

--- a/tests/OpenClaw.SetupEngine.Tests/LocalAiGatewayUninstallTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/LocalAiGatewayUninstallTests.cs
@@ -129,6 +129,7 @@ public sealed class LocalAiGatewayUninstallTests
         var commands = new GatewayStateCommandRunner(originalProvider, primary);
         SetupContext context = CreateRecoveryContext(temp.Path, commands);
         context.LocalAiRecoveryOriginalInstall = original;
+        context.LocalAiRecoveryReceiptRollbackAllowed = true;
         LocalAiInstallManifest replacementManifest = original.Manifest with
         {
             Endpoint = "http://127.0.0.1:39876/v1",
@@ -163,6 +164,7 @@ public sealed class LocalAiGatewayUninstallTests
         var commands = new GatewayStateCommandRunner(driftedProvider, primary);
         SetupContext context = CreateRecoveryContext(temp.Path, commands);
         context.LocalAiRecoveryOriginalInstall = original;
+        context.LocalAiRecoveryReceiptRollbackAllowed = true;
         LocalAiInstallManifest replacementManifest = original.Manifest with
         {
             Endpoint = "http://127.0.0.1:39876/v1",
@@ -192,6 +194,7 @@ public sealed class LocalAiGatewayUninstallTests
         var commands = new GatewayStateCommandRunner(originalProvider, primary);
         SetupContext context = CreateRecoveryContext(temp.Path, commands);
         context.LocalAiRecoveryOriginalInstall = original;
+        context.LocalAiRecoveryReceiptRollbackAllowed = true;
         LocalAiInstallManifest replacementManifest = original.Manifest with
         {
             Endpoint = "http://127.0.0.1:39876/v1",
@@ -230,6 +233,7 @@ public sealed class LocalAiGatewayUninstallTests
         };
         SetupContext context = CreateRecoveryContext(temp.Path, commands);
         context.LocalAiRecoveryOriginalInstall = original;
+        context.LocalAiRecoveryReceiptRollbackAllowed = true;
         LocalAiInstallManifest replacementManifest = original.Manifest with
         {
             Endpoint = "http://127.0.0.1:39876/v1",
@@ -264,6 +268,7 @@ public sealed class LocalAiGatewayUninstallTests
             primaryJson: JsonSerializer.Serialize("openai/gpt-5"));
         SetupContext context = CreateRecoveryContext(temp.Path, commands);
         context.LocalAiRecoveryOriginalInstall = original;
+        context.LocalAiRecoveryReceiptRollbackAllowed = true;
         LocalAiInstallManifest replacementManifest = original.Manifest with
         {
             Endpoint = "http://127.0.0.1:39876/v1",
@@ -302,6 +307,7 @@ public sealed class LocalAiGatewayUninstallTests
         };
         SetupContext context = CreateRecoveryContext(temp.Path, commands);
         context.LocalAiRecoveryOriginalInstall = original;
+        context.LocalAiRecoveryReceiptRollbackAllowed = true;
         LocalAiInstallManifest replacementManifest = original.Manifest with
         {
             Endpoint = "http://127.0.0.1:39876/v1",
@@ -326,6 +332,99 @@ public sealed class LocalAiGatewayUninstallTests
         Assert.Equal(primary, commands.PrimaryJson);
         Assert.Equal(original.Endpoint, (await store.LoadAsync())!.Endpoint);
         Assert.False(context.LocalAiRecoveryProviderTransition);
+    }
+
+    [Fact]
+    public async Task Recovery_FailedProviderCompensationKeepsReplacementReceipt()
+    {
+        using var temp = new TempDirectory("local-ai-gateway-recovery-");
+        LocalAiResolvedInstall original = await SaveManifestAsync(temp.Path, "openai/gpt-5");
+        string originalProvider = LocalAiGatewayProviderDefinition.BuildProviderJson(original);
+        string primary = JsonSerializer.Serialize(
+            LocalAiGatewayProviderDefinition.BuildPrimaryModel(original));
+        var commands = new GatewayStateCommandRunner(originalProvider, primary);
+        SetupContext context = CreateRecoveryContext(temp.Path, commands);
+        context.Config.RollbackOnFailure = true;
+        context.LocalAiRecoveryOriginalInstall = original;
+        context.LocalAiRecoveryReceiptRollbackAllowed = true;
+        LocalAiInstallManifest replacementManifest = original.Manifest with
+        {
+            Endpoint = "http://127.0.0.1:39876/v1",
+        };
+        var store = new LocalAiManifestStore(new LocalAiPaths(temp.Path));
+        await store.SaveAsync(replacementManifest);
+        context.LocalAiResolvedInstall = store.ResolveAndValidate(replacementManifest);
+        var configure = new ConfigureLocalAiGatewayStep();
+        StepResult configured = await configure.ExecuteAsync(context, CancellationToken.None);
+        commands.FailRestoreBatchOnce = true;
+        var pipeline = new SetupPipeline(
+        [
+            new PreserveLocalAiRecoveryGatewayStep((_, _) =>
+                Task.FromResult(StepResult.Ok("not needed"))),
+            new DelegatingRollbackStep("configured", configure.RollbackAsync),
+            new DelegatingRollbackStep(
+                "fail",
+                (_, _) => Task.CompletedTask,
+                (_, _) => Task.FromResult(StepResult.Fail("forced failure"))),
+        ]);
+
+        PipelineResult result = await pipeline.RunAsync(context);
+
+        Assert.Equal(StepOutcome.Success, configured.Outcome);
+        Assert.Equal(PipelineOutcome.Failed, result.Outcome);
+        Assert.True(LocalAiGatewayProviderDefinition.MatchesProviderJson(
+            commands.ProviderJson!,
+            context.LocalAiResolvedInstall));
+        Assert.Equal(new Uri(replacementManifest.Endpoint!), (await store.LoadAsync())!.Endpoint);
+        Assert.False(context.LocalAiRecoveryProviderTransition);
+        Assert.False(context.LocalAiRecoveryReceiptRollbackAllowed);
+    }
+
+    [Fact]
+    public async Task Recovery_LostRollbackAcknowledgementRestoresOriginalReceipt()
+    {
+        using var temp = new TempDirectory("local-ai-gateway-recovery-");
+        LocalAiResolvedInstall original = await SaveManifestAsync(temp.Path, "openai/gpt-5");
+        string originalProvider = LocalAiGatewayProviderDefinition.BuildProviderJson(original);
+        string primary = JsonSerializer.Serialize(
+            LocalAiGatewayProviderDefinition.BuildPrimaryModel(original));
+        var commands = new GatewayStateCommandRunner(originalProvider, primary);
+        SetupContext context = CreateRecoveryContext(temp.Path, commands);
+        context.Config.RollbackOnFailure = true;
+        context.LocalAiRecoveryOriginalInstall = original;
+        context.LocalAiRecoveryReceiptRollbackAllowed = true;
+        LocalAiInstallManifest replacementManifest = original.Manifest with
+        {
+            Endpoint = "http://127.0.0.1:39876/v1",
+        };
+        var store = new LocalAiManifestStore(new LocalAiPaths(temp.Path));
+        await store.SaveAsync(replacementManifest);
+        context.LocalAiResolvedInstall = store.ResolveAndValidate(replacementManifest);
+        var configure = new ConfigureLocalAiGatewayStep();
+        StepResult configured = await configure.ExecuteAsync(context, CancellationToken.None);
+        commands.LoseRestoreAcknowledgementOnce = true;
+        var pipeline = new SetupPipeline(
+        [
+            new PreserveLocalAiRecoveryGatewayStep((_, _) =>
+                Task.FromResult(StepResult.Ok("not needed"))),
+            new DelegatingRollbackStep("configured", configure.RollbackAsync),
+            new DelegatingRollbackStep(
+                "fail",
+                (_, _) => Task.CompletedTask,
+                (_, _) => Task.FromResult(StepResult.Fail("forced failure"))),
+        ]);
+
+        PipelineResult result = await pipeline.RunAsync(context);
+
+        Assert.Equal(StepOutcome.Success, configured.Outcome);
+        Assert.Equal(PipelineOutcome.Failed, result.Outcome);
+        Assert.True(LocalAiGatewayProviderDefinition.MatchesProviderJson(
+            commands.ProviderJson!,
+            original));
+        Assert.Equal(primary, commands.PrimaryJson);
+        Assert.Equal(original.Endpoint, (await store.LoadAsync())!.Endpoint);
+        Assert.False(context.LocalAiRecoveryProviderTransition);
+        Assert.False(context.LocalAiRecoveryReceiptRollbackAllowed);
     }
 
     private static SetupContext CreateContext(string localDataDirectory, ICommandRunner commands)
@@ -426,6 +525,8 @@ public sealed class LocalAiGatewayUninstallTests
         public bool FailCapture { get; init; }
         public bool FailConfiguredBatchOnce { get; set; }
         public bool LoseConfiguredAcknowledgementOnce { get; set; }
+        public bool FailRestoreBatchOnce { get; set; }
+        public bool LoseRestoreAcknowledgementOnce { get; set; }
         public List<string> WslCalls { get; } = [];
 
         public Task<CommandResult> RunAsync(
@@ -451,6 +552,17 @@ public sealed class LocalAiGatewayUninstallTests
             WslCalls.Add(command);
             if (environment is not null && environment.Count == 1)
             {
+                if (FailRestoreBatchOnce &&
+                    command.Contains("LOCAL_AI_GATEWAY_RESTORED", StringComparison.Ordinal))
+                {
+                    FailRestoreBatchOnce = false;
+                    return Task.FromResult(new CommandResult(
+                        1,
+                        "",
+                        "gateway rollback failed",
+                        TimeSpan.Zero,
+                        TimedOut: false));
+                }
                 if (FailConfiguredBatchOnce &&
                     command.Contains("LOCAL_AI_GATEWAY_CONFIGURED", StringComparison.Ordinal))
                 {
@@ -473,6 +585,17 @@ public sealed class LocalAiGatewayUninstallTests
                         ProviderJson = value;
                     else if (path == LocalAiGatewayProviderDefinition.PrimaryModelPath)
                         PrimaryJson = value;
+                }
+                if (LoseRestoreAcknowledgementOnce &&
+                    command.Contains("LOCAL_AI_GATEWAY_RESTORED", StringComparison.Ordinal))
+                {
+                    LoseRestoreAcknowledgementOnce = false;
+                    return Task.FromResult(new CommandResult(
+                        1,
+                        "",
+                        "gateway rollback acknowledgement lost",
+                        TimeSpan.Zero,
+                        TimedOut: false));
                 }
                 if (LoseConfiguredAcknowledgementOnce &&
                     command.Contains("LOCAL_AI_GATEWAY_CONFIGURED", StringComparison.Ordinal))
@@ -529,5 +652,21 @@ public sealed class LocalAiGatewayUninstallTests
         private static string EncodeOrMissing(string? value) => value is null
             ? "MISSING"
             : Convert.ToBase64String(Encoding.UTF8.GetBytes(value));
+    }
+
+    private sealed class DelegatingRollbackStep(
+        string id,
+        Func<SetupContext, CancellationToken, Task> rollback,
+        Func<SetupContext, CancellationToken, Task<StepResult>>? execute = null) : SetupStep
+    {
+        public override string Id => id;
+        public override string DisplayName => id;
+        public override bool CanRetry => false;
+
+        public override Task<StepResult> ExecuteAsync(SetupContext ctx, CancellationToken ct) =>
+            execute?.Invoke(ctx, ct) ?? Task.FromResult(StepResult.Ok());
+
+        public override Task RollbackAsync(SetupContext ctx, CancellationToken ct) =>
+            rollback(ctx, ct);
     }
 }

--- a/tests/OpenClaw.SetupEngine.Tests/LocalAiWslNetworkingConsentTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/LocalAiWslNetworkingConsentTests.cs
@@ -60,6 +60,62 @@ public sealed class LocalAiWslNetworkingConsentTests
         Assert.Empty(commands.Invocations);
     }
 
+    [Fact]
+    public async Task Step_RecoveryShutdown_ArmsGatewayRollbackRestart()
+    {
+        using var temp = new TempDirectory("local-ai-recovery-shutdown-");
+        var commands = new SuccessfulCommandRunner();
+        SetupContext context = CreateContext(temp.Path, consent: true, commands);
+        context.Config.LocalAiRecoveryGatewayId = "gateway-id";
+        var step = new ConfigureLocalAiWslNetworkingStep(_ => new ChangedManager());
+
+        StepResult result = await step.ExecuteAsync(context, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.Success, result.Outcome);
+        Assert.True(context.LocalAiRecoveryStoppedWsl);
+        Assert.Equal(["wsl.exe --shutdown"], commands.Invocations);
+    }
+
+    [Theory]
+    [InlineData(1, false)]
+    [InlineData(-1, true)]
+    public async Task Step_RecoveryShutdownFailure_StillArmsGatewayRollbackRestart(
+        int exitCode,
+        bool timedOut)
+    {
+        using var temp = new TempDirectory("local-ai-recovery-shutdown-fail-");
+        var commands = new SuccessfulCommandRunner(new CommandResult(
+            exitCode,
+            string.Empty,
+            "failed",
+            TimeSpan.Zero,
+            timedOut));
+        SetupContext context = CreateContext(temp.Path, consent: true, commands);
+        context.Config.LocalAiRecoveryGatewayId = "gateway-id";
+        var step = new ConfigureLocalAiWslNetworkingStep(_ => new ChangedManager());
+
+        StepResult result = await step.ExecuteAsync(context, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.Failed, result.Outcome);
+        Assert.True(context.LocalAiRecoveryStoppedWsl);
+    }
+
+    [Fact]
+    public async Task Step_RecoveryShutdownCancellation_StillArmsGatewayRollbackRestart()
+    {
+        using var temp = new TempDirectory("local-ai-recovery-shutdown-cancel-");
+        using var cts = new CancellationTokenSource();
+        var commands = new CancelingCommandRunner(cts);
+        SetupContext context = CreateContext(temp.Path, consent: true, commands);
+        context.Config.LocalAiRecoveryGatewayId = "gateway-id";
+        var step = new ConfigureLocalAiWslNetworkingStep(_ => new ChangedManager());
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => step.ExecuteAsync(context, cts.Token));
+
+        Assert.True(context.LocalAiRecoveryStoppedWsl);
+    }
+
     private static SetupContext CreateContext(
         string localDataDirectory,
         bool consent,
@@ -121,6 +177,69 @@ public sealed class LocalAiWslNetworkingConsentTests
         }
     }
 
+    private sealed class SuccessfulCommandRunner(
+        CommandResult? result = null) : ICommandRunner
+    {
+        public List<string> Invocations { get; } = [];
+
+        public Task<CommandResult> RunAsync(
+            string executable,
+            string[] arguments,
+            TimeSpan timeout,
+            IReadOnlyDictionary<string, string>? environment = null,
+            string? workingDirectory = null,
+            string? stdinInput = null,
+            CancellationToken ct = default,
+            Stream? stdinStream = null)
+        {
+            Invocations.Add($"{Path.GetFileName(executable)} {string.Join(' ', arguments)}");
+            return Task.FromResult(result ?? new CommandResult(
+                0,
+                string.Empty,
+                string.Empty,
+                TimeSpan.Zero,
+                TimedOut: false));
+        }
+
+        public Task<CommandResult> RunInWslAsync(
+            string distroName,
+            string command,
+            TimeSpan timeout,
+            IReadOnlyDictionary<string, string>? environment = null,
+            CancellationToken ct = default,
+            string? user = null,
+            bool inputViaStdin = false) =>
+            throw new NotSupportedException();
+    }
+
+    private sealed class CancelingCommandRunner(
+        CancellationTokenSource cancellation) : ICommandRunner
+    {
+        public Task<CommandResult> RunAsync(
+            string executable,
+            string[] arguments,
+            TimeSpan timeout,
+            IReadOnlyDictionary<string, string>? environment = null,
+            string? workingDirectory = null,
+            string? stdinInput = null,
+            CancellationToken ct = default,
+            Stream? stdinStream = null)
+        {
+            cancellation.Cancel();
+            throw new OperationCanceledException(ct);
+        }
+
+        public Task<CommandResult> RunInWslAsync(
+            string distroName,
+            string command,
+            TimeSpan timeout,
+            IReadOnlyDictionary<string, string>? environment = null,
+            CancellationToken ct = default,
+            string? user = null,
+            bool inputViaStdin = false) =>
+            throw new NotSupportedException();
+    }
+
     private sealed class RecordingManager(string configPath) : IWslGlobalConfigManager
     {
         public bool ApplyCalled { get; private set; }
@@ -140,5 +259,17 @@ public sealed class LocalAiWslNetworkingConsentTests
             RestoreCalled = true;
             return WslGlobalConfigRestoreResult.NoBackup;
         }
+
+    }
+
+    private sealed class ChangedManager : IWslGlobalConfigManager
+    {
+        public WslGlobalConfigStatus Inspect() => new(Exists: false, IsMirrored: false);
+
+        public WslGlobalConfigApplyResult ApplyMirroredNetworking() =>
+            new(Changed: true, RollbackMetadata: null);
+
+        public WslGlobalConfigRestoreResult RestoreIfUnchanged() =>
+            WslGlobalConfigRestoreResult.NoBackup;
     }
 }

--- a/tests/OpenClaw.SetupEngine.Tests/SetupPipelineTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupPipelineTests.cs
@@ -147,6 +147,106 @@ public class SetupPipelineTests
     }
 
     [Fact]
+    public void BuildLocalAiRecoverySteps_PreservesExistingWslGateway()
+    {
+        var steps = SetupStepFactory.BuildLocalAiRecoverySteps();
+
+        Assert.DoesNotContain(steps, step => step is ValidateDistroInstallPathStep);
+        Assert.Equal(2, steps.Count(step => step is ValidateLocalAiRecoveryGatewayStep));
+        Assert.Contains(steps, step => step is PreserveLocalAiRecoveryGatewayStep);
+        Assert.DoesNotContain(steps, step => step is CleanupStaleDistroStep);
+        Assert.DoesNotContain(steps, step => step is CleanupStaleGatewayStep);
+        Assert.DoesNotContain(steps, step => step is CreateWslInstanceStep);
+        Assert.DoesNotContain(steps, step => step is ConfigureWslInstanceStep);
+        Assert.DoesNotContain(steps, step => step is InstallCliStep);
+        Assert.Contains(steps, step => step is AcquireLocalAiRuntimeStep);
+        Assert.Contains(steps, step => step is AcquireLocalAiModelStep);
+        Assert.Contains(steps, step => step is VerifyLocalAiWslStep);
+        Assert.IsType<ConfigureLocalAiGatewayStep>(steps[^2]);
+        Assert.IsType<RestartGatewayStep>(steps[^1]);
+        Assert.True(
+            steps.FindIndex(step => step is ValidateLocalAiRecoveryGatewayStep) <
+            steps.FindIndex(step => step is AcquireLocalAiRuntimeStep));
+        Assert.True(
+            steps.FindIndex(step => step is PreserveLocalAiRecoveryGatewayStep) <
+            steps.FindIndex(step => step is ConfigureLocalAiWslNetworkingStep));
+        Assert.IsType<ValidateLocalAiRecoveryGatewayStep>(
+            steps[steps.FindIndex(step => step is ConfigureLocalAiWslNetworkingStep) - 1]);
+    }
+
+    [Fact]
+    public async Task ValidateLocalAiRecoveryGateway_MissingDistro_BlocksBeforeRecovery()
+    {
+        var context = CreateContext(LocalAiRecoveryConfig());
+        var step = new ValidateLocalAiRecoveryGatewayStep(
+            (_, _, _, _) => ExistingLocalAiGateway(hasDistro: false, appOwned: false),
+            _ => [ManagedGatewayRecord()]);
+
+        var result = await step.ExecuteAsync(context, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.FailedTerminal, result.Outcome);
+        Assert.Contains("run full setup", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ValidateLocalAiRecoveryGateway_AppOwnedDistro_AllowsRecovery()
+    {
+        var context = CreateContext(LocalAiRecoveryConfig());
+        var step = new ValidateLocalAiRecoveryGatewayStep(
+            (_, _, _, _) => ExistingLocalAiGateway(hasDistro: true, appOwned: true),
+            _ => [ManagedGatewayRecord()]);
+
+        var result = await step.ExecuteAsync(context, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.Success, result.Outcome);
+    }
+
+    [Fact]
+    public async Task ValidateLocalAiRecoveryGateway_OwnerDrift_BlocksBeforeRecovery()
+    {
+        var context = CreateContext(LocalAiRecoveryConfig());
+        var step = new ValidateLocalAiRecoveryGatewayStep(
+            (_, _, _, _) => ExistingLocalAiGateway(hasDistro: true, appOwned: true),
+            _ => [ManagedGatewayRecord() with { Id = "replacement-gateway" }]);
+
+        var result = await step.ExecuteAsync(context, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.FailedTerminal, result.Outcome);
+        Assert.Contains("owner changed", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task PreserveLocalAiRecoveryGateway_RestartsAfterWslShutdown()
+    {
+        var context = CreateContext(LocalAiRecoveryConfig());
+        context.LocalAiRecoveryStoppedWsl = true;
+        var restartCalls = 0;
+        var step = new PreserveLocalAiRecoveryGatewayStep((_, _) =>
+        {
+            restartCalls++;
+            return Task.FromResult(StepResult.Ok("restarted"));
+        });
+
+        await step.RollbackAsync(context, CancellationToken.None);
+
+        Assert.Equal(1, restartCalls);
+        Assert.False(context.LocalAiRecoveryStoppedWsl);
+    }
+
+    [Fact]
+    public async Task RestartGatewayStep_FailureArmsRecoveryRollbackRestart()
+    {
+        var context = CreateContext(LocalAiRecoveryConfig());
+        var step = new RestartGatewayStep((_, _) =>
+            Task.FromResult(StepResult.Fail("restart failed")));
+
+        StepResult result = await step.ExecuteAsync(context, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.Failed, result.Outcome);
+        Assert.True(context.LocalAiRecoveryStoppedWsl);
+    }
+
+    [Fact]
     public void LocalAiDisabled_SkipsEveryLocalAiMutation()
     {
         var ctx = CreateContext(new SetupConfig
@@ -174,6 +274,36 @@ public class SetupPipelineTests
         Assert.False(steps.Single(step => step is PreflightWslStep).CanSkip(ctx));
         Assert.False(steps.Single(step => step is EnsureWslPlatformStep).CanSkip(ctx));
     }
+
+    private static ExistingConfigDetector.ExistingConfig ExistingLocalAiGateway(
+        bool hasDistro,
+        bool appOwned) =>
+        new(
+            HasLocalGateway: true,
+            LocalGatewayId: "gateway-id",
+            LocalGatewayUrl: "ws://127.0.0.1:18789",
+            HasDistro: hasDistro,
+            HasDistroDataDirectory: hasDistro,
+            DistroIsAppOwned: appOwned,
+            DistroName: hasDistro ? "OpenClawGateway" : null,
+            HasIdentityFiles: true,
+            PreservedGatewayCount: 0,
+            PreservedGatewayNames: []);
+
+    private static SetupConfig LocalAiRecoveryConfig() => new()
+    {
+        DistroName = "OpenClawGateway",
+        GatewayPort = 18789,
+        LocalAiRecoveryGatewayId = "gateway-id",
+    };
+
+    private static OpenClaw.Connection.GatewayRecord ManagedGatewayRecord() => new()
+    {
+        Id = "gateway-id",
+        Url = "ws://127.0.0.1:18789",
+        IsLocal = true,
+        SetupManagedDistroName = "OpenClawGateway",
+    };
 
     [Theory]
     [InlineData(false)]

--- a/tests/OpenClaw.Tray.Tests/LocalAiGatewayProviderCoordinatorTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalAiGatewayProviderCoordinatorTests.cs
@@ -352,6 +352,24 @@ public sealed class LocalAiGatewayProviderCoordinatorTests
     }
 
     [Fact]
+    public void DistroResolver_ResolvesLegacyManagedOwner()
+    {
+        GatewayRecord owner = new()
+        {
+            Id = "legacy-managed",
+            Url = "ws://localhost:18789",
+            IsLocal = true,
+            FriendlyName = "Local (LegacyGateway)",
+        };
+        var resolver = new LocalAiGatewayDistroResolver(CreateRegistry(owner));
+
+        LocalAiGatewayDistroResolution resolution = resolver.Resolve();
+
+        Assert.True(resolution.Success);
+        Assert.Equal("LegacyGateway", resolution.DistroName);
+    }
+
+    [Fact]
     public void LocalAiSetupRoute_ProvisionsOnlyWhenManagedGatewayIsConclusivelyAbsent()
     {
         LocalAiSetupResolution resolution = LocalAiSetupRoutePolicy.Decide(

--- a/tests/OpenClaw.Tray.Tests/LocalAiGatewayProviderCoordinatorTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalAiGatewayProviderCoordinatorTests.cs
@@ -303,6 +303,100 @@ public sealed class LocalAiGatewayProviderCoordinatorTests
     }
 
     [Fact]
+    public void LocalAiSetupRoute_UsesUniqueManagedOwnerEvenWhenItIsNotActive()
+    {
+        GatewayRecord owner = ManagedRecord("managed", "CustomGateway") with
+        {
+            Url = "ws://127.0.0.1:29999",
+        };
+        IReadOnlyList<GatewayRecord> owners =
+            LocalAiGatewayDistroResolver.FindOwners([owner]);
+
+        LocalAiSetupResolution resolution = LocalAiSetupRoutePolicy.Decide(
+            owners,
+            hasLocalGateway: true,
+            localGatewayId: owner.Id,
+            hasDistro: true,
+            hasDistroDataDirectory: true,
+            distroIsAppOwned: true);
+
+        Assert.Equal(LocalAiSetupRoute.Recovery, resolution.Route);
+        Assert.Equal("managed", resolution.RecoveryTarget?.GatewayId);
+        Assert.Equal("CustomGateway", resolution.RecoveryTarget?.DistroName);
+        Assert.Equal(29999, resolution.RecoveryTarget?.GatewayPort);
+    }
+
+    [Fact]
+    public void LocalAiSetupRoute_AcceptsLegacyManagedOwner()
+    {
+        GatewayRecord owner = new()
+        {
+            Id = "legacy-managed",
+            Url = "ws://localhost:18789",
+            IsLocal = true,
+            FriendlyName = "Local (LegacyGateway)",
+        };
+        IReadOnlyList<GatewayRecord> owners =
+            LocalAiGatewayDistroResolver.FindOwners([owner]);
+
+        LocalAiSetupResolution resolution = LocalAiSetupRoutePolicy.Decide(
+            owners,
+            hasLocalGateway: true,
+            localGatewayId: owner.Id,
+            hasDistro: true,
+            hasDistroDataDirectory: true,
+            distroIsAppOwned: true);
+
+        Assert.Equal(LocalAiSetupRoute.Recovery, resolution.Route);
+        Assert.Equal("LegacyGateway", resolution.RecoveryTarget?.DistroName);
+    }
+
+    [Fact]
+    public void LocalAiSetupRoute_ProvisionsOnlyWhenManagedGatewayIsConclusivelyAbsent()
+    {
+        LocalAiSetupResolution resolution = LocalAiSetupRoutePolicy.Decide(
+            owners: [],
+            hasLocalGateway: false,
+            localGatewayId: null,
+            hasDistro: false,
+            hasDistroDataDirectory: false,
+            distroIsAppOwned: false);
+
+        Assert.Equal(LocalAiSetupRoute.Provision, resolution.Route);
+        Assert.Null(resolution.RecoveryTarget);
+    }
+
+    [Fact]
+    public void LocalAiSetupRoute_BlocksAmbiguousOrStaleOwnership()
+    {
+        IReadOnlyList<GatewayRecord> ambiguousOwners =
+        [
+            ManagedRecord("managed-a", "GatewayA"),
+            ManagedRecord("managed-b", "GatewayB"),
+        ];
+        Assert.Equal(
+            LocalAiSetupRoute.Blocked,
+            LocalAiSetupRoutePolicy.Decide(
+                ambiguousOwners,
+                hasLocalGateway: true,
+                localGatewayId: "managed-a",
+                hasDistro: true,
+                hasDistroDataDirectory: true,
+                distroIsAppOwned: true).Route);
+
+        GatewayRecord staleOwner = ManagedRecord("managed", "OpenClawGateway");
+        Assert.Equal(
+            LocalAiSetupRoute.Blocked,
+            LocalAiSetupRoutePolicy.Decide(
+                [staleOwner],
+                hasLocalGateway: true,
+                localGatewayId: staleOwner.Id,
+                hasDistro: false,
+                hasDistroDataDirectory: true,
+                distroIsAppOwned: true).Route);
+    }
+
+    [Fact]
     public async Task Publish_AmbiguousManagedGatewayOwners_FailsWithoutWslCommand()
     {
         LocalAiResolvedInstall install = Install(28_773);

--- a/tests/OpenClaw.Tray.Tests/LocalAiSetupUxContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalAiSetupUxContractTests.cs
@@ -570,9 +570,11 @@ public sealed class LocalAiSetupUxContractTests
         // on the toggle being off, or requires a fully resolved, eligible, consented state.
         string primaryButtonMethod = ExtractMethod(source, "private void UpdatePrimaryButtonState");
         Assert.DoesNotContain("_localAiAvailability", primaryButtonMethod);
-        Assert.Contains("LocalAiToggle.IsOn != true ||", primaryButtonMethod);
         Assert.Contains(
-            "(_localAiSelectionEligible &&\r\n             (!_localAiNetworkingConsentRequired || LocalAiNetworkingConsentCheckBox.IsChecked == true));",
+            "(!_localAiRecoveryOnly && LocalAiToggle.IsOn != true) ||",
+            primaryButtonMethod);
+        Assert.Contains(
+            "(LocalAiToggle.IsOn == true &&\r\n             _localAiSelectionEligible &&\r\n             (!_localAiNetworkingConsentRequired || LocalAiNetworkingConsentCheckBox.IsChecked == true));",
             primaryButtonMethod);
     }
 

--- a/tests/OpenClaw.Tray.Tests/Presentation/LocalAiPageViewModelTests.cs
+++ b/tests/OpenClaw.Tray.Tests/Presentation/LocalAiPageViewModelTests.cs
@@ -563,7 +563,7 @@ public sealed class LocalAiPageViewModelTests
     [Theory]
     [InlineData(LocalAiModelAvailabilityState.Unknown)]
     [InlineData(LocalAiModelAvailabilityState.NotInstalled)]
-    public void MissingModel_KeepsRetrySetupAndDoesNotOfferChangeModel(
+    public void MissingModel_UsesLocalAiSetupRouteAndDoesNotOfferChangeModel(
         LocalAiModelAvailabilityState modelState)
     {
         using var harness = new LocalAiHarness(modelState);
@@ -576,7 +576,8 @@ public sealed class LocalAiPageViewModelTests
         Assert.True(harness.ViewModel.RetrySetup());
 
         Assert.Equal(0, harness.Commands.ShowGatewayWizardCount);
-        Assert.Equal(1, harness.Commands.ShowOnboardingCount);
+        Assert.Equal(0, harness.Commands.ShowOnboardingCount);
+        Assert.Equal(1, harness.Commands.ShowLocalAiSetupCount);
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/Presentation/PresentationTestDoubles.cs
+++ b/tests/OpenClaw.Tray.Tests/Presentation/PresentationTestDoubles.cs
@@ -67,6 +67,7 @@ internal sealed class FakeAppCommands : IAppCommands, IDisposable
     public int ReconnectCount { get; private set; }
     public int ShowChatCount { get; private set; }
     public int ShowOnboardingCount { get; private set; }
+    public int ShowLocalAiSetupCount { get; private set; }
     public int OpenLocalAiLogsCount { get; private set; }
 
     public void ClearOperationLog() => _operationLog.Clear();
@@ -79,6 +80,7 @@ internal sealed class FakeAppCommands : IAppCommands, IDisposable
     public void ShowChat() => ShowChatCount++;
     public void CheckForUpdates() { }
     public void ShowOnboarding() => ShowOnboardingCount++;
+    public void ShowLocalAiSetup() => ShowLocalAiSetupCount++;
     public void ShowGatewayWizard() => ShowGatewayWizardCount++;
     public void OpenLocalAiLogs() => OpenLocalAiLogsCount++;
     public void ShowConnectionStatus() { }
@@ -148,6 +150,7 @@ internal sealed class SelfWritingAppCommands : IAppCommands
     public void ShowChat() { }
     public void CheckForUpdates() { }
     public void ShowOnboarding() { }
+    public void ShowLocalAiSetup() { }
     public void ShowGatewayWizard() { }
     public void ShowConnectionStatus() { }
     public void NotifySettingsSaved() { }

--- a/tests/OpenClaw.Tray.Tests/WindowManagerTests.cs
+++ b/tests/OpenClaw.Tray.Tests/WindowManagerTests.cs
@@ -49,6 +49,58 @@ public sealed class WindowManagerTests
     }
 
     [Fact]
+    public void LocalAiSetup_ChoosesRecoveryOnlyAfterManagedGatewayProof()
+    {
+        var manager = ReadManager();
+
+        Assert.Contains("public async Task ShowLocalAiSetupAsync()", manager);
+        Assert.Contains("LocalAiGatewayDistroResolver.FindOwners(", manager);
+        Assert.Contains("ExistingConfigDetector.Detect(", manager);
+        Assert.Contains("LocalAiSetupRoutePolicy.Decide(", manager);
+        AssertInOrder(
+            manager,
+            "if (resolution.Route == LocalAiSetupRoute.Provision)",
+            "await ShowOnboardingAsync();",
+            "if (resolution.Route == LocalAiSetupRoute.Blocked",
+            "await ShowLocalAiSetupRecoveryAsync(");
+    }
+
+    [Fact]
+    public void LocalAiRecoveryMode_IsNotAppliedToAnExistingSetupWindow()
+    {
+        var manager = ReadManager();
+        var setupWindow = File.ReadAllText(Path.Combine(
+            TestRepositoryPaths.GetRepositoryRoot(),
+            "src",
+            "OpenClaw.SetupEngine.UI",
+            "SetupWindow.xaml.cs"));
+
+        Assert.DoesNotContain("TryNavigateToOnboardingStart", manager);
+        Assert.DoesNotContain("TryNavigateToLocalAiRecoveryReview", manager);
+        Assert.Contains("private void ResetLocalAiRecoveryMode()", setupWindow);
+        AssertInOrder(
+            setupWindow,
+            "public void NavigateToWelcome(bool back = false)",
+            "ResetLocalAiRecoveryMode();",
+            "NavigateTo(typeof(WelcomePage), _config, back);");
+        Assert.Contains("_config.LocalAi.Enabled = true;", setupWindow);
+        Assert.Contains("_config.SkipWizard = true;", setupWindow);
+
+        var capabilities = File.ReadAllText(Path.Combine(
+            TestRepositoryPaths.GetRepositoryRoot(),
+            "src",
+            "OpenClaw.SetupEngine.UI",
+            "Pages",
+            "CapabilitiesPage.xaml.cs"));
+        AssertInOrder(
+            capabilities,
+            "private void Back_Click(object sender, RoutedEventArgs e)",
+            "if (_localAiRecoveryOnly)",
+            "SetupWindow.Active?.NavigateToWelcome(back: true);",
+            "return;");
+    }
+
+    [Fact]
     public void CloseForShutdown_GatesCreationAndClosesOwnedWindowsOnce()
     {
         var manager = ReadManager();


### PR DESCRIPTION
## Problem

Supersedes #1342 (Add recovery flow for local AI setup) and fixes #1307 while preserving @karkarl's dedicated recovery direction.

Local AI **Retry setup or download** currently routes into full onboarding. The default setup pipeline can unregister and recreate the existing app-owned WSL gateway, then leave Local AI without a usable retry path.

## Fix

- route Local AI retry through one owner-aware setup command
- select non-destructive recovery only when exactly one setup-managed local gateway and its app-owned registered distro are proven
- carry the exact gateway ID, custom distro name, and custom port into the recovery window and pipeline
- route to normal provisioning only when managed gateway, distro, and data absence are conclusive
- block ambiguous or stale ownership with a visible warning and Connection navigation
- revalidate the exact owner before downloads and again immediately before WSL shutdown or gateway configuration
- exclude WSL/gateway cleanup, distro creation/configuration, CLI install, and service install from recovery
- repair Local AI assets, verify native inference and WSL reachability, configure the Local AI provider, and restart the existing gateway
- retain the previous verified Local AI receipt throughout the recovery transaction
- atomically replace an exact old managed provider with the verified replacement endpoint when automatic port selection changes
- reject provider state that matches neither the retained old receipt nor the new verified receipt
- preserve the first accepted provider snapshot across automatic configuration retries and lost acknowledgements
- apply the same transition safeguards when recovery creates a provider from a valid provider-absent state
- restore the original provider and primary model when a completed switch rolls back
- restore the original endpoint receipt from the transaction-level recovery guard for failures before or after gateway configuration
- re-inspect failed or unacknowledged provider compensation and restore receipt A only when live route A is confirmed
- conservatively retain receipt B for live route B, unknown state, timeout, rollback cancellation, or failed provider removal
- keep existing setup windows in their current mode; a newly created recovery window exits to normal setup only through Back
- force Local AI enabled during recovery and prevent a successful no-op
- preserve recovery for legacy managed gateway records by resolving their effective distro name consistently during initial ownership binding and revalidation

## Required proof pools

- `windows-wsl-dgx-blackwell`: not complete. The current host exposes an RTX 4080 SUPER in both Windows and WSL, but its 16 GiB VRAM is below the approximately 22.2 GiB minimum required by the smallest current new-install catalog recipe.
- `windows-wsl-gateway-e2e`: automated current-head Setup and connect E2E passed in workflow run [34182468367](https://github.com/openclaw/openclaw-windows-node/actions/runs/34182468367). A real existing-gateway Local AI recovery transaction remains blocked by the native proof constraints below.
- `windows-winui-interactive`: not complete. On this host the real hardware probe correctly marks current Local AI installation unavailable, so the enabled recovery review cannot be captured without a catalog-capable GPU.

## Validation

Current head: `aec64355`.

- `.\build.ps1`: passed
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore`: 3,943 passed, 32 skipped
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore`: 2,868 passed
- `dotnet test .\tests\OpenClaw.SetupEngine.Tests\OpenClaw.SetupEngine.Tests.csproj --no-restore`: 1,119 passed
- focused endpoint handoff and transaction tests: 50 passed
- focused Tray routing/UI contract tests: 67 passed
- current-head CI run `34182468367`: Core and CLI, Tray/setup/integration, UI/functional/accessibility, Setup and connect E2E, network recovery E2E, revocation recovery E2E, proof contracts, and CI Gate passed
- final structured autoreview on the recovery implementation: clean, no accepted/actionable findings
- final independent rubber-duck review on the recovery implementation: clean; all transaction, timeout, and provider-absent findings were verified closed

## Real behavior proof

Automated current-head proof establishes:

- retry invokes the Local AI setup route, not general onboarding directly
- a unique managed gateway can be recovered even when it is not the active gateway
- custom managed distro names and ports are preserved
- legacy managed records resolve their effective distro safely through both construction and revalidation
- conclusively absent installations route to normal provisioning
- ambiguous, stale, replaced, or missing owners fail closed before Local AI acquisition or WSL mutation
- the recovery pipeline contains two owner checks and excludes destructive WSL/gateway provisioning steps
- an exact managed provider using the previous automatic port is atomically switched to the newly verified endpoint
- provider drift matching neither the old nor new verified endpoint is preserved and blocks recovery
- provider creation from a valid provider-absent state is tracked as a recovery transition
- a provider batch that fails before mutation restores the retained original receipt without rewriting the unchanged live route
- a lost provider-switch acknowledgement cannot replace the original rollback baseline on retry
- rollback after a completed switch restores the original provider, primary model, and endpoint receipt
- failures before gateway configuration still restore the original receipt through the transaction-level preservation step
- failed provider compensation is re-inspected so receipt rollback follows observed live provider state rather than command exit status
- rollback timeout or cancellation defaults to retaining the replacement receipt rather than blindly rewinding it
- failed removal of a recovery-created provider also retains the replacement receipt
- WSL shutdown arms rollback restart before command execution, including cancellation, timeout, and nonzero exit
- a failed final gateway restart also arms rollback; a successful restart clears it
- recovery mode cannot complete with Local AI disabled
- Back exits recovery to normal setup, while clicks against an already-open setup window do not repurpose its current flow

Additional current-host proof:

- Windows and Ubuntu WSL both enumerate the NVIDIA GeForce RTX 4080 SUPER with driver 620.02 and 16,376 MiB
- the pinned `b10655` CUDA 13.3 x64 llama-server archives matched their catalog SHA-256 digests
- the recovery-compatible pinned Qwen3.5 9B model was downloaded with the Hugging Face client and matched its exact 5,868,826,976-byte size and SHA-256 digest
- the pinned Windows CUDA runtime loaded that model successfully and reported a healthy listener on `127.0.0.1`

Not verified / blocked:

- WSL could not reach the Windows loopback listener even after applying the already-configured `networkingMode=Mirrored` through an approved `wsl --shutdown`; the active Hyper-V firewall policy defaults inbound WSL traffic to Block and has no TCP allowance for the Local AI port
- a task-owned temporary Hyper-V firewall rule could not be added because the current session is not elevated (`Access is denied`); no rule or llama-server process was left behind
- no current-head screenshot or video of the enabled recovery review page was captured because the current 16 GiB GPU is correctly ineligible for the current new-install model catalog
- no full real existing-gateway Local AI recovery transaction was performed

## Ownership notes

- old owner: Local AI retry called general onboarding and entered the destructive-capable default pipeline
- new owner: `WindowManager.ShowLocalAiSetupAsync` chooses provision/recovery/blocked routing; `BuildLocalAiRecoverySteps` owns the owner-bound non-destructive pipeline
- preserved invariant: `App.xaml.cs` remains a one-line command forwarder; setup-window orchestration remains in `WindowManager`

## Security impact

No new credentials or permissions. Recovery is fail-closed on ambiguous ownership and binds all WSL/gateway changes to one revalidated registry owner, distro, loopback endpoint, and retained managed-provider receipt.