### PR TITLE
chore(gateway): gate plugin-capable release promotion

### DIFF
--- a/docs/adr/0001-gateway-release-policy.md
+++ b/docs/adr/0001-gateway-release-policy.md
@@ -78,6 +78,15 @@ candidate proof.
 provenance and its GitHub release does not publish stable release-validation
 evidence.
 
+The Windows Extensions hub needs the stable Plugins lifecycle first released in
+`2026.8.1`. The newest stable candidate checked on 2026-09-08, `2026.9.3`, is
+evidence-rejected. It passed protocol v4, the security floor, SHA-512 package
+integrity, registry signatures, exact package-build/tag commit binding, the
+stable release manifest, and verified tag checks. Its npm SLSA provenance did
+not verify against the package digest and OpenClaw release identity. The
+Windows recommendation therefore remains `2026.6.34`; runtime UI uses advertised
+Gateway methods and fails closed when the Plugins APIs are absent.
+
 ## Consequences
 
 - Setup is reproducible and cannot silently move when npm tags change.

--- a/docs/proof/gateway-release/2026.9.3-preflight.json
+++ b/docs/proof/gateway-release/2026.9.3-preflight.json
@@ -1,0 +1,27 @@
+{
+  "version": "2026.9.3",
+  "eligible": false,
+  "protocolGeneration": 4,
+  "securityFloor": "2026.6.11",
+  "atOrAboveSecurityFloor": true,
+  "npmIntegrity": "sha512-CzDHMeHdnjlIZ76ZyBb1lvLO4H/yBIMYXupFGGBN87x0853y3hg5nLAnKfxSKqLzqhbUKqy9ebDRAWWV4t8aew==",
+  "npmIntegrityVerified": true,
+  "npmSignatureCount": 2,
+  "npmSignatureVerified": true,
+  "npmProvenance": false,
+  "npmProvenanceSourceCommit": "",
+  "tagCommit": "1391f7cd2d40ab5bbcf2f5f831d3a64f520e72d7",
+  "npmProvenanceTagBound": false,
+  "embeddedPolicyException": false,
+  "packageBuildVersion": "2026.9.3",
+  "packageBuildCommit": "1391f7cd2d40ab5bbcf2f5f831d3a64f520e72d7",
+  "packageBuildMatchesTag": true,
+  "githubStableRelease": true,
+  "stableReleaseManifest": true,
+  "githubVerifiedTag": true,
+  "extendedStableTag": false,
+  "checkedAtUtc": "2026-09-08T18:25:21.6780022Z",
+  "failures": [
+    "npm SLSA provenance did not verify against the package digest and OpenClaw release identity."
+  ]
+}

--- a/docs/proof/gateway-release/README.md
+++ b/docs/proof/gateway-release/README.md
@@ -1,0 +1,21 @@
+# Gateway 2026.9.3 candidate proof
+
+Captured on Windows ARM64 from production commit `5c1fb828` on September 8, 2026.
+
+The repository validator was run against the public npm package and GitHub release:
+
+```powershell
+.\scripts\Test-GatewayReleaseCandidate.ps1 -Version 2026.9.3 -SummaryPath .\docs\proof\gateway-release\2026.9.3-preflight.json
+```
+
+The command rejected the candidate, as expected. The linked [preflight report](./2026.9.3-preflight.json) records:
+
+- Protocol generation 4 and security-floor checks passed.
+- npm SHA-512 integrity and both registry signatures verified.
+- Package build version and commit matched the exact Git tag.
+- The stable GitHub release, release manifest, and verified tag checks passed.
+- npm SLSA provenance did not verify against the package digest and OpenClaw release identity, so `eligible` remained `false`.
+
+The current-head `GatewayReleasePolicyTests` passed 26 of 26. They prove that the embedded recommendation remains 2026.6.34, the Plugin readiness signal remains false, the 2026.9.3 evidence entry remains rejected, and exact selection of an evidence-rejected release fails before setup can install it. The full SetupEngine suite previously passed 1,100 of 1,100 on the same production commit.
+
+No candidate package was installed. This PR records an evidence decision without changing the recommended or fallback Gateway.

