### PR TITLE
Preserve normal setup command output drains

### DIFF
--- a/src/OpenClaw.SetupEngine/CleanupStaleDistroStep.cs
+++ b/src/OpenClaw.SetupEngine/CleanupStaleDistroStep.cs
@@ -37,7 +37,11 @@ public sealed class CleanupStaleDistroStep : SetupStep
         if (!DistroInstallPathPolicy.TryGetManagedInstallPath(ctx.LocalDataDir, distro, out var wslDir, out var pathError))
             return StepResult.Terminal(pathError);
 
-        var list = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--list", "--quiet"], TimeSpan.FromSeconds(15), ct: ct);
+        var list = await ctx.Commands.RunAsyncAllowingInheritedPipeHandleEscape(
+            WslConstants.WslExePath,
+            ["--list", "--quiet"],
+            TimeSpan.FromSeconds(15),
+            ct: ct);
         if (list.ExitCode != 0)
             return StepResult.Ok("WSL not available or no distros - nothing to clean");
 

--- a/src/OpenClaw.SetupEngine/CommandRunner.cs
+++ b/src/OpenClaw.SetupEngine/CommandRunner.cs
@@ -19,6 +19,25 @@ public interface ICommandRunner
         CancellationToken ct = default,
         Stream? stdinStream = null);
 
+    Task<CommandResult> RunAsyncAllowingInheritedPipeHandleEscape(
+        string executable,
+        string[] arguments,
+        TimeSpan timeout,
+        IReadOnlyDictionary<string, string>? environment = null,
+        string? workingDirectory = null,
+        string? stdinInput = null,
+        CancellationToken ct = default,
+        Stream? stdinStream = null) =>
+        RunAsync(
+            executable,
+            arguments,
+            timeout,
+            environment,
+            workingDirectory,
+            stdinInput,
+            ct,
+            stdinStream);
+
     /// <summary>
     /// Run a command inside a WSL distro.
     /// </summary>
@@ -73,10 +92,9 @@ public sealed class CommandRunner : ICommandRunner
     private static readonly TimeSpan s_outputDrainGrace = TimeSpan.FromMilliseconds(250);
 
     /// <summary>
-    /// Upper bound on how long an exited process is given to reach EOF on its redirected
-    /// pipes. Large enough that a saturated thread pool cannot make a process that did
-    /// write output look silent, small enough that a descendant holding the pipes open
-    /// cannot stall the caller.
+    /// Upper bound on how long known inherited-pipe callers are given to reach EOF
+    /// after their direct child exits. Normal commands wait for EOF so trailing output
+    /// remains complete.
     /// </summary>
     private static readonly TimeSpan s_outputDrainCap = TimeSpan.FromSeconds(3);
     private const int MaxCapturedStreamChars = 1_048_576;
@@ -86,7 +104,7 @@ public sealed class CommandRunner : ICommandRunner
     /// <summary>
     /// Run a process and capture output. Timeout kills the process.
     /// </summary>
-    public async Task<CommandResult> RunAsync(
+    public Task<CommandResult> RunAsync(
         string executable,
         string[] arguments,
         TimeSpan timeout,
@@ -94,7 +112,48 @@ public sealed class CommandRunner : ICommandRunner
         string? workingDirectory = null,
         string? stdinInput = null,
         CancellationToken ct = default,
-        Stream? stdinStream = null)
+        Stream? stdinStream = null) =>
+        RunAsyncCore(
+            executable,
+            arguments,
+            timeout,
+            environment,
+            workingDirectory,
+            stdinInput,
+            ct,
+            stdinStream,
+            allowInheritedPipeHandleEscape: false);
+
+    public Task<CommandResult> RunAsyncAllowingInheritedPipeHandleEscape(
+        string executable,
+        string[] arguments,
+        TimeSpan timeout,
+        IReadOnlyDictionary<string, string>? environment = null,
+        string? workingDirectory = null,
+        string? stdinInput = null,
+        CancellationToken ct = default,
+        Stream? stdinStream = null) =>
+        RunAsyncCore(
+            executable,
+            arguments,
+            timeout,
+            environment,
+            workingDirectory,
+            stdinInput,
+            ct,
+            stdinStream,
+            allowInheritedPipeHandleEscape: true);
+
+    private async Task<CommandResult> RunAsyncCore(
+        string executable,
+        string[] arguments,
+        TimeSpan timeout,
+        IReadOnlyDictionary<string, string>? environment,
+        string? workingDirectory,
+        string? stdinInput,
+        CancellationToken ct,
+        Stream? stdinStream,
+        bool allowInheritedPipeHandleEscape)
     {
         ArgumentNullException.ThrowIfNull(executable);
         ArgumentNullException.ThrowIfNull(arguments);
@@ -210,20 +269,14 @@ public sealed class CommandRunner : ICommandRunner
             throw;
         }
 
