### PR TITLE
fix(setup): complete npm latest Gateway landing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ Notes:
 - Apply the label only to work that is actively moving. Do not use it for queued, parked, or indefinitely blocked items.
 - Remove the label when active work pauses, ownership returns to the author, or the item closes or merges.
 - This maintainer-ownership label may coexist with contributor-facing status labels such as `status: 📣 needs proof`.
+- When referring to a pull request, include its title in parentheses after the number, for example `#1312 (improve(setup): install latest stable Gateway from npm)`.
 
 ## Targeted Validation Paths
 

--- a/docs/CONNECTION_PROTOCOL_RESEARCH.md
+++ b/docs/CONNECTION_PROTOCOL_RESEARCH.md
@@ -282,8 +282,9 @@ Upstream default setup-code profile for `wss://` or same-host loopback:
 `openclaw qr --limited` and plaintext LAN setup codes use the limited profile,
 which omits `operator.admin`. The setup-code payload does not identify the
 profile. Its opaque bootstrap token carries the server-enforced scope boundary,
-so clients request the full bootstrap scope set and the gateway strips admin
-when the issued token is limited.
+so Windows first requests the full bootstrap profile required by normal setup.
+If the gateway rejects that request as invalid for the issued profile, Windows
+reconnects once with the bounded scopes shared by full and limited profiles.
 
 Expected flow:
 

--- a/docs/CONNECTION_PROTOCOL_RESEARCH.md
+++ b/docs/CONNECTION_PROTOCOL_RESEARCH.md
@@ -282,10 +282,8 @@ Upstream default setup-code profile for `wss://` or same-host loopback:
 `openclaw qr --limited` and plaintext LAN setup codes use the limited profile,
 which omits `operator.admin`. The setup-code payload does not identify the
 profile. Its opaque bootstrap token carries the server-enforced scope boundary,
-so Windows requests only the bounded scopes shared by both profiles:
-`operator.approvals`, `operator.read`, `operator.talk.secrets`, and
-`operator.write`. After bootstrap handoff, normal shared-token or device-token
-finalization may request the full operator scope set when the gateway permits it.
+so clients request the full bootstrap scope set and the gateway strips admin
+when the issued token is limited.
 
 Expected flow:
 

--- a/docs/CONNECTION_PROTOCOL_RESEARCH.md
+++ b/docs/CONNECTION_PROTOCOL_RESEARCH.md
@@ -282,8 +282,10 @@ Upstream default setup-code profile for `wss://` or same-host loopback:
 `openclaw qr --limited` and plaintext LAN setup codes use the limited profile,
 which omits `operator.admin`. The setup-code payload does not identify the
 profile. Its opaque bootstrap token carries the server-enforced scope boundary,
-so clients request the full bootstrap scope set and the gateway strips admin
-when the issued token is limited.
+so Windows requests only the bounded scopes shared by both profiles:
+`operator.approvals`, `operator.read`, `operator.talk.secrets`, and
+`operator.write`. After bootstrap handoff, normal shared-token or device-token
+finalization may request the full operator scope set when the gateway permits it.
 
 Expected flow:
 

--- a/docs/SETUP_ENGINE_REDESIGN.md
+++ b/docs/SETUP_ENGINE_REDESIGN.md
@@ -333,9 +333,9 @@ name an exact stable release to offer after a typed compatibility failure.
 Legacy `recommended`, `exact`, and `fallback` selections are migrated when the
 configuration is loaded. Legacy recommendation and fallback configurations
 without a recorded version follow the upstream `latest` and `extended-stable`
-tags. Explicit legacy versions remain exact. Versionless legacy custom-installer
-configurations retain their old exact pins because custom installers cannot resolve
-npm tags. The cross-repository release gate may pass
+tags. Explicit legacy versions remain exact. Custom installers still require an
+explicit exact version because they cannot resolve npm tags. The cross-repository
+release gate may pass
 `--gateway-candidate-package <absolute-tgz>` with
 `--validate-gateway-candidate`, headless mode, and rollback-on-failure. The
 package input is runtime-only and does not change normal npm setup.

--- a/docs/adr/0001-gateway-release-policy.md
+++ b/docs/adr/0001-gateway-release-policy.md
@@ -35,9 +35,9 @@ evidence.
 - Legacy `recommended`, `exact`, and `fallback` configurations are translated
   into the new selector model. Legacy selections without a recorded version
   follow the upstream `latest` recommendation or `extended-stable` fallback
-  tag. An explicitly recorded legacy version remains exact. Versionless legacy
-  configurations with a custom installer retain their former exact pins because
-  custom installers cannot resolve npm tags.
+  tag. An explicitly recorded legacy version remains exact. Custom installers
+  still require an explicitly recorded exact version because they cannot resolve
+  npm tags.
 - Embedded release evidence, the product security floor, and the
   candidate-promotion workflow are removed.
 - Setup continues to pin and verify Node `24.19.0`. This decision changes the

