### PR TITLE
build(deps): upgrade Microsoft.UI.Reactor to 0.1.0-preview.14

### DIFF
--- a/.agents/skills/openclaw-proof-validation/PARALLELS.md
+++ b/.agents/skills/openclaw-proof-validation/PARALLELS.md
@@ -18,7 +18,7 @@ the `openclaw` and `openclaw-windows-node` checkouts beside each other, or set `
 
 The wrapper restores the newest general `e2e` snapshot, then adds only the native app prerequisites:
 
-1. .NET 10 SDK.
+1. .NET SDK 10.0.400 or newer.
 2. Windows SDK 10.0.26100.
 3. WebView2 Runtime.
 4. A clean `openclaw-windows-node` checkout and `scripts/setup-dev.ps1 -CheckOnly`.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -17,7 +17,7 @@ A comprehensive guide for building, running, and contributing to the OpenClaw Wi
 
 ### Required
 
-- **.NET 10 SDK** - [Download here](https://dotnet.microsoft.com/download)
+- **.NET SDK 10.0.400 or newer** - [Download here](https://dotnet.microsoft.com/download)
 - **Windows 10/11** - WinUI 3 and Windows App SDK require Windows 10 version 1903 or later
 - **Node.js LTS with npm** - Required by the WinUI build to restore JavaScript build assets
 - **Windows 10 SDK** - Required for WinUI builds

--- a/build.ps1
+++ b/build.ps1
@@ -183,18 +183,12 @@ if (-not (Test-WindowsHost)) {
 Write-Success "Windows detected"
 
 # Check .NET SDK
-$dotnetVersion = $null
-try {
-    $dotnetVersion = & dotnet --version 2>$null
-} catch {}
-
-if (-not $dotnetVersion) {
+$dotnet = Get-Command dotnet -ErrorAction SilentlyContinue
+if (-not $dotnet) {
     Write-Error ".NET SDK not found"
     Write-Info "Download from: https://dotnet.microsoft.com/download"
     $issues += "Missing .NET SDK"
 } else {
-    Write-Success ".NET SDK: $dotnetVersion"
-    
     # Reactor preview.14 source generators require Roslyn 5.9, first shipped
     # in the .NET 10.0.400 feature band.
     $minimumNet10Sdk = [version]"10.0.400"
@@ -211,6 +205,10 @@ if (-not $dotnetVersion) {
         Write-Info "Download from: https://dotnet.microsoft.com/download/dotnet/10.0"
         $issues += "Missing .NET SDK 10.0.400 or newer"
     } else {
+        $dotnetVersion = & dotnet --version 2>$null
+        if ($LASTEXITCODE -eq 0 -and $dotnetVersion) {
+            Write-Success ".NET SDK: $dotnetVersion"
+        }
         Write-Success ".NET SDK 10.0.400 or newer available"
     }
 }

--- a/build.ps1
+++ b/build.ps1
@@ -195,16 +195,23 @@ if (-not $dotnetVersion) {
 } else {
     Write-Success ".NET SDK: $dotnetVersion"
     
-    # Check for .NET 10 (needed for all projects)
+    # Reactor preview.14 source generators require Roslyn 5.9, first shipped
+    # in the .NET 10.0.400 feature band.
+    $minimumNet10Sdk = [version]"10.0.400"
     $sdks = & dotnet --list-sdks 2>$null
-    $hasNet10 = $sdks | Where-Object { $_ -match "^10\." }
+    $hasNet10 = $sdks |
+        ForEach-Object {
+            $match = [regex]::Match($_, "^(\d+\.\d+\.\d+)")
+            if ($match.Success) { [version]$match.Groups[1].Value }
+        } |
+        Where-Object { $_.Major -eq 10 -and $_ -ge $minimumNet10Sdk }
     
     if (-not $hasNet10) {
-        Write-Error ".NET 10 SDK not found (required for all projects)"
-        Write-Info "Download preview from: https://dotnet.microsoft.com/download/dotnet/10.0"
-        $issues += "Missing .NET 10 SDK"
+        Write-Error ".NET SDK 10.0.400 or newer not found (required for all projects)"
+        Write-Info "Download from: https://dotnet.microsoft.com/download/dotnet/10.0"
+        $issues += "Missing .NET SDK 10.0.400 or newer"
     } else {
-        Write-Success ".NET 10 SDK available"
+        Write-Success ".NET SDK 10.0.400 or newer available"
     }
 }
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.100",
+    "version": "10.0.400",
     "rollForward": "latestFeature"
   }
 }

--- a/scripts/parallels-windows-vm.sh
+++ b/scripts/parallels-windows-vm.sh
@@ -134,17 +134,23 @@ set_app_paths() {
   GUEST_REPO_PS="$(powershell_literal_content "$GUEST_CHECKOUT")"
 }
 
+dotnet_sdk_ready() {
+  guest_user_ps '@(dotnet.exe --list-sdks | ForEach-Object { if ($_ -match "^(\d+\.\d+\.\d+)") { [version]$matches[1] } } | Where-Object { $_.Major -eq 10 -and $_ -ge [version]"10.0.400" }).Count -gt 0' |
+    grep -q True
+}
+
 ensure_dotnet() {
-  guest_user_cmd 'dotnet.exe --list-sdks | findstr /B 10.' >/dev/null 2>&1 && return
+  dotnet_sdk_ready && return
   winget_download Microsoft.DotNet.SDK.10
   local installer
   installer="$(downloaded_installer 'Microsoft .NET SDK 10.0*.exe')"
   [[ -n "$installer" ]] || die "winget did not download the .NET SDK installer"
   installer="$(stage_installer "$installer" DotNetSDK 'Microsoft Corporation' "$WINGET_EXPECTED_HASH")"
-  say "Installing .NET 10 SDK"
+  say "Installing .NET SDK 10.0.400 or newer"
   run_windows_installer prlctl exec "$VM_NAME" "$installer" /install /quiet /norestart
   finish_installer_reboot
-  wait_for_check '.NET 10 SDK' 'dotnet.exe --list-sdks | findstr /B 10.'
+  wait_for_check '.NET SDK' 'dotnet.exe --list-sdks | findstr /B 10.'
+  dotnet_sdk_ready || die ".NET SDK 10.0.400 or newer is unavailable after installation"
 }
 
 ensure_windows_sdk() {
@@ -182,7 +188,7 @@ ensure_guest_checkout() {
 
 verify_app() {
   set_app_paths
-  guest_user_cmd 'dotnet.exe --list-sdks | findstr /B 10.' >/dev/null || die ".NET 10 SDK is unavailable"
+  dotnet_sdk_ready || die ".NET SDK 10.0.400 or newer is unavailable"
   guest_user_ps "Test-Path 'C:/Program Files (x86)/Windows Kits/10/Include/10.0.26100.0/um'" | grep -q True || die "Windows SDK 10.0.26100 is unavailable"
   guest_system_ps "Test-Path 'HKLM:/SOFTWARE/WOW6432Node/Microsoft/EdgeUpdate/Clients/{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}'" | grep -q True || die "WebView2 is unavailable"
   guest_user_ps "Test-Path '${GUEST_REPO_PS}/scripts/setup-dev.ps1'" | grep -q True || die "guest checkout missing: $GUEST_CHECKOUT"

--- a/scripts/parallels-windows-vm.sh
+++ b/scripts/parallels-windows-vm.sh
@@ -154,8 +154,12 @@ ensure_dotnet() {
   say "Installing .NET SDK 10.0.400 or newer"
   run_windows_installer prlctl exec "$VM_NAME" "$installer" /install /quiet /norestart
   finish_installer_reboot
-  wait_for_check '.NET SDK' 'dotnet.exe --list-sdks | findstr /B 10.'
-  dotnet_sdk_ready || die ".NET SDK 10.0.400 or newer is unavailable after installation"
+  local attempt
+  for ((attempt = 1; attempt <= 120; attempt++)); do
+    dotnet_sdk_ready && return
+    sleep 3
+  done
+  die ".NET SDK 10.0.400 or newer is unavailable after installation"
 }
 
 ensure_windows_sdk() {

--- a/scripts/parallels-windows-vm.sh
+++ b/scripts/parallels-windows-vm.sh
@@ -135,7 +135,12 @@ set_app_paths() {
 }
 
 dotnet_sdk_ready() {
-  guest_user_ps '@(dotnet.exe --list-sdks | ForEach-Object { if ($_ -match "^(\d+\.\d+\.\d+)") { [version]$matches[1] } } | Where-Object { $_.Major -eq 10 -and $_ -ge [version]"10.0.400" }).Count -gt 0' |
+  local check
+  check="$(cat <<'POWERSHELL'
+@(dotnet.exe --list-sdks | ForEach-Object { if ($_ -match '^(\d+\.\d+\.\d+)') { [version]$matches[1] } } | Where-Object { $_.Major -eq 10 -and $_ -ge [version]'10.0.400' }).Count -gt 0
+POWERSHELL
+)"
+  guest_user_ps "$check" |
     grep -q True
 }
 

--- a/scripts/setup-dev.ps1
+++ b/scripts/setup-dev.ps1
@@ -66,7 +66,17 @@ function Test-DotNet10Sdk {
     }
 
     $sdks = & dotnet --list-sdks 2>$null
-    return $LASTEXITCODE -eq 0 -and ($sdks | Where-Object { $_ -match "^10\." })
+    if ($LASTEXITCODE -ne 0) {
+        return $false
+    }
+
+    $minimum = [version]"10.0.400"
+    return [bool]($sdks |
+        ForEach-Object {
+            $match = [regex]::Match($_, "^(\d+\.\d+\.\d+)")
+            if ($match.Success) { [version]$match.Groups[1].Value }
+        } |
+        Where-Object { $_.Major -eq 10 -and $_ -ge $minimum })
 }
 
 function Test-NodeAndNpm {
@@ -212,7 +222,7 @@ if ($CheckOnly) {
 Update-ProcessPath
 
 Require-Prerequisite "Git" (Test-CommandAvailable "git") "Git.Git"
-Require-Prerequisite ".NET 10 SDK" (Test-DotNet10Sdk) "Microsoft.DotNet.SDK.10"
+Require-Prerequisite ".NET SDK 10.0.400 or newer" (Test-DotNet10Sdk) "Microsoft.DotNet.SDK.10"
 Require-Prerequisite "Node.js LTS with npm" (Test-NodeAndNpm) "OpenJS.NodeJS.LTS"
 Require-Prerequisite "Windows SDK 10.0.26100" ([bool](Get-WindowsSdkVersion)) "Microsoft.WindowsSDK.10.0.26100"
 
@@ -228,7 +238,7 @@ Ensure-RepositoryTrust
 
 $missing = @()
 if (-not (Test-CommandAvailable "git")) { $missing += "Git" }
-if (-not (Test-DotNet10Sdk)) { $missing += ".NET 10 SDK" }
+if (-not (Test-DotNet10Sdk)) { $missing += ".NET SDK 10.0.400 or newer" }
 if (-not (Test-NodeAndNpm)) { $missing += "Node.js LTS with npm" }
 if (-not (Get-WindowsSdkVersion)) { $missing += "Windows SDK 10.0.26100" }
 if (-not (Get-WebView2RuntimeVersion)) { $missing += "WebView2 Runtime" }

--- a/src/OpenClaw.Tray.WinUI/Chat/ChatAssistantMediaRenderer.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ChatAssistantMediaRenderer.cs
@@ -250,7 +250,7 @@ internal sealed class ChatAssistantImageCard : Component<ChatAssistantImageCardP
             Math.Min(maximumWidth / pixelWidth, maximumHeight / pixelHeight),
             1.0);
         var preview = Border(Empty())
-            .Set(border => border.Background = new ImageBrush
+            .Background(new ImageBrush
             {
                 ImageSource = bitmap,
                 Stretch = Stretch.Uniform,
@@ -282,7 +282,7 @@ internal sealed class ChatAssistantImageCard : Component<ChatAssistantImageCardP
             1.0);
         return ScrollViewer(
             Border(Empty())
-                .Set(border => border.Background = new ImageBrush
+                .Background(new ImageBrush
                 {
                     ImageSource = bitmap,
                     Stretch = Stretch.Uniform,

--- a/src/OpenClaw.Tray.WinUI/Chat/ChatAssistantMediaRenderer.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ChatAssistantMediaRenderer.cs
@@ -53,7 +53,7 @@ internal static class ChatAssistantMediaRenderer
             .FontSize(18)
             .FontWeight(FontWeights.Normal)
             .Foreground(Theme.Ref("TextFillColorSecondaryBrush"))
-            .Set(text => text.FontFamily = FluentIconCatalog.SymbolThemeFontFamily)
+            .FontFamily(FluentIconCatalog.SymbolThemeFontFamily)
             .Center();
         var glyphBackground = Border(glyph)
             .Size(36, 36)
@@ -63,21 +63,15 @@ internal static class ChatAssistantMediaRenderer
             .FontSize(13)
             .FontWeight(FontWeights.SemiBold)
             .Foreground(Theme.Ref("TextFillColorPrimaryBrush"))
-            .Set(text =>
-            {
-                text.TextWrapping = TextWrapping.NoWrap;
-                text.TextTrimming = TextTrimming.CharacterEllipsis;
-            })
+            .TextWrapping(TextWrapping.NoWrap)
+            .TextTrimming(TextTrimming.CharacterEllipsis)
             .MaxWidth(320);
         var status = TextBlock(detail)
             .FontSize(11)
             .FontWeight(FontWeights.Normal)
             .Foreground(Theme.Ref("TextFillColorSecondaryBrush"))
-            .Set(text =>
-            {
-                text.TextWrapping = TextWrapping.NoWrap;
-                text.TextTrimming = TextTrimming.CharacterEllipsis;
-            })
+            .TextWrapping(TextWrapping.NoWrap)
+            .TextTrimming(TextTrimming.CharacterEllipsis)
             .MaxWidth(320);
         var content = HStack(
             10,

--- a/src/OpenClaw.Tray.WinUI/Chat/ReactorChatComposer.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ReactorChatComposer.cs
@@ -177,11 +177,8 @@ internal sealed class ReactorChatComposer : Component<ReactorChatComposerViewPro
             return Button(
                     TextBlock(glyph)
                         .AccessibilityView(Microsoft.UI.Xaml.Automation.Peers.AccessibilityView.Raw)
-                        .Set(textBlock =>
-                        {
-                            textBlock.FontFamily = FluentIconCatalog.SymbolThemeFontFamily;
-                            textBlock.FontSize = 16;
-                        }),
+                        .FontFamily(FluentIconCatalog.SymbolThemeFontFamily)
+                        .FontSize(16),
                     onClick)
                 .AutomationName(automationName)
                 .Foreground(Theme.SecondaryText)
@@ -219,20 +216,14 @@ internal sealed class ReactorChatComposer : Component<ReactorChatComposerViewPro
                         4,
                         TextBlock(label)
                             .MaxWidth(maxLabelWidth)
-                            .Set(textBlock =>
-                            {
-                                textBlock.FontSize = 13;
-                                textBlock.TextTrimming = TextTrimming.CharacterEllipsis;
-                                textBlock.TextWrapping = TextWrapping.NoWrap;
-                            }),
+                            .FontSize(13)
+                            .TextTrimming(TextTrimming.CharacterEllipsis)
+                            .TextWrapping(TextWrapping.NoWrap),
                         TextBlock("\uE70D")
                             .Margin(2, 4, 0, 0)
                             .AccessibilityView(Microsoft.UI.Xaml.Automation.Peers.AccessibilityView.Raw)
-                            .Set(textBlock =>
-                            {
-                                textBlock.FontFamily = FluentIconCatalog.SymbolThemeFontFamily;
-                                textBlock.FontSize = 10;
-                            })),
+                            .FontFamily(FluentIconCatalog.SymbolThemeFontFamily)
+                            .FontSize(10)),
                     () => { })
                 .AutomationName(automationName)
                 .Foreground(Theme.SecondaryText)
@@ -351,7 +342,7 @@ internal sealed class ReactorChatComposer : Component<ReactorChatComposerViewPro
                         8,
                         TextBlock(queuedCountText)
                             .FontSize(13)
-                            .Set(textBlock => textBlock.FontWeight = Microsoft.UI.Text.FontWeights.SemiBold),
+                            .FontWeight(Microsoft.UI.Text.FontWeights.SemiBold),
                         ScrollView(VStack(4, queuedRows))
                             .MaxHeight(props.IsCompact ? 144 : 220)
                             .Set(scrollView =>
@@ -516,11 +507,11 @@ internal sealed class ReactorChatComposer : Component<ReactorChatComposerViewPro
             .BorderThickness(0)
             .BorderBrush(transparentInputBrush)
             .Background(transparentInputBrush)
+            .AcceptsReturn(false)
+            .FontSize(14)
             .Set(control =>
             {
                 inputControl.Current = control;
-                control.FontSize = 14;
-                control.AcceptsReturn = false;
                 control.Resources["TextControlBorderThemeThickness"] = new Thickness(0);
                 control.Resources["TextControlBorderThemeThicknessFocused"] = new Thickness(0);
                 control.Resources["TextControlBackground"] = transparentInputBrush;
@@ -659,11 +650,8 @@ internal sealed class ReactorChatComposer : Component<ReactorChatComposerViewPro
             : Button(
                     TextBlock("\uE724")
                         .AccessibilityView(Microsoft.UI.Xaml.Automation.Peers.AccessibilityView.Raw)
-                        .Set(textBlock =>
-                        {
-                            textBlock.FontFamily = FluentIconCatalog.SymbolThemeFontFamily;
-                            textBlock.FontSize = 16;
-                        }),
+                        .FontFamily(FluentIconCatalog.SymbolThemeFontFamily)
+                        .FontSize(16),
                     Send)
                 .AccentButton()
                 .AutomationName(actionLabel)
@@ -879,7 +867,7 @@ internal sealed class ReactorChatComposer : Component<ReactorChatComposerViewPro
             .Resources(resources => resources
                 .Set("ButtonBackground", background)
                 .Set("ButtonBorderBrush", Theme.Ref("SubtleFillColorTransparentBrush")))
-            .Set(button => button.HorizontalContentAlignment = HorizontalAlignment.Left)
+            .HorizontalContentAlignment(HorizontalAlignment.Left)
             .BorderThickness(0)
             .OnMount(element =>
             {
@@ -972,7 +960,7 @@ internal sealed class ReactorChatComposer : Component<ReactorChatComposerViewPro
             .Resources(resources => resources
                 .Set("ButtonBackground", background)
                 .Set("ButtonBorderBrush", Theme.Ref("SubtleFillColorTransparentBrush")))
-            .Set(button => button.HorizontalContentAlignment = HorizontalAlignment.Stretch)
+            .HorizontalContentAlignment(HorizontalAlignment.Stretch)
             .BorderThickness(0)
             .OnMount(element =>
             {

--- a/src/OpenClaw.Tray.WinUI/Chat/ReactorChatComposer.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ReactorChatComposer.cs
@@ -165,7 +165,7 @@ internal sealed class ReactorChatComposer : Component<ReactorChatComposerViewPro
         var actionLabel = inputs.TurnActive
             ? Localized("Chat_Composer_Tooltip_Stop", "Stop")
             : Localized("Chat_Composer_Tooltip_Send", "Send");
-        var controlCornerRadius = new CornerRadius(4);
+        const double controlCornerRadius = 4;
 
         Element IconButton(
             string glyph,
@@ -175,14 +175,13 @@ internal sealed class ReactorChatComposer : Component<ReactorChatComposerViewPro
             string? automationId = null)
         {
             return Button(
-                    TextBlock(glyph).Set(textBlock =>
-                    {
-                        textBlock.FontFamily = FluentIconCatalog.SymbolThemeFontFamily;
-                        textBlock.FontSize = 16;
-                        Microsoft.UI.Xaml.Automation.AutomationProperties.SetAccessibilityView(
-                            textBlock,
-                            Microsoft.UI.Xaml.Automation.Peers.AccessibilityView.Raw);
-                    }),
+                    TextBlock(glyph)
+                        .AccessibilityView(Microsoft.UI.Xaml.Automation.Peers.AccessibilityView.Raw)
+                        .Set(textBlock =>
+                        {
+                            textBlock.FontFamily = FluentIconCatalog.SymbolThemeFontFamily;
+                            textBlock.FontSize = 16;
+                        }),
                     onClick)
                 .AutomationName(automationName)
                 .Foreground(Theme.SecondaryText)
@@ -193,25 +192,17 @@ internal sealed class ReactorChatComposer : Component<ReactorChatComposerViewPro
                     .Set("ButtonBorderBrush", Theme.Ref("SubtleFillColorTransparentBrush"))
                     .Set("ButtonBorderBrushPointerOver", Theme.Ref("SubtleFillColorTransparentBrush"))
                     .Set("ButtonBorderBrushPressed", Theme.Ref("SubtleFillColorTransparentBrush")))
-                .Set(button =>
-                {
-                    button.Width = 32;
-                    button.Height = 32;
-                    button.MinWidth = 32;
-                    button.MinHeight = 32;
-                    button.Padding = new Thickness(0);
-                    button.CornerRadius = controlCornerRadius;
-                    button.IsEnabled = enabled;
-                    button.BorderThickness = new Thickness(0);
-                    if (!string.IsNullOrWhiteSpace(automationId))
-                    {
-                        Microsoft.UI.Xaml.Automation.AutomationProperties.SetAutomationId(
-                            button,
-                            automationId);
-                    }
-                    ComposerAutomationVisibility.Prepare(button);
-                    ToolTipService.SetToolTip(button, automationName);
-                })
+                .Width(32)
+                .Height(32)
+                .MinWidth(32)
+                .MinHeight(32)
+                .Padding(0)
+                .CornerRadius(controlCornerRadius)
+                .IsEnabled(enabled)
+                .BorderThickness(0)
+                .AutomationId(string.IsNullOrWhiteSpace(automationId) ? string.Empty : automationId)
+                .ToolTip(automationName)
+                .Set(button => ComposerAutomationVisibility.Prepare(button))
                 .OnUnmount(control => ComposerAutomationVisibility.Detach(
                     (FrameworkElement)control));
         }
@@ -226,22 +217,22 @@ internal sealed class ReactorChatComposer : Component<ReactorChatComposerViewPro
             return Button(
                     HStack(
                         4,
-                        TextBlock(label).Set(textBlock =>
-                        {
-                            textBlock.FontSize = 13;
-                            textBlock.MaxWidth = maxLabelWidth;
-                            textBlock.TextTrimming = TextTrimming.CharacterEllipsis;
-                            textBlock.TextWrapping = TextWrapping.NoWrap;
-                        }),
-                        TextBlock("\uE70D").Set(textBlock =>
-                        {
-                            textBlock.FontFamily = FluentIconCatalog.SymbolThemeFontFamily;
-                            textBlock.FontSize = 10;
-                            textBlock.Margin = new Thickness(2, 4, 0, 0);
-                            Microsoft.UI.Xaml.Automation.AutomationProperties.SetAccessibilityView(
-                                textBlock,
-                                Microsoft.UI.Xaml.Automation.Peers.AccessibilityView.Raw);
-                        })),
+                        TextBlock(label)
+                            .MaxWidth(maxLabelWidth)
+                            .Set(textBlock =>
+                            {
+                                textBlock.FontSize = 13;
+                                textBlock.TextTrimming = TextTrimming.CharacterEllipsis;
+                                textBlock.TextWrapping = TextWrapping.NoWrap;
+                            }),
+                        TextBlock("\uE70D")
+                            .Margin(2, 4, 0, 0)
+                            .AccessibilityView(Microsoft.UI.Xaml.Automation.Peers.AccessibilityView.Raw)
+                            .Set(textBlock =>
+                            {
+                                textBlock.FontFamily = FluentIconCatalog.SymbolThemeFontFamily;
+                                textBlock.FontSize = 10;
+                            })),
                     () => { })
                 .AutomationName(automationName)
                 .Foreground(Theme.SecondaryText)
@@ -252,20 +243,15 @@ internal sealed class ReactorChatComposer : Component<ReactorChatComposerViewPro
                     .Set("ButtonBorderBrush", Theme.Ref("SubtleFillColorTransparentBrush"))
                     .Set("ButtonBorderBrushPointerOver", Theme.Ref("SubtleFillColorTransparentBrush"))
                     .Set("ButtonBorderBrushPressed", Theme.Ref("SubtleFillColorTransparentBrush")))
-                .Set(button =>
-                {
-                    button.Height = 32;
-                    button.MinHeight = 32;
-                    button.MinWidth = 0;
-                    button.Padding = new Thickness(8, 0, 8, 0);
-                    button.CornerRadius = controlCornerRadius;
-                    button.IsEnabled = enabled;
-                    button.BorderThickness = new Thickness(0);
-                    Microsoft.UI.Xaml.Automation.AutomationProperties.SetAutomationId(
-                        button,
-                        automationId);
-                    ComposerAutomationVisibility.Prepare(button);
-                })
+                .Height(32)
+                .MinHeight(32)
+                .MinWidth(0)
+                .Padding(8, 0, 8, 0)
+                .CornerRadius(controlCornerRadius)
+                .IsEnabled(enabled)
+                .BorderThickness(0)
+                .AutomationId(automationId)
+                .Set(button => ComposerAutomationVisibility.Prepare(button))
                 .OnUnmount(control => ComposerAutomationVisibility.Detach(
                     (FrameworkElement)control));
         }
@@ -375,9 +361,7 @@ internal sealed class ReactorChatComposer : Component<ReactorChatComposerViewPro
                                 scrollView.HorizontalScrollMode = ScrollingScrollMode.Disabled;
                                 scrollView.HorizontalContentAlignment = HorizontalAlignment.Stretch;
                             })))
-                .Set(border => Microsoft.UI.Xaml.Automation.AutomationProperties.SetLiveSetting(
-                    border,
-                    Microsoft.UI.Xaml.Automation.Peers.AutomationLiveSetting.Polite))
+                .LiveRegion(Microsoft.UI.Xaml.Automation.Peers.AutomationLiveSetting.Polite)
                 .AutomationName(queuedCountText);
 
         var slashPopupVisible = slashDisplay.IsVisible
@@ -446,6 +430,7 @@ internal sealed class ReactorChatComposer : Component<ReactorChatComposerViewPro
             slashPopupContentRef.Current = (popupStateKey, slashPopupContent);
         }
 
+        var transparentInputBrush = new SolidColorBrush(Microsoft.UI.Colors.Transparent);
         var input = TextBox(
                 text,
                 vm.SetDraft,
@@ -524,27 +509,26 @@ internal sealed class ReactorChatComposer : Component<ReactorChatComposerViewPro
                 Send();
             })
             .TextWrapping(TextWrapping.Wrap)
+            .MinHeight(56)
+            .MaxHeight(200)
+            .Padding(8)
+            .IsEnabled(inputs.ConnectionState == "connected")
+            .BorderThickness(0)
+            .BorderBrush(transparentInputBrush)
+            .Background(transparentInputBrush)
             .Set(control =>
             {
                 inputControl.Current = control;
-                var transparent = new SolidColorBrush(Microsoft.UI.Colors.Transparent);
-                control.MinHeight = 56;
-                control.MaxHeight = 200;
                 control.FontSize = 14;
-                control.Padding = new Thickness(8);
-                control.IsEnabled = inputs.ConnectionState == "connected";
                 control.AcceptsReturn = false;
-                control.BorderThickness = new Thickness(0);
-                control.BorderBrush = transparent;
-                control.Background = transparent;
                 control.Resources["TextControlBorderThemeThickness"] = new Thickness(0);
                 control.Resources["TextControlBorderThemeThicknessFocused"] = new Thickness(0);
-                control.Resources["TextControlBackground"] = transparent;
-                control.Resources["TextControlBackgroundFocused"] = transparent;
-                control.Resources["TextControlBackgroundPointerOver"] = transparent;
-                control.Resources["TextControlBorderBrush"] = transparent;
-                control.Resources["TextControlBorderBrushFocused"] = transparent;
-                control.Resources["TextControlBorderBrushPointerOver"] = transparent;
+                control.Resources["TextControlBackground"] = transparentInputBrush;
+                control.Resources["TextControlBackgroundFocused"] = transparentInputBrush;
+                control.Resources["TextControlBackgroundPointerOver"] = transparentInputBrush;
+                control.Resources["TextControlBorderBrush"] = transparentInputBrush;
+                control.Resources["TextControlBorderBrushFocused"] = transparentInputBrush;
+                control.Resources["TextControlBorderBrushPointerOver"] = transparentInputBrush;
                 ComposerAutomationVisibility.Prepare(control);
             })
             .OnMount(control =>
@@ -673,32 +657,26 @@ internal sealed class ReactorChatComposer : Component<ReactorChatComposerViewPro
                 controller.Stop,
                 automationId: "ChatComposerPrimaryAction")
             : Button(
-                    TextBlock("\uE724").Set(textBlock =>
-                    {
-                        textBlock.FontFamily = FluentIconCatalog.SymbolThemeFontFamily;
-                        textBlock.FontSize = 16;
-                        Microsoft.UI.Xaml.Automation.AutomationProperties.SetAccessibilityView(
-                            textBlock,
-                            Microsoft.UI.Xaml.Automation.Peers.AccessibilityView.Raw);
-                    }),
+                    TextBlock("\uE724")
+                        .AccessibilityView(Microsoft.UI.Xaml.Automation.Peers.AccessibilityView.Raw)
+                        .Set(textBlock =>
+                        {
+                            textBlock.FontFamily = FluentIconCatalog.SymbolThemeFontFamily;
+                            textBlock.FontSize = 16;
+                        }),
                     Send)
                 .AccentButton()
                 .AutomationName(actionLabel)
-                .Set(button =>
-                {
-                    button.Width = 32;
-                    button.Height = 32;
-                    button.MinWidth = 32;
-                    button.MinHeight = 32;
-                    button.Padding = new Thickness(0);
-                    button.CornerRadius = controlCornerRadius;
-                    Microsoft.UI.Xaml.Automation.AutomationProperties.SetAutomationId(
-                        button,
-                        "ChatComposerPrimaryAction");
-                    button.IsEnabled = vm.CanSend;
-                    ComposerAutomationVisibility.Prepare(button);
-                    ToolTipService.SetToolTip(button, actionLabel);
-                })
+                .Width(32)
+                .Height(32)
+                .MinWidth(32)
+                .MinHeight(32)
+                .Padding(0)
+                .CornerRadius(controlCornerRadius)
+                .AutomationId("ChatComposerPrimaryAction")
+                .IsEnabled(vm.CanSend)
+                .ToolTip(actionLabel)
+                .Set(button => ComposerAutomationVisibility.Prepare(button))
                 .OnUnmount(control => ComposerAutomationVisibility.Detach(
                     (FrameworkElement)control));
 
@@ -901,11 +879,8 @@ internal sealed class ReactorChatComposer : Component<ReactorChatComposerViewPro
             .Resources(resources => resources
                 .Set("ButtonBackground", background)
                 .Set("ButtonBorderBrush", Theme.Ref("SubtleFillColorTransparentBrush")))
-            .Set(button =>
-            {
-                button.HorizontalContentAlignment = HorizontalAlignment.Left;
-                button.BorderThickness = new Thickness(0);
-            })
+            .Set(button => button.HorizontalContentAlignment = HorizontalAlignment.Left)
+            .BorderThickness(0)
             .OnMount(element =>
             {
                 if (selected)
@@ -997,11 +972,8 @@ internal sealed class ReactorChatComposer : Component<ReactorChatComposerViewPro
             .Resources(resources => resources
                 .Set("ButtonBackground", background)
                 .Set("ButtonBorderBrush", Theme.Ref("SubtleFillColorTransparentBrush")))
-            .Set(button =>
-            {
-                button.HorizontalContentAlignment = HorizontalAlignment.Stretch;
-                button.BorderThickness = new Thickness(0);
-            })
+            .Set(button => button.HorizontalContentAlignment = HorizontalAlignment.Stretch)
+            .BorderThickness(0)
             .OnMount(element =>
             {
                 if (selected)

--- a/src/OpenClaw.Tray.WinUI/Chat/ReactorChatComposer.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ReactorChatComposer.cs
@@ -1197,6 +1197,10 @@ internal sealed class ReactorChatComposer : Component<ReactorChatComposerViewPro
 
 internal static class ComposerAutomationVisibility
 {
+    // Intentional Reactor escape hatch. Readiness depends on post-layout measurements
+    // and temporary Loaded/SizeChanged subscriptions, so it cannot be represented by
+    // static modifiers alone. Prepare runs on every render, detaches stale handlers,
+    // and reapplies the correct pooled-control state before subscribing when needed.
     public static void Prepare(FrameworkElement control)
     {
         Detach(control);

--- a/src/OpenClaw.Tray.WinUI/Chat/ReactorChatTimeline.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ReactorChatTimeline.cs
@@ -144,10 +144,10 @@ public sealed class ReactorChatTimeline : Component<ReactorChatTimelineProps>
                     .Set("ItemContainerSelectedPointerOverBackground", Theme.Ref("SubtleFillColorTransparentBrush"))
                     .Set("ItemContainerSelectedPressedBackground", Theme.Ref("SubtleFillColorTransparentBrush"))
                     .Set("ItemContainerSelectedInnerBorderBrush", Theme.Ref("SubtleFillColorTransparentBrush")))
+                .IsTabStop(false)
                 .Set(itemContainer =>
                 {
                     itemContainer.IsSelected = false;
-                    itemContainer.IsTabStop = false;
                     itemContainer.HorizontalContentAlignment = HorizontalAlignment.Stretch;
                 })
                 .HAlign(HorizontalAlignment.Stretch)
@@ -347,7 +347,7 @@ public sealed class ReactorChatTimeline : Component<ReactorChatTimelineProps>
                 12,
                 FontWeights.Normal,
                 "TextFillColorSecondaryBrush")
-            .Set(text => text.FontStyle = global::Windows.UI.Text.FontStyle.Italic)
+            .FontStyle(global::Windows.UI.Text.FontStyle.Italic)
             .Margin(64, 8, 24, 8);
     }
 
@@ -398,7 +398,7 @@ public sealed class ReactorChatTimeline : Component<ReactorChatTimelineProps>
                     14,
                     FontWeights.Normal,
                     "TextOnAccentFillColorPrimaryBrush")
-                .Set(text => text.IsTextSelectionEnabled = true));
+                .IsTextSelectionEnabled(true));
         }
 
         var bubble = Border(VStack(8, content.ToArray()))
@@ -555,14 +555,14 @@ public sealed class ReactorChatTimeline : Component<ReactorChatTimelineProps>
                     14,
                     FontWeights.Normal,
                     "TextFillColorPrimaryBrush")
-                .Set(value => value.IsTextSelectionEnabled = true),
+                .IsTextSelectionEnabled(true),
             LinkBuilder = (children, _) => HStack(children),
             HtmlBlock = raw => Text(
                     ChatMarkdownSanitizer.FlattenRawHtmlBlockToInertText(raw),
                     14,
                     FontWeights.Normal,
                     "TextFillColorPrimaryBrush")
-                .Set(value => value.IsTextSelectionEnabled = true),
+                .IsTextSelectionEnabled(true),
         };
 
         // Fully qualified: the markdown factory ships in Microsoft.UI.Reactor.Advanced, and importing
@@ -631,7 +631,7 @@ public sealed class ReactorChatTimeline : Component<ReactorChatTimelineProps>
         return Button(
                 TextBlock(glyph)
                     .FontSize(12)
-                    .Set(text => text.FontFamily = FluentIconCatalog.SymbolThemeFontFamily)
+                    .FontFamily(FluentIconCatalog.SymbolThemeFontFamily)
                     .Foreground(Theme.SecondaryText),
                 onClick)
             .Width(20)
@@ -652,7 +652,7 @@ public sealed class ReactorChatTimeline : Component<ReactorChatTimelineProps>
             .OnLostFocus((_, _) => onLostFocus())
             .Opacity(isVisible ? 1 : 0)
             .IsTabStop(true)
-            .Set(button => button.IsHitTestVisible = isVisible);
+            .IsHitTestVisible(isVisible);
     }
 
     private static (string Message, IReadOnlyList<ChatAttachmentPresentation> Attachments) ParseAttachments(string? text)
@@ -736,7 +736,7 @@ public sealed class ReactorChatTimeline : Component<ReactorChatTimelineProps>
                 16,
                 FontWeights.Normal,
                 "TextOnAccentFillColorPrimaryBrush")
-            .Set(text => text.FontFamily = FluentIconCatalog.SymbolThemeFontFamily)
+            .FontFamily(FluentIconCatalog.SymbolThemeFontFamily)
             .Center();
         var glyphBackground = Border(glyph)
             .Size(32, 32)
@@ -747,11 +747,8 @@ public sealed class ReactorChatTimeline : Component<ReactorChatTimelineProps>
                 13,
                 FontWeights.Normal,
                 "TextOnAccentFillColorPrimaryBrush")
-            .Set(text =>
-            {
-                text.TextWrapping = TextWrapping.NoWrap;
-                text.TextTrimming = TextTrimming.CharacterEllipsis;
-            })
+            .TextWrapping(TextWrapping.NoWrap)
+            .TextTrimming(TextTrimming.CharacterEllipsis)
             .MaxWidth(240)
             .VAlign(VerticalAlignment.Center);
 
@@ -760,11 +757,8 @@ public sealed class ReactorChatTimeline : Component<ReactorChatTimelineProps>
                 11,
                 FontWeights.Normal,
                 "TextOnAccentFillColorSecondaryBrush")
-            .Set(text =>
-            {
-                text.TextWrapping = TextWrapping.NoWrap;
-                text.TextTrimming = TextTrimming.CharacterEllipsis;
-            })
+            .TextWrapping(TextWrapping.NoWrap)
+            .TextTrimming(TextTrimming.CharacterEllipsis)
             .MaxWidth(240);
 
         return Border(HStack(8, glyphBackground, VStack(1, name, mimeType)))
@@ -802,15 +796,12 @@ public sealed class ReactorChatTimeline : Component<ReactorChatTimelineProps>
                 12,
                 FontWeights.Normal,
                 "TextFillColorSecondaryBrush")
-            .Set(text => text.IsTextSelectionEnabled = true);
+            .IsTextSelectionEnabled(true);
         return Expander(
                 LocalizedOrDefault("Chat_Reasoning_ThinkingHeader", "Thinking"),
                 content)
-            .Set(control =>
-            {
-                control.HorizontalAlignment = HorizontalAlignment.Stretch;
-                control.HorizontalContentAlignment = HorizontalAlignment.Stretch;
-            })
+            .HAlign(HorizontalAlignment.Stretch)
+            .HorizontalContentAlignment(HorizontalAlignment.Stretch)
             .Margin(52, 4);
     }
 
@@ -892,11 +883,8 @@ public sealed class ReactorChatTimeline : Component<ReactorChatTimelineProps>
                 12,
                 FontWeights.Normal,
                 "TextFillColorPrimaryBrush")
-            .Set(text =>
-            {
-                text.FontFamily = new FontFamily("Cascadia Code, Consolas");
-                text.IsTextSelectionEnabled = true;
-            }))
+            .FontFamily(new FontFamily("Cascadia Code, Consolas"))
+            .IsTextSelectionEnabled(true))
             .Padding(10, 8)
             .CornerRadius(6)
             .Background(BrushFor(
@@ -932,7 +920,7 @@ public sealed class ReactorChatTimeline : Component<ReactorChatTimelineProps>
                 12,
                 FontWeights.Normal,
                 isError ? "SystemFillColorCriticalBrush" : "TextFillColorSecondaryBrush")
-            .Set(text => text.TextAlignment = TextAlignment.Center))
+            .TextAlignment(TextAlignment.Center))
             .Margin(40, 4)
             .Padding(10, 4)
             .HAlign(HorizontalAlignment.Center)
@@ -961,7 +949,7 @@ public sealed class ReactorChatTimeline : Component<ReactorChatTimelineProps>
                     Text(presentation.Title, 13, FontWeights.SemiBold)
                         .HAlign(HorizontalAlignment.Center),
                     Text(presentation.Detail, 12, FontWeights.Normal, "TextFillColorSecondaryBrush")
-                        .Set(text => text.TextAlignment = TextAlignment.Center)
+                        .TextAlignment(TextAlignment.Center)
                         .HAlign(HorizontalAlignment.Center),
                     Button(
                             presentation.ActionLabel,
@@ -1036,7 +1024,7 @@ public sealed class ReactorChatTimeline : Component<ReactorChatTimelineProps>
     {
         return Border(child)
             .Opacity(isHovered ? 1 : 0)
-            .Set(border => border.IsHitTestVisible = false);
+            .IsHitTestVisible(false);
     }
 
     private static TextBlockElement Text(
@@ -1045,7 +1033,7 @@ public sealed class ReactorChatTimeline : Component<ReactorChatTimelineProps>
         global::Windows.UI.Text.FontWeight? weight = null,
         string foregroundResource = "TextFillColorPrimaryBrush") =>
         TextBlock(text)
-            .Set(control => control.TextWrapping = TextWrapping.Wrap)
+            .TextWrapping(TextWrapping.Wrap)
             .FontSize(fontSize)
             .FontWeight(weight ?? FontWeights.Normal)
             .Foreground(BrushFor(foregroundResource, Microsoft.UI.Colors.Black));

--- a/src/OpenClaw.Tray.WinUI/Chat/ReactorChatTimeline.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ReactorChatTimeline.cs
@@ -565,7 +565,9 @@ public sealed class ReactorChatTimeline : Component<ReactorChatTimelineProps>
                 .Set(value => value.IsTextSelectionEnabled = true),
         };
 
-        return Factories.Markdown(ChatMarkdownSanitizer.Sanitize(text), options);
+        // Fully qualified: the markdown factory ships in Microsoft.UI.Reactor.Advanced, and importing
+        // that namespace would make the simple name `Factories` ambiguous with Microsoft.UI.Reactor.Factories.
+        return Microsoft.UI.Reactor.Advanced.Factories.Markdown(ChatMarkdownSanitizer.Sanitize(text), options);
     }
 
     private static Element BuildAssistantFooter(
@@ -648,12 +650,9 @@ public sealed class ReactorChatTimeline : Component<ReactorChatTimelineProps>
             .ToolTip(label)
             .OnGotFocus((_, _) => onGotFocus())
             .OnLostFocus((_, _) => onLostFocus())
-            .Set(button =>
-            {
-                button.Opacity = isVisible ? 1 : 0;
-                button.IsHitTestVisible = isVisible;
-                button.IsTabStop = true;
-            });
+            .Opacity(isVisible ? 1 : 0)
+            .IsTabStop(true)
+            .Set(button => button.IsHitTestVisible = isVisible);
     }
 
     private static (string Message, IReadOnlyList<ChatAttachmentPresentation> Attachments) ParseAttachments(string? text)
@@ -721,7 +720,7 @@ public sealed class ReactorChatTimeline : Component<ReactorChatTimelineProps>
             var pixelHeight = bitmap.PixelHeight > 0 ? bitmap.PixelHeight : (int)maxHeight;
             var scale = Math.Min(Math.Min(maxWidth / pixelWidth, maxHeight / pixelHeight), 1.0);
             return Border(Empty())
-                .Set(border => border.Background = new ImageBrush
+                .Background(new ImageBrush
                 {
                     ImageSource = bitmap,
                     Stretch = Stretch.UniformToFill,
@@ -1036,11 +1035,8 @@ public sealed class ReactorChatTimeline : Component<ReactorChatTimelineProps>
     private static Element HoverMetadata(Element child, bool isHovered)
     {
         return Border(child)
-            .Set(border =>
-            {
-                border.Opacity = isHovered ? 1 : 0;
-                border.IsHitTestVisible = false;
-            });
+            .Opacity(isHovered ? 1 : 0)
+            .Set(border => border.IsHitTestVisible = false);
     }
 
     private static TextBlockElement Text(

--- a/src/OpenClaw.Tray.WinUI/Chat/ToolCallCardRenderer.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ToolCallCardRenderer.cs
@@ -70,18 +70,17 @@ internal static class ToolCallCardRenderer
             .HAlign(HorizontalAlignment.Stretch)
             .HorizontalContentAlignment(HorizontalAlignment.Stretch)
             .AutomationId($"ChatToolCall_{SanitizeAutomationId(entry.Id)}")
-            .Set(control =>
-            {
-                if (isNested)
-                {
-                    control.FontSize = 12;
-                    control.MinHeight = 28;
-                    control.Padding = new Thickness(4, 0, 4, 0);
-                }
-            })
             .AutomationName(
                 $"{LocalizedOrDefault("Chat_Tool_CallLabel", "Tool call")} {toolName}. {statusLabel}.")
             .WithKey($"tool-expander:{entry.Id}:collapse:{props.ToolCallsCollapseVersion}");
+
+        if (isNested)
+        {
+            expander = expander
+                .FontSize(12)
+                .MinHeight(28)
+                .Padding(4, 0, 4, 0);
+        }
 
         return Border(expander)
             .Margin(isNested ? 0 : 68, isNested ? 0 : 4, isNested ? 0 : 40, isNested ? 0 : 4)

--- a/src/OpenClaw.Tray.WinUI/Chat/ToolCallCardRenderer.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ToolCallCardRenderer.cs
@@ -67,19 +67,17 @@ internal static class ToolCallCardRenderer
                 $"{toolName} · {statusLabel}",
                 Border(VStack(6, details.ToArray()))
                     .Padding(18, 8, 18, 10))
+            .HAlign(HorizontalAlignment.Stretch)
+            .HorizontalContentAlignment(HorizontalAlignment.Stretch)
+            .AutomationId($"ChatToolCall_{SanitizeAutomationId(entry.Id)}")
             .Set(control =>
             {
-                control.HorizontalAlignment = HorizontalAlignment.Stretch;
-                control.HorizontalContentAlignment = HorizontalAlignment.Stretch;
                 if (isNested)
                 {
                     control.FontSize = 12;
                     control.MinHeight = 28;
                     control.Padding = new Thickness(4, 0, 4, 0);
                 }
-                AutomationProperties.SetAutomationId(
-                    control,
-                    $"ChatToolCall_{SanitizeAutomationId(entry.Id)}");
             })
             .AutomationName(
                 $"{LocalizedOrDefault("Chat_Tool_CallLabel", "Tool call")} {toolName}. {statusLabel}.")
@@ -189,13 +187,11 @@ internal static class ToolCallCardRenderer
         var expander = Expander(
                 summaryText,
                 details)
+            .HAlign(HorizontalAlignment.Stretch)
+            .HorizontalContentAlignment(HorizontalAlignment.Stretch)
+            .AutomationId($"ChatToolActivity_{SanitizeAutomationId(activity.Tools[0].Id)}")
             .Set(control =>
             {
-                control.HorizontalAlignment = HorizontalAlignment.Stretch;
-                control.HorizontalContentAlignment = HorizontalAlignment.Stretch;
-                AutomationProperties.SetAutomationId(
-                    control,
-                    $"ChatToolActivity_{SanitizeAutomationId(activity.Tools[0].Id)}");
                 ApplyActivityExpander(
                     control,
                     onUserExpansionChanged,
@@ -304,7 +300,7 @@ internal static class ToolCallCardRenderer
         global::Windows.UI.Text.FontWeight weight,
         string foregroundResource) =>
         TextBlock(text)
-            .Set(control => control.TextWrapping = TextWrapping.Wrap)
+            .TextWrapping(TextWrapping.Wrap)
             .FontSize(fontSize)
             .FontWeight(weight)
             .Foreground(BrushFor(foregroundResource, Microsoft.UI.Colors.Black));

--- a/src/OpenClaw.Tray.WinUI/Chat/ToolCallCardRenderer.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ToolCallCardRenderer.cs
@@ -86,21 +86,10 @@ internal static class ToolCallCardRenderer
             .WithKey($"tool-expander:{entry.Id}:collapse:{props.ToolCallsCollapseVersion}");
 
         return Border(expander)
-            .Set(border =>
-            {
-                border.Margin = isNested
-                    ? new Thickness(0)
-                    : new Thickness(68, 4, 40, 4);
-                border.Padding = isNested
-                    ? new Thickness(0)
-                    : new Thickness(12, 8, 12, 8);
-                border.BorderThickness = isNested
-                    ? new Thickness(0)
-                    : new Thickness(1);
-                border.CornerRadius = isNested
-                    ? new CornerRadius(4)
-                    : new CornerRadius(12);
-            })
+            .Margin(isNested ? 0 : 68, isNested ? 0 : 4, isNested ? 0 : 40, isNested ? 0 : 4)
+            .Padding(isNested ? 0 : 12, isNested ? 0 : 8, isNested ? 0 : 12, isNested ? 0 : 8)
+            .BorderThickness(isNested ? 0 : 1)
+            .CornerRadius(isNested ? 4 : 12)
             .Background(BrushFor(
                 isNested
                     ? "SubtleFillColorTransparentBrush"

--- a/src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj
+++ b/src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj
@@ -82,7 +82,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
-    <PackageReference Include="Microsoft.UI.Reactor" Version="0.1.0-preview.12" />
+    <PackageReference Include="Microsoft.UI.Reactor" Version="0.1.0-preview.14" />
+    <PackageReference Include="Microsoft.UI.Reactor.Advanced" Version="0.1.0-preview.14" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="$(MicrosoftWindowsAppSDKVersion)" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$(MicrosoftWindowsSdkBuildToolsVersion)" />
     <PackageReference Include="OpenTelemetry" Version="1.16.0" />
@@ -92,7 +93,7 @@
     <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.3.260402-preview2" />
     <PackageReference Include="CommunityToolkit.WinUI.Controls.Sizers" Version="8.3.260402-preview2" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="10.0.0" />
-    <PackageReference Include="System.Drawing.Common" Version="10.0.9" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.11" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="10.0.0" />
     <PackageReference Include="Updatum" Version="1.3.4" />
     <PackageReference Include="NAudio.Wasapi" Version="2.3.0" />

--- a/src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj
+++ b/src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj
@@ -82,7 +82,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="5.9.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.UI.Reactor" Version="0.1.0-preview.14" />
     <PackageReference Include="Microsoft.UI.Reactor.Advanced" Version="0.1.0-preview.14" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="$(MicrosoftWindowsAppSDKVersion)" />

--- a/src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj
+++ b/src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj
@@ -82,6 +82,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="5.9.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.UI.Reactor" Version="0.1.0-preview.14" />
     <PackageReference Include="Microsoft.UI.Reactor.Advanced" Version="0.1.0-preview.14" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="$(MicrosoftWindowsAppSDKVersion)" />

--- a/tests/OpenClaw.Tray.Tests/ChatTimelinePresentationTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ChatTimelinePresentationTests.cs
@@ -253,7 +253,7 @@ public sealed class ChatTimelinePresentationTests
         Assert.True(
             composer.Split("AccessibilityView.Raw", StringSplitOptions.None).Length - 1 >= 4);
         Assert.Contains(".AutomationId(\"ChatComposerInput\")", composer);
-        Assert.Contains("AutomationProperties.SetAutomationId(", composer);
+        Assert.Contains(".AutomationId(automationId)", composer);
         Assert.Contains("RaisePropertyChangedEvent(", composer);
         Assert.Contains("AutomationElementIdentifiers.IsOffscreenProperty", composer);
         Assert.Equal(
@@ -581,8 +581,8 @@ public sealed class ChatTimelinePresentationTests
         Assert.Contains("internal sealed class ToolActivityCard : Component<ToolActivityCardProps>", renderer);
         Assert.Contains("Element details = isExpanded", renderer);
         Assert.Contains("? VStack(", renderer);
-        Assert.Contains("control.MinHeight = 28;", renderer);
-        Assert.Contains("control.FontSize = 12;", renderer);
+        Assert.Contains(".MinHeight(28)", renderer);
+        Assert.Contains(".FontSize(12)", renderer);
         Assert.Contains(".BorderThickness(isNested ? 0 : 1)", renderer);
         Assert.Contains(".Margin(isNested ? 0 : 68, isNested ? 0 : 4, isNested ? 0 : 40, isNested ? 0 : 4)", renderer);
         Assert.Contains("? \"SubtleFillColorTransparentBrush\"", renderer);

--- a/tests/OpenClaw.Tray.Tests/ChatTimelinePresentationTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ChatTimelinePresentationTests.cs
@@ -230,7 +230,7 @@ public sealed class ChatTimelinePresentationTests
             "Chat",
             "ReactorChatComposer.cs"));
 
-        Assert.Contains("textBlock.Margin = new Thickness(2, 4, 0, 0)", composer);
+        Assert.Contains(".Margin(2, 4, 0, 0)", composer);
     }
 
     [Fact]
@@ -583,8 +583,8 @@ public sealed class ChatTimelinePresentationTests
         Assert.Contains("? VStack(", renderer);
         Assert.Contains("control.MinHeight = 28;", renderer);
         Assert.Contains("control.FontSize = 12;", renderer);
-        Assert.Contains("border.BorderThickness = isNested", renderer);
-        Assert.Contains("? new Thickness(0)", renderer);
+        Assert.Contains(".BorderThickness(isNested ? 0 : 1)", renderer);
+        Assert.Contains(".Margin(isNested ? 0 : 68, isNested ? 0 : 4, isNested ? 0 : 40, isNested ? 0 : 4)", renderer);
         Assert.Contains("? \"SubtleFillColorTransparentBrush\"", renderer);
         Assert.Contains(": Empty();", renderer);
         Assert.DoesNotContain("activity.Tools.Select(BuildStandalone)", renderer);

--- a/tests/OpenClaw.Tray.Tests/ChatTimelinePresentationTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ChatTimelinePresentationTests.cs
@@ -575,7 +575,7 @@ public sealed class ChatTimelinePresentationTests
         Assert.Contains("text.IsTextSelectionEnabled = true", renderer);
         Assert.DoesNotContain("var stateText =", renderer);
         Assert.DoesNotContain("var glyph =", renderer);
-        Assert.Contains("AutomationProperties.SetAutomationId(", renderer);
+        Assert.Contains(".AutomationId(", renderer);
         Assert.Contains("ChatToolActivity_", renderer);
         Assert.Contains("ChatToolCall_", renderer);
         Assert.Contains("internal sealed class ToolActivityCard : Component<ToolActivityCardProps>", renderer);

--- a/tests/OpenClaw.Tray.Tests/ChatTimelineRenderIdentityContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ChatTimelineRenderIdentityContractTests.cs
@@ -92,7 +92,7 @@ public sealed class ChatTimelineRenderIdentityContractTests
 
         Assert.Contains("timeline.TurnActive || hasPendingQueuedSend", root);
         Assert.Contains("message.SendState is ChatQueuedMessageSendState.Queued or ChatQueuedMessageSendState.Sending", root);
-        Assert.Contains("button.IsEnabled = enabled;", composer);
+        Assert.Contains(".IsEnabled(enabled)", composer);
         Assert.Equal(3, Regex.Matches(composer, @"!inputs\.MessageOptionsDisabled").Count);
     }
 

--- a/tests/OpenClaw.Tray.Tests/ChatUserBubbleTextContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ChatUserBubbleTextContractTests.cs
@@ -10,7 +10,7 @@ public sealed class ChatUserBubbleTextContractTests
         Assert.Contains("private static Element BuildUser(", timeline);
         Assert.Contains("content.Add(Text(", timeline);
         Assert.Contains("messageText,", timeline);
-        Assert.Contains(".Set(text => text.IsTextSelectionEnabled = true)", timeline);
+        Assert.Contains(".IsTextSelectionEnabled(true)", timeline);
         Assert.Contains("var accessibleText = BuildAccessibleUserText(messageText, attachments)", timeline);
         Assert.Contains(".AutomationName(accessibleText)", timeline);
     }


### PR DESCRIPTION
## What this changes

Upgrades the native chat surface from `Microsoft.UI.Reactor` `0.1.0-preview.12` to `0.1.0-preview.14`, adapts to the Advanced package split and fluent modifier guidance, and raises the repository build prerequisite to .NET SDK 10.0.400 or newer because preview.14's analyzers require Roslyn 5.9.

## Implementation

- upgrade `Microsoft.UI.Reactor` to `0.1.0-preview.14`
- add `Microsoft.UI.Reactor.Advanced` `0.1.0-preview.14` for markdown, which adds transitive `Microsoft.Graphics.Win2D` `1.4.0`
- upgrade the direct `System.Drawing.Common` pin to `10.0.11` to satisfy Reactor's new floor while continuing to override the vulnerable old transitive version
- move markdown rendering to `Microsoft.UI.Reactor.Advanced.Factories.Markdown`
- replace pooled chat-control property writes with Reactor fluent modifiers so values are reapplied and unwound through reconciliation
- preserve the intentional composer automation readiness escape hatch because it depends on post-layout measurements and temporary `Loaded`/`SizeChanged` subscriptions
- set `global.json` to the .NET 10.0.400 feature band with `latestFeature` roll-forward
- make `build.ps1`, `scripts/setup-dev.ps1`, developer docs, and Parallels proof provisioning require .NET SDK 10.0.400 or newer
- keep release artifacts self-contained, so end users do not acquire a machine-wide .NET runtime prerequisite

The permanently disabled MSIX job still contains its old exact SDK pin. It must be updated if that `if: false` lane is ever re-enabled; it does not affect active CI, Inno/portable release artifacts, or this PR's build.

## Required proof pools

- `windows-winui-interactive`: contributor screenshots at the original rendering head show the real isolated native chat surface, nested tool cards, composer glyphs, markdown table rendering, and redaction behavior. Current maintainer commits only align the build SDK/prerequisite and do not alter the rendered output.

## Validation

Current head: `8afdcada`.

Current `main` merge validation with .NET SDK `10.0.401`:

- `.\build.ps1`: passed
- `scripts\test-ci-workflow-contract.ps1`: passed
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore`: 3,943 passed, 32 skipped
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore`: 2,865 passed
- fresh restore plus `dotnet test .\tests\OpenClaw.Tray.UITests\OpenClaw.Tray.UITests.csproj --no-restore -p:Platform=x64`: 136 passed
- `build.ps1 -CheckOnly`: recognizes SDK 10.0.401 and the 10.0.400 minimum
- `scripts\setup-dev.ps1 -CheckOnly`: recognizes SDK 10.0.401 and the 10.0.400 minimum
- simulated old SDK 10.0.303: reports `.NET SDK 10.0.400 or newer not found` instead of incorrectly reporting that dotnet is absent
- `bash -n scripts\parallels-windows-vm.sh`: passed
- the exact Parallels PowerShell feature-band payload returns `True` with SDK 10.0.401 and `False` for an old-band-only simulated list
- NuGet vulnerability audit: no vulnerable direct or transitive packages
- final structured autoreview: clean, no actionable findings
- final independent rubber-duck review: no product, rendering, package, or prerequisite blockers after correcting the Parallels command transport

Resolved package graph:

- `Microsoft.UI.Reactor` `0.1.0-preview.14`
- `Microsoft.UI.Reactor.Advanced` `0.1.0-preview.14`
- `Microsoft.Graphics.Win2D` `1.4.0`
- `System.Drawing.Common` `10.0.11`
- `Microsoft.WindowsAppSDK.WinUI` `2.3.6`
- no `Microsoft.Net.Compilers.Toolset` package

## Real behavior proof

Contributor current-rendering proof at `a8790d35` remains applicable because later commits only change compiler/prerequisite selection:

1. The real isolated `OpenClaw.Tray.WinUI.exe` rendered grouped activity cards, nested tool expanders, the full composer, Fluent glyphs, picker chevrons, and monospace tool input.
2. Production `ReactorChatTimeline.BuildSafeMarkdown` rendered a GFM table and inert literal-pipe code fence through the relocated Advanced markdown factory.
3. Accessibility scans located `ChatComposerInput` and validated the chat page after automation properties moved to modifiers.
4. Redaction sentinels remained absent and sensitive command input stayed redacted.

Current-head local proof additionally confirms all 136 WinUI tests pass after a fresh preview.14 restore with the new SDK floor.

Not verified / blocked:

- live composer typing against a paired gateway and long scrollback recycling were not captured; the host had no paired gateway. Seeded real-app proof, component proofs, contract tests, and the full WinUI suite cover realization and accessibility.
- no end-to-end Parallels VM prepare was run; the transport payload was verified by construction, Bash syntax, and Windows PowerShell execution.

## Security impact

No permissions, credentials, network calls, command surfaces, or data-access behavior changed. `Microsoft.Graphics.Win2D` is the only new native transitive dependency; it is resolved at 1.4.0, included by the Advanced package, and the current dependency audit reports no known vulnerabilities.