--- a/docs/proof/gateway-release/README.md
+++ b/docs/proof/gateway-release/README.md
@@ -18,4 +18,32 @@ The command rejected the candidate, as expected. The linked [preflight report](.
 
 The current-head `GatewayReleasePolicyTests` passed 26 of 26. They prove that the embedded recommendation remains 2026.6.34, the Plugin readiness signal remains false, the 2026.9.3 evidence entry remains rejected, and exact selection of an evidence-rejected release fails before setup can install it. The full SetupEngine suite previously passed 1,100 of 1,100 on the same production commit.
 
+The production `OpenClaw.SetupEngine.Program.Main` entry point was then invoked from a minimal executable host with the checked-in [rejected config](./setup-policy-rejected.json). It stopped before setup or installation and returned the configuration-error exit code:
+
+```text
+OpenClaw Setup Engine v1.0.0
+─────────────────────────────
+Loading config from: .\docs\proof\gateway-release\setup-policy-rejected.json
+ERROR: Gateway 2026.9.3 is not an eligible protocol-v4 Windows release. npm SLSA provenance did not verify against the package digest and OpenClaw release identity.
+EXIT_CODE=2
+```
+
+The same current production entry point accepted the checked-in [recommended config](./setup-policy-recommended.json), retained 2026.6.34, and completed dry-run validation:
+
+```text
+OpenClaw Setup Engine v1.0.0
+─────────────────────────────
+Loading config from: .\docs\proof\gateway-release\setup-policy-recommended.json
+Log file: .\.proof-runtime\data\Logs\Setup\setup-engine-20260908-185533.jsonl
+Distro: OpenClawGatewayProofRecommended
+Gateway: ws://127.0.0.1:18789
+Gateway release: 2026.6.34 (recommended, protocol v4)
+Mode: SETUP
+
+DRY RUN: config validated, exiting.
+EXIT_CODE=0
+```
+
+Current-head full-suite validation also passed: Shared 3,943 with 32 environment-gated skips, Tray 2,861, and SetupEngine 1,100.
+
 No candidate package was installed. This PR records an evidence decision without changing the recommended or fallback Gateway.

--- a/docs/proof/gateway-release/setup-policy-recommended.json
+++ b/docs/proof/gateway-release/setup-policy-recommended.json
@@ -1,0 +1,6 @@
+{
+  "DistroName": "OpenClawGatewayProofRecommended",
+  "Gateway": {
+    "Selection": "recommended"
+  }
+}

--- a/docs/proof/gateway-release/setup-policy-rejected.json
+++ b/docs/proof/gateway-release/setup-policy-rejected.json
@@ -1,0 +1,7 @@
+{
+  "DistroName": "OpenClawGatewayProofRejected",
+  "Gateway": {
+    "Selection": "exact",
+    "Version": "2026.9.3"
+  }
+}

--- a/src/OpenClaw.SetupEngine/GatewayReleasePolicy.cs
+++ b/src/OpenClaw.SetupEngine/GatewayReleasePolicy.cs
@@ -130,6 +130,8 @@ public static class GatewayReleasePolicy
     public const string NodeVersion = "24.19.0";
     public const string SecurityFloor = "2026.6.11";
     public const string RecommendedVersion = "2026.6.34";
+    public const string PluginLifecycleFirstStableVersion = "2026.8.1";
+    public const string PluginCapableEvidenceRejectedVersion = "2026.9.3";
     public const string RuntimeRejectedVersion = "2026.7.1";
     public const string EvidenceRejectedVersion = "2026.7.1-2";
 
@@ -166,11 +168,39 @@ public static class GatewayReleasePolicy
                 "https://github.com/openclaw/openclaw/releases/tag/v2026.7.1-2",
                 "Candidate preflight on 2026-08-06",
                 "npm provenance attestation and a stable release-validation manifest were not published"),
+            [PluginCapableEvidenceRejectedVersion] = new(
+                PluginCapableEvidenceRejectedVersion,
+                GatewayReleaseStatus.Rejected,
+                ProtocolGeneration,
+                "sha512-CzDHMeHdnjlIZ76ZyBb1lvLO4H/yBIMYXupFGGBN87x0853y3hg5nLAnKfxSKqLzqhbUKqy9ebDRAWWV4t8aew==",
+                "https://github.com/openclaw/openclaw/releases/tag/v2026.9.3",
+                "Candidate preflight on 2026-09-08 for the first Windows Extensions release",
+                "npm SLSA provenance did not verify against the package digest and OpenClaw release identity"),
         };
 
     public static string? FallbackVersion => "2026.6.11";
 
     public static IReadOnlyDictionary<string, GatewayReleaseEvidence> Releases => s_releases;
+
+    /// <summary>
+    /// True only when the embedded recommendation is both new enough to contain
+    /// the stable Plugins lifecycle and already promoted through the Windows gate.
+    /// Feature advertisements remain authoritative at runtime.
+    /// </summary>
+    public static bool RecommendedHasValidatedPluginLifecycle
+    {
+        get
+        {
+            if (!GatewayReleaseVersion.TryParse(RecommendedVersion, out var recommended) ||
+                !GatewayReleaseVersion.TryParse(PluginLifecycleFirstStableVersion, out var firstStable) ||
+                !s_releases.TryGetValue(RecommendedVersion, out var evidence))
+            {
+                return false;
+            }
+            return recommended.CompareTo(firstStable) >= 0 &&
+                evidence.Status == GatewayReleaseStatus.Validated;
+        }
+    }
 
     public static bool IsOfficialInstallerUrl(string? installUrl) =>
         string.IsNullOrWhiteSpace(installUrl) ||

--- a/tests/OpenClaw.SetupEngine.Tests/GatewayReleasePolicyTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/GatewayReleasePolicyTests.cs
@@ -37,6 +37,19 @@ public sealed class GatewayReleasePolicyTests
         Assert.False(GatewayReleasePolicy.IsReleaseEligible(rejected, allowCandidate: true));
     }
 
+    [Fact]
+    public void PluginLifecycleRelease_RemainsBlockedUntilAPluginCapableCandidateIsValidated()
+    {
+        Assert.False(GatewayReleasePolicy.RecommendedHasValidatedPluginLifecycle);
+        Assert.Equal(
+            GatewayReleaseStatus.Rejected,
+            GatewayReleasePolicy.Releases[GatewayReleasePolicy.PluginCapableEvidenceRejectedVersion].Status);
+        Assert.Contains(
+            "provenance",
+            GatewayReleasePolicy.Releases[GatewayReleasePolicy.PluginCapableEvidenceRejectedVersion].RejectionReason,
+            StringComparison.OrdinalIgnoreCase);
+    }
+
     [Theory]
     [InlineData("2026.7.1")]
     [InlineData("2026.7.1-2")]


### PR DESCRIPTION
## Summary

- Record the first stable Gateway version that contains the Plugin lifecycle required by the Windows Extensions hub.
- Add an explicit policy signal that stays false until the embedded recommended Gateway is both plugin-capable and evidence-validated.
- Record the 2026.9.3 candidate preflight result without changing the current Windows recommendation.

## Why this stays separate

The Extensions UI is runtime feature-negotiated and fails closed when Plugin RPCs are absent. Gateway promotion remains an independent supply-chain decision: the current 2026.9.3 preflight passed protocol, security-floor, integrity, registry-signature, tag/build binding, release-manifest, and verified-tag checks, but its npm SLSA provenance did not validate against the package digest and OpenClaw release identity.

This PR does not weaken the release gate and does not bundle or install an unvalidated Gateway.

## Required proof pools

- `windows-11-arm64`: completed for the native build, policy tests, production SetupEngine dry runs, and current-head release-candidate validation.

`windows-clean-installer-upgrade` and `windows-wsl-gateway-e2e` are not applicable because this PR rejects the candidate and leaves both selected Gateway versions unchanged. They become required when a later candidate is actually promoted.

## Validation

- `build.ps1`: passed on Windows ARM64.
- Current-head Gateway release policy tests: 26 passed.
- Shared: 3,943 passed, 32 environment-gated skips.
- Tray: 2,861 passed.
- SetupEngine: 1,100 passed.
- Documentation validation after adding proof: 48 Markdown files checked.

## Real Behavior Proof

- [Auditable proof notes and production SetupEngine output](https://github.com/joelagnel/openclaw-windows-node/blob/chore/gateway-plugin-capable-release/docs/proof/gateway-release/README.md)
- [Machine-readable 2026.9.3 preflight report](https://github.com/joelagnel/openclaw-windows-node/blob/chore/gateway-plugin-capable-release/docs/proof/gateway-release/2026.9.3-preflight.json)
- [Rejected exact-selection input](https://github.com/joelagnel/openclaw-windows-node/blob/chore/gateway-plugin-capable-release/docs/proof/gateway-release/setup-policy-rejected.json)
- [Retained recommended-selection input](https://github.com/joelagnel/openclaw-windows-node/blob/chore/gateway-plugin-capable-release/docs/proof/gateway-release/setup-policy-recommended.json)

The fresh preflight report records `eligible=false`. npm integrity, registry signatures, package/tag binding, stable release manifest, verified tag, protocol generation 4, and security-floor checks passed. npm SLSA provenance failed verification, so the validator rejected 2026.9.3.

The current production SetupEngine entry point rejected exact selection of 2026.9.3 before installation with exit code 2. A second dry run retained recommended Gateway 2026.6.34 and exited successfully. Both exact inputs and the complete command output are linked above.

## Relationship

Independent companion to #1370. A later, provenance-valid plugin-capable Gateway release can update the recommended version through the existing promotion process.