--- a/scripts/Get-CiChangeClassification.ps1
+++ b/scripts/Get-CiChangeClassification.ps1
@@ -154,7 +154,7 @@ function Add-PathImpact {
     )
 
     if ($Path.Equals(
-            "src/OpenClaw.SetupEngine/GatewayReleasePolicy.cs",
+            "src/OpenClaw.SetupEngine/GatewayInstallPolicy.cs",
             [StringComparison]::OrdinalIgnoreCase)) {
         Add-Lanes -Impact $Impact -Tray -SetupE2e -RevocationE2e -NetworkE2e
         return $true

--- a/scripts/test-ci-change-classifier.ps1
+++ b/scripts/test-ci-change-classifier.ps1
@@ -128,8 +128,8 @@ $cases = @(
         Required = @("tray_tests", "setup_e2e")
     },
     @{
-        Scenario = "Gateway release policy change"
-        Paths = @("src/OpenClaw.SetupEngine/GatewayReleasePolicy.cs")
+        Scenario = "Gateway install policy change"
+        Paths = @("src/OpenClaw.SetupEngine/GatewayInstallPolicy.cs")
         Classification = "targeted"
         Required = @("tray_tests", "setup_e2e", "revocation_e2e", "network_e2e")
     },

--- a/src/OpenClaw.SetupEngine.UI/Pages/CompletePage.xaml
+++ b/src/OpenClaw.SetupEngine.UI/Pages/CompletePage.xaml
@@ -173,6 +173,10 @@
         </ScrollViewer>
 
         <Grid Grid.Row="1" ColumnDefinitions="Auto,*,Auto" Margin="0,16,0,0">
+            <Button x:Name="FallbackButton" Grid.Column="0"
+                    Content="Retry with configured fallback"
+                    Visibility="Collapsed"
+                    Click="FallbackButton_Click" />
             <Button x:Name="RestartLaterButton" Grid.Column="0"
                     Content="No, I'm not ready yet"
                     Visibility="Collapsed"

--- a/src/OpenClaw.SetupEngine.UI/Pages/CompletePage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/CompletePage.xaml.cs
@@ -41,6 +41,7 @@ public sealed partial class CompletePage : Page
                 SubtitleText.Visibility = Visibility.Visible;
                 ErrorCard.Visibility = Visibility.Collapsed;
                 HelpLink.Visibility = Visibility.Collapsed;
+                FallbackButton.Visibility = Visibility.Collapsed;
                 SummaryPanel.Visibility = Visibility.Visible;
                 LocalAiSummaryCard.Visibility = review.LocalAiEnabled ? Visibility.Visible : Visibility.Collapsed;
                 if (review.LocalAiEnabled)
@@ -72,6 +73,7 @@ public sealed partial class CompletePage : Page
                     LocalAiSummaryCard.Visibility = Visibility.Collapsed;
                     ErrorCard.Visibility = Visibility.Collapsed;
                     HelpLink.Visibility = Visibility.Collapsed;
+                    FallbackButton.Visibility = Visibility.Collapsed;
                     LaunchButton.Visibility = Visibility.Collapsed;
                     StepIndicator.Visibility = Visibility.Collapsed;
                     RestartLaterButton.Visibility = Visibility.Visible;
@@ -94,6 +96,13 @@ public sealed partial class CompletePage : Page
                 SummaryPanel.Visibility = Visibility.Collapsed;
                 LocalAiSummaryCard.Visibility = Visibility.Collapsed;
                 LaunchButton.Content = "Close";
+                FallbackButton.Visibility = args.CanRetryGatewayFallback
+                    ? Visibility.Visible
+                    : Visibility.Collapsed;
+                FallbackButton.Content = string.IsNullOrWhiteSpace(args.GatewayFallbackVersion)
+                    ? "Retry with configured fallback"
+                    : $"Retry with fallback {args.GatewayFallbackVersion}";
+
                 // Show error card with details and log link
                 ErrorCard.Visibility = Visibility.Visible;
                 ErrorText.Text = errorMessage;
@@ -191,6 +200,20 @@ public sealed partial class CompletePage : Page
     private void ViewLog_Click(object sender, RoutedEventArgs e)
     {
         LogFileLauncher.RevealInExplorer(_logPath);
+    }
+
+    private void FallbackButton_Click(object sender, RoutedEventArgs e)
+    {
+        string? error = null;
+        if (SetupWindow.Active is { } window &&
+            window.TryRetryWithGatewayFallback(out error))
+        {
+            return;
+        }
+
+        FallbackButton.Visibility = Visibility.Collapsed;
+        if (!string.IsNullOrWhiteSpace(error))
+            ErrorText.Text = $"{ErrorText.Text}{Environment.NewLine}{error}";
     }
 
     private void RestartLaterButton_Click(object sender, RoutedEventArgs e)

--- a/src/OpenClaw.SetupEngine.UI/SetupWindow.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/SetupWindow.xaml.cs
@@ -310,6 +310,9 @@ public sealed partial class SetupWindow : Window
         LocalAiFailureDetail? detail = null,
         bool restartRequired = false)
     {
+        var canRetryFallback =
+            compatibilityFailure is { } failureKind &&
+            GatewayInstallPolicy.CanRetryWithFallback(_config, failureKind);
         NavigateTo(
             typeof(CompletePage),
             new CompletePageArgs(
@@ -320,10 +323,23 @@ public sealed partial class SetupWindow : Window
                 DefaultAutoStart: true,
                 ShowStartupPreference: _showStartupPreferenceOnComplete,
                 ReviewSummary: SetupReviewSummaryBuilder.Build(_config, _dataDir, _localDataDir),
+                CanRetryGatewayFallback: canRetryFallback,
+                GatewayFallbackVersion: canRetryFallback
+                    ? _config.Gateway.FallbackVersion
+                    : null,
                 Detail: detail)
             {
                 RequiresRestart = restartRequired,
             });
+    }
+
+    public bool TryRetryWithGatewayFallback(out string? error)
+    {
+        if (!GatewayInstallPolicy.TryApplyFallback(_config, out error))
+            return false;
+
+        NavigateToProgress();
+        return true;
     }
 
     private void ShowConfigurationError(string errorMessage)