-        // A surviving descendant can keep inherited pipe handles open after the child
-        // exits, so the EOF wait must stay bounded and cannot simply run to the command
-        // timeout. It also cannot be as tight as a few hundred milliseconds: the
-        // OutputDataReceived callbacks are queued to the thread pool, and on a saturated
-        // pool they can miss that window even though the process already exited and
-        // wrote its output. That surfaced as an exited process being reported with empty
-        // stdout and stderr, which every caller that classifies command output then
-        // misreads as silence. Wait up to a short cap instead, clamped by whatever
-        // remains of the caller's own deadline so the accepted timeout is never exceeded.
-        TimeSpan drainBudget = GetOutputDrainBudget(timeout, sw.Elapsed, timedOut);
-
-        await Task.WhenAny(
-            Task.WhenAll(stdoutClosed.Task, stderrClosed.Task),
-            Task.Delay(drainBudget));
+        var outputClosed = Task.WhenAll(stdoutClosed.Task, stderrClosed.Task);
+        await WaitForOutputDrainAsync(
+            outputClosed,
+            timeout,
+            sw.Elapsed,
+            timedOut,
+            allowInheritedPipeHandleEscape,
+            ct).ConfigureAwait(false);
 
         sw.Stop();
         var result = new CommandResult(
@@ -250,6 +303,31 @@ public sealed class CommandRunner : ICommandRunner
             return TimeSpan.Zero;
 
         return remaining < s_outputDrainCap ? remaining : s_outputDrainCap;
+    }
+
+    internal static async Task WaitForOutputDrainAsync(
+        Task outputClosed,
+        TimeSpan timeout,
+        TimeSpan elapsed,
+        bool timedOut,
+        bool allowInheritedPipeHandleEscape,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(outputClosed);
+
+        if (timedOut || allowInheritedPipeHandleEscape)
+        {
+            // A surviving descendant can keep inherited pipe handles open after the
+            // child exits. Bound only known inherited-pipe callers and timeout cleanup.
+            TimeSpan drainBudget = GetOutputDrainBudget(timeout, elapsed, timedOut);
+            var delay = Task.Delay(drainBudget, cancellationToken);
+            var completed = await Task.WhenAny(outputClosed, delay).ConfigureAwait(false);
+            if (ReferenceEquals(completed, delay))
+                await delay.ConfigureAwait(false);
+            return;
+        }
+
+        await outputClosed.WaitAsync(cancellationToken).ConfigureAwait(false);
     }
 
     internal static bool IsWslExecutable(string executable) =>

--- a/src/OpenClaw.SetupEngine/CreateWslInstanceStep.cs
+++ b/src/OpenClaw.SetupEngine/CreateWslInstanceStep.cs
@@ -41,7 +41,11 @@ public sealed class CreateWslInstanceStep : SetupStep
 
         ctx.Logger.Info($"Creating clean app-owned WSL distro '{distro}' from '{baseDistro}' at '{installPath}'");
 
-        var existing = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--list", "--quiet"], TimeSpan.FromSeconds(15), ct: ct);
+        var existing = await ctx.Commands.RunAsyncAllowingInheritedPipeHandleEscape(
+            WslConstants.WslExePath,
+            ["--list", "--quiet"],
+            TimeSpan.FromSeconds(15),
+            ct: ct);
         if (existing.ExitCode != 0)
             return StepResult.Fail($"Failed to list WSL distros before creating '{distro}': {existing.Stderr}");
 
@@ -126,7 +130,11 @@ public sealed class CreateWslInstanceStep : SetupStep
 
     private static async Task<StepResult> VerifyFreshDistro(SetupContext ctx, string distro, string installPath, CancellationToken ct)
     {
-        var list = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--list", "--quiet"], TimeSpan.FromSeconds(15), ct: ct);
+        var list = await ctx.Commands.RunAsyncAllowingInheritedPipeHandleEscape(
+            WslConstants.WslExePath,
+            ["--list", "--quiet"],
+            TimeSpan.FromSeconds(15),
+            ct: ct);
         if (list.ExitCode != 0 || !WslInstallSupport.ContainsDistro(list.Stdout, distro))
         {
             var environmentIssue = await PreflightWslStep.DetectEnvironmentIssueAsync(ctx, ct);
@@ -134,7 +142,7 @@ public sealed class CreateWslInstanceStep : SetupStep
             return StepResult.Fail(environmentIssue != null ? $"{baseMessage} {environmentIssue}" : baseMessage);
         }
 
-        var verbose = await ctx.Commands.RunAsync(
+        var verbose = await ctx.Commands.RunAsyncAllowingInheritedPipeHandleEscape(
             WslConstants.WslExePath,
             ["--list", "--verbose"],
             DistroVersionVerificationTimeout,
@@ -182,7 +190,11 @@ public sealed class CreateWslInstanceStep : SetupStep
     {
         var cleanupErrors = new List<string>();
         var installPathExists = Directory.Exists(installPath) || File.Exists(installPath);
-        var list = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--list", "--quiet"], TimeSpan.FromSeconds(15), ct: ct);
+        var list = await ctx.Commands.RunAsyncAllowingInheritedPipeHandleEscape(
+            WslConstants.WslExePath,
+            ["--list", "--quiet"],
+            TimeSpan.FromSeconds(15),
+            ct: ct);
         var registrationStateKnown = list.ExitCode == 0;
         var distroExists = registrationStateKnown && WslInstallSupport.ContainsDistro(list.Stdout, distro);
         var canDeleteInstallPath = registrationStateKnown && !distroExists;

--- a/src/OpenClaw.SetupEngine/ExistingConfigDetector.cs
+++ b/src/OpenClaw.SetupEngine/ExistingConfigDetector.cs
@@ -37,7 +37,10 @@ public sealed class ExistingConfigDetector
 
         var logger = new SetupLogger(filePath: null, LogLevel.Warn);
         var result = new CommandRunner(logger)
-            .RunAsync(WslConstants.WslExePath, ["--list", "--quiet"], TimeSpan.FromSeconds(5))
+            .RunAsyncAllowingInheritedPipeHandleEscape(
+                WslConstants.WslExePath,
+                ["--list", "--quiet"],
+                TimeSpan.FromSeconds(5))
             .GetAwaiter()
             .GetResult();
         var hasDistro = InterpretDistroList(result, targetDistroName);

--- a/src/OpenClaw.SetupEngine/PreflightWslStep.cs
+++ b/src/OpenClaw.SetupEngine/PreflightWslStep.cs
@@ -44,7 +44,7 @@ internal static class WslViabilityInspector
         CommandResult versionResult;
         try
         {
-            versionResult = await commands.RunAsync(
+            versionResult = await commands.RunAsyncAllowingInheritedPipeHandleEscape(
                 WslConstants.WslExePath,
                 ["--version"],
                 TimeSpan.FromSeconds(5),
@@ -102,7 +102,7 @@ internal static class WslViabilityInspector
         CommandResult status;
         try
         {
-            status = await commands.RunAsync(
+            status = await commands.RunAsyncAllowingInheritedPipeHandleEscape(
                 WslConstants.WslExePath,
                 ["--status"],
                 TimeSpan.FromSeconds(10),
@@ -201,7 +201,7 @@ public sealed class PreflightWslStep : SetupStep
 
     internal static async Task<string?> DetectEnvironmentIssueAsync(SetupContext ctx, CancellationToken ct)
     {
-        var status = await ctx.Commands.RunAsync(
+        var status = await ctx.Commands.RunAsyncAllowingInheritedPipeHandleEscape(
             WslConstants.WslExePath,
             ["--status"],
             TimeSpan.FromSeconds(10),
@@ -245,7 +245,7 @@ public sealed class PreflightWslStep : SetupStep
                 return StepResult.Fail(WslPlatformInstallDiagnostics.DescribeFailure(process.ExitCode, quota));
             }
 
-            var probe = await ctx.Commands.RunAsync(
+            var probe = await ctx.Commands.RunAsyncAllowingInheritedPipeHandleEscape(
                 WslConstants.WslExePath,
                 ["--version"],
                 TimeSpan.FromSeconds(5),

--- a/src/OpenClaw.SetupEngine/StartGatewayStep.cs
+++ b/src/OpenClaw.SetupEngine/StartGatewayStep.cs
@@ -148,7 +148,11 @@ public sealed class StartGatewayStep : SetupStep
         var distro = ctx.DistroName!;
 
         // Check if distro is running before trying systemctl stop
-        var list = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--list", "--quiet"], TimeSpan.FromSeconds(15), ct: ct);
+        var list = await ctx.Commands.RunAsyncAllowingInheritedPipeHandleEscape(
+            WslConstants.WslExePath,
+            ["--list", "--quiet"],
+            TimeSpan.FromSeconds(15),
+            ct: ct);
         if (!WslInstallSupport.ContainsDistro(list.Stdout, distro))
         {
             ctx.Logger.Info("[Uninstall] Distro not registered — skipping gateway stop");
@@ -156,7 +160,11 @@ public sealed class StartGatewayStep : SetupStep
         }
 
         // Check distro state — only stop if Running
-        var verbose = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--list", "--verbose"], TimeSpan.FromSeconds(15), ct: ct);
+        var verbose = await ctx.Commands.RunAsyncAllowingInheritedPipeHandleEscape(
+            WslConstants.WslExePath,
+            ["--list", "--verbose"],
+            TimeSpan.FromSeconds(15),
+            ct: ct);
         var isRunning = WslInstallSupport.Normalize(verbose.Stdout)
             .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)
             .Any(line => line.Contains(distro, StringComparison.OrdinalIgnoreCase)

--- a/src/OpenClaw.SetupEngine/WindowsNodeBootstrapContextStep.cs
+++ b/src/OpenClaw.SetupEngine/WindowsNodeBootstrapContextStep.cs
@@ -178,7 +178,7 @@ public sealed class WindowsNodeBootstrapContextStep : SetupStep
         var distro = ctx.DistroName;
         if (string.IsNullOrWhiteSpace(distro))
             return null;
-        var registered = await ctx.Commands.RunAsync(
+        var registered = await ctx.Commands.RunAsyncAllowingInheritedPipeHandleEscape(
             WslConstants.WslExePath,
             ["--list", "--quiet"],
             TimeSpan.FromSeconds(15),

--- a/tests/OpenClaw.SetupEngine.Tests/CommandRunnerTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/CommandRunnerTests.cs
@@ -142,11 +142,67 @@ public class CommandRunnerTests
         var (executable, arguments) = ExitsLeavingPipeHolderCommand();
         var stopwatch = Stopwatch.StartNew();
 
-        var result = await runner.RunAsync(executable, arguments, TimeSpan.FromSeconds(30));
+        var result = await runner.RunAsyncAllowingInheritedPipeHandleEscape(
+            executable,
+            arguments,
+            TimeSpan.FromSeconds(30));
 
         Assert.False(result.TimedOut);
         Assert.Equal(0, result.ExitCode);
         Assert.InRange(stopwatch.Elapsed, TimeSpan.Zero, TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task WaitForOutputDrainAsync_WaitsPastCommandDeadlineOnNormalExit()
+    {
+        var outputClosed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var wait = CommandRunner.WaitForOutputDrainAsync(
+            outputClosed.Task,
+            TimeSpan.FromMilliseconds(100),
+            TimeSpan.Zero,
+            timedOut: false,
+            allowInheritedPipeHandleEscape: false);
+
+        var completed = await Task.WhenAny(wait, Task.Delay(TimeSpan.FromMilliseconds(250)));
+        Assert.NotSame(wait, completed);
+
+        outputClosed.SetResult();
+        await wait;
+    }
+
+    [Fact]
+    public async Task WaitForOutputDrainAsync_CancellationInterruptsNormalPostExitDrain()
+    {
+        var outputClosed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            CommandRunner.WaitForOutputDrainAsync(
+                outputClosed.Task,
+                TimeSpan.FromSeconds(30),
+                TimeSpan.Zero,
+                timedOut: false,
+                allowInheritedPipeHandleEscape: false,
+                cancellation.Token));
+    }
+
+    [Fact]
+    public async Task RunAsync_DrainsHighVolumeStdoutAndStderrThroughTrailingMarkers()
+    {
+        const int lineCount = 8_000;
+        var (executable, arguments) = HighVolumeOutputCommand(lineCount);
+
+        var result = await CreateRunner().RunAsync(
+            executable,
+            arguments,
+            TimeSpan.FromSeconds(30));
+
+        Assert.False(result.TimedOut);
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(lineCount, CountLinesStartingWith(result.Stdout, "stdout-"));
+        Assert.Equal(lineCount, CountLinesStartingWith(result.Stderr, "stderr-"));
+        Assert.EndsWith($"STDOUT_MARKER{Environment.NewLine}", result.Stdout, StringComparison.Ordinal);
+        Assert.EndsWith($"STDERR_MARKER{Environment.NewLine}", result.Stderr, StringComparison.Ordinal);
     }
 
     [Theory]
@@ -180,6 +236,32 @@ public class CommandRunnerTests
         => OperatingSystem.IsWindows()
             ? ("cmd.exe", ["/d", "/s", "/c", "ping 127.0.0.1 -n 30 >nul"])
             : ("/bin/sh", ["-c", "sleep 30"]);
+
+    private static (string Executable, string[] Arguments) HighVolumeOutputCommand(int lineCount)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return ("/bin/sh",
+            [
+                "-c",
+                "i=0; while [ $i -lt " + lineCount + " ]; do printf 'stdout-%s\\n' \"$i\"; i=$((i+1)); done; " +
+                "printf 'STDOUT_MARKER\\n'; " +
+                "i=0; while [ $i -lt " + lineCount + " ]; do printf 'stderr-%s\\n' \"$i\" >&2; i=$((i+1)); done; " +
+                "printf 'STDERR_MARKER\\n' >&2"
+            ]);
+        }
+
+        var script =
+            $"for ($i = 0; $i -lt {lineCount}; $i++) {{ [Console]::Out.WriteLine(\"stdout-$i\") }}; " +
+            "[Console]::Out.WriteLine(\"STDOUT_MARKER\"); " +
+            $"for ($i = 0; $i -lt {lineCount}; $i++) {{ [Console]::Error.WriteLine(\"stderr-$i\") }}; " +
+            "[Console]::Error.WriteLine(\"STDERR_MARKER\")";
+        return ("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", script]);
+    }
+
+    private static int CountLinesStartingWith(string value, string prefix) =>
+        value.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)
+            .Count(line => line.StartsWith(prefix, StringComparison.Ordinal));
 
     private static (string Executable, string[] Arguments) CopyStdinCommand(string path)
     {

--- a/tests/OpenClaw.SetupEngine.Tests/CommandRunnerTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/CommandRunnerTests.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Diagnostics;
 
 namespace OpenClaw.SetupEngine.Tests;
@@ -139,17 +140,36 @@ public class CommandRunnerTests
     public async Task RunAsync_ReturnsWhenDescendantKeepsOutputPipesOpen()
     {
         var runner = CreateRunner();
-        var (executable, arguments) = ExitsLeavingPipeHolderCommand();
-        var stopwatch = Stopwatch.StartNew();
+        var pidFile = Path.GetTempFileName();
+        var childPid = 0;
 
-        var result = await runner.RunAsyncAllowingInheritedPipeHandleEscape(
-            executable,
-            arguments,
-            TimeSpan.FromSeconds(30));
+        try
+        {
+            var result = await runner.RunAsyncAllowingInheritedPipeHandleEscape(
+                FindTestHost(),
+                ["--process-fixture", "inherit-handles", "30000", pidFile],
+                TimeSpan.FromSeconds(30));
+            var completedAt = DateTime.UtcNow;
 
-        Assert.False(result.TimedOut);
-        Assert.Equal(0, result.ExitCode);
-        Assert.InRange(stopwatch.Elapsed, TimeSpan.Zero, TimeSpan.FromSeconds(5));
+            Assert.False(
+                result.TimedOut,
+                $"Command timed out. stdout={result.Stdout} stderr={result.Stderr}");
+            Assert.True(
+                result.ExitCode == 0,
+                $"exit={result.ExitCode} stdout={result.Stdout} stderr={result.Stderr}");
+
+            childPid = int.Parse(await File.ReadAllTextAsync(pidFile));
+            var drainElapsed = completedAt - File.GetLastWriteTimeUtc(pidFile);
+
+            using var child = Process.GetProcessById(childPid);
+            Assert.False(child.HasExited);
+            Assert.InRange(drainElapsed, TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(15));
+        }
+        finally
+        {
+            KillProcessTree(childPid);
+            File.Delete(pidFile);
+        }
     }
 
     [Fact]
@@ -227,15 +247,45 @@ public class CommandRunnerTests
     private static CommandRunner CreateRunner()
         => new(new SetupLogger(filePath: null, LogLevel.Trace));
 
-    private static (string Executable, string[] Arguments) ExitsLeavingPipeHolderCommand()
-        => OperatingSystem.IsWindows()
-            ? ("cmd.exe", ["/d", "/s", "/c", "start /b ping 127.0.0.1 -n 20"])
-            : ("/bin/sh", ["-c", "sleep 20 & exit 0"]);
-
     private static (string Executable, string[] Arguments) SleepingCommand()
         => OperatingSystem.IsWindows()
             ? ("cmd.exe", ["/d", "/s", "/c", "ping 127.0.0.1 -n 30 >nul"])
             : ("/bin/sh", ["-c", "sleep 30"]);
+
+    private static string FindTestHost()
+    {
+        var executableName = OperatingSystem.IsWindows()
+            ? "OpenClaw.Shared.TestHost.exe"
+            : "OpenClaw.Shared.TestHost";
+        var hostPath = Path.Combine(AppContext.BaseDirectory, executableName);
+        Assert.True(File.Exists(hostPath), $"Process test host was not built: {hostPath}");
+        return hostPath;
+    }
+
+    private static void KillProcessTree(int processId)
+    {
+        if (processId <= 0)
+            return;
+
+        try
+        {
+            using var process = Process.GetProcessById(processId);
+            process.Kill(entireProcessTree: true);
+            process.WaitForExit(2_000);
+        }
+        catch (ArgumentException)
+        {
+        }
+        catch (InvalidOperationException)
+        {
+        }
+        catch (Win32Exception)
+        {
+        }
+        catch (AggregateException)
+        {
+        }
+    }
 
     private static (string Executable, string[] Arguments) HighVolumeOutputCommand(int lineCount)
     {

--- a/tests/OpenClaw.SetupEngine.Tests/OpenClaw.SetupEngine.Tests.csproj
+++ b/tests/OpenClaw.SetupEngine.Tests/OpenClaw.SetupEngine.Tests.csproj
@@ -3,6 +3,10 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\OpenClaw.SetupEngine\OpenClaw.SetupEngine.csproj" />
     <ProjectReference Include="..\OpenClaw.TestSupport\OpenClaw.TestSupport.csproj" />
+    <ProjectReference Include="..\OpenClaw.Shared.TestHost\OpenClaw.Shared.TestHost.csproj"
+                      ReferenceOutputAssembly="false"
+                      OutputItemType="Content"
+                      CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Supersedes #1343 (fix(setup): preserve normal command output drains), fixes #1194 (Preserve trailing command output while bounding inherited-pipe waits), and preserves @karkarl's focused design on current `main`.

- wait for both redirected streams to reach EOF after normal successful command exits so trailing JSON and success markers are not truncated
- preserve caller cancellation while waiting for normal stream closure
- keep bounded output draining for timeout cleanup
- add a source-compatible default-interface escape method for known inherited-pipe inspections without changing the existing public `RunAsync` signature
- opt current `wsl.exe --list`, `--version`, and `--status` inspection calls into the bounded three-second escape
- include the newer Windows-node bootstrap uninstall inspection that did not exist on the contributor branch
- retain full EOF draining for `RunInWslAsync`, installation, pairing, gateway commands, and destructive WSL operations
- preserve the current deterministic WSL UTF-8 output handling
- use the shared process test host for deterministic inherited-pipe regression coverage instead of relying on `cmd.exe start /b` timing

## Required proof pools

- `windows-wsl-gateway-e2e`: selected because setup WSL inspection and command-output behavior changed. Current-head workflow run [34180664096](https://github.com/openclaw/openclaw-windows-node/actions/runs/34180664096) passed Setup and connect E2E, network recovery E2E, and revocation recovery E2E.

## Validation

Current head: `29686d14`.

- `.\build.ps1`: passed
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore`: 3,943 passed, 32 skipped
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore`: 2,861 passed
- `dotnet test .\tests\OpenClaw.SetupEngine.Tests\OpenClaw.SetupEngine.Tests.csproj --no-restore`: 1,099 passed
- deterministic inherited-pipe regression: 10 consecutive focused runs passed locally
- current-head CI run `34180664096`: Core and CLI, Tray/setup/integration, UI/functional/accessibility, Setup and connect E2E, network recovery E2E, revocation recovery E2E, x64 publish, release metadata, proof contracts, and CI Gate passed
- final structured autoreview: clean, no accepted/actionable findings
- final rubber-duck review: no blockers after replacing the shell-timing fixture and widening the integration threshold while retaining exact unit coverage for the three-second cap

## Real behavior proof

- 8,000 stdout lines and 8,000 stderr lines plus final `STDOUT_MARKER` and `STDERR_MARKER` are captured completely
- normal output draining continues past the old command deadline until EOF
- caller cancellation interrupts normal post-exit draining
- the deterministic shared test host launches a descendant that holds inherited stdout/stderr handles for 30 seconds; the opted-in runner returns while that descendant is still alive and cleanup terminates it afterward
- exact three-second bounded-drain behavior is covered by deterministic unit tests, while the process integration test proves return well before the 30-second descendant exits
- ten real current-head `CommandRunner.RunInWslAsync` executions against Ubuntu via `wsl.exe -d Ubuntu -- bash -s` each captured 2,000 stdout lines plus trailing stdout/stderr markers and completed without a pipe hang; warmed runs completed in roughly 0.2 to 0.35 seconds
- current-head hosted Setup and connect E2E passed in run `34180664096`

Not verified / blocked: none for the changed behavior.

## Ownership notes

- old owner: `CommandRunner.RunAsync` universally capped every successful output drain
- new owner: normal `RunAsync` waits for EOF; `RunAsyncAllowingInheritedPipeHandleEscape` explicitly identifies known WSL inspection callers
- preserved invariant: the original public `ICommandRunner.RunAsync` and `CommandRunner.RunAsync` signatures remain unchanged for source and binary compatibility

## Security impact

No credential, permission, or command-policy changes. The change only controls post-exit output draining and cancellation.