### PR TITLE
feat(gateway): add typed extensions lifecycle contracts

### DIFF
--- a/src/OpenClaw.Shared/GatewayExtensionApi.cs
+++ b/src/OpenClaw.Shared/GatewayExtensionApi.cs
@@ -1,0 +1,62 @@
+using System.Text.Json;
+
+namespace OpenClaw.Shared;
+
+internal abstract class GatewayExtensionApi
+{
+    private readonly Func<string, object?, int, Task<JsonElement>> _sendRequest;
+    private readonly Action<string> _ensureMethodSupported;
+
+    protected GatewayExtensionApi(
+        Func<string, object?, int, Task<JsonElement>> sendRequest,
+        Action<string> ensureMethodSupported)
+    {
+        _sendRequest = sendRequest;
+        _ensureMethodSupported = ensureMethodSupported;
+    }
+
+    protected async Task<T> SendAsync<T>(string method, object? parameters, int timeoutMs)
+        where T : class
+    {
+        _ensureMethodSupported(method);
+        var payload = await _sendRequest(method, parameters, timeoutMs).ConfigureAwait(false);
+        try
+        {
+            return JsonSerializer.Deserialize<T>(payload, JsonSerializerOptionsCache.GatewayProtocol)
+                ?? throw new JsonException("Payload was null.");
+        }
+        catch (JsonException ex)
+        {
+            throw new InvalidOperationException(
+                $"Gateway returned an invalid {method} response.", ex);
+        }
+    }
+
+    protected static Dictionary<string, object?> OptionalAgentParameters(string? agentId)
+    {
+        var parameters = new Dictionary<string, object?>();
+        AddOptionalString(parameters, "agentId", agentId);
+        return parameters;
+    }
+
+    protected static void AddOptionalString(
+        IDictionary<string, object?> parameters,
+        string propertyName,
+        string? value)
+    {
+        if (!string.IsNullOrWhiteSpace(value))
+            parameters[propertyName] = value;
+    }
+
+    protected static void ValidateLimit(int limit)
+    {
+        if (limit is < 1 or > 100)
+            throw new ArgumentOutOfRangeException(nameof(limit), "Limit must be between 1 and 100.");
+    }
+
+    protected static void RequireNonEmpty(string? value, string parameterName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            throw new ArgumentException("Value cannot be empty.", parameterName);
+    }
+}

--- a/src/OpenClaw.Shared/GatewayExtensionApi.cs
+++ b/src/OpenClaw.Shared/GatewayExtensionApi.cs
@@ -18,8 +18,17 @@ internal abstract class GatewayExtensionApi
     protected async Task<T> SendAsync<T>(string method, object? parameters, int timeoutMs)
         where T : class
     {
-        _ensureMethodSupported(method);
+        EnsureMethodSupported(method);
         var payload = await _sendRequest(method, parameters, timeoutMs).ConfigureAwait(false);
+        return DeserializePayload<T>(payload, method);
+    }
+
+    protected void EnsureMethodSupported(string method) =>
+        _ensureMethodSupported(method);
+
+    protected static T DeserializePayload<T>(JsonElement payload, string method)
+        where T : class
+    {
         try
         {
             return JsonSerializer.Deserialize<T>(payload, JsonSerializerOptionsCache.GatewayProtocol)

--- a/src/OpenClaw.Shared/GatewayFeatureSet.cs
+++ b/src/OpenClaw.Shared/GatewayFeatureSet.cs
@@ -1,0 +1,72 @@
+using System.Text.Json;
+
+namespace OpenClaw.Shared;
+
+/// <summary>
+/// Immutable method and event inventory advertised by the Gateway in
+/// <c>hello-ok.features</c>. Clients must use this inventory instead of guessing
+/// support from a version string.
+/// </summary>
+public sealed class GatewayFeatureSet
+{
+    private readonly HashSet<string> _methodSet;
+    private readonly HashSet<string> _eventSet;
+
+    public static GatewayFeatureSet Empty { get; } = new([], []);
+
+    public GatewayFeatureSet(
+        IEnumerable<string> methods,
+        IEnumerable<string> events)
+    {
+        Methods = Normalize(methods);
+        Events = Normalize(events);
+        _methodSet = new HashSet<string>(Methods, StringComparer.Ordinal);
+        _eventSet = new HashSet<string>(Events, StringComparer.Ordinal);
+    }
+
+    public IReadOnlyList<string> Methods { get; }
+    public IReadOnlyList<string> Events { get; }
+
+    public bool SupportsMethod(string method) =>
+        !string.IsNullOrWhiteSpace(method) && _methodSet.Contains(method);
+
+    public bool SupportsEvent(string eventName) =>
+        !string.IsNullOrWhiteSpace(eventName) && _eventSet.Contains(eventName);
+
+    internal static GatewayFeatureSet FromHelloOk(JsonElement payload)
+    {
+        if (payload.ValueKind != JsonValueKind.Object ||
+            !payload.TryGetProperty("features", out var features) ||
+            features.ValueKind != JsonValueKind.Object)
+        {
+            return Empty;
+        }
+
+        return new GatewayFeatureSet(
+            ReadStringArray(features, "methods"),
+            ReadStringArray(features, "events"));
+    }
+
+    private static string[] ReadStringArray(JsonElement parent, string propertyName)
+    {
+        if (!parent.TryGetProperty(propertyName, out var value) ||
+            value.ValueKind != JsonValueKind.Array)
+        {
+            return [];
+        }
+
+        return value.EnumerateArray()
+            .Where(static item => item.ValueKind == JsonValueKind.String)
+            .Select(static item => item.GetString())
+            .Where(static item => !string.IsNullOrWhiteSpace(item))
+            .Cast<string>()
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static string[] Normalize(IEnumerable<string> values) =>
+        values
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+}

--- a/src/OpenClaw.Shared/GatewayRequestException.cs
+++ b/src/OpenClaw.Shared/GatewayRequestException.cs
@@ -1,0 +1,167 @@
+using System.Buffers;
+using System.Text.Json;
+
+namespace OpenClaw.Shared;
+
+/// <summary>
+/// A response-aware Gateway RPC rejection. Structured details are bounded and
+/// sanitized before being retained, while capability review tokens remain exact
+/// so a caller can complete the Gateway's artifact-bound consent handshake.
+/// </summary>
+public sealed class GatewayRequestException : InvalidOperationException
+{
+    internal GatewayRequestException(
+        string method,
+        string message,
+        string? code,
+        JsonElement? details)
+        : base(message)
+    {
+        Method = method;
+        Code = code;
+        Details = details;
+    }
+
+    public string Method { get; }
+    public string? Code { get; }
+    public JsonElement? Details { get; }
+
+    internal static GatewayRequestException FromResponse(
+        string method,
+        JsonElement response,
+        string fallbackMessage)
+    {
+        var message = ReadErrorString(response, "message") ?? fallbackMessage;
+        var code = ReadErrorString(response, "code");
+        var details = ReadErrorDetails(response);
+        return new GatewayRequestException(
+            method,
+            TokenSanitizer.Sanitize(message),
+            code,
+            details.HasValue ? GatewayErrorDetailsSanitizer.Sanitize(details.Value) : null);
+    }
+
+    private static string? ReadErrorString(JsonElement response, string propertyName)
+    {
+        if (!response.TryGetProperty("error", out var error))
+            return null;
+        if (propertyName == "message" && error.ValueKind == JsonValueKind.String)
+            return error.GetString();
+        if (error.ValueKind != JsonValueKind.Object ||
+            !error.TryGetProperty(propertyName, out var value) ||
+            value.ValueKind != JsonValueKind.String)
+        {
+            return null;
+        }
+
+        return value.GetString();
+    }
+
+    private static JsonElement? ReadErrorDetails(JsonElement response)
+    {
+        if (!response.TryGetProperty("error", out var error) ||
+            error.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+
+        if (error.TryGetProperty("details", out var details))
+            return details.Clone();
+
+        if (error.TryGetProperty("data", out var data) &&
+            data.ValueKind == JsonValueKind.Object &&
+            data.TryGetProperty("details", out details))
+        {
+            return details.Clone();
+        }
+
+        return null;
+    }
+}
+
+internal static class GatewayErrorDetailsSanitizer
+{
+    private const int MaxDepth = 8;
+    private const int MaxItems = 128;
+    private const int MaxStringLength = 4096;
+    private const string Redacted = "[REDACTED]";
+
+    internal static JsonElement Sanitize(JsonElement value)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        using (var writer = new Utf8JsonWriter(buffer))
+        {
+            WriteValue(writer, value, depth: 0, propertyName: null);
+        }
+
+        using var document = JsonDocument.Parse(buffer.WrittenMemory);
+        return document.RootElement.Clone();
+    }
+
+    private static void WriteValue(
+        Utf8JsonWriter writer,
+        JsonElement value,
+        int depth,
+        string? propertyName)
+    {
+        if (depth >= MaxDepth)
+        {
+            writer.WriteStringValue("[TRUNCATED]");
+            return;
+        }
+
+        switch (value.ValueKind)
+        {
+            case JsonValueKind.Object:
+                writer.WriteStartObject();
+                var propertyCount = 0;
+                foreach (var property in value.EnumerateObject())
+                {
+                    if (propertyCount++ >= MaxItems) break;
+                    writer.WritePropertyName(property.Name);
+                    if (IsSensitiveProperty(property.Name))
+                        writer.WriteStringValue(Redacted);
+                    else
+                        WriteValue(writer, property.Value, depth + 1, property.Name);
+                }
+                writer.WriteEndObject();
+                break;
+
+            case JsonValueKind.Array:
+                writer.WriteStartArray();
+                var itemCount = 0;
+                foreach (var item in value.EnumerateArray())
+                {
+                    if (itemCount++ >= MaxItems) break;
+                    WriteValue(writer, item, depth + 1, propertyName);
+                }
+                writer.WriteEndArray();
+                break;
+
+            case JsonValueKind.String:
+                var text = value.GetString() ?? string.Empty;
+                if (text.Length > MaxStringLength)
+                    text = text[..MaxStringLength];
+                writer.WriteStringValue(
+                    string.Equals(propertyName, "reviewToken", StringComparison.Ordinal)
+                        ? text
+                        : TokenSanitizer.Sanitize(text));
+                break;
+
+            case JsonValueKind.Number:
+            case JsonValueKind.True:
+            case JsonValueKind.False:
+            case JsonValueKind.Null:
+                value.WriteTo(writer);
+                break;
+
+            default:
+                writer.WriteNullValue();
+                break;
+        }
+    }
+
+    private static bool IsSensitiveProperty(string propertyName) =>
+        !string.Equals(propertyName, "reviewToken", StringComparison.Ordinal) &&
+        TokenSanitizer.IsSensitiveMetadataKeyName(propertyName);
+}

--- a/src/OpenClaw.Shared/IOperatorGatewayClient.cs
+++ b/src/OpenClaw.Shared/IOperatorGatewayClient.cs
@@ -45,6 +45,13 @@ public interface IOperatorGatewayClient
     string? MainSessionKey { get; }
     /// <summary>True once the hello-ok handshake has been processed.</summary>
     bool HasHandshakeSnapshot { get; }
+    /// <summary>Gateway RPC methods and events advertised by the current hello-ok handshake.</summary>
+    GatewayFeatureSet AdvertisedFeatures => GatewayFeatureSet.Empty;
+    /// <summary>
+    /// Monotonic transport generation used to invalidate artifact-bound consent
+    /// after a disconnect or reconnect.
+    /// </summary>
+    long ConnectionEpoch => 0;
 
     // ─── Connection events (from WebSocketClientBase) ───
     event EventHandler<ConnectionStatus>? StatusChanged;
@@ -112,8 +119,37 @@ public interface IOperatorGatewayClient
     Task<bool> UpdateCronJobAsync(string id, object patch);
     Task RequestCronRunsAsync(string? id = null, int limit = 20, int offset = 0);
     Task RequestSkillsStatusAsync(string? agentId = null);
+    Task<SkillsStatusReport> GetSkillsStatusAsync(string? agentId = null, int timeoutMs = 15000)
+        => Task.FromResult(SkillsStatusReport.Unsupported);
+    Task<SkillsSearchResult> SearchSkillsAsync(string? query = null, int limit = 20, int timeoutMs = 15000)
+        => Task.FromResult(SkillsSearchResult.Unsupported);
+    Task<SkillsDetailResult> GetSkillDetailAsync(string installReference, int timeoutMs = 15000)
+        => Task.FromResult(SkillsDetailResult.Unsupported);
+    Task<SkillsSecurityVerdictsResult> GetSkillSecurityVerdictsAsync(string? agentId = null, int timeoutMs = 15000)
+        => Task.FromResult(SkillsSecurityVerdictsResult.Unsupported);
+    Task<SkillCardResult> GetSkillCardAsync(string skillKey, string? agentId = null, int timeoutMs = 15000)
+        => Task.FromResult(SkillCardResult.Unsupported);
+    Task<SkillMutationResult> InstallClawHubSkillAsync(ClawHubSkillInstallRequest request, int timeoutMs = 120000)
+        => Task.FromResult(SkillMutationResult.Unsupported);
+    Task<SkillMutationResult> UpdateClawHubSkillAsync(ClawHubSkillUpdateRequest request, int timeoutMs = 120000)
+        => Task.FromResult(SkillMutationResult.Unsupported);
+    Task<SkillMutationResult> SetSkillEnabledDetailedAsync(string skillKey, bool enabled, int timeoutMs = 15000)
+        => Task.FromResult(SkillMutationResult.Unsupported);
+    [Obsolete("Use InstallClawHubSkillAsync with the exact skills.search installRef.")]
     Task<bool> InstallSkillAsync(string skillId);
     Task<bool> SetSkillEnabledAsync(string skillKey, bool enabled);
+    Task<PluginsListResult> ListPluginsAsync(int timeoutMs = 15000)
+        => Task.FromResult(PluginsListResult.Unsupported);
+    Task<PluginsSearchResult> SearchPluginsAsync(string query, int limit = 20, int timeoutMs = 15000)
+        => Task.FromResult(PluginsSearchResult.Unsupported);
+    Task<PluginInspectResult> InspectPluginAsync(string pluginId, int timeoutMs = 15000)
+        => Task.FromResult(PluginInspectResult.Unsupported);
+    Task<PluginMutationResult> InstallPluginAsync(PluginInstallRequest request, int timeoutMs = 120000)
+        => Task.FromResult(PluginMutationResult.Unsupported);
+    Task<PluginMutationResult> SetPluginEnabledAsync(PluginSetEnabledRequest request, int timeoutMs = 30000)
+        => Task.FromResult(PluginMutationResult.Unsupported);
+    Task<PluginMutationResult> UninstallPluginAsync(string pluginId, int timeoutMs = 120000)
+        => Task.FromResult(PluginMutationResult.Unsupported);
     Task RequestConfigAsync();
     Task RequestConfigSchemaAsync();
     Task<bool> SetConfigAsync(string path, object value);

--- a/src/OpenClaw.Shared/JsonSerializerOptionsCache.cs
+++ b/src/OpenClaw.Shared/JsonSerializerOptionsCache.cs
@@ -10,6 +10,16 @@ namespace OpenClaw.Shared;
 internal static class JsonSerializerOptionsCache
 {
     /// <summary>
+    /// Gateway protocol payloads use camelCase and evolve additively. Unknown
+    /// properties are ignored while property names are matched case-insensitively.
+    /// </summary>
+    internal static readonly JsonSerializerOptions GatewayProtocol =
+        new(JsonSerializerDefaults.Web)
+        {
+            PropertyNameCaseInsensitive = true
+        };
+
+    /// <summary>
     /// Pretty-print JSON with no additional overrides.
     /// Suitable for writing human-readable configuration and diagnostic files.
     /// </summary>

--- a/src/OpenClaw.Shared/OpenClawGatewayClient.Extensions.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.Extensions.cs
@@ -14,80 +14,115 @@ public partial class OpenClawGatewayClient
     public Task<SkillsStatusReport> GetSkillsStatusAsync(
         string? agentId = null,
         int timeoutMs = 15000) =>
-        _skillsGatewayApi.GetStatusAsync(agentId, timeoutMs);
+        SupportsExtensionMethod("skills.status")
+            ? _skillsGatewayApi.GetStatusAsync(agentId, timeoutMs)
+            : Task.FromResult(SkillsStatusReport.Unsupported);
 
     public Task<SkillsSearchResult> SearchSkillsAsync(
         string? query = null,
         int limit = 20,
         int timeoutMs = 15000) =>
-        _skillsGatewayApi.SearchAsync(query, limit, timeoutMs);
+        SupportsExtensionMethod("skills.search")
+            ? _skillsGatewayApi.SearchAsync(query, limit, timeoutMs)
+            : Task.FromResult(SkillsSearchResult.Unsupported);
 
     public Task<SkillsDetailResult> GetSkillDetailAsync(
         string installReference,
         int timeoutMs = 15000) =>
-        _skillsGatewayApi.GetDetailAsync(installReference, timeoutMs);
+        SupportsExtensionMethod("skills.detail")
+            ? _skillsGatewayApi.GetDetailAsync(installReference, timeoutMs)
+            : Task.FromResult(SkillsDetailResult.Unsupported);
 
     public Task<SkillsSecurityVerdictsResult> GetSkillSecurityVerdictsAsync(
         string? agentId = null,
         int timeoutMs = 15000) =>
-        _skillsGatewayApi.GetSecurityVerdictsAsync(agentId, timeoutMs);
+        SupportsExtensionMethod("skills.securityVerdicts")
+            ? _skillsGatewayApi.GetSecurityVerdictsAsync(agentId, timeoutMs)
+            : Task.FromResult(SkillsSecurityVerdictsResult.Unsupported);
 
     public Task<SkillCardResult> GetSkillCardAsync(
         string skillKey,
         string? agentId = null,
         int timeoutMs = 15000) =>
-        _skillsGatewayApi.GetCardAsync(skillKey, agentId, timeoutMs);
+        SupportsExtensionMethod("skills.skillCard")
+            ? _skillsGatewayApi.GetCardAsync(skillKey, agentId, timeoutMs)
+            : Task.FromResult(SkillCardResult.Unsupported);
 
     public Task<SkillMutationResult> InstallClawHubSkillAsync(
         ClawHubSkillInstallRequest request,
         int timeoutMs = 120000) =>
-        _skillsGatewayApi.InstallAsync(request, timeoutMs);
+        SupportsExtensionMethod("skills.install")
+            ? _skillsGatewayApi.InstallAsync(request, timeoutMs)
+            : Task.FromResult(SkillMutationResult.Unsupported);
 
     public Task<SkillMutationResult> UpdateClawHubSkillAsync(
         ClawHubSkillUpdateRequest request,
         int timeoutMs = 120000) =>
-        _skillsGatewayApi.UpdateAsync(request, timeoutMs);
+        SupportsExtensionMethod("skills.update")
+            ? _skillsGatewayApi.UpdateAsync(request, timeoutMs)
+            : Task.FromResult(SkillMutationResult.Unsupported);
 
     public Task<SkillMutationResult> SetSkillEnabledDetailedAsync(
         string skillKey,
         bool enabled,
         int timeoutMs = 15000) =>
-        _skillsGatewayApi.SetEnabledAsync(skillKey, enabled, timeoutMs);
+        SupportsExtensionMethod("skills.update")
+            ? _skillsGatewayApi.SetEnabledAsync(skillKey, enabled, timeoutMs)
+            : Task.FromResult(SkillMutationResult.Unsupported);
 
     public Task<PluginsListResult> ListPluginsAsync(int timeoutMs = 15000) =>
-        _pluginsGatewayApi.ListAsync(timeoutMs);
+        SupportsExtensionMethod("plugins.list")
+            ? _pluginsGatewayApi.ListAsync(timeoutMs)
+            : Task.FromResult(PluginsListResult.Unsupported);
 
     public Task<PluginsSearchResult> SearchPluginsAsync(
         string query,
         int limit = 20,
         int timeoutMs = 15000) =>
-        _pluginsGatewayApi.SearchAsync(query, limit, timeoutMs);
+        SupportsExtensionMethod("plugins.search")
+            ? _pluginsGatewayApi.SearchAsync(query, limit, timeoutMs)
+            : Task.FromResult(PluginsSearchResult.Unsupported);
 
     public Task<PluginInspectResult> InspectPluginAsync(
         string pluginId,
         int timeoutMs = 15000) =>
-        _pluginsGatewayApi.InspectAsync(pluginId, timeoutMs);
+        SupportsExtensionMethod("plugins.inspect")
+            ? _pluginsGatewayApi.InspectAsync(pluginId, timeoutMs)
+            : Task.FromResult(PluginInspectResult.Unsupported);
 
     public Task<PluginMutationResult> InstallPluginAsync(
         PluginInstallRequest request,
         int timeoutMs = 120000) =>
-        _pluginsGatewayApi.InstallAsync(request, timeoutMs);
+        SupportsExtensionMethod("plugins.install")
+            ? _pluginsGatewayApi.InstallAsync(request, timeoutMs)
+            : Task.FromResult(PluginMutationResult.Unsupported);
 
     public Task<PluginMutationResult> SetPluginEnabledAsync(
         PluginSetEnabledRequest request,
         int timeoutMs = 30000) =>
-        _pluginsGatewayApi.SetEnabledAsync(request, timeoutMs);
+        SupportsExtensionMethod("plugins.setEnabled")
+            ? _pluginsGatewayApi.SetEnabledAsync(request, timeoutMs)
+            : Task.FromResult(PluginMutationResult.Unsupported);
 
     public Task<PluginMutationResult> UninstallPluginAsync(
         string pluginId,
         int timeoutMs = 120000) =>
-        _pluginsGatewayApi.UninstallAsync(pluginId, timeoutMs);
+        SupportsExtensionMethod("plugins.uninstall")
+            ? _pluginsGatewayApi.UninstallAsync(pluginId, timeoutMs)
+            : Task.FromResult(PluginMutationResult.Unsupported);
 
     private void CaptureAdvertisedFeatures(JsonElement helloOk) =>
         Volatile.Write(ref _advertisedFeatures, GatewayFeatureSet.FromHelloOk(helloOk));
 
     private void ResetAdvertisedFeatures() =>
         Volatile.Write(ref _advertisedFeatures, GatewayFeatureSet.Empty);
+
+    private bool SupportsExtensionMethod(string method)
+    {
+        if (!HasHandshakeSnapshot)
+            throw new InvalidOperationException("Gateway handshake is not ready");
+        return AdvertisedFeatures.SupportsMethod(method);
+    }
 
     private void EnsureExtensionMethodSupported(string method)
     {

--- a/src/OpenClaw.Shared/OpenClawGatewayClient.Extensions.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.Extensions.cs
@@ -1,0 +1,99 @@
+using System.Text.Json;
+
+namespace OpenClaw.Shared;
+
+public partial class OpenClawGatewayClient
+{
+    private GatewayFeatureSet _advertisedFeatures = GatewayFeatureSet.Empty;
+    private readonly SkillsGatewayApi _skillsGatewayApi;
+    private readonly PluginsGatewayApi _pluginsGatewayApi;
+
+    public GatewayFeatureSet AdvertisedFeatures => Volatile.Read(ref _advertisedFeatures);
+    public long ConnectionEpoch => ConnectionGeneration;
+
+    public Task<SkillsStatusReport> GetSkillsStatusAsync(
+        string? agentId = null,
+        int timeoutMs = 15000) =>
+        _skillsGatewayApi.GetStatusAsync(agentId, timeoutMs);
+
+    public Task<SkillsSearchResult> SearchSkillsAsync(
+        string? query = null,
+        int limit = 20,
+        int timeoutMs = 15000) =>
+        _skillsGatewayApi.SearchAsync(query, limit, timeoutMs);
+
+    public Task<SkillsDetailResult> GetSkillDetailAsync(
+        string installReference,
+        int timeoutMs = 15000) =>
+        _skillsGatewayApi.GetDetailAsync(installReference, timeoutMs);
+
+    public Task<SkillsSecurityVerdictsResult> GetSkillSecurityVerdictsAsync(
+        string? agentId = null,
+        int timeoutMs = 15000) =>
+        _skillsGatewayApi.GetSecurityVerdictsAsync(agentId, timeoutMs);
+
+    public Task<SkillCardResult> GetSkillCardAsync(
+        string skillKey,
+        string? agentId = null,
+        int timeoutMs = 15000) =>
+        _skillsGatewayApi.GetCardAsync(skillKey, agentId, timeoutMs);
+
+    public Task<SkillMutationResult> InstallClawHubSkillAsync(
+        ClawHubSkillInstallRequest request,
+        int timeoutMs = 120000) =>
+        _skillsGatewayApi.InstallAsync(request, timeoutMs);
+
+    public Task<SkillMutationResult> UpdateClawHubSkillAsync(
+        ClawHubSkillUpdateRequest request,
+        int timeoutMs = 120000) =>
+        _skillsGatewayApi.UpdateAsync(request, timeoutMs);
+
+    public Task<SkillMutationResult> SetSkillEnabledDetailedAsync(
+        string skillKey,
+        bool enabled,
+        int timeoutMs = 15000) =>
+        _skillsGatewayApi.SetEnabledAsync(skillKey, enabled, timeoutMs);
+
+    public Task<PluginsListResult> ListPluginsAsync(int timeoutMs = 15000) =>
+        _pluginsGatewayApi.ListAsync(timeoutMs);
+
+    public Task<PluginsSearchResult> SearchPluginsAsync(
+        string query,
+        int limit = 20,
+        int timeoutMs = 15000) =>
+        _pluginsGatewayApi.SearchAsync(query, limit, timeoutMs);
+
+    public Task<PluginInspectResult> InspectPluginAsync(
+        string pluginId,
+        int timeoutMs = 15000) =>
+        _pluginsGatewayApi.InspectAsync(pluginId, timeoutMs);
+
+    public Task<PluginMutationResult> InstallPluginAsync(
+        PluginInstallRequest request,
+        int timeoutMs = 120000) =>
+        _pluginsGatewayApi.InstallAsync(request, timeoutMs);
+
+    public Task<PluginMutationResult> SetPluginEnabledAsync(
+        PluginSetEnabledRequest request,
+        int timeoutMs = 30000) =>
+        _pluginsGatewayApi.SetEnabledAsync(request, timeoutMs);
+
+    public Task<PluginMutationResult> UninstallPluginAsync(
+        string pluginId,
+        int timeoutMs = 120000) =>
+        _pluginsGatewayApi.UninstallAsync(pluginId, timeoutMs);
+
+    private void CaptureAdvertisedFeatures(JsonElement helloOk) =>
+        Volatile.Write(ref _advertisedFeatures, GatewayFeatureSet.FromHelloOk(helloOk));
+
+    private void ResetAdvertisedFeatures() =>
+        Volatile.Write(ref _advertisedFeatures, GatewayFeatureSet.Empty);
+
+    private void EnsureExtensionMethodSupported(string method)
+    {
+        if (!HasHandshakeSnapshot)
+            throw new InvalidOperationException("Gateway handshake is not ready");
+        if (!AdvertisedFeatures.SupportsMethod(method))
+            throw new NotSupportedException($"The connected Gateway does not advertise {method}.");
+    }
+}

--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -325,7 +325,11 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
         _connectEnvelopeSigner = new DeviceIdentityConnectEnvelopeSigner(_deviceIdentity);
         _connectAuthToken = HasUsableOperatorDeviceToken ? _deviceIdentity.DeviceToken! : (_tokenIsBootstrapToken ? string.Empty : _token);
         _useV2Signature |= _tokenIsBootstrapToken && !HasUsableOperatorDeviceToken;
-        _skillsGatewayApi = new SkillsGatewayApi(SendWizardRequestAsync, EnsureExtensionMethodSupported);
+        _skillsGatewayApi = new SkillsGatewayApi(
+            SendWizardRequestAsync,
+            EnsureExtensionMethodSupported,
+            () => ConnectionEpoch,
+            SendExtensionMutationRequestAsync);
         _pluginsGatewayApi = new PluginsGatewayApi(
             SendWizardRequestAsync,
             EnsureExtensionMethodSupported,

--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -329,7 +329,8 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
         _pluginsGatewayApi = new PluginsGatewayApi(
             SendWizardRequestAsync,
             EnsureExtensionMethodSupported,
-            () => ConnectionEpoch);
+            () => ConnectionEpoch,
+            SendExtensionMutationRequestAsync);
     }
 
     /// <summary>
@@ -1194,7 +1195,24 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
     /// Sends a wizard RPC request and waits for the response payload.
     /// Used for wizard.start, wizard.next, wizard.cancel, wizard.status.
     /// </summary>
-    public async Task<JsonElement> SendWizardRequestAsync(string method, object? parameters = null, int timeoutMs = 30000)
+    public Task<JsonElement> SendWizardRequestAsync(
+        string method,
+        object? parameters = null,
+        int timeoutMs = 30000) =>
+        SendWizardRequestCoreAsync(method, parameters, timeoutMs, expectedConnectionEpoch: null);
+
+    private Task<JsonElement> SendExtensionMutationRequestAsync(
+        string method,
+        object? parameters,
+        int timeoutMs,
+        long expectedConnectionEpoch) =>
+        SendWizardRequestCoreAsync(method, parameters, timeoutMs, expectedConnectionEpoch);
+
+    private async Task<JsonElement> SendWizardRequestCoreAsync(
+        string method,
+        object? parameters,
+        int timeoutMs,
+        long? expectedConnectionEpoch)
     {
         if (!IsConnected)
             throw new InvalidOperationException("Gateway connection is not open");
@@ -1205,7 +1223,23 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
 
         try
         {
-            await SendRawAsync(SerializeRequest(requestId, method, parameters));
+            var serializedRequest = SerializeRequest(requestId, method, parameters);
+            if (expectedConnectionEpoch.HasValue)
+            {
+                var sent = await SendRawAsync(
+                    serializedRequest,
+                    expectedConnectionEpoch.Value,
+                    CancellationToken).ConfigureAwait(false);
+                if (!sent)
+                {
+                    throw new InvalidOperationException(
+                        "Plugin operation expired after the Gateway connection changed.");
+                }
+            }
+            else
+            {
+                await SendRawAsync(serializedRequest).ConfigureAwait(false);
+            }
             return await pending.Task.WaitAsync(TimeSpan.FromMilliseconds(timeoutMs), CancellationToken);
         }
         catch (TimeoutException ex)

--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -1495,7 +1495,14 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
         try
         {
             var result = await SetSkillEnabledDetailedAsync(skillKey, enabled).ConfigureAwait(false);
-            return result.Ok;
+            if (!result.Ok)
+                return false;
+
+            // The legacy API historically refreshed the last requested agent scope after a
+            // successful toggle. The typed mutation response bypasses the tracked-response
+            // switch that performed that refresh, so preserve it explicitly for legacy callers.
+            await RequestSkillsStatusAsync(_lastSkillsStatusAgentId).ConfigureAwait(false);
+            return true;
         }
         catch (Exception ex)
         {

--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -169,6 +169,7 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
     {
         _handshakeChallengeGate.Reset(CurrentConnectionGeneration);
         _pendingRequests.OpenConnection();
+        ResetAdvertisedFeatures();
         ResetUnsupportedMethodFlags();
         RaiseTransportConnected();
         return Task.CompletedTask;
@@ -193,6 +194,7 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
         Volatile.Write(ref _mainSessionKey, null);
         Volatile.Write(ref _mainSessionKeyIsCanonical, false);
         Volatile.Write(ref _hasHandshakeSnapshot, false);
+        ResetAdvertisedFeatures();
         _pendingRequests.Drain(
             new GatewayConnectionLostException(
                 RemoteCloseStatusCode,
@@ -323,6 +325,11 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
         _connectEnvelopeSigner = new DeviceIdentityConnectEnvelopeSigner(_deviceIdentity);
         _connectAuthToken = HasUsableOperatorDeviceToken ? _deviceIdentity.DeviceToken! : (_tokenIsBootstrapToken ? string.Empty : _token);
         _useV2Signature |= _tokenIsBootstrapToken && !HasUsableOperatorDeviceToken;
+        _skillsGatewayApi = new SkillsGatewayApi(SendWizardRequestAsync, EnsureExtensionMethodSupported);
+        _pluginsGatewayApi = new PluginsGatewayApi(
+            SendWizardRequestAsync,
+            EnsureExtensionMethodSupported,
+            () => ConnectionEpoch);
     }
 
     /// <summary>
@@ -1436,14 +1443,27 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
             await SendTrackedRequestAsync("skills.status");
     }
 
+    [Obsolete("Use InstallClawHubSkillAsync with the exact skills.search installRef.")]
     public Task<bool> InstallSkillAsync(string skillId)
     {
-        return TrySendTrackedRequestAsync("skills.install", new { id = skillId });
+        // The former { id } payload is rejected by every supported Gateway skill
+        // install schema and is unsafe once publishers share a slug. Keep the
+        // compatibility member non-mutating until callers migrate to the typed API.
+        return Task.FromResult(false);
     }
 
-    public Task<bool> SetSkillEnabledAsync(string skillKey, bool enabled)
+    public async Task<bool> SetSkillEnabledAsync(string skillKey, bool enabled)
     {
-        return TrySendTrackedRequestAsync("skills.update", new { skillKey, enabled });
+        try
+        {
+            var result = await SetSkillEnabledDetailedAsync(skillKey, enabled).ConfigureAwait(false);
+            return result.Ok;
+        }
+        catch (Exception ex)
+        {
+            _logger.Warn($"skills.update failed: {TokenSanitizer.Sanitize(ex.Message)}");
+            return false;
+        }
     }
 
     // Gateway config management
@@ -2220,8 +2240,11 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
                 if (root.TryGetProperty("ok", out var okWiz) &&
                     okWiz.ValueKind == JsonValueKind.False)
                 {
-                    var message = TryGetErrorMessage(root) ?? "wizard request failed";
-                    wizardCompletion.TryFault(new InvalidOperationException(message));
+                    wizardCompletion.TryFault(
+                        GatewayRequestException.FromResponse(
+                            wizardCompletion.Method,
+                            root,
+                            "wizard request failed"));
                 }
                 else if (root.TryGetProperty("payload", out var wizPayload))
                 {
@@ -2318,6 +2341,7 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
             ResetReconnectAttempts();
             _operatorDeviceId = TryGetHandshakeDeviceId(payload);
             _grantedOperatorScopes = TryGetHandshakeScopes(payload);
+            CaptureAdvertisedFeatures(payload);
             // Write the key first, then publish the readiness flag. Pair with
             // Volatile.Read on the public getters so a reader observing
             // HasHandshakeSnapshot==true is guaranteed to see the populated

--- a/src/OpenClaw.Shared/PluginsGatewayApi.cs
+++ b/src/OpenClaw.Shared/PluginsGatewayApi.cs
@@ -5,14 +5,17 @@ namespace OpenClaw.Shared;
 internal sealed class PluginsGatewayApi : GatewayExtensionApi
 {
     private readonly Func<long> _getConnectionEpoch;
+    private readonly Func<string, object?, int, long, Task<JsonElement>> _sendMutationRequest;
 
     internal PluginsGatewayApi(
         Func<string, object?, int, Task<JsonElement>> sendRequest,
         Action<string> ensureMethodSupported,
-        Func<long> getConnectionEpoch)
+        Func<long> getConnectionEpoch,
+        Func<string, object?, int, long, Task<JsonElement>> sendMutationRequest)
         : base(sendRequest, ensureMethodSupported)
     {
         _getConnectionEpoch = getConnectionEpoch;
+        _sendMutationRequest = sendMutationRequest;
     }
 
     internal async Task<PluginsListResult> ListAsync(int timeoutMs)
@@ -47,7 +50,7 @@ internal sealed class PluginsGatewayApi : GatewayExtensionApi
         int timeoutMs)
     {
         ArgumentNullException.ThrowIfNull(request);
-        ValidateAcknowledgement(request.AcknowledgeCapabilities);
+        var connectionEpoch = CaptureMutationEpoch(request.AcknowledgeCapabilities);
         var parameters = new Dictionary<string, object?>();
         switch (request.Source)
         {
@@ -69,7 +72,7 @@ internal sealed class PluginsGatewayApi : GatewayExtensionApi
         if (request.AcknowledgeInstallPolicyWarning)
             parameters["acknowledgeInstallPolicyWarning"] = true;
         AddAcknowledgement(parameters, request.AcknowledgeCapabilities);
-        return SendAsync<PluginMutationResult>("plugins.install", parameters, timeoutMs);
+        return SendMutationAsync("plugins.install", parameters, timeoutMs, connectionEpoch);
     }
 
     internal Task<PluginMutationResult> SetEnabledAsync(
@@ -78,33 +81,50 @@ internal sealed class PluginsGatewayApi : GatewayExtensionApi
     {
         ArgumentNullException.ThrowIfNull(request);
         RequireNonEmpty(request.PluginId, nameof(request.PluginId));
-        ValidateAcknowledgement(request.AcknowledgeCapabilities);
+        var connectionEpoch = CaptureMutationEpoch(request.AcknowledgeCapabilities);
         var parameters = new Dictionary<string, object?>
         {
             ["pluginId"] = request.PluginId,
             ["enabled"] = request.Enabled,
         };
         AddAcknowledgement(parameters, request.AcknowledgeCapabilities);
-        return SendAsync<PluginMutationResult>("plugins.setEnabled", parameters, timeoutMs);
+        return SendMutationAsync("plugins.setEnabled", parameters, timeoutMs, connectionEpoch);
     }
 
     internal Task<PluginMutationResult> UninstallAsync(string pluginId, int timeoutMs)
     {
         RequireNonEmpty(pluginId, nameof(pluginId));
-        return SendAsync<PluginMutationResult>(
-            "plugins.uninstall", new { pluginId }, timeoutMs);
+        return SendMutationAsync(
+            "plugins.uninstall", new { pluginId }, timeoutMs, _getConnectionEpoch());
     }
 
-    private void ValidateAcknowledgement(PluginCapabilityAcknowledgement? acknowledgement)
+    private long CaptureMutationEpoch(PluginCapabilityAcknowledgement? acknowledgement)
     {
+        var connectionEpoch = _getConnectionEpoch();
         if (acknowledgement is null)
-            return;
+            return connectionEpoch;
         RequireNonEmpty(acknowledgement.ReviewToken, nameof(acknowledgement.ReviewToken));
-        if (acknowledgement.ConnectionEpoch != _getConnectionEpoch())
+        if (acknowledgement.ConnectionEpoch != connectionEpoch)
         {
             throw new InvalidOperationException(
                 "Plugin capability review expired after the Gateway connection changed.");
         }
+        return connectionEpoch;
+    }
+
+    private async Task<PluginMutationResult> SendMutationAsync(
+        string method,
+        object? parameters,
+        int timeoutMs,
+        long connectionEpoch)
+    {
+        EnsureMethodSupported(method);
+        var payload = await _sendMutationRequest(
+            method,
+            parameters,
+            timeoutMs,
+            connectionEpoch).ConfigureAwait(false);
+        return DeserializePayload<PluginMutationResult>(payload, method);
     }
 
     private static void AddAcknowledgement(

--- a/src/OpenClaw.Shared/PluginsGatewayApi.cs
+++ b/src/OpenClaw.Shared/PluginsGatewayApi.cs
@@ -1,0 +1,117 @@
+using System.Text.Json;
+
+namespace OpenClaw.Shared;
+
+internal sealed class PluginsGatewayApi : GatewayExtensionApi
+{
+    private readonly Func<long> _getConnectionEpoch;
+
+    internal PluginsGatewayApi(
+        Func<string, object?, int, Task<JsonElement>> sendRequest,
+        Action<string> ensureMethodSupported,
+        Func<long> getConnectionEpoch)
+        : base(sendRequest, ensureMethodSupported)
+    {
+        _getConnectionEpoch = getConnectionEpoch;
+    }
+
+    internal async Task<PluginsListResult> ListAsync(int timeoutMs)
+    {
+        var wire = await SendAsync<PluginsListWireResult>(
+            "plugins.list", new { }, timeoutMs).ConfigureAwait(false);
+        return new PluginsListResult
+        {
+            Plugins = wire.Plugins,
+            DiagnosticCount = wire.Diagnostics.Count,
+            MutationAllowed = wire.MutationAllowed,
+        };
+    }
+
+    internal Task<PluginsSearchResult> SearchAsync(string query, int limit, int timeoutMs)
+    {
+        RequireNonEmpty(query, nameof(query));
+        ValidateLimit(limit);
+        return SendAsync<PluginsSearchResult>(
+            "plugins.search", new { query, limit }, timeoutMs);
+    }
+
+    internal Task<PluginInspectResult> InspectAsync(string pluginId, int timeoutMs)
+    {
+        RequireNonEmpty(pluginId, nameof(pluginId));
+        return SendAsync<PluginInspectResult>(
+            "plugins.inspect", new { pluginId }, timeoutMs);
+    }
+
+    internal Task<PluginMutationResult> InstallAsync(
+        PluginInstallRequest request,
+        int timeoutMs)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ValidateAcknowledgement(request.AcknowledgeCapabilities);
+        var parameters = new Dictionary<string, object?>();
+        switch (request.Source)
+        {
+            case PluginInstallSource.ClawHub:
+                RequireNonEmpty(request.PackageName, nameof(request.PackageName));
+                parameters["source"] = "clawhub";
+                parameters["packageName"] = request.PackageName;
+                AddOptionalString(parameters, "version", request.Version);
+                break;
+            case PluginInstallSource.Official:
+                RequireNonEmpty(request.PluginId, nameof(request.PluginId));
+                parameters["source"] = "official";
+                parameters["pluginId"] = request.PluginId;
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(request), "Unknown plugin install source.");
+        }
+
+        if (request.AcknowledgeInstallPolicyWarning)
+            parameters["acknowledgeInstallPolicyWarning"] = true;
+        AddAcknowledgement(parameters, request.AcknowledgeCapabilities);
+        return SendAsync<PluginMutationResult>("plugins.install", parameters, timeoutMs);
+    }
+
+    internal Task<PluginMutationResult> SetEnabledAsync(
+        PluginSetEnabledRequest request,
+        int timeoutMs)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        RequireNonEmpty(request.PluginId, nameof(request.PluginId));
+        ValidateAcknowledgement(request.AcknowledgeCapabilities);
+        var parameters = new Dictionary<string, object?>
+        {
+            ["pluginId"] = request.PluginId,
+            ["enabled"] = request.Enabled,
+        };
+        AddAcknowledgement(parameters, request.AcknowledgeCapabilities);
+        return SendAsync<PluginMutationResult>("plugins.setEnabled", parameters, timeoutMs);
+    }
+
+    internal Task<PluginMutationResult> UninstallAsync(string pluginId, int timeoutMs)
+    {
+        RequireNonEmpty(pluginId, nameof(pluginId));
+        return SendAsync<PluginMutationResult>(
+            "plugins.uninstall", new { pluginId }, timeoutMs);
+    }
+
+    private void ValidateAcknowledgement(PluginCapabilityAcknowledgement? acknowledgement)
+    {
+        if (acknowledgement is null)
+            return;
+        RequireNonEmpty(acknowledgement.ReviewToken, nameof(acknowledgement.ReviewToken));
+        if (acknowledgement.ConnectionEpoch != _getConnectionEpoch())
+        {
+            throw new InvalidOperationException(
+                "Plugin capability review expired after the Gateway connection changed.");
+        }
+    }
+
+    private static void AddAcknowledgement(
+        IDictionary<string, object?> parameters,
+        PluginCapabilityAcknowledgement? acknowledgement)
+    {
+        if (acknowledgement is not null)
+            parameters["acknowledgeCapabilities"] = new { reviewToken = acknowledgement.ReviewToken };
+    }
+}

--- a/src/OpenClaw.Shared/PluginsGatewayModels.cs
+++ b/src/OpenClaw.Shared/PluginsGatewayModels.cs
@@ -1,0 +1,372 @@
+using System.Text.Json;
+
+namespace OpenClaw.Shared;
+
+public enum PluginInstallSource
+{
+    ClawHub,
+    Official,
+}
+
+public sealed class PluginCatalogInstallAction
+{
+    public string Source { get; set; } = string.Empty;
+    public string? PackageName { get; set; }
+    public string? PluginId { get; set; }
+}
+
+public sealed class PluginCatalogEntry
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string? PackageName { get; set; }
+    public string? Description { get; set; }
+    public string? Version { get; set; }
+    public IReadOnlyList<string> Kind { get; set; } = [];
+    public string? Origin { get; set; }
+    public bool Installed { get; set; }
+    public bool Enabled { get; set; }
+    public string State { get; set; } = string.Empty;
+    public bool Featured { get; set; }
+    public long? FeaturedAt { get; set; }
+    public double? Order { get; set; }
+    public bool HasIcon { get; set; }
+    public PluginCatalogInstallAction? Install { get; set; }
+    public string? Error { get; set; }
+    public string? Category { get; set; }
+    public bool Removable { get; set; }
+}
+
+public sealed class PluginsListResult
+{
+    public IReadOnlyList<PluginCatalogEntry> Plugins { get; set; } = [];
+    public int DiagnosticCount { get; set; }
+    public bool MutationAllowed { get; set; }
+    public bool IsSupported { get; set; } = true;
+
+    public static PluginsListResult Unsupported { get; } = new() { IsSupported = false };
+}
+
+internal sealed class PluginsListWireResult
+{
+    public IReadOnlyList<PluginCatalogEntry> Plugins { get; set; } = [];
+    public IReadOnlyList<JsonElement> Diagnostics { get; set; } = [];
+    public bool MutationAllowed { get; set; }
+}
+
+public sealed class PluginInspectSource
+{
+    public string Kind { get; set; } = string.Empty;
+    public string? Spec { get; set; }
+    public string? PackageName { get; set; }
+    public string? Integrity { get; set; }
+    public string? IntegrityKind { get; set; }
+}
+
+public sealed class PluginDeclaredSurface
+{
+    public IReadOnlyList<string> Channels { get; set; } = [];
+    public IReadOnlyList<string> Providers { get; set; } = [];
+    public IReadOnlyList<string> Tools { get; set; } = [];
+    public IReadOnlyList<string> Contracts { get; set; } = [];
+    public IReadOnlyList<string> Hooks { get; set; } = [];
+    public IReadOnlyList<string> McpServers { get; set; } = [];
+    public IReadOnlyList<string> CliCommands { get; set; } = [];
+    public IReadOnlyList<string> CliBackends { get; set; } = [];
+    public IReadOnlyList<string> Skills { get; set; } = [];
+    public IReadOnlyList<string> DangerousConfigFlags { get; set; } = [];
+
+    public bool HasAny =>
+        Channels.Count > 0 || Providers.Count > 0 || Tools.Count > 0 ||
+        Contracts.Count > 0 || Hooks.Count > 0 || McpServers.Count > 0 ||
+        CliCommands.Count > 0 || CliBackends.Count > 0 || Skills.Count > 0 ||
+        DangerousConfigFlags.Count > 0;
+}
+
+public sealed class PluginHookGrant
+{
+    public bool Effective { get; set; }
+    public bool? Configured { get; set; }
+}
+
+public sealed class PluginHookGrants
+{
+    public PluginHookGrant AllowPromptInjection { get; set; } = new();
+    public PluginHookGrant AllowConversationAccess { get; set; } = new();
+}
+
+public sealed class PluginLlmGrants
+{
+    public bool? AllowModelOverride { get; set; }
+    public IReadOnlyList<string> AllowedModels { get; set; } = [];
+    public IReadOnlyList<string> AllowedCompletionModels { get; set; } = [];
+    public bool? AllowAuthProfileOverride { get; set; }
+    public bool? AllowAgentIdOverride { get; set; }
+}
+
+public sealed class PluginSubagentGrants
+{
+    public bool? AllowModelOverride { get; set; }
+    public IReadOnlyList<string> AllowedModels { get; set; } = [];
+}
+
+public sealed class PluginOperatorGrants
+{
+    public PluginHookGrants Hooks { get; set; } = new();
+    public PluginLlmGrants? Llm { get; set; }
+    public PluginSubagentGrants? Subagent { get; set; }
+}
+
+public sealed class PluginInstallTrust
+{
+    public string Disposition { get; set; } = string.Empty;
+    public IReadOnlyList<string> Reasons { get; set; } = [];
+    public string? CheckedAt { get; set; }
+    public string? AcknowledgedAt { get; set; }
+    public bool Pending { get; set; }
+    public bool Stale { get; set; }
+}
+
+public sealed class PluginInspectEntry
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string? Version { get; set; }
+    public string? Description { get; set; }
+    public string? Origin { get; set; }
+    public bool Installed { get; set; }
+    public bool Enabled { get; set; }
+}
+
+public sealed class PluginInspectResult
+{
+    public bool Ok { get; set; }
+    public PluginInspectEntry Plugin { get; set; } = new();
+    public PluginInspectSource? Source { get; set; }
+    public PluginDeclaredSurface Declared { get; set; } = new();
+    public string ReviewToken { get; set; } = string.Empty;
+    public PluginOperatorGrants Grants { get; set; } = new();
+    public PluginInstallTrust? Trust { get; set; }
+    public bool IsSupported { get; set; } = true;
+
+    public static PluginInspectResult Unsupported { get; } = new() { IsSupported = false };
+}
+
+public sealed class PluginSearchPackage
+{
+    public string Name { get; set; } = string.Empty;
+    public string DisplayName { get; set; } = string.Empty;
+    public string Family { get; set; } = string.Empty;
+    public string Channel { get; set; } = string.Empty;
+    public bool IsOfficial { get; set; }
+    public string? Summary { get; set; }
+    public string? LatestVersion { get; set; }
+    public string? RuntimeId { get; set; }
+    public double? Downloads { get; set; }
+    public string? VerificationTier { get; set; }
+}
+
+public sealed class PluginSearchEntry
+{
+    public double Score { get; set; }
+    public PluginSearchPackage Package { get; set; } = new();
+}
+
+public sealed class PluginsSearchResult
+{
+    public IReadOnlyList<PluginSearchEntry> Results { get; set; } = [];
+    public bool IsSupported { get; set; } = true;
+
+    public static PluginsSearchResult Unsupported { get; } = new() { IsSupported = false };
+}
+
+public sealed record PluginCapabilityAcknowledgement(
+    string ReviewToken,
+    long ConnectionEpoch);
+
+public sealed record PluginInstallRequest
+{
+    private PluginInstallRequest() { }
+
+    public PluginInstallSource Source { get; private init; }
+    public string? PackageName { get; private init; }
+    public string? PluginId { get; private init; }
+    public string? Version { get; init; }
+    public bool AcknowledgeInstallPolicyWarning { get; init; }
+    public PluginCapabilityAcknowledgement? AcknowledgeCapabilities { get; init; }
+
+    public static PluginInstallRequest FromClawHub(string packageName) =>
+        new() { Source = PluginInstallSource.ClawHub, PackageName = packageName };
+
+    public static PluginInstallRequest FromOfficialCatalog(string pluginId) =>
+        new() { Source = PluginInstallSource.Official, PluginId = pluginId };
+}
+
+public sealed record PluginSetEnabledRequest(
+    string PluginId,
+    bool Enabled,
+    PluginCapabilityAcknowledgement? AcknowledgeCapabilities = null);
+
+public sealed class PluginMutationResult
+{
+    public bool Ok { get; set; }
+    public PluginCatalogEntry? Plugin { get; set; }
+    public string? PluginId { get; set; }
+    public bool RestartRequired { get; set; }
+    public IReadOnlyList<string> Removed { get; set; } = [];
+    public IReadOnlyList<string> Warnings { get; set; } = [];
+    public bool IsSupported { get; set; } = true;
+
+    public static PluginMutationResult Unsupported { get; } = new() { IsSupported = false };
+}
+
+public sealed class PluginCapabilityConsentDetails
+{
+    public const string RequiredCode = "PLUGIN_CAPABILITY_CONSENT_REQUIRED";
+
+    public string PluginId { get; private init; } = string.Empty;
+    public string ReviewToken { get; private init; } = string.Empty;
+    public PluginDeclaredSurface Widened { get; private init; } = new();
+    public string? AcceptedAt { get; private init; }
+
+    public static bool TryParse(
+        GatewayRequestException exception,
+        out PluginCapabilityConsentDetails? consent)
+    {
+        consent = null;
+        if (exception.Details is not { ValueKind: JsonValueKind.Object } details ||
+            !HasOnlyProperties(details, "capabilityConsentCode", "pluginId", "reviewToken", "widened", "acceptedAt") ||
+            !TryReadRequiredString(details, "capabilityConsentCode", out var code) ||
+            !string.Equals(code, RequiredCode, StringComparison.Ordinal) ||
+            !TryReadRequiredString(details, "pluginId", out var pluginId) ||
+            !TryReadRequiredString(details, "reviewToken", out var reviewToken))
+        {
+            return false;
+        }
+
+        var widened = new PluginDeclaredSurface();
+        if (details.TryGetProperty("widened", out var widenedElement))
+        {
+            if (widenedElement.ValueKind != JsonValueKind.Object ||
+                !HasOnlyProperties(
+                    widenedElement,
+                    "channels", "providers", "tools", "contracts", "hooks",
+                    "mcpServers", "cliCommands", "cliBackends", "skills",
+                    "dangerousConfigFlags"))
+            {
+                return false;
+            }
+
+            try
+            {
+                widened = JsonSerializer.Deserialize<PluginDeclaredSurface>(
+                    widenedElement,
+                    JsonSerializerOptionsCache.GatewayProtocol) ?? new PluginDeclaredSurface();
+            }
+            catch (JsonException)
+            {
+                return false;
+            }
+        }
+
+        string? acceptedAt = null;
+        if (details.TryGetProperty("acceptedAt", out var acceptedAtElement))
+        {
+            if (acceptedAtElement.ValueKind != JsonValueKind.String ||
+                string.IsNullOrWhiteSpace(acceptedAtElement.GetString()))
+            {
+                return false;
+            }
+            acceptedAt = acceptedAtElement.GetString();
+        }
+
+        consent = new PluginCapabilityConsentDetails
+        {
+            PluginId = pluginId!,
+            ReviewToken = reviewToken!,
+            Widened = widened,
+            AcceptedAt = acceptedAt,
+        };
+        return true;
+    }
+
+    private static bool TryReadRequiredString(
+        JsonElement parent,
+        string propertyName,
+        out string? value)
+    {
+        value = null;
+        if (!parent.TryGetProperty(propertyName, out var element) ||
+            element.ValueKind != JsonValueKind.String ||
+            string.IsNullOrWhiteSpace(element.GetString()))
+        {
+            return false;
+        }
+        value = element.GetString();
+        return true;
+    }
+
+    private static bool HasOnlyProperties(JsonElement element, params string[] names)
+    {
+        var allowed = new HashSet<string>(names, StringComparer.Ordinal);
+        return element.EnumerateObject().All(property => allowed.Contains(property.Name));
+    }
+}
+
+public sealed class InstallPolicyFinding
+{
+    public string RuleId { get; set; } = string.Empty;
+    public string Severity { get; set; } = string.Empty;
+    public string Message { get; set; } = string.Empty;
+    public int? Line { get; set; }
+}
+
+public sealed class InstallPolicyWarningDetails
+{
+    public const string AcknowledgementRequiredCode =
+        "install_policy_warning_acknowledgement_required";
+
+    public string TargetName { get; set; } = string.Empty;
+    public string TargetType { get; set; } = string.Empty;
+    public string RequestMode { get; set; } = string.Empty;
+    public string Reason { get; set; } = string.Empty;
+    public IReadOnlyList<InstallPolicyFinding> Findings { get; set; } = [];
+
+    public static bool TryParse(
+        GatewayRequestException exception,
+        out InstallPolicyWarningDetails? warning)
+    {
+        warning = null;
+        if (exception.Details is not { ValueKind: JsonValueKind.Object } details ||
+            !details.TryGetProperty("installPolicyCode", out var code) ||
+            code.ValueKind != JsonValueKind.String ||
+            !string.Equals(
+                code.GetString(),
+                AcknowledgementRequiredCode,
+                StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        try
+        {
+            var parsed = JsonSerializer.Deserialize<InstallPolicyWarningDetails>(
+                details,
+                JsonSerializerOptionsCache.GatewayProtocol);
+            if (parsed is null ||
+                string.IsNullOrWhiteSpace(parsed.TargetName) ||
+                string.IsNullOrWhiteSpace(parsed.Reason) ||
+                (parsed.TargetType != "skill" && parsed.TargetType != "plugin") ||
+                (parsed.RequestMode != "install" && parsed.RequestMode != "update"))
+            {
+                return false;
+            }
+            warning = parsed;
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+}

--- a/src/OpenClaw.Shared/SkillsGatewayApi.cs
+++ b/src/OpenClaw.Shared/SkillsGatewayApi.cs
@@ -4,11 +4,18 @@ namespace OpenClaw.Shared;
 
 internal sealed class SkillsGatewayApi : GatewayExtensionApi
 {
+    private readonly Func<long> _getConnectionEpoch;
+    private readonly Func<string, object?, int, long, Task<JsonElement>> _sendMutationRequest;
+
     internal SkillsGatewayApi(
         Func<string, object?, int, Task<JsonElement>> sendRequest,
-        Action<string> ensureMethodSupported)
+        Action<string> ensureMethodSupported,
+        Func<long> getConnectionEpoch,
+        Func<string, object?, int, long, Task<JsonElement>> sendMutationRequest)
         : base(sendRequest, ensureMethodSupported)
     {
+        _getConnectionEpoch = getConnectionEpoch;
+        _sendMutationRequest = sendMutationRequest;
     }
 
     internal Task<SkillsStatusReport> GetStatusAsync(string? agentId, int timeoutMs) =>
@@ -58,7 +65,13 @@ internal sealed class SkillsGatewayApi : GatewayExtensionApi
         AddOptionalString(parameters, "version", request.Version);
         if (request.TimeoutMs.HasValue)
             parameters["timeoutMs"] = request.TimeoutMs.Value;
-        return SendAsync<SkillMutationResult>("skills.install", parameters, timeoutMs);
+        var connectionEpoch = _getConnectionEpoch();
+        if (request.ConnectionEpoch.HasValue && request.ConnectionEpoch.Value != connectionEpoch)
+        {
+            throw new InvalidOperationException(
+                "Skill review expired after the Gateway connection changed.");
+        }
+        return SendInstallAsync(parameters, timeoutMs, connectionEpoch);
     }
 
     internal Task<SkillMutationResult> UpdateAsync(
@@ -81,5 +94,20 @@ internal sealed class SkillsGatewayApi : GatewayExtensionApi
         RequireNonEmpty(skillKey, nameof(skillKey));
         return SendAsync<SkillMutationResult>(
             "skills.update", new { skillKey, enabled }, timeoutMs);
+    }
+
+    private async Task<SkillMutationResult> SendInstallAsync(
+        object? parameters,
+        int timeoutMs,
+        long connectionEpoch)
+    {
+        const string method = "skills.install";
+        EnsureMethodSupported(method);
+        var payload = await _sendMutationRequest(
+            method,
+            parameters,
+            timeoutMs,
+            connectionEpoch).ConfigureAwait(false);
+        return DeserializePayload<SkillMutationResult>(payload, method);
     }
 }

--- a/src/OpenClaw.Shared/SkillsGatewayApi.cs
+++ b/src/OpenClaw.Shared/SkillsGatewayApi.cs
@@ -1,0 +1,85 @@
+using System.Text.Json;
+
+namespace OpenClaw.Shared;
+
+internal sealed class SkillsGatewayApi : GatewayExtensionApi
+{
+    internal SkillsGatewayApi(
+        Func<string, object?, int, Task<JsonElement>> sendRequest,
+        Action<string> ensureMethodSupported)
+        : base(sendRequest, ensureMethodSupported)
+    {
+    }
+
+    internal Task<SkillsStatusReport> GetStatusAsync(string? agentId, int timeoutMs) =>
+        SendAsync<SkillsStatusReport>("skills.status", OptionalAgentParameters(agentId), timeoutMs);
+
+    internal Task<SkillsSearchResult> SearchAsync(string? query, int limit, int timeoutMs)
+    {
+        ValidateLimit(limit);
+        var parameters = new Dictionary<string, object?> { ["limit"] = limit };
+        AddOptionalString(parameters, "query", query);
+        return SendAsync<SkillsSearchResult>("skills.search", parameters, timeoutMs);
+    }
+
+    internal Task<SkillsDetailResult> GetDetailAsync(string installReference, int timeoutMs)
+    {
+        RequireNonEmpty(installReference, nameof(installReference));
+        return SendAsync<SkillsDetailResult>(
+            "skills.detail", new { slug = installReference }, timeoutMs);
+    }
+
+    internal Task<SkillsSecurityVerdictsResult> GetSecurityVerdictsAsync(
+        string? agentId,
+        int timeoutMs) =>
+        SendAsync<SkillsSecurityVerdictsResult>(
+            "skills.securityVerdicts", OptionalAgentParameters(agentId), timeoutMs);
+
+    internal Task<SkillCardResult> GetCardAsync(
+        string skillKey,
+        string? agentId,
+        int timeoutMs)
+    {
+        RequireNonEmpty(skillKey, nameof(skillKey));
+        var parameters = OptionalAgentParameters(agentId);
+        parameters["skillKey"] = skillKey;
+        return SendAsync<SkillCardResult>("skills.skillCard", parameters, timeoutMs);
+    }
+
+    internal Task<SkillMutationResult> InstallAsync(
+        ClawHubSkillInstallRequest request,
+        int timeoutMs)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        RequireNonEmpty(request.InstallReference, nameof(request.InstallReference));
+        var parameters = OptionalAgentParameters(request.AgentId);
+        parameters["source"] = "clawhub";
+        parameters["slug"] = request.InstallReference;
+        AddOptionalString(parameters, "version", request.Version);
+        if (request.TimeoutMs.HasValue)
+            parameters["timeoutMs"] = request.TimeoutMs.Value;
+        return SendAsync<SkillMutationResult>("skills.install", parameters, timeoutMs);
+    }
+
+    internal Task<SkillMutationResult> UpdateAsync(
+        ClawHubSkillUpdateRequest request,
+        int timeoutMs)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        RequireNonEmpty(request.InstallReference, nameof(request.InstallReference));
+        var parameters = OptionalAgentParameters(request.AgentId);
+        parameters["source"] = "clawhub";
+        parameters["slug"] = request.InstallReference;
+        return SendAsync<SkillMutationResult>("skills.update", parameters, timeoutMs);
+    }
+
+    internal Task<SkillMutationResult> SetEnabledAsync(
+        string skillKey,
+        bool enabled,
+        int timeoutMs)
+    {
+        RequireNonEmpty(skillKey, nameof(skillKey));
+        return SendAsync<SkillMutationResult>(
+            "skills.update", new { skillKey, enabled }, timeoutMs);
+    }
+}

--- a/src/OpenClaw.Shared/SkillsGatewayModels.cs
+++ b/src/OpenClaw.Shared/SkillsGatewayModels.cs
@@ -1,0 +1,249 @@
+namespace OpenClaw.Shared;
+
+public enum SkillReadinessState
+{
+    Ready,
+    Disabled,
+    Blocked,
+    Incompatible,
+    NeedsSetup,
+}
+
+public sealed class SkillRequirements
+{
+    public IReadOnlyList<string> Bins { get; set; } = [];
+    public IReadOnlyList<string> AnyBins { get; set; } = [];
+    public IReadOnlyList<string> Env { get; set; } = [];
+    public IReadOnlyList<string> Config { get; set; } = [];
+    public IReadOnlyList<string> Os { get; set; } = [];
+
+    public bool HasAny =>
+        Bins.Count > 0 || AnyBins.Count > 0 || Env.Count > 0 ||
+        Config.Count > 0 || Os.Count > 0;
+}
+
+public sealed class SkillConfigCheck
+{
+    public string Path { get; set; } = string.Empty;
+    public bool Satisfied { get; set; }
+}
+
+public sealed class SkillInstallOption
+{
+    public string Id { get; set; } = string.Empty;
+    public string Kind { get; set; } = string.Empty;
+    public string Label { get; set; } = string.Empty;
+    public IReadOnlyList<string> Bins { get; set; } = [];
+}
+
+public sealed class ClawHubSkillLink
+{
+    public string? Status { get; set; }
+    public bool Valid { get; set; }
+    public string? Reason { get; set; }
+    public string? Registry { get; set; }
+    public string? Slug { get; set; }
+    public string? OwnerHandle { get; set; }
+    public string? RequestedReference { get; set; }
+    public string? TrustState { get; set; }
+    public string? InstalledVersion { get; set; }
+    public long? InstalledAt { get; set; }
+}
+
+public sealed class SkillCardMetadata
+{
+    public bool Present { get; set; }
+    public long SizeBytes { get; set; }
+}
+
+public sealed class SkillStatusEntry
+{
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public string Source { get; set; } = string.Empty;
+    public bool Bundled { get; set; }
+    public string SkillKey { get; set; } = string.Empty;
+    public string? PrimaryEnv { get; set; }
+    public string? Emoji { get; set; }
+    public string? Homepage { get; set; }
+    public bool Always { get; set; }
+    public bool Disabled { get; set; }
+    public bool BlockedByAllowlist { get; set; }
+    public bool BlockedByAgentFilter { get; set; }
+    public bool Eligible { get; set; }
+    public bool PlatformIncompatible { get; set; }
+    public bool ModelVisible { get; set; }
+    public bool UserInvocable { get; set; }
+    public bool CommandVisible { get; set; }
+    public SkillRequirements Requirements { get; set; } = new();
+    public SkillRequirements Missing { get; set; } = new();
+    public IReadOnlyList<SkillConfigCheck> ConfigChecks { get; set; } = [];
+    public IReadOnlyList<SkillInstallOption> Install { get; set; } = [];
+    public ClawHubSkillLink? Clawhub { get; set; }
+    public SkillCardMetadata? SkillCard { get; set; }
+
+    public SkillReadinessState Readiness =>
+        Disabled ? SkillReadinessState.Disabled :
+        BlockedByAllowlist || BlockedByAgentFilter ? SkillReadinessState.Blocked :
+        PlatformIncompatible ? SkillReadinessState.Incompatible :
+        Eligible ? SkillReadinessState.Ready :
+        SkillReadinessState.NeedsSetup;
+}
+
+public sealed class SkillsStatusReport
+{
+    public string? AgentId { get; set; }
+    public IReadOnlyList<string> AgentSkillFilter { get; set; } = [];
+    public IReadOnlyList<SkillStatusEntry> Skills { get; set; } = [];
+    public bool IsSupported { get; set; } = true;
+
+    public static SkillsStatusReport Unsupported { get; } = new() { IsSupported = false };
+}
+
+public sealed class ClawHubSkillSearchEntry
+{
+    public double Score { get; set; }
+    public string Slug { get; set; } = string.Empty;
+    public string? InstallRef { get; set; }
+    public bool InstallOnly { get; set; }
+    public string? TrustState { get; set; }
+    public string DisplayName { get; set; } = string.Empty;
+    public string? Summary { get; set; }
+    public string? Icon { get; set; }
+    public string? Version { get; set; }
+    public long? UpdatedAt { get; set; }
+
+    /// <summary>
+    /// Exact source-qualified identity that must be echoed to detail/install.
+    /// A missing value means the connected Gateway predates the safe identity contract.
+    /// </summary>
+    public string? SafeInstallReference =>
+        string.IsNullOrWhiteSpace(InstallRef) ? null : InstallRef;
+}
+
+public sealed class SkillsSearchResult
+{
+    public IReadOnlyList<ClawHubSkillSearchEntry> Results { get; set; } = [];
+    public bool IsSupported { get; set; } = true;
+
+    public static SkillsSearchResult Unsupported { get; } = new() { IsSupported = false };
+}
+
+public sealed class ClawHubSkillDetail
+{
+    public string Slug { get; set; } = string.Empty;
+    public string DisplayName { get; set; } = string.Empty;
+    public string? Summary { get; set; }
+    public IReadOnlyDictionary<string, string> Tags { get; set; } =
+        new Dictionary<string, string>();
+    public string? Channel { get; set; }
+    public bool? IsOfficial { get; set; }
+    public long CreatedAt { get; set; }
+    public long UpdatedAt { get; set; }
+}
+
+public sealed class ClawHubSkillVersion
+{
+    public string Version { get; set; } = string.Empty;
+    public long CreatedAt { get; set; }
+    public string? Changelog { get; set; }
+}
+
+public sealed class ClawHubSkillMetadata
+{
+    public IReadOnlyList<string> Os { get; set; } = [];
+    public IReadOnlyList<string> Systems { get; set; } = [];
+}
+
+public sealed class ClawHubSkillOwner
+{
+    public string? Handle { get; set; }
+    public string? DisplayName { get; set; }
+    public string? Image { get; set; }
+    public bool? Official { get; set; }
+    public string? Channel { get; set; }
+    public bool? IsOfficial { get; set; }
+}
+
+public sealed class SkillsDetailResult
+{
+    public ClawHubSkillDetail? Skill { get; set; }
+    public ClawHubSkillVersion? LatestVersion { get; set; }
+    public ClawHubSkillMetadata? Metadata { get; set; }
+    public ClawHubSkillOwner? Owner { get; set; }
+    public bool IsSupported { get; set; } = true;
+
+    public static SkillsDetailResult Unsupported { get; } = new() { IsSupported = false };
+}
+
+public sealed class SkillSecurityVerdictError
+{
+    public string? Code { get; set; }
+    public string? Message { get; set; }
+}
+
+public sealed class SkillSecurityVerdict
+{
+    public string Registry { get; set; } = string.Empty;
+    public bool Ok { get; set; }
+    public string Decision { get; set; } = string.Empty;
+    public IReadOnlyList<string> Reasons { get; set; } = [];
+    public string RequestedSlug { get; set; } = string.Empty;
+    public string? RequestedOwnerHandle { get; set; }
+    public string RequestedVersion { get; set; } = string.Empty;
+    public string? Slug { get; set; }
+    public string? Version { get; set; }
+    public string? DisplayName { get; set; }
+    public string? PublisherHandle { get; set; }
+    public string? PublisherDisplayName { get; set; }
+    public long? CreatedAt { get; set; }
+    public long? CheckedAt { get; set; }
+    public string? SkillUrl { get; set; }
+    public string? SecurityAuditUrl { get; set; }
+    public string? SecurityStatus { get; set; }
+    public bool? SecurityPassed { get; set; }
+    public SkillSecurityVerdictError? Error { get; set; }
+}
+
+public sealed class SkillsSecurityVerdictsResult
+{
+    public string Schema { get; set; } = string.Empty;
+    public IReadOnlyList<SkillSecurityVerdict> Items { get; set; } = [];
+    public bool IsSupported { get; set; } = true;
+
+    public static SkillsSecurityVerdictsResult Unsupported { get; } = new() { IsSupported = false };
+}
+
+public sealed class SkillCardResult
+{
+    public string Schema { get; set; } = string.Empty;
+    public string SkillKey { get; set; } = string.Empty;
+    public long SizeBytes { get; set; }
+    public string Content { get; set; } = string.Empty;
+    public bool IsSupported { get; set; } = true;
+
+    public static SkillCardResult Unsupported { get; } = new() { IsSupported = false };
+}
+
+public sealed class SkillMutationResult
+{
+    public bool Ok { get; set; }
+    public string? Message { get; set; }
+    public string? SkillKey { get; set; }
+    public string? Slug { get; set; }
+    public string? Version { get; set; }
+    public string? Warning { get; set; }
+    public bool IsSupported { get; set; } = true;
+
+    public static SkillMutationResult Unsupported { get; } = new() { IsSupported = false };
+}
+
+public sealed record ClawHubSkillInstallRequest(
+    string InstallReference,
+    string? AgentId = null,
+    string? Version = null,
+    int? TimeoutMs = null);
+
+public sealed record ClawHubSkillUpdateRequest(
+    string InstallReference,
+    string? AgentId = null);

--- a/src/OpenClaw.Shared/SkillsGatewayModels.cs
+++ b/src/OpenClaw.Shared/SkillsGatewayModels.cs
@@ -242,7 +242,8 @@ public sealed record ClawHubSkillInstallRequest(
     string InstallReference,
     string? AgentId = null,
     string? Version = null,
-    int? TimeoutMs = null);
+    int? TimeoutMs = null,
+    long? ConnectionEpoch = null);
 
 public sealed record ClawHubSkillUpdateRequest(
     string InstallReference,

--- a/tests/OpenClaw.Shared.Tests/GatewayExtensionsTests.cs
+++ b/tests/OpenClaw.Shared.Tests/GatewayExtensionsTests.cs
@@ -1,0 +1,143 @@
+using System.Text.Json;
+using OpenClaw.Shared;
+
+namespace OpenClaw.Shared.Tests;
+
+public sealed class GatewayExtensionsTests
+{
+    [Fact]
+    public void GatewayFeatureSet_FromHelloOk_PreservesExactDistinctMethodsAndEvents()
+    {
+        using var document = JsonDocument.Parse("""
+        {
+          "features": {
+            "methods": ["skills.search", "plugins.list", "skills.search", ""],
+            "events": ["skills.changed", "plugins.changed", 12]
+          }
+        }
+        """);
+
+        var features = GatewayFeatureSet.FromHelloOk(document.RootElement);
+
+        Assert.Equal(["skills.search", "plugins.list"], features.Methods);
+        Assert.Equal(["skills.changed", "plugins.changed"], features.Events);
+        Assert.True(features.SupportsMethod("plugins.list"));
+        Assert.False(features.SupportsMethod("Plugins.List"));
+    }
+
+    [Theory]
+    [InlineData(true, false, false, false, true, SkillReadinessState.Disabled)]
+    [InlineData(false, true, false, false, true, SkillReadinessState.Blocked)]
+    [InlineData(false, false, true, false, false, SkillReadinessState.Blocked)]
+    [InlineData(false, false, false, true, false, SkillReadinessState.Incompatible)]
+    [InlineData(false, false, false, false, false, SkillReadinessState.NeedsSetup)]
+    [InlineData(false, false, false, false, true, SkillReadinessState.Ready)]
+    public void SkillStatusEntry_Readiness_DoesNotConflateEnabledWithEligible(
+        bool disabled,
+        bool allowlistBlocked,
+        bool agentBlocked,
+        bool platformIncompatible,
+        bool eligible,
+        SkillReadinessState expected)
+    {
+        var skill = new SkillStatusEntry
+        {
+            Disabled = disabled,
+            BlockedByAllowlist = allowlistBlocked,
+            BlockedByAgentFilter = agentBlocked,
+            PlatformIncompatible = platformIncompatible,
+            Eligible = eligible,
+        };
+
+        Assert.Equal(expected, skill.Readiness);
+    }
+
+    [Fact]
+    public void GatewayRequestException_PreservesConsentTokenAndRedactsOtherSecrets()
+    {
+        using var document = JsonDocument.Parse("""
+        {
+          "ok": false,
+          "error": {
+            "code": "UNAVAILABLE",
+            "message": "Consent required",
+            "details": {
+              "capabilityConsentCode": "PLUGIN_CAPABILITY_CONSENT_REQUIRED",
+              "pluginId": "voice-call",
+              "reviewToken": "review-token-exact",
+              "apiToken": "must-not-survive"
+            }
+          }
+        }
+        """);
+
+        var exception = GatewayRequestException.FromResponse(
+            "plugins.install",
+            document.RootElement,
+            "request failed");
+
+        Assert.Equal("plugins.install", exception.Method);
+        Assert.Equal("UNAVAILABLE", exception.Code);
+        Assert.Equal("review-token-exact", exception.Details!.Value.GetProperty("reviewToken").GetString());
+        Assert.Equal("[REDACTED]", exception.Details.Value.GetProperty("apiToken").GetString());
+    }
+
+    [Fact]
+    public void PluginCapabilityConsentDetails_ParsesExactGatewayShape()
+    {
+        using var document = JsonDocument.Parse("""
+        {
+          "ok": false,
+          "error": {
+            "code": "UNAVAILABLE",
+            "message": "Consent required",
+            "details": {
+              "capabilityConsentCode": "PLUGIN_CAPABILITY_CONSENT_REQUIRED",
+              "pluginId": "voice-call",
+              "reviewToken": "review-token-exact",
+              "widened": {
+                "tools": ["voice.call"],
+                "mcpServers": ["voice"]
+              }
+            }
+          }
+        }
+        """);
+        var exception = GatewayRequestException.FromResponse(
+            "plugins.install",
+            document.RootElement,
+            "request failed");
+
+        var parsed = PluginCapabilityConsentDetails.TryParse(exception, out var consent);
+
+        Assert.True(parsed);
+        Assert.NotNull(consent);
+        Assert.Equal("voice-call", consent!.PluginId);
+        Assert.Equal("review-token-exact", consent.ReviewToken);
+        Assert.Equal(["voice.call"], consent.Widened.Tools);
+        Assert.Equal(["voice"], consent.Widened.McpServers);
+    }
+
+    [Fact]
+    public void PluginCapabilityConsentDetails_RejectsUnknownFields()
+    {
+        using var document = JsonDocument.Parse("""
+        {
+          "error": {
+            "details": {
+              "capabilityConsentCode": "PLUGIN_CAPABILITY_CONSENT_REQUIRED",
+              "pluginId": "voice-call",
+              "reviewToken": "review-token-exact",
+              "unexpected": true
+            }
+          }
+        }
+        """);
+        var exception = GatewayRequestException.FromResponse(
+            "plugins.install",
+            document.RootElement,
+            "request failed");
+
+        Assert.False(PluginCapabilityConsentDetails.TryParse(exception, out _));
+    }
+}

--- a/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
@@ -48,6 +48,11 @@ public class OpenClawGatewayClientTests
                 identityPath: CreateTempIdentityPath());
         }
 
+        public GatewayClientTestHelper(OpenClawGatewayClient client)
+        {
+            _client = client;
+        }
+
         public string ClassifyNotification(string text)
         {
             var (_, type) = NotificationCategorizer.ClassifyByKeywords(text);
@@ -551,6 +556,54 @@ public class OpenClawGatewayClientTests
 
     }
 
+    private sealed class PausingGatewayClient : OpenClawGatewayClient
+    {
+        private readonly TaskCompletionSource<bool> _mutationSendEntered =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<bool> _continueMutationSend =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private bool _pauseMutationSend;
+
+        public PausingGatewayClient(string gatewayUrl, string identityPath)
+            : base(gatewayUrl, "test-token", new TestLogger(), identityPath: identityPath)
+        {
+        }
+
+        public Task MutationSendEntered => _mutationSendEntered.Task;
+
+        public void ArmMutationSendPause() => _pauseMutationSend = true;
+
+        public void AdvanceConnectionEpochForTest()
+        {
+            var field = typeof(WebSocketClientBase).GetField(
+                "_connectionGeneration",
+                System.Reflection.BindingFlags.NonPublic |
+                System.Reflection.BindingFlags.Instance);
+            field!.SetValue(this, ConnectionEpoch + 1);
+        }
+
+        public void ContinueMutationSend() => _continueMutationSend.TrySetResult(true);
+
+        protected override async Task<bool> SendRawAsync(
+            string message,
+            long expectedConnectionGeneration,
+            CancellationToken cancellationToken)
+        {
+            if (_pauseMutationSend &&
+                (message.Contains("plugins.install", StringComparison.Ordinal) ||
+                 message.Contains("plugins.setEnabled", StringComparison.Ordinal)))
+            {
+                _mutationSendEntered.TrySetResult(true);
+                await _continueMutationSend.Task.WaitAsync(cancellationToken);
+            }
+
+            return await base.SendRawAsync(
+                message,
+                expectedConnectionGeneration,
+                cancellationToken);
+        }
+    }
+
     private static string CreateTempIdentityPath() =>
         Path.Combine(Path.GetTempPath(), "OpenClawGatewayClientTests", Guid.NewGuid().ToString("N"));
 
@@ -731,7 +784,97 @@ public class OpenClawGatewayClientTests
     }
 
     [Fact]
-    public async Task ExtensionMethod_NotAdvertised_FailsBeforeSending()
+    public async Task InstallPluginAsync_RejectsReconnectBetweenConsentCheckAndFinalWrite()
+    {
+        using var server = new LoopbackWebSocketServer();
+        using var identity = new TempDirectory("plugin-install-race-");
+        await server.StartAsync();
+        using var client = new PausingGatewayClient(server.WebSocketUrl, identity.Path);
+        var helper = new GatewayClientTestHelper(client);
+        await client.ConnectAsync();
+        helper.TrackPendingRequest("connect-plugins-race", "connect");
+        helper.ProcessRawMessage("""
+        {
+          "type": "res",
+          "id": "connect-plugins-race",
+          "ok": true,
+          "payload": {
+            "type": "hello-ok",
+            "protocol": 4,
+            "features": {
+              "methods": ["plugins.install"],
+              "events": []
+            },
+            "snapshot": {}
+          }
+        }
+        """);
+        var request = PluginInstallRequest.FromClawHub("@openclaw/voice-call") with
+        {
+            AcknowledgeCapabilities = new PluginCapabilityAcknowledgement(
+                "review-token",
+                client.ConnectionEpoch),
+        };
+        client.ArmMutationSendPause();
+
+        var installTask = client.InstallPluginAsync(request, timeoutMs: 10_000);
+        await client.MutationSendEntered.WaitAsync(TimeSpan.FromSeconds(2));
+        client.AdvanceConnectionEpochForTest();
+        client.ContinueMutationSend();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => installTask);
+        Assert.Contains("expired", exception.Message, StringComparison.OrdinalIgnoreCase);
+        using var noRequestTimeout = new CancellationTokenSource(TimeSpan.FromMilliseconds(250));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => server.ReceiveTextAsync(noRequestTimeout.Token));
+    }
+
+    [Fact]
+    public async Task SetPluginEnabledAsync_RejectsReconnectBetweenConsentCheckAndFinalWrite()
+    {
+        using var server = new LoopbackWebSocketServer();
+        using var identity = new TempDirectory("plugin-enable-race-");
+        await server.StartAsync();
+        using var client = new PausingGatewayClient(server.WebSocketUrl, identity.Path);
+        var helper = new GatewayClientTestHelper(client);
+        await client.ConnectAsync();
+        helper.TrackPendingRequest("connect-plugin-enable-race", "connect");
+        helper.ProcessRawMessage("""
+        {
+          "type": "res",
+          "id": "connect-plugin-enable-race",
+          "ok": true,
+          "payload": {
+            "type": "hello-ok",
+            "protocol": 4,
+            "features": {
+              "methods": ["plugins.setEnabled"],
+              "events": []
+            },
+            "snapshot": {}
+          }
+        }
+        """);
+        var request = new PluginSetEnabledRequest(
+            "voice-call",
+            Enabled: true,
+            new PluginCapabilityAcknowledgement("review-token", client.ConnectionEpoch));
+        client.ArmMutationSendPause();
+
+        var enableTask = client.SetPluginEnabledAsync(request, timeoutMs: 10_000);
+        await client.MutationSendEntered.WaitAsync(TimeSpan.FromSeconds(2));
+        client.AdvanceConnectionEpochForTest();
+        client.ContinueMutationSend();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => enableTask);
+        Assert.Contains("expired", exception.Message, StringComparison.OrdinalIgnoreCase);
+        using var noRequestTimeout = new CancellationTokenSource(TimeSpan.FromMilliseconds(250));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => server.ReceiveTextAsync(noRequestTimeout.Token));
+    }
+
+    [Fact]
+    public async Task ExtensionMethods_NotAdvertised_ReturnUnsupportedWithoutSending()
     {
         using var server = new LoopbackWebSocketServer();
         using var identity = new TempDirectory("extension-gate-");
@@ -750,13 +893,19 @@ public class OpenClawGatewayClientTests
           "payload": {
             "type": "hello-ok",
             "protocol": 4,
-            "features": { "methods": ["skills.status"], "events": [] },
+            "features": { "methods": [], "events": [] },
             "snapshot": {}
           }
         }
         """);
 
-        await Assert.ThrowsAsync<NotSupportedException>(() => client.ListPluginsAsync());
+        Assert.False((await client.ListPluginsAsync()).IsSupported);
+        Assert.False((await client.GetSkillsStatusAsync()).IsSupported);
+        Assert.False((await client.SetSkillEnabledDetailedAsync("weather", enabled: false)).IsSupported);
+        Assert.False(await client.SetSkillEnabledAsync("weather", enabled: false));
+        using var noRequestTimeout = new CancellationTokenSource(TimeSpan.FromMilliseconds(250));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => server.ReceiveTextAsync(noRequestTimeout.Token));
     }
 
     [Fact]

--- a/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
@@ -613,11 +613,150 @@ public class OpenClawGatewayClientTests
                 error = new { message = "wizard rejected" }
             }));
 
-        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+        var exception = await Assert.ThrowsAsync<GatewayRequestException>(
             async () => await responseTask.WaitAsync(TimeSpan.FromSeconds(2)));
 
         Assert.Equal("wizard rejected", exception.Message);
+        Assert.Equal("wizard.next", exception.Method);
         Assert.Equal(0, helper.GetPendingRequestCount());
+    }
+
+    [Fact]
+    public async Task InstallClawHubSkillAsync_SendsExactSearchIdentityAndAgent()
+    {
+        using var server = new LoopbackWebSocketServer();
+        using var identity = new TempDirectory("skill-install-");
+        await server.StartAsync();
+        var helper = new GatewayClientTestHelper(
+            gatewayUrl: server.WebSocketUrl,
+            identityPath: identity.Path);
+        using var client = helper.Client;
+        await client.ConnectAsync();
+        helper.TrackPendingRequest("connect-extensions", "connect");
+        helper.ProcessRawMessage("""
+        {
+          "type": "res",
+          "id": "connect-extensions",
+          "ok": true,
+          "payload": {
+            "type": "hello-ok",
+            "protocol": 4,
+            "features": {
+              "methods": ["skills.install"],
+              "events": ["skills.changed"]
+            },
+            "snapshot": {}
+          }
+        }
+        """);
+
+        var resultTask = client.InstallClawHubSkillAsync(
+            new ClawHubSkillInstallRequest(
+                "@publisher/shared-slug",
+                AgentId: "researcher",
+                Version: "1.2.3"),
+            timeoutMs: 10_000);
+        var requestText = await server.ReceiveTextAsync().WaitAsync(TimeSpan.FromSeconds(2));
+        using var request = JsonDocument.Parse(requestText);
+        var root = request.RootElement;
+        Assert.Equal("skills.install", root.GetProperty("method").GetString());
+        var parameters = root.GetProperty("params");
+        Assert.Equal("clawhub", parameters.GetProperty("source").GetString());
+        Assert.Equal("@publisher/shared-slug", parameters.GetProperty("slug").GetString());
+        Assert.Equal("researcher", parameters.GetProperty("agentId").GetString());
+        Assert.Equal("1.2.3", parameters.GetProperty("version").GetString());
+        Assert.False(parameters.TryGetProperty("id", out _));
+        Assert.False(parameters.TryGetProperty("force", out _));
+
+        await server.SendTextAsync(JsonSerializer.Serialize(new
+        {
+            type = "res",
+            id = root.GetProperty("id").GetString(),
+            ok = true,
+            payload = new
+            {
+                ok = true,
+                message = "Installed shared-slug@1.2.3",
+                slug = "shared-slug",
+                version = "1.2.3",
+            },
+        }));
+
+        var result = await resultTask.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.True(result.Ok);
+        Assert.Equal("shared-slug", result.Slug);
+        Assert.True(client.AdvertisedFeatures.SupportsEvent("skills.changed"));
+    }
+
+    [Fact]
+    public async Task InstallPluginAsync_RejectsConsentFromPriorConnectionEpochBeforeSending()
+    {
+        using var server = new LoopbackWebSocketServer();
+        using var identity = new TempDirectory("plugin-install-");
+        await server.StartAsync();
+        var helper = new GatewayClientTestHelper(
+            gatewayUrl: server.WebSocketUrl,
+            identityPath: identity.Path);
+        using var client = helper.Client;
+        await client.ConnectAsync();
+        helper.TrackPendingRequest("connect-plugins", "connect");
+        helper.ProcessRawMessage("""
+        {
+          "type": "res",
+          "id": "connect-plugins",
+          "ok": true,
+          "payload": {
+            "type": "hello-ok",
+            "protocol": 4,
+            "features": {
+              "methods": ["plugins.install"],
+              "events": []
+            },
+            "snapshot": {}
+          }
+        }
+        """);
+        var staleEpoch = client.ConnectionEpoch - 1;
+        var request = PluginInstallRequest.FromClawHub("@openclaw/voice-call") with
+        {
+            AcknowledgeCapabilities = new PluginCapabilityAcknowledgement(
+                "review-token",
+                staleEpoch),
+        };
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => client.InstallPluginAsync(request, timeoutMs: 10_000));
+
+        Assert.Contains("expired", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ExtensionMethod_NotAdvertised_FailsBeforeSending()
+    {
+        using var server = new LoopbackWebSocketServer();
+        using var identity = new TempDirectory("extension-gate-");
+        await server.StartAsync();
+        var helper = new GatewayClientTestHelper(
+            gatewayUrl: server.WebSocketUrl,
+            identityPath: identity.Path);
+        using var client = helper.Client;
+        await client.ConnectAsync();
+        helper.TrackPendingRequest("connect-no-plugins", "connect");
+        helper.ProcessRawMessage("""
+        {
+          "type": "res",
+          "id": "connect-no-plugins",
+          "ok": true,
+          "payload": {
+            "type": "hello-ok",
+            "protocol": 4,
+            "features": { "methods": ["skills.status"], "events": [] },
+            "snapshot": {}
+          }
+        }
+        """);
+
+        await Assert.ThrowsAsync<NotSupportedException>(() => client.ListPluginsAsync());
     }
 
     [Fact]

--- a/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
@@ -591,7 +591,8 @@ public class OpenClawGatewayClientTests
         {
             if (_pauseMutationSend &&
                 (message.Contains("plugins.install", StringComparison.Ordinal) ||
-                 message.Contains("plugins.setEnabled", StringComparison.Ordinal)))
+                 message.Contains("plugins.setEnabled", StringComparison.Ordinal) ||
+                 message.Contains("skills.install", StringComparison.Ordinal)))
             {
                 _mutationSendEntered.TrySetResult(true);
                 await _continueMutationSend.Task.WaitAsync(cancellationToken);
@@ -867,6 +868,50 @@ public class OpenClawGatewayClientTests
         client.ContinueMutationSend();
 
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => enableTask);
+        Assert.Contains("expired", exception.Message, StringComparison.OrdinalIgnoreCase);
+        using var noRequestTimeout = new CancellationTokenSource(TimeSpan.FromMilliseconds(250));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => server.ReceiveTextAsync(noRequestTimeout.Token));
+    }
+
+    [Fact]
+    public async Task InstallClawHubSkillAsync_RejectsReconnectBetweenReviewAndFinalWrite()
+    {
+        using var server = new LoopbackWebSocketServer();
+        using var identity = new TempDirectory("skill-install-race-");
+        await server.StartAsync();
+        using var client = new PausingGatewayClient(server.WebSocketUrl, identity.Path);
+        var helper = new GatewayClientTestHelper(client);
+        await client.ConnectAsync();
+        helper.TrackPendingRequest("connect-skill-install-race", "connect");
+        helper.ProcessRawMessage("""
+        {
+          "type": "res",
+          "id": "connect-skill-install-race",
+          "ok": true,
+          "payload": {
+            "type": "hello-ok",
+            "protocol": 4,
+            "features": {
+              "methods": ["skills.install"],
+              "events": []
+            },
+            "snapshot": {}
+          }
+        }
+        """);
+        var request = new ClawHubSkillInstallRequest(
+            "@openclaw/weather",
+            Version: "1.2.3",
+            ConnectionEpoch: client.ConnectionEpoch);
+        client.ArmMutationSendPause();
+
+        var installTask = client.InstallClawHubSkillAsync(request, timeoutMs: 10_000);
+        await client.MutationSendEntered.WaitAsync(TimeSpan.FromSeconds(2));
+        client.AdvanceConnectionEpochForTest();
+        client.ContinueMutationSend();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => installTask);
         Assert.Contains("expired", exception.Message, StringComparison.OrdinalIgnoreCase);
         using var noRequestTimeout = new CancellationTokenSource(TimeSpan.FromMilliseconds(250));
         await Assert.ThrowsAnyAsync<OperationCanceledException>(

--- a/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
@@ -769,6 +769,75 @@ public class OpenClawGatewayClientTests
     }
 
     [Fact]
+    public async Task SetSkillEnabledAsync_SuccessRefreshesLastAgentScope()
+    {
+        using var server = new LoopbackWebSocketServer();
+        using var identity = new TempDirectory("skill-toggle-refresh-");
+        await server.StartAsync();
+        var helper = new GatewayClientTestHelper(
+            gatewayUrl: server.WebSocketUrl,
+            identityPath: identity.Path);
+        using var client = helper.Client;
+        await client.ConnectAsync();
+        helper.TrackPendingRequest("connect-skill-toggle-refresh", "connect");
+        helper.ProcessRawMessage("""
+        {
+          "type": "res",
+          "id": "connect-skill-toggle-refresh",
+          "ok": true,
+          "payload": {
+            "type": "hello-ok",
+            "protocol": 4,
+            "features": {
+              "methods": ["skills.status", "skills.update"],
+              "events": ["skills.changed"]
+            },
+            "snapshot": {}
+          }
+        }
+        """);
+
+        await client.RequestSkillsStatusAsync("researcher");
+        var initialStatusText = await server.ReceiveTextAsync().WaitAsync(TimeSpan.FromSeconds(2));
+        using (var initialStatus = JsonDocument.Parse(initialStatusText))
+        {
+            Assert.Equal("skills.status", initialStatus.RootElement.GetProperty("method").GetString());
+            Assert.Equal(
+                "researcher",
+                initialStatus.RootElement.GetProperty("params").GetProperty("agentId").GetString());
+            helper.ProcessRawMessage(JsonSerializer.Serialize(new
+            {
+                type = "res",
+                id = initialStatus.RootElement.GetProperty("id").GetString(),
+                ok = true,
+                payload = new { skills = Array.Empty<object>() },
+            }));
+        }
+
+        var toggleTask = client.SetSkillEnabledAsync("weather", enabled: false);
+        var updateText = await server.ReceiveTextAsync().WaitAsync(TimeSpan.FromSeconds(2));
+        using (var update = JsonDocument.Parse(updateText))
+        {
+            Assert.Equal("skills.update", update.RootElement.GetProperty("method").GetString());
+            helper.ProcessRawMessage(JsonSerializer.Serialize(new
+            {
+                type = "res",
+                id = update.RootElement.GetProperty("id").GetString(),
+                ok = true,
+                payload = new { ok = true },
+            }));
+        }
+
+        Assert.True(await toggleTask.WaitAsync(TimeSpan.FromSeconds(2)));
+        var refreshedStatusText = await server.ReceiveTextAsync().WaitAsync(TimeSpan.FromSeconds(2));
+        using var refreshedStatus = JsonDocument.Parse(refreshedStatusText);
+        Assert.Equal("skills.status", refreshedStatus.RootElement.GetProperty("method").GetString());
+        Assert.Equal(
+            "researcher",
+            refreshedStatus.RootElement.GetProperty("params").GetProperty("agentId").GetString());
+    }
+
+    [Fact]
     public async Task InstallPluginAsync_RejectsConsentFromPriorConnectionEpochBeforeSending()
     {
         using var server = new LoopbackWebSocketServer();

--- a/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
@@ -608,6 +608,32 @@ public class OpenClawGatewayClientTests
     private static string CreateTempIdentityPath() =>
         Path.Combine(Path.GetTempPath(), "OpenClawGatewayClientTests", Guid.NewGuid().ToString("N"));
 
+    private static async Task AssertServerDoesNotReceiveMethodAsync(
+        LoopbackWebSocketServer server,
+        string forbiddenMethod)
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromMilliseconds(250));
+        while (true)
+        {
+            string requestText;
+            try
+            {
+                requestText = await server.ReceiveTextAsync(timeout.Token);
+            }
+            catch (OperationCanceledException) when (timeout.IsCancellationRequested)
+            {
+                return;
+            }
+
+            using var request = JsonDocument.Parse(requestText);
+            if (request.RootElement.TryGetProperty("method", out var method) &&
+                string.Equals(method.GetString(), forbiddenMethod, StringComparison.Ordinal))
+            {
+                Assert.Fail($"Server received forbidden '{forbiddenMethod}' request.");
+            }
+        }
+    }
+
     [Fact]
     public async Task SendWizardRequestAsync_ResponseBeforeDispose_ReturnsPayloadAndCleansTracking()
     {
@@ -825,9 +851,7 @@ public class OpenClawGatewayClientTests
 
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => installTask);
         Assert.Contains("expired", exception.Message, StringComparison.OrdinalIgnoreCase);
-        using var noRequestTimeout = new CancellationTokenSource(TimeSpan.FromMilliseconds(250));
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            () => server.ReceiveTextAsync(noRequestTimeout.Token));
+        await AssertServerDoesNotReceiveMethodAsync(server, "plugins.install");
     }
 
     [Fact]
@@ -869,9 +893,7 @@ public class OpenClawGatewayClientTests
 
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => enableTask);
         Assert.Contains("expired", exception.Message, StringComparison.OrdinalIgnoreCase);
-        using var noRequestTimeout = new CancellationTokenSource(TimeSpan.FromMilliseconds(250));
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            () => server.ReceiveTextAsync(noRequestTimeout.Token));
+        await AssertServerDoesNotReceiveMethodAsync(server, "plugins.setEnabled");
     }
 
     [Fact]
@@ -913,9 +935,7 @@ public class OpenClawGatewayClientTests
 
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => installTask);
         Assert.Contains("expired", exception.Message, StringComparison.OrdinalIgnoreCase);
-        using var noRequestTimeout = new CancellationTokenSource(TimeSpan.FromMilliseconds(250));
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            () => server.ReceiveTextAsync(noRequestTimeout.Token));
+        await AssertServerDoesNotReceiveMethodAsync(server, "skills.install");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Add typed, feature-negotiated Gateway clients for Skills and Plugin lifecycle RPCs.
- Add exact wire models for catalogs, inspection, declared surfaces, operator grants, trust, mutation results, and capability acknowledgement.
- Strictly parse capability-consent and install-policy errors before the UI can act on them.
- Preserve compatibility with older Gateways by returning typed `IsSupported=false` results when methods are not advertised.
- Bind every Plugin mutation and every reviewed Skill install to the captured connection epoch through the final socket write.
- Preserve the legacy skill-toggle contract by refreshing the last selected agent scope after a successful supported toggle.

## Security and compatibility

Plugin install, Plugin enable, and reviewed Skill install carry the reviewed connection epoch to the generation-aware transport. Focused loopback tests pause after consent validation, advance the connection epoch, resume at the final send, and prove that all three operations fail closed before the test server receives the forbidden mutation request.

The legacy skill-toggle path returns `false` without sending when an older Gateway does not advertise `skills.update`. A successful supported toggle sends a follow-up `skills.status` request for the last selected agent scope, preserving the existing shared-cache refresh behavior.

## Required proof pools

- `windows-11-arm64`: completed for the native build and local contract suites.
- `windows-wsl-gateway-e2e`: not verified and blocked until a provenance-validated plugin-capable Gateway release is available for live lifecycle mutation and server-side revoked-authority proof.

## Validation

- `build.ps1`: passed on Windows ARM64.
- Focused Gateway extension, reconnect-fence, and legacy-refresh tests: 17 passed.
- Full Shared suite: 3,960 passed, 32 environment-gated skips.
- Full Tray suite: 2,861 passed.

## Real Behavior Proof

- Loopback Gateway proof covers source-qualified skill installation, exact Plugin wire payloads, typed older-Gateway fallback, selected-agent refresh, and reconnect between consent admission and the final transport write.
- For the Skill install, Plugin install, and Plugin enable reconnect cases, the operation returns an expired-review failure and the server observes no forbidden mutation request.
- Live allowed Plugin mutation is intentionally not claimed because the installed Gateway does not advertise the lifecycle RPCs.

## Stack

This is merge step 1 of 2 for the Extensions hub. Merge this PR before #1370.