@@ -489,6 +505,8 @@ public sealed record CompletePageArgs(
     bool DefaultAutoStart = true,
     bool ShowStartupPreference = true,
     SetupReviewSummary? ReviewSummary = null,
+    bool CanRetryGatewayFallback = false,
+    string? GatewayFallbackVersion = null,
     LocalAiFailureDetail? Detail = null)
 {
     public bool RequiresRestart { get; init; }

--- a/src/OpenClaw.SetupEngine/GatewayInstallPolicy.cs
+++ b/src/OpenClaw.SetupEngine/GatewayInstallPolicy.cs
@@ -149,8 +149,6 @@ public static class GatewayInstallPolicy
     public const string NodeVersion = "24.19.0";
     public const string RecommendedTag = "latest";
     public const string FallbackTag = "extended-stable";
-    private const string LegacyCustomInstallerRecommendedVersion = "2026.6.34";
-    private const string LegacyCustomInstallerFallbackVersion = "2026.6.11";
 
     private static readonly HashSet<string> s_supportedTags = new(
         ["latest", "next", "beta", "extended-stable", "dev"],
@@ -166,7 +164,7 @@ public static class GatewayInstallPolicy
 
         var gateway = config.Gateway;
         var customInstaller = !IsOfficialInstallerUrl(gateway.InstallUrl);
-        var requestedVersion = ResolveLegacySelection(gateway, customInstaller);
+        var requestedVersion = ResolveLegacySelection(gateway);
         gateway.InstalledVersion = null;
 
         if (customInstaller)
@@ -297,7 +295,7 @@ public static class GatewayInstallPolicy
         return true;
     }
 
-    private static string? ResolveLegacySelection(GatewayConfig gateway, bool customInstaller)
+    private static string? ResolveLegacySelection(GatewayConfig gateway)
     {
         var selection = gateway.Selection?.Trim();
         var version = gateway.Version?.Trim();
@@ -308,9 +306,7 @@ public static class GatewayInstallPolicy
 
         if (selection.Equals("recommended", StringComparison.OrdinalIgnoreCase))
             return string.IsNullOrWhiteSpace(version)
-                ? customInstaller
-                    ? LegacyCustomInstallerRecommendedVersion
-                    : RecommendedTag
+                ? RecommendedTag
                 : version;
 
         if (selection.Equals("exact", StringComparison.OrdinalIgnoreCase))
@@ -322,11 +318,7 @@ public static class GatewayInstallPolicy
         if (selection.Equals("fallback", StringComparison.OrdinalIgnoreCase))
         {
             if (string.IsNullOrWhiteSpace(version))
-            {
-                return customInstaller
-                    ? LegacyCustomInstallerFallbackVersion
-                    : FallbackTag;
-            }
+                return FallbackTag;
 
             RequireExactVersion(
                 version,

--- a/src/OpenClaw.SetupEngine/GatewayInstallPolicy.cs
+++ b/src/OpenClaw.SetupEngine/GatewayInstallPolicy.cs
@@ -203,7 +203,8 @@ public static class GatewayInstallPolicy
 
     public static GatewayCompatibilityException? ValidateHandshake(
         SetupConfig config,
-        GatewaySelfInfo? gatewaySelf)
+        GatewaySelfInfo? gatewaySelf,
+        bool allowInstalledVersionDiscovery = false)
     {
         if (gatewaySelf?.Protocol != ProtocolGeneration)
         {
@@ -214,6 +215,30 @@ public static class GatewayInstallPolicy
         }
 
         var installedVersion = config.Gateway.InstalledVersion;
+        if (string.IsNullOrWhiteSpace(installedVersion) &&
+            allowInstalledVersionDiscovery)
+        {
+            var observedVersion = gatewaySelf.ServerVersion?.Trim();
+            if (!GatewayPackageVersion.IsExact(observedVersion))
+            {
+                return Failure(
+                    GatewayCompatibilityFailureKind.InvalidPolicy,
+                    "Gateway compatibility check failed: the existing server did not report an exact package version.");
+            }
+
+            var requestedVersion = config.Gateway.Version?.Trim();
+            if (GatewayPackageVersion.IsExact(requestedVersion) &&
+                !string.Equals(requestedVersion, observedVersion, StringComparison.Ordinal))
+            {
+                return Failure(
+                    GatewayCompatibilityFailureKind.InstalledVersionMismatch,
+                    $"Gateway compatibility check failed: configured version {requestedVersion}, server reported {observedVersion}.");
+            }
+
+            installedVersion = observedVersion;
+            config.Gateway.InstalledVersion = observedVersion;
+        }
+
         if (string.IsNullOrWhiteSpace(installedVersion))
         {
             return Failure(

--- a/src/OpenClaw.SetupEngine/PairOperatorStep.cs
+++ b/src/OpenClaw.SetupEngine/PairOperatorStep.cs
@@ -428,7 +428,8 @@ public sealed class PairOperatorStep : SetupStep
         SetupContext ctx,
         TimeSpan timeout,
         CancellationToken ct,
-        bool retryGatewayStartupDisconnects = false)
+        bool retryGatewayStartupDisconnects = false,
+        bool allowInstalledVersionDiscovery = false)
     {
         var tcs = new TaskCompletionSource<ConnectionOutcome>();
         ctx.ObservedGatewaySelf = null;
@@ -441,7 +442,8 @@ public sealed class PairOperatorStep : SetupStep
             {
                 var compatibilityFailure = GatewayInstallPolicy.ValidateHandshake(
                     ctx.Config,
-                    ctx.ObservedGatewaySelf);
+                    ctx.ObservedGatewaySelf,
+                    allowInstalledVersionDiscovery);
                 if (compatibilityFailure is null)
                 {
                     tcs.TrySetResult(ConnectionOutcome.Connected);

--- a/src/OpenClaw.SetupEngine/Program.cs
+++ b/src/OpenClaw.SetupEngine/Program.cs
@@ -334,6 +334,9 @@ public static class Program
             PipelineOutcome.Cancelled => $"═══ {label} CANCELLED ═══",
             _ => "═══ UNKNOWN STATE ═══"
         });
+        if (result.CompatibilityFailure is { } failureKind)
+            Console.WriteLine($"\n{BuildCompatibilityFallbackMessage(config, failureKind)}");
+
         Console.WriteLine($"\nLog: {config.LogPath}");
         Console.WriteLine($"Journal: {journalPath}");
 
@@ -365,11 +368,27 @@ public static class Program
             compatibilityFailure = result.CompatibilityFailure?.ToString(),
             installedGatewayVersion = config.Gateway.InstalledVersion,
             gatewayProtocolGeneration = GatewayInstallPolicy.ProtocolGeneration,
+            fallbackGatewayVersion =
+                result.CompatibilityFailure is { } failureKind &&
+                GatewayInstallPolicy.CanRetryWithFallback(config, failureKind)
+                    ? config.Gateway.FallbackVersion
+                    : null,
             logPath = config.LogPath,
             journalPath
         };
         return System.Text.Json.JsonSerializer.Serialize(jsonResult, SetupConfig.JsonWriteOptions);
     }
+
+    internal static string BuildCompatibilityFallbackMessage(
+        SetupConfig config,
+        GatewayCompatibilityFailureKind failureKind)
+    {
+        var fallback = config.Gateway.FallbackVersion?.Trim();
+        return !GatewayInstallPolicy.CanRetryWithFallback(config, failureKind)
+            ? "No configured Gateway fallback is available for this compatibility failure."
+            : $"To retry with configured fallback {fallback}, set Gateway.Version to \"{fallback}\" and rerun setup.";
+    }
+
     private static List<SetupStep> BuildSteps(SetupConfig config)
         => SetupStepFactory.BuildDefaultSteps();
 

--- a/src/OpenClaw.SetupEngine/SetupWizardRunner.cs
+++ b/src/OpenClaw.SetupEngine/SetupWizardRunner.cs
@@ -192,7 +192,12 @@ public sealed class SetupWizardRunner
             if (provenanceCheck is not null)
                 return provenanceCheck;
             client = CreateWizardClient(credential, identityPath, wsLogger);
-            var connection = await PairOperatorStep.WaitForConnectionOrPairing(client, _ctx, TimeSpan.FromSeconds(20), ct);
+            var connection = await PairOperatorStep.WaitForConnectionOrPairing(
+                client,
+                _ctx,
+                TimeSpan.FromSeconds(20),
+                ct,
+                allowInstalledVersionDiscovery: true);
             if (connection == PairOperatorStep.ConnectionOutcome.PairingRequired && _ctx.Config.AutoApprovePairing)
             {
                 _ctx.Logger.Info("Wizard operator pairing required — auto-approving");
@@ -208,7 +213,12 @@ public sealed class SetupWizardRunner
                 if (provenanceCheck is not null)
                     return provenanceCheck;
                 client = CreateWizardClient(credential, identityPath, wsLogger);
-                connection = await PairOperatorStep.WaitForConnectionOrPairing(client, _ctx, TimeSpan.FromSeconds(20), ct);
+                connection = await PairOperatorStep.WaitForConnectionOrPairing(
+                    client,
+                    _ctx,
+                    TimeSpan.FromSeconds(20),
+                    ct,
+                    allowInstalledVersionDiscovery: true);
             }
 
             if (connection != PairOperatorStep.ConnectionOutcome.Connected)
@@ -242,7 +252,8 @@ public sealed class SetupWizardRunner
                 _ctx,
                 TimeSpan.FromSeconds(30),
                 ct,
-                retryGatewayStartupDisconnects: true);
+                retryGatewayStartupDisconnects: true,
+                allowInstalledVersionDiscovery: true);
             if (connection != PairOperatorStep.ConnectionOutcome.Connected)
             {
                 return StepResult.Fail(
@@ -310,7 +321,8 @@ public sealed class SetupWizardRunner
                         _ctx,
                         TimeSpan.FromSeconds(30),
                         ct,
-                        retryGatewayStartupDisconnects: true);
+                        retryGatewayStartupDisconnects: true,
+                        allowInstalledVersionDiscovery: true);
                     if (reconnect != PairOperatorStep.ConnectionOutcome.Connected)
                     {
                         throw new WizardFatalException(
@@ -352,7 +364,8 @@ public sealed class SetupWizardRunner
                         _ctx,
                         TimeSpan.FromSeconds(30),
                         ct,
-                        retryGatewayStartupDisconnects: true);
+                        retryGatewayStartupDisconnects: true,
+                        allowInstalledVersionDiscovery: true);
                     if (reconnect != PairOperatorStep.ConnectionOutcome.Connected)
                         throw new WizardFatalException($"Gateway wizard reconnect failed after restart: {reconnect}");
 

--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -31,6 +31,13 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
         "operator.talk.secrets",
         "operator.write"
     ];
+    private static readonly string[] s_operatorBoundedBootstrapScopes =
+    [
+        "operator.approvals",
+        "operator.read",
+        "operator.talk.secrets",
+        "operator.write"
+    ];
 
     // Tracked state
     private readonly Dictionary<string, SessionInfo> _sessions = new();
@@ -104,6 +111,7 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
     private readonly bool _bootstrapPairAsNode;
     private readonly bool _ignoreStoredDeviceToken;
     private readonly bool _persistHandshakeDeviceTokens;
+    private bool _useBoundedBootstrapScopes;
 
     /// <summary>True when the gateway reported "pairing required" for this device.</summary>
     public bool IsPairingRequired => Volatile.Read(ref _pairingRequiredAwaitingApproval);
@@ -2047,7 +2055,9 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
             if (!_tokenIsBootstrapToken)
                 return s_operatorScopes;
 
-            return s_operatorBootstrapScopes;
+            return _useBoundedBootstrapScopes
+                ? s_operatorBoundedBootstrapScopes
+                : s_operatorBootstrapScopes;
         }
 
         return _deviceIdentity.DeviceTokenScopes is { Count: > 0 } scopes
@@ -2263,7 +2273,7 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
         if (root.TryGetProperty("ok", out var okProp) &&
             okProp.ValueKind == JsonValueKind.False)
         {
-            HandleRequestError(requestMethod, root);
+            HandleRequestError(requestMethod, root, sourceConnectionGeneration);
             return;
         }
 
@@ -2602,7 +2612,10 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
             _ => null
         };
 
-    private void HandleRequestError(string? method, JsonElement root)
+    private void HandleRequestError(
+        string? method,
+        JsonElement root,
+        long sourceConnectionGeneration)
     {
         var message = TryGetErrorMessage(root) ?? "request failed";
         var detailCode = method == "connect" ? TryGetErrorDetailCode(root) : null;
@@ -2621,6 +2634,18 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
             var rawJson = root.ToString() ?? "";
             if (rawJson.Length > 500) rawJson = rawJson[..500] + "...";
             _logger.Info($"[HANDSHAKE] Raw error response: {rawJson}");
+        }
+
+        if (method == "connect" &&
+            _tokenIsBootstrapToken &&
+            !_useBoundedBootstrapScopes &&
+            string.Equals(GetConnectRole(), OperatorRole, StringComparison.Ordinal) &&
+            IsBootstrapTokenInvalid(message, topLevelCode, detailCode))
+        {
+            _useBoundedBootstrapScopes = true;
+            _logger.Warn("[HANDSHAKE] Full bootstrap profile rejected; retrying once with bounded scopes.");
+            AbortCurrentWebSocket(sourceConnectionGeneration);
+            return;
         }
 
         if (method == "connect" &&
@@ -2946,6 +2971,16 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
                errorMessage.Contains("too many failed", StringComparison.OrdinalIgnoreCase) ||
                errorMessage.Contains("bootstrap token invalid", StringComparison.OrdinalIgnoreCase);
     }
+
+    private static bool IsBootstrapTokenInvalid(
+        string message,
+        string? topLevelCode,
+        string? detailCode) =>
+        message.Contains("bootstrap token invalid", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(topLevelCode, "AUTH_BOOTSTRAP_TOKEN_INVALID", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(topLevelCode, "bootstrap_token_invalid", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(detailCode, "AUTH_BOOTSTRAP_TOKEN_INVALID", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(detailCode, "bootstrap_token_invalid", StringComparison.OrdinalIgnoreCase);
 
     private static bool IsTerminalAuthDetailCode(string? code) => code is
         "AUTH_TOKEN_MISMATCH" or "AUTH_BOOTSTRAP_TOKEN_INVALID" or

--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -25,6 +25,7 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
     ];
     private static readonly string[] s_operatorBootstrapScopes =
     [
+        "operator.admin",
         "operator.approvals",
         "operator.read",
         "operator.talk.secrets",
@@ -2041,9 +2042,8 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
         if (!HasUsableOperatorDeviceToken)
         {
             // Shared gateway token (non-bootstrap) → request admin scope.
-            // Bootstrap tokens are opaque and can carry limited profiles, so keep
-            // the initial request bounded. Later shared-token finalization can
-            // request the full operator scope set when the gateway permits it.
+            // Bootstrap tokens carry their own server-enforced profile. Full
+            // setup tokens grant admin; limited tokens strip it.
             if (!_tokenIsBootstrapToken)
                 return s_operatorScopes;
 

--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -25,7 +25,6 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
     ];
     private static readonly string[] s_operatorBootstrapScopes =
     [
-        "operator.admin",
         "operator.approvals",
         "operator.read",
         "operator.talk.secrets",
@@ -2042,8 +2041,9 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
         if (!HasUsableOperatorDeviceToken)
         {
             // Shared gateway token (non-bootstrap) → request admin scope.
-            // Bootstrap tokens enforce their own server-side profile, which strips
-            // admin from limited setup codes.
+            // Bootstrap tokens are opaque and can carry limited profiles, so keep
+            // the initial request bounded. Later shared-token finalization can
+            // request the full operator scope set when the gateway permits it.
             if (!_tokenIsBootstrapToken)
                 return s_operatorScopes;
 

--- a/tests/OpenClaw.SetupEngine.Tests/GatewayInstallPolicyTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/GatewayInstallPolicyTests.cs
@@ -344,4 +344,27 @@ public sealed class GatewayInstallPolicyTests
             config,
             GatewayCompatibilityFailureKind.ProtocolMismatch));
     }
+
+    [Fact]
+    public void ConfiguredFallback_DoesNotReplaceCustomInstallerVersion()
+    {
+        var config = new SetupConfig
+        {
+            Gateway = new GatewayConfig
+            {
+                InstallUrl = "https://example.test/install.sh",
+                Version = "2026.9.1",
+                InstalledVersion = "2026.9.1",
+                FallbackVersion = "2026.6.34"
+            }
+        };
+
+        Assert.False(GatewayInstallPolicy.CanRetryWithFallback(
+            config,
+            GatewayCompatibilityFailureKind.ProtocolMismatch));
+        Assert.False(GatewayInstallPolicy.TryApplyFallback(config, out var error));
+        Assert.Contains("Custom Gateway installers", error, StringComparison.Ordinal);
+        Assert.Equal("2026.9.1", config.Gateway.Version);
+        Assert.Equal("2026.9.1", config.Gateway.InstalledVersion);
+    }
 }

--- a/tests/OpenClaw.SetupEngine.Tests/GatewayInstallPolicyTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/GatewayInstallPolicyTests.cs
@@ -237,6 +237,66 @@ public sealed class GatewayInstallPolicyTests
     }
 
     [Fact]
+    public void ValidateHandshake_WizardOnlyAdoptsAuthenticatedServerVersion()
+    {
+        var config = new SetupConfig
+        {
+            Gateway = new GatewayConfig { Version = "latest" }
+        };
+
+        var error = GatewayInstallPolicy.ValidateHandshake(
+            config,
+            new GatewaySelfInfo
+            {
+                Protocol = GatewayInstallPolicy.ProtocolGeneration,
+                ServerVersion = "2026.9.1"
+            },
+            allowInstalledVersionDiscovery: true);
+
+        Assert.Null(error);
+        Assert.Equal("2026.9.1", config.Gateway.InstalledVersion);
+    }
+
+    [Fact]
+    public void ValidateHandshake_WizardOnlyRejectsConfiguredVersionMismatch()
+    {
+        var config = new SetupConfig
+        {
+            Gateway = new GatewayConfig { Version = "2026.8.1" }
+        };
+
+        var error = GatewayInstallPolicy.ValidateHandshake(
+            config,
+            new GatewaySelfInfo
+            {
+                Protocol = GatewayInstallPolicy.ProtocolGeneration,
+                ServerVersion = "2026.9.1"
+            },
+            allowInstalledVersionDiscovery: true);
+
+        Assert.Equal(GatewayCompatibilityFailureKind.InstalledVersionMismatch, error?.Kind);
+        Assert.Null(config.Gateway.InstalledVersion);
+    }
+
+    [Fact]
+    public void ValidateHandshake_WizardOnlyRejectsNonPackageServerVersion()
+    {
+        var config = new SetupConfig();
+
+        var error = GatewayInstallPolicy.ValidateHandshake(
+            config,
+            new GatewaySelfInfo
+            {
+                Protocol = GatewayInstallPolicy.ProtocolGeneration,
+                ServerVersion = "dev"
+            },
+            allowInstalledVersionDiscovery: true);
+
+        Assert.Equal(GatewayCompatibilityFailureKind.InvalidPolicy, error?.Kind);
+        Assert.Null(config.Gateway.InstalledVersion);
+    }
+
+    [Fact]
     public void ConfiguredFallback_IsOfferedOnlyForTypedCompatibilityFailures()
     {
         var config = new SetupConfig

--- a/tests/OpenClaw.SetupEngine.Tests/GatewayInstallPolicyTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/GatewayInstallPolicyTests.cs
@@ -110,11 +110,10 @@ public sealed class GatewayInstallPolicyTests
     }
 
     [Theory]
-    [InlineData("recommended", "2026.6.34")]
-    [InlineData("fallback", "2026.6.11")]
-    public void ValidateAndApply_CustomInstallerPreservesVersionlessLegacyPin(
-        string selection,
-        string expectedVersion)
+    [InlineData("recommended")]
+    [InlineData("fallback")]
+    public void ValidateAndApply_CustomInstallerRejectsVersionlessLegacySelection(
+        string selection)
     {
         var config = new SetupConfig
         {
@@ -125,10 +124,32 @@ public sealed class GatewayInstallPolicyTests
             }
         };
 
+        var error = Assert.Throws<GatewayCompatibilityException>(
+            () => GatewayInstallPolicy.ValidateAndApply(config));
+
+        Assert.Equal(GatewayCompatibilityFailureKind.InvalidPolicy, error.Kind);
+    }
+
+    [Theory]
+    [InlineData("recommended")]
+    [InlineData("fallback")]
+    public void ValidateAndApply_CustomInstallerPreservesExplicitLegacyVersion(
+        string selection)
+    {
+        var config = new SetupConfig
+        {
+            Gateway = new GatewayConfig
+            {
+                InstallUrl = "https://example.test/install.sh",
+                Selection = selection,
+                Version = "2026.6.34"
+            }
+        };
+
         GatewayInstallPolicy.ValidateAndApply(config);
 
         Assert.Null(config.Gateway.Selection);
-        Assert.Equal(expectedVersion, config.Gateway.Version);
+        Assert.Equal("2026.6.34", config.Gateway.Version);
     }
 
     [Fact]

--- a/tests/OpenClaw.SetupEngine.Tests/ProgramArgumentTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/ProgramArgumentTests.cs
@@ -506,4 +506,66 @@ public sealed class ProgramArgumentTests : IDisposable
         Assert.True(document.RootElement.TryGetProperty("requiresRestart", out var requiresRestart));
         Assert.True(requiresRestart.GetBoolean());
     }
+
+    [Fact]
+    public void SerializeJsonOutput_IncludesConfiguredFallbackForCompatibilityFailure()
+    {
+        var config = new SetupConfig
+        {
+            Gateway = new GatewayConfig
+            {
+                Version = "latest",
+                FallbackVersion = "2026.8.1",
+                InstalledVersion = "2026.9.1"
+            }
+        };
+        var result = new PipelineResult(PipelineOutcome.Failed, "pair-operator")
+        {
+            CompatibilityFailure = GatewayCompatibilityFailureKind.ProtocolMismatch
+        };
+
+        var json = Program.SerializeJsonOutput(result, config, "journal.json");
+
+        using var document = JsonDocument.Parse(json);
+        Assert.Equal(
+            "2026.8.1",
+            document.RootElement.GetProperty("fallbackGatewayVersion").GetString());
+    }
+
+    [Fact]
+    public void CompatibilityFallbackMessage_NamesConfiguredExactVersion()
+    {
+        var config = new SetupConfig
+        {
+            Gateway = new GatewayConfig
+            {
+                Version = "latest",
+                FallbackVersion = "2026.8.1",
+                InstalledVersion = "2026.9.1"
+            }
+        };
+
+        var message = Program.BuildCompatibilityFallbackMessage(
+            config,
+            GatewayCompatibilityFailureKind.ServerVersionMismatch);
+
+        Assert.Contains("2026.8.1", message, StringComparison.Ordinal);
+        Assert.Contains("Gateway.Version", message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CompatibilityFallbackMessage_DoesNotOfferFallbackForRuntimeMismatch()
+    {
+        var config = new SetupConfig
+        {
+            Gateway = new GatewayConfig { FallbackVersion = "2026.8.1" }
+        };
+
+        var message = Program.BuildCompatibilityFallbackMessage(
+            config,
+            GatewayCompatibilityFailureKind.InstalledRuntimeMismatch);
+
+        Assert.DoesNotContain("To retry", message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("No configured Gateway fallback", message, StringComparison.Ordinal);
+    }
 }

--- a/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
@@ -2049,7 +2049,7 @@ public class SetupStepsTests : IDisposable
                     ? Ok()
                     : throw new InvalidOperationException($"Unexpected command: {command}"));
         var config = new SetupConfig();
-        GatewayReleasePolicy.ResolveAndApply(config);
+        GatewayInstallPolicy.ValidateAndApply(config);
         var ctx = CreateContext(config, commands);
 
         var result = await new InstallCliStep().ExecuteAsync(ctx, CancellationToken.None);

--- a/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
@@ -840,6 +840,48 @@ public class OpenClawGatewayClientTests
     }
 
     [Fact]
+    public void OperatorConnect_BootstrapProfileRejection_RetriesOnceWithBoundedScopes()
+    {
+        var helper = new GatewayClientTestHelper(tokenIsBootstrapToken: true);
+        helper.SetDeviceTokenForTest(null);
+
+        Assert.Contains("operator.admin", helper.GetRequestedOperatorScopes());
+
+        helper.TrackPendingRequest("req-bootstrap-full", "connect");
+        helper.ProcessRawMessage("""
+        {
+          "type": "res",
+          "id": "req-bootstrap-full",
+          "ok": false,
+          "error": {
+            "code": "AUTH_BOOTSTRAP_TOKEN_INVALID",
+            "message": "bootstrap token invalid"
+          }
+        }
+        """);
+
+        Assert.False(helper.Client.IsAuthFailed);
+        Assert.Equal(
+            ["operator.approvals", "operator.read", "operator.talk.secrets", "operator.write"],
+            helper.GetRequestedOperatorScopes());
+
+        helper.TrackPendingRequest("req-bootstrap-bounded", "connect");
+        helper.ProcessRawMessage("""
+        {
+          "type": "res",
+          "id": "req-bootstrap-bounded",
+          "ok": false,
+          "error": {
+            "code": "AUTH_BOOTSTRAP_TOKEN_INVALID",
+            "message": "bootstrap token invalid"
+          }
+        }
+        """);
+
+        Assert.True(helper.Client.IsAuthFailed);
+    }
+
+    [Fact]
     public void OperatorConnect_FreshBootstrapDevice_StartsWithV2Signature()
     {
         var tmpDir = Path.Combine(Path.GetTempPath(), $"oca-gw-test-{Guid.NewGuid():N}");

--- a/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
@@ -821,7 +821,7 @@ public class OpenClawGatewayClientTests
     }
 
     [Fact]
-    public void OperatorConnect_FreshDevice_RequestsFullBootstrapProfileScopes()
+    public void OperatorConnect_FreshDevice_RequestsBoundedBootstrapScopes()
     {
         var helper = new GatewayClientTestHelper(tokenIsBootstrapToken: true);
         helper.SetDeviceTokenForTest(null);
@@ -830,9 +830,9 @@ public class OpenClawGatewayClientTests
         var auth = helper.BuildAuthPayload();
 
         Assert.Equal(
-            ["operator.admin", "operator.approvals", "operator.read", "operator.talk.secrets", "operator.write"],
+            ["operator.approvals", "operator.read", "operator.talk.secrets", "operator.write"],
             scopes);
-        Assert.Contains("operator.admin", scopes);
+        Assert.DoesNotContain("operator.admin", scopes);
         Assert.DoesNotContain("operator.pairing", scopes);
         Assert.Equal("test-token", auth["bootstrapToken"]);
         Assert.False(auth.ContainsKey("token"));

--- a/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
@@ -821,7 +821,7 @@ public class OpenClawGatewayClientTests
     }
 
     [Fact]
-    public void OperatorConnect_FreshDevice_RequestsBoundedBootstrapScopes()
+    public void OperatorConnect_FreshDevice_RequestsFullBootstrapProfileScopes()
     {
         var helper = new GatewayClientTestHelper(tokenIsBootstrapToken: true);
         helper.SetDeviceTokenForTest(null);
@@ -830,9 +830,9 @@ public class OpenClawGatewayClientTests
         var auth = helper.BuildAuthPayload();
 
         Assert.Equal(
-            ["operator.approvals", "operator.read", "operator.talk.secrets", "operator.write"],
+            ["operator.admin", "operator.approvals", "operator.read", "operator.talk.secrets", "operator.write"],
             scopes);
-        Assert.DoesNotContain("operator.admin", scopes);
+        Assert.Contains("operator.admin", scopes);
         Assert.DoesNotContain("operator.pairing", scopes);
         Assert.Equal("test-token", auth["bootstrapToken"]);
         Assert.False(auth.ContainsKey("token"));

--- a/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
@@ -1311,6 +1311,21 @@ public sealed class AppRefactorContractTests
     }
 
     [Fact]
+    public void CompletePage_OffersConfiguredFallbackOnlyThroughTypedCompatibilityPath()
+    {
+        var root = TestRepositoryPaths.GetRepositoryRoot();
+        var setupWindow = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.SetupEngine.UI", "SetupWindow.xaml.cs"));
+        var complete = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.SetupEngine.UI", "Pages", "CompletePage.xaml.cs"));
+        var progress = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.SetupEngine.UI", "Pages", "ProgressPage.xaml.cs"));
+
+        Assert.Contains("result.CompatibilityFailure", progress);
+        Assert.Contains("GatewayInstallPolicy.CanRetryWithFallback(_config, failureKind)", setupWindow);
+        Assert.Contains("GatewayInstallPolicy.TryApplyFallback(_config, out error)", setupWindow);
+        Assert.Contains("Retry with fallback {args.GatewayFallbackVersion}", complete);
+        Assert.Contains("FallbackButton.Visibility = args.CanRetryGatewayFallback", complete);
+    }
+
+    [Fact]
     public void CompletePage_OffersTypedRestartChoiceWithoutForcingApplicationsClosed()
     {
         var root = TestRepositoryPaths.GetRepositoryRoot();


### PR DESCRIPTION
## Summary

Follow up immediately on #1312 (improve(setup): install latest stable Gateway from npm), which merged the original remote contributor head after workflow-scope restrictions prevented the reviewed maintainer repairs from being pushed.

This PR applies the reviewed repair stack directly to the new `main`:

- request the full bootstrap profile required for normal setup, with a one-time bounded-scope retry when the gateway explicitly rejects a limited bootstrap profile;
- allow wizard-only setup to adopt an authenticated protocol-v4 server version while preserving strict install-time equality checks;
- require custom installer URLs to provide an explicit exact stable version;
- restore configured fallback recovery for typed compatibility failures in WinUI and headless output;
- retarget CI classification from deleted `GatewayReleasePolicy.cs` to `GatewayInstallPolicy.cs`;
- fix the merged compile break in the newer installer diagnostic test;
- align protocol, migration, and agent guidance with the implemented behavior.

## Required proof pools

- `windows-wsl-gateway-e2e`: current-head setup, bootstrap, pairing, recovery, and Gateway behavior.
- `windows-wsl-mxc`: current-head Gateway to Windows node containment proof where MXC cannot skip.

## Validation

- `.\build.ps1`: passed on the preceding full-profile correction
- Adaptive bootstrap focused tests: 2 passed
- Previous full local run on the preceding commit: 3,943 Shared tests with 32 environment-gated skips, 2,865 Tray tests, and 1,118 SetupEngine tests passed
- `.\scripts\test-ci-change-classifier.ps1`: passed
- Earlier repair commits passed structured autoreview and rubber-duck review

A fresh full required local rerun, structured review of the adaptive change, and hosted CI are in progress on the current head.

## Real behavior proof

- The first hosted run proved a bounded-only request is incorrect: all seven setup/connect failures showed normal setup lacked `operator.admin`.
- The adaptive correction first requests the full profile required by normal setup. If the gateway explicitly returns `AUTH_BOOTSTRAP_TOKEN_INVALID` for a limited profile, Windows reconnects once with the bounded scopes shared by both profiles. A second rejection remains a terminal authentication failure.
- Local `validate-mxc-e2e.ps1` reaches the real setup harness but is blocked before the changed code runs because this host's `wsl --install` cannot attach `%LOCALAPPDATA%\Temp\swap.vhdx` (`Access is denied`).
- Crabbox proof was abandoned at maintainer direction after its WSL controller prerequisite stalled.
- Current-head hosted setup/connect, revocation-recovery, and network-recovery success remain the final merge gate.

## Compatibility and security

- Normal install-time handshake validation remains fail closed.
- Wizard-only version discovery requires protocol v4 and an exact reported package version; an exact configured version must match.
- Custom installers cannot inherit or synthesize product fallback/recommendation versions.
- Full bootstrap tokens retain admin authority. Limited bootstrap tokens receive one explicit bounded-profile compatibility retry and remain server-enforced.

Fixes the post-merge regressions from #1312 (improve(setup): install latest stable Gateway from npm).