### PR TITLE
fix(setup): advance managed Node runtime to 24.19.0

### DIFF
--- a/scripts/Get-CiChangeClassification.ps1
+++ b/scripts/Get-CiChangeClassification.ps1
@@ -153,6 +153,13 @@ function Add-PathImpact {
         [Parameter(Mandatory)][string]$Path
     )
 
+    if ($Path.Equals(
+            "src/OpenClaw.SetupEngine/GatewayReleasePolicy.cs",
+            [StringComparison]::OrdinalIgnoreCase)) {
+        Add-Lanes -Impact $Impact -Tray -SetupE2e -RevocationE2e -NetworkE2e
+        return $true
+    }
+
     if ($Path.StartsWith("src/OpenClaw.Cli/", [StringComparison]::OrdinalIgnoreCase) -or
         $Path.StartsWith("src/OpenClaw.WinNode.Cli/", [StringComparison]::OrdinalIgnoreCase)) {
         Add-Lanes -Impact $Impact -Core

--- a/scripts/test-ci-change-classifier.ps1
+++ b/scripts/test-ci-change-classifier.ps1
@@ -128,6 +128,12 @@ $cases = @(
         Required = @("tray_tests", "setup_e2e")
     },
     @{
+        Scenario = "Gateway release policy change"
+        Paths = @("src/OpenClaw.SetupEngine/GatewayReleasePolicy.cs")
+        Classification = "targeted"
+        Required = @("tray_tests", "setup_e2e", "revocation_e2e", "network_e2e")
+    },
+    @{
         Scenario = "Connection change"
         Paths = @("src/OpenClaw.Connection/GatewayConnectionManager.cs")
         Classification = "targeted"

--- a/src/OpenClaw.SetupEngine/InstallCliStep.cs
+++ b/src/OpenClaw.SetupEngine/InstallCliStep.cs
@@ -110,9 +110,12 @@ public sealed class InstallCliStep : SetupStep
 
             if (result.ExitCode != 0)
             {
+                var diagnostic = string.IsNullOrWhiteSpace(result.Stderr)
+                    ? result.Stdout.Trim()
+                    : result.Stderr.Trim();
                 var cleanup = FormatCleanupError(cleanupError);
                 return StepResult.Fail(
-                    $"CLI install failed (exit {result.ExitCode}): {result.Stderr}{cleanup}");
+                    $"CLI install failed (exit {result.ExitCode}): {diagnostic}{cleanup}");
             }
 
             if (cleanupError is not null)

--- a/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
@@ -2033,6 +2033,27 @@ public class SetupStepsTests : IDisposable
     }
 
     [Fact]
+    public async Task InstallCli_InstallFailureSurfacesStdoutWhenStderrIsEmpty()
+    {
+        var commands = new FakeCommandRunner(
+            _ => Ok(),
+            (_, command, _) => command.Contains("curl -fsSL", StringComparison.Ordinal)
+                ? FailWithStdout("ERROR: Node 22.22.3 is unsupported; use Node 24.16.0+.")
+                : command.StartsWith("rm -rf -- /tmp/openclaw-installer-", StringComparison.Ordinal)
+                    ? Ok()
+                    : throw new InvalidOperationException($"Unexpected command: {command}"));
+        var config = new SetupConfig();
+        GatewayReleasePolicy.ResolveAndApply(config);
+        var ctx = CreateContext(config, commands);
+
+        var result = await new InstallCliStep().ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.Failed, result.Outcome);
+        Assert.Contains("Node 22.22.3 is unsupported", result.Message);
+        AssertCleanupRan(commands);
+    }
+
+    [Fact]
     public void InstallCli_BuildInstallCommand_EscapesSingleQuotesInUrlAndVersion()
     {
         var command = InstallCliStep.BuildInstallCommand("https://openclaw.ai/install-cli's.sh", "2026.5.22'a");


### PR DESCRIPTION
## Summary
- advance the official installer runtime pin from Node 22.22.3 to Node 24.19.0
- preserve the exact-runtime compatibility policy and verification
- surface installer stdout when stderr is empty so validation failures remain actionable
- route Gateway release-policy changes through setup, revocation, and network-recovery E2E lanes

## Why
OpenClaw raised its supported runtime floor to Node 24.16.0 / 26.1.0 for lossless SQLite reads. The live official installer now rejects the Windows setup pin before installation, which caused all three alpha.92 E2E lanes in [Build and Test run 34161675309](https://github.com/openclaw/openclaw-windows-node/actions/runs/34161675309) to fail at `install-cli`. Node 24.19.0 is the official installer default.

## Required proof pools
- `windows-wsl-gateway-e2e`: the exact runtime used for Gateway setup, pairing, invocation, and recovery changed.

## Validation
- `git diff --check`: passed.
- `./build.ps1`: not run locally because this host is macOS and has no .NET SDK or Windows prerequisites. The current-head Windows workflow build passed.
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore`: not run locally for the same host blocker. Core and CLI tests passed in current-head Windows CI.
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore`: not run locally for the same host blocker. Tray, SetupEngine, and integration tests passed in current-head Windows CI.
- [Full current-head run 34166096993](https://github.com/openclaw/openclaw-windows-node/actions/runs/34166096993): 12 jobs succeeded, 0 failed, and 3 intentionally skipped. Setup/connect, revocation recovery, network recovery, core/CLI, tray/SetupEngine, UI/accessibility, proof-pool contracts, x64 release smoke, and CI Gate passed.
- [Fallback validation run 34167352277](https://github.com/openclaw/openclaw-windows-node/actions/runs/34167352277) on isolated commit `f3ed1a3b`: 13 jobs succeeded, 0 failed, and 2 intentionally skipped. All three E2Es forced `OPENCLAW_E2E_GATEWAY_VERSION=2026.6.11`; ARM64 and x64 release validation also passed.

## Real behavior proof
- Recommended Gateway 2026.6.34: full current-head setup/connect, revocation recovery, and network recovery E2Es passed with the PR runtime policy.
- Retained fallback Gateway 2026.6.11: redacted setup artifacts record installer exit 0 with `Installing Node 24.19.0` and `Installing OpenClaw (2026.6.11)`, followed by `Gateway Node runtime: v24.19.0`, `OpenClaw CLI version: OpenClaw 2026.6.11`, and successful setup/connect, revocation recovery, and network recovery jobs. See [run 34167352277](https://github.com/openclaw/openclaw-windows-node/actions/runs/34167352277).
- Existing-install migration is not applicable to this path: SetupEngine creates a fresh managed WSL distro and refuses an existing target distro; wizard-only setup excludes installation.
- Rubber-duck review: ClawSweeper found no concrete patch defect and identified fallback compatibility as the remaining question. The isolated fallback run above directly validates that tuple.
- UI/MCP screenshots: not applicable; this changes the headless installer runtime and diagnostic propagation.