### PR TITLE
fix(setup): verify gateway listener service ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,0 @@
-# Changelog
-
-## Unreleased
-
-- Fix local gateway setup rejecting its own newly started service as a port conflict. Verify the service PID and include available process names for genuine conflicts. Related context: #547 from @ranjeshj.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+
+- Fix local gateway setup rejecting its own newly started service as a port conflict. Verify the service PID and include available process names for genuine conflicts. Related context: #547 from @ranjeshj.

--- a/docs/SETUP_ENGINE_REDESIGN.md
+++ b/docs/SETUP_ENGINE_REDESIGN.md
@@ -201,6 +201,14 @@ Executed sequentially. Each step is a small class (30–120 lines) in its own fi
 | 23 | `WindowsNodeBootstrapContextStep` | Inject Windows-node context into the WSL workspace `AGENTS.md` |
 | 24 | `StartKeepaliveStep` | Background WSL keepalive to prevent VM shutdown |
 
+The Windows port preflight requires a free port before installation. Installing
+the gateway service can start it immediately, so the subsequent WSL port check
+accepts listeners only when every reported owner PID matches the installed
+`openclaw-gateway.service` systemd `MainPID` in the configured distro. A process
+name such as `node` or `openclaw` alone is insufficient. Conflicts retain the
+port-in-use error and include owning process names when available. Missing
+listener ownership or a failed listener inspection does not bypass the check.
+
 ### Step Base Class
 
 ```csharp

--- a/src/OpenClaw.SetupEngine/PreflightPortStep.cs
+++ b/src/OpenClaw.SetupEngine/PreflightPortStep.cs
@@ -1,12 +1,6 @@
-using System.Diagnostics;
 using System.Net;
-using System.Net.Http;
 using System.Net.Sockets;
-using System.Runtime.InteropServices;
-using System.Security.Cryptography;
-using System.Text.Json;
 using OpenClaw.Connection;
-using OpenClaw.Shared;
 
 namespace OpenClaw.SetupEngine;
 
@@ -30,7 +24,13 @@ public sealed class PreflightPortStep : SetupStep
         foreach (var address in addresses)
         {
             if (!CanBind(address, port, out var error))
-                return StepResult.Fail($"Port {port} is already in use for {DescribeBind(address)} ({error.SocketErrorCode})");
+            {
+                var owners = string.Join(", ", WindowsTcpListenerSnapshot.Capture().Listeners
+                    .Where(listener => listener.Port == port && listener.Address.AddressFamily == address.AddressFamily)
+                    .Select(listener => listener.ProcessName).Where(name => !string.IsNullOrWhiteSpace(name)).Distinct());
+                return StepResult.Fail($"Port {port} is already in use for {DescribeBind(address)} ({error.SocketErrorCode})" +
+                    (owners.Length > 0 ? $". Owning process: {owners}." : ""));
+            }
         }
 
         return StepResult.Ok($"Port {port} is available");

--- a/src/OpenClaw.SetupEngine/StartGatewayStep.cs
+++ b/src/OpenClaw.SetupEngine/StartGatewayStep.cs
@@ -1,12 +1,4 @@
-using System.Diagnostics;
-using System.Net;
-using System.Net.Http;
-using System.Net.Sockets;
-using System.Runtime.InteropServices;
-using System.Security.Cryptography;
-using System.Text.Json;
-using OpenClaw.Connection;
-using OpenClaw.Shared;
+using System.Text.RegularExpressions;
 
 namespace OpenClaw.SetupEngine;
 
@@ -36,19 +28,32 @@ public sealed class StartGatewayStep : SetupStep
         if (!restart)
         {
             var portCheck = await ctx.Commands.RunInWslAsync(
-                distro, $"ss -tlnp 2>/dev/null | grep ':{ctx.Config.GatewayPort}\\b' || true",
+                distro, $"ss -H -ltnp 'sport = :{ctx.Config.GatewayPort}'",
                 TimeSpan.FromSeconds(10), ct: ct);
 
-            if (!string.IsNullOrWhiteSpace(portCheck.Stdout) && portCheck.Stdout.Contains($":{ctx.Config.GatewayPort}"))
+            if (portCheck.ExitCode != 0)
+                return StepResult.Fail($"Could not inspect gateway port {ctx.Config.GatewayPort} (exit {portCheck.ExitCode}).");
+
+            if (!string.IsNullOrWhiteSpace(portCheck.Stdout))
             {
-                if (!portCheck.Stdout.Contains("openclaw", StringComparison.OrdinalIgnoreCase))
+                // Installation may already start the service. Process names (including node) are not ownership proof.
+                var service = await ctx.Commands.RunInWslAsync(
+                    distro, "systemctl --user show openclaw-gateway.service -p MainPID --value",
+                    TimeSpan.FromSeconds(10), ct: ct);
+                var listeners = portCheck.Stdout.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                if (service.ExitCode != 0 || !int.TryParse(service.Stdout.Trim(), out var pid) || pid <= 0 ||
+                    listeners.Any(line => Regex.Matches(line, @"pid=(\d+),") is var owners &&
+                        (owners.Count == 0 || owners.Any(owner => owner.Groups[1].Value != pid.ToString()))))
                 {
-                    ctx.Logger.Warn($"Port {ctx.Config.GatewayPort} is in use by another process:\n{portCheck.Stdout.Trim()}");
+                    var names = string.Join(", ", Regex.Matches(portCheck.Stdout, "\\(\\\"([^\\\"]+)\\\",")
+                        .Select(owner => owner.Groups[1].Value).Distinct());
+                    var ownerDetail = names.Length > 0 ? $" Owning process: {names}." : "";
+                    ctx.Logger.Warn($"Port {ctx.Config.GatewayPort} is in use by another process.{ownerDetail}");
                     return StepResult.Fail(
-                        $"Port {ctx.Config.GatewayPort} is already in use by another process. Either stop the conflicting process or change GatewayPort in the setup config.");
+                        $"Port {ctx.Config.GatewayPort} is already in use by another process.{ownerDetail} Either stop the conflicting process or change GatewayPort in the setup config.");
                 }
 
-                ctx.Logger.Info($"Port {ctx.Config.GatewayPort} appears to be in use by openclaw — proceeding");
+                ctx.Logger.Info($"Port {ctx.Config.GatewayPort} is owned by openclaw-gateway.service (PID {pid}). Post-install port check succeeded.");
             }
         }
 

--- a/src/OpenClaw.SetupEngine/StartGatewayStep.cs
+++ b/src/OpenClaw.SetupEngine/StartGatewayStep.cs
@@ -32,7 +32,11 @@ public sealed class StartGatewayStep : SetupStep
                 TimeSpan.FromSeconds(10), ct: ct);
 
             if (portCheck.ExitCode != 0)
-                return StepResult.Fail($"Could not inspect gateway port {ctx.Config.GatewayPort} (exit {portCheck.ExitCode}).");
+            {
+                return StepResult.Fail(
+                    $"Could not inspect gateway port {ctx.Config.GatewayPort} " +
+                    $"(exit {portCheck.ExitCode}){FormatCommandDetail(portCheck)}.");
+            }
 
             if (!string.IsNullOrWhiteSpace(portCheck.Stdout))
             {
@@ -40,17 +44,50 @@ public sealed class StartGatewayStep : SetupStep
                 var service = await ctx.Commands.RunInWslAsync(
                     distro, "systemctl --user show openclaw-gateway.service -p MainPID --value",
                     TimeSpan.FromSeconds(10), ct: ct);
+                if (service.ExitCode != 0)
+                {
+                    return StepResult.Fail(
+                        "Could not inspect openclaw-gateway.service MainPID " +
+                        $"(exit {service.ExitCode}){FormatCommandDetail(service)}.");
+                }
+
+                if (!int.TryParse(service.Stdout.Trim(), out var pid) || pid <= 0)
+                {
+                    return StepResult.Fail(
+                        "openclaw-gateway.service is not running with a valid MainPID" +
+                        $"{FormatCommandDetail(service)}.");
+                }
+
                 var listeners = portCheck.Stdout.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-                if (service.ExitCode != 0 || !int.TryParse(service.Stdout.Trim(), out var pid) || pid <= 0 ||
-                    listeners.Any(line => Regex.Matches(line, @"pid=(\d+),") is var owners &&
-                        (owners.Count == 0 || owners.Any(owner => owner.Groups[1].Value != pid.ToString()))))
+                var listenerOwners = listeners
+                    .Select(line => Regex.Matches(line, @"pid=(\d+),")
+                        .Select(owner => owner.Groups[1].Value)
+                        .ToArray())
+                    .ToArray();
+                if (listenerOwners.Any(owners => owners.Length == 0))
+                {
+                    return StepResult.Fail(
+                        $"Could not determine which process owns gateway port {ctx.Config.GatewayPort}. " +
+                        "Verify the WSL listener and openclaw-gateway.service status, then retry setup.");
+                }
+
+                var expectedPid = pid.ToString();
+                var foreignPids = listenerOwners
+                    .SelectMany(owners => owners)
+                    .Where(ownerPid => !string.Equals(ownerPid, expectedPid, StringComparison.Ordinal))
+                    .Distinct(StringComparer.Ordinal)
+                    .ToArray();
+                if (foreignPids.Length > 0)
                 {
                     var names = string.Join(", ", Regex.Matches(portCheck.Stdout, "\\(\\\"([^\\\"]+)\\\",")
                         .Select(owner => owner.Groups[1].Value).Distinct());
                     var ownerDetail = names.Length > 0 ? $" Owning process: {names}." : "";
-                    ctx.Logger.Warn($"Port {ctx.Config.GatewayPort} is in use by another process.{ownerDetail}");
-                    return StepResult.Fail(
-                        $"Port {ctx.Config.GatewayPort} is already in use by another process.{ownerDetail} Either stop the conflicting process or change GatewayPort in the setup config.");
+                    var failure =
+                        $"Port {ctx.Config.GatewayPort} is already in use by another process. " +
+                        $"Listener PIDs outside openclaw-gateway.service: {string.Join(", ", foreignPids)}." +
+                        ownerDetail;
+                    ctx.Logger.Warn(failure);
+                    return StepResult.Fail($"{failure} Either stop the conflicting process or change GatewayPort in the setup config.");
                 }
 
                 ctx.Logger.Info($"Port {ctx.Config.GatewayPort} is owned by openclaw-gateway.service (PID {pid}). Post-install port check succeeded.");
@@ -87,6 +124,18 @@ public sealed class StartGatewayStep : SetupStep
         }
 
         return await WaitForHealthAsync(ctx, ct);
+    }
+
+    private static string FormatCommandDetail(CommandResult result)
+    {
+        var detail = string.IsNullOrWhiteSpace(result.Stderr)
+            ? result.Stdout.Trim()
+            : result.Stderr.Trim();
+        if (string.IsNullOrWhiteSpace(detail))
+            return "";
+
+        detail = detail.ReplaceLineEndings(" ");
+        return $": {(detail.Length <= 240 ? detail : detail[..240] + "...")}";
     }
 
     internal static async Task<StepResult> WaitForHealthAsync(

--- a/tests/OpenClaw.E2ETests/Setup/SetupAndConnectTests.cs
+++ b/tests/OpenClaw.E2ETests/Setup/SetupAndConnectTests.cs
@@ -1,5 +1,3 @@
-using System.Net;
-using System.Net.Sockets;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using OpenClaw.E2ETests;
@@ -193,21 +191,23 @@ public class SetupAndConnectTests
 
         var proofLogPath = Path.Combine(_fixture.ArtifactDir, "service-owned-gateway-start.jsonl");
         var config = SetupConfig.LoadFromFile(_fixture.ConfigPath);
-        using var logger = new SetupLogger(proofLogPath, LogLevel.Trace);
-        using var journal = new TransactionJournal(filePath: null, logger);
-        var context = new SetupContext(
-            config,
-            logger,
-            journal,
-            new CommandRunner(logger),
-            CancellationToken.None,
-            _fixture.DataDir,
-            _fixture.LocalAppDataRoot)
+        StepResult result;
+        using (var logger = new SetupLogger(proofLogPath, LogLevel.Trace))
+        using (var journal = new TransactionJournal(filePath: null, logger))
         {
-            DistroName = _fixture.DistroName,
-        };
-
-        var result = await new StartGatewayStep().ExecuteAsync(context, CancellationToken.None);
+            var context = new SetupContext(
+                config,
+                logger,
+                journal,
+                new CommandRunner(logger),
+                CancellationToken.None,
+                _fixture.DataDir,
+                _fixture.LocalAppDataRoot)
+            {
+                DistroName = _fixture.DistroName,
+            };
+            result = await new StartGatewayStep().ExecuteAsync(context, CancellationToken.None);
+        }
 
         Assert.True(result.IsSuccess, result.Message);
         var proofLog = await File.ReadAllTextAsync(proofLogPath);
@@ -221,12 +221,17 @@ public class SetupAndConnectTests
     public async Task FullSetup_ForeignWslListener_IsRejectedBeforeGatewayStart()
     {
         var config = SetupConfig.LoadFromFile(_fixture.ConfigPath);
-        var port = GetFreeTcpPort();
         var nodePath = $"/home/{config.Wsl.User}/.openclaw/tools/node/bin/node";
+        var proofId = Guid.NewGuid().ToString("N");
+        var portPath = $"/tmp/openclaw-foreign-listener-{proofId}.port";
+        var logPath = $"/tmp/openclaw-foreign-listener-{proofId}.log";
+        var nodeScript =
+            $"const fs=require(\"fs\"),net=require(\"net\");const server=net.createServer();" +
+            $"server.listen(0,\"127.0.0.1\",()=>fs.writeFileSync(\"{portPath}\",String(server.address().port)))";
         var start = await _fixture.RunInWslAsync(
             $"""
-            nohup '{nodePath}' -e 'require("net").createServer().listen({port}, "127.0.0.1")' \
-              >/tmp/openclaw-foreign-listener-{port}.log 2>&1 </dev/null &
+            rm -f '{portPath}' '{logPath}'
+            nohup '{nodePath}' -e '{nodeScript}' >'{logPath}' 2>&1 </dev/null &
             echo $!
             """,
             TimeSpan.FromSeconds(15),
@@ -236,6 +241,28 @@ public class SetupAndConnectTests
 
         try
         {
+            string? publishedPort = null;
+            for (var attempt = 0; attempt < 50; attempt++)
+            {
+                var portResult = await _fixture.RunInWslAsync(
+                    $"cat '{portPath}' 2>/dev/null || true",
+                    TimeSpan.FromSeconds(15));
+                if (int.TryParse(portResult.Stdout.Trim(), out _))
+                {
+                    publishedPort = portResult.Stdout.Trim();
+                    break;
+                }
+                await Task.Delay(100);
+            }
+            if (!int.TryParse(publishedPort, out var port))
+            {
+                var startupLog = await _fixture.RunInWslAsync(
+                    $"cat '{logPath}' 2>/dev/null || true",
+                    TimeSpan.FromSeconds(15));
+                Assert.Fail($"Foreign listener did not publish a port. Log: {startupLog.Stdout} {startupLog.Stderr}");
+                return;
+            }
+
             OpenClaw.SetupEngine.CommandResult? listeners = null;
             for (var attempt = 0; attempt < 20; attempt++)
             {
@@ -279,16 +306,9 @@ public class SetupAndConnectTests
         finally
         {
             _ = await _fixture.RunInWslAsync(
-                $"kill {foreignPid} 2>/dev/null || true",
+                $"kill {foreignPid} 2>/dev/null || true; rm -f '{portPath}' '{logPath}'",
                 TimeSpan.FromSeconds(15));
         }
-    }
-
-    private static int GetFreeTcpPort()
-    {
-        using var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        return ((IPEndPoint)listener.LocalEndpoint).Port;
     }
 
     private static string ResolveNodeCommandsAllowKey()

--- a/tests/OpenClaw.E2ETests/Setup/SetupAndConnectTests.cs
+++ b/tests/OpenClaw.E2ETests/Setup/SetupAndConnectTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using OpenClaw.E2ETests;
@@ -223,45 +224,41 @@ public class SetupAndConnectTests
         var config = SetupConfig.LoadFromFile(_fixture.ConfigPath);
         var nodePath = $"/home/{config.Wsl.User}/.openclaw/tools/node/bin/node";
         var proofId = Guid.NewGuid().ToString("N");
-        var portPath = $"/tmp/openclaw-foreign-listener-{proofId}.port";
-        var logPath = $"/tmp/openclaw-foreign-listener-{proofId}.log";
+        var statePath = $"/tmp/openclaw-foreign-listener-{proofId}.state";
         var nodeScript =
             $"const fs=require(\"fs\"),net=require(\"net\");const server=net.createServer();" +
-            $"server.listen(0,\"127.0.0.1\",()=>fs.writeFileSync(\"{portPath}\",String(server.address().port)))";
-        var start = await _fixture.RunInWslAsync(
-            $"""
-            rm -f '{portPath}' '{logPath}'
-            nohup '{nodePath}' -e '{nodeScript}' >'{logPath}' 2>&1 </dev/null &
-            echo $!
-            """,
-            TimeSpan.FromSeconds(15),
-            inputViaStdin: true);
-        AssertCommandSucceeded(start, "start foreign WSL listener");
-        Assert.True(int.TryParse(start.Stdout.Trim(), out var foreignPid) && foreignPid > 0);
+            $"server.listen(0,\"127.0.0.1\",()=>fs.writeFileSync(\"{statePath}\",process.pid+\" \"+server.address().port))";
+        _ = await _fixture.RunInWslAsync($"rm -f '{statePath}'", TimeSpan.FromSeconds(15));
+        using var foreignProcess = StartWslProcess(_fixture.DistroName, nodePath, nodeScript);
+        var foreignPid = 0;
 
         try
         {
-            string? publishedPort = null;
+            var port = 0;
             for (var attempt = 0; attempt < 50; attempt++)
             {
-                var portResult = await _fixture.RunInWslAsync(
-                    $"cat '{portPath}' 2>/dev/null || true",
+                var stateResult = await _fixture.RunInWslAsync(
+                    $"cat '{statePath}' 2>/dev/null || true",
                     TimeSpan.FromSeconds(15));
-                if (int.TryParse(portResult.Stdout.Trim(), out _))
+                var values = stateResult.Stdout.Split(
+                    ' ',
+                    StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                if (values.Length == 2 &&
+                    int.TryParse(values[0], out foreignPid) &&
+                    int.TryParse(values[1], out port) &&
+                    foreignPid > 0 &&
+                    port > 0)
                 {
-                    publishedPort = portResult.Stdout.Trim();
                     break;
+                }
+                if (foreignProcess.HasExited)
+                {
+                    var stderr = await foreignProcess.StandardError.ReadToEndAsync();
+                    Assert.Fail($"Foreign listener exited before publishing its state: {stderr}");
                 }
                 await Task.Delay(100);
             }
-            if (!int.TryParse(publishedPort, out var port))
-            {
-                var startupLog = await _fixture.RunInWslAsync(
-                    $"cat '{logPath}' 2>/dev/null || true",
-                    TimeSpan.FromSeconds(15));
-                Assert.Fail($"Foreign listener did not publish a port. Log: {startupLog.Stdout} {startupLog.Stderr}");
-                return;
-            }
+            Assert.True(foreignPid > 0 && port > 0, "Foreign listener did not publish a PID and port.");
 
             OpenClaw.SetupEngine.CommandResult? listeners = null;
             for (var attempt = 0; attempt < 20; attempt++)
@@ -305,10 +302,41 @@ public class SetupAndConnectTests
         }
         finally
         {
-            _ = await _fixture.RunInWslAsync(
-                $"kill {foreignPid} 2>/dev/null || true; rm -f '{portPath}' '{logPath}'",
-                TimeSpan.FromSeconds(15));
+            if (foreignPid > 0)
+            {
+                _ = await _fixture.RunInWslAsync(
+                    $"kill {foreignPid} 2>/dev/null || true; rm -f '{statePath}'",
+                    TimeSpan.FromSeconds(15));
+            }
+            try
+            {
+                await foreignProcess.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(5));
+            }
+            catch (TimeoutException)
+            {
+                foreignProcess.Kill(entireProcessTree: true);
+            }
         }
+    }
+
+    private static Process StartWslProcess(string distroName, string executable, string argument)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "wsl.exe",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        startInfo.Environment["WSL_UTF8"] = "1";
+        startInfo.ArgumentList.Add("-d");
+        startInfo.ArgumentList.Add(distroName);
+        startInfo.ArgumentList.Add("--");
+        startInfo.ArgumentList.Add(executable);
+        startInfo.ArgumentList.Add("-e");
+        startInfo.ArgumentList.Add(argument);
+        return Process.Start(startInfo) ?? throw new InvalidOperationException("Could not start the foreign WSL listener.");
     }
 
     private static string ResolveNodeCommandsAllowKey()

--- a/tests/OpenClaw.E2ETests/Setup/SetupAndConnectTests.cs
+++ b/tests/OpenClaw.E2ETests/Setup/SetupAndConnectTests.cs
@@ -279,21 +279,23 @@ public class SetupAndConnectTests
 
             config.GatewayPort = port;
             var proofLogPath = Path.Combine(_fixture.ArtifactDir, "foreign-gateway-listener.jsonl");
-            using var logger = new SetupLogger(proofLogPath, LogLevel.Trace);
-            using var journal = new TransactionJournal(filePath: null, logger);
-            var context = new SetupContext(
-                config,
-                logger,
-                journal,
-                new CommandRunner(logger),
-                CancellationToken.None,
-                _fixture.DataDir,
-                _fixture.LocalAppDataRoot)
+            StepResult result;
+            using (var logger = new SetupLogger(proofLogPath, LogLevel.Trace))
+            using (var journal = new TransactionJournal(filePath: null, logger))
             {
-                DistroName = _fixture.DistroName,
-            };
-
-            var result = await new StartGatewayStep().ExecuteAsync(context, CancellationToken.None);
+                var context = new SetupContext(
+                    config,
+                    logger,
+                    journal,
+                    new CommandRunner(logger),
+                    CancellationToken.None,
+                    _fixture.DataDir,
+                    _fixture.LocalAppDataRoot)
+                {
+                    DistroName = _fixture.DistroName,
+                };
+                result = await new StartGatewayStep().ExecuteAsync(context, CancellationToken.None);
+            }
 
             Assert.False(result.IsSuccess);
             Assert.Contains($"Port {port} is already in use by another process.", result.Message);

--- a/tests/OpenClaw.E2ETests/Setup/SetupAndConnectTests.cs
+++ b/tests/OpenClaw.E2ETests/Setup/SetupAndConnectTests.cs
@@ -1,4 +1,7 @@
+using System.Net;
+using System.Net.Sockets;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using OpenClaw.E2ETests;
 using OpenClaw.SetupEngine;
 using OpenClaw.Shared;
@@ -165,6 +168,127 @@ public class SetupAndConnectTests
         var identityDir = Path.Combine(_fixture.DataDir, "gateways", gateway.ActiveId);
         Assert.True(Directory.Exists(identityDir), $"Expected identity directory: {identityDir}");
         Assert.Contains(Directory.EnumerateFiles(identityDir), path => Path.GetFileName(path).Contains("device-key", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [E2EFact]
+    public async Task FullSetup_AlreadyRunningGateway_IsRecognizedAsServiceOwned()
+    {
+        var listeners = await _fixture.RunInWslAsync(
+            $"ss -H -ltnp 'sport = :{_fixture.GatewayPort}'",
+            TimeSpan.FromSeconds(15));
+        AssertCommandSucceeded(listeners, "inspect running gateway listeners");
+
+        var mainPid = await _fixture.RunInWslAsync(
+            "systemctl --user show openclaw-gateway.service -p MainPID --value",
+            TimeSpan.FromSeconds(15));
+        AssertCommandSucceeded(mainPid, "read gateway service MainPID");
+
+        var parsedMainPid = mainPid.Stdout.Trim();
+        Assert.True(int.TryParse(parsedMainPid, out var pid) && pid > 0, $"Invalid gateway MainPID: {parsedMainPid}");
+        var listenerPids = Regex.Matches(listeners.Stdout, @"pid=(\d+),")
+            .Select(match => int.Parse(match.Groups[1].Value))
+            .ToArray();
+        Assert.NotEmpty(listenerPids);
+        Assert.All(listenerPids, listenerPid => Assert.Equal(pid, listenerPid));
+
+        var proofLogPath = Path.Combine(_fixture.ArtifactDir, "service-owned-gateway-start.jsonl");
+        var config = SetupConfig.LoadFromFile(_fixture.ConfigPath);
+        using var logger = new SetupLogger(proofLogPath, LogLevel.Trace);
+        using var journal = new TransactionJournal(filePath: null, logger);
+        var context = new SetupContext(
+            config,
+            logger,
+            journal,
+            new CommandRunner(logger),
+            CancellationToken.None,
+            _fixture.DataDir,
+            _fixture.LocalAppDataRoot)
+        {
+            DistroName = _fixture.DistroName,
+        };
+
+        var result = await new StartGatewayStep().ExecuteAsync(context, CancellationToken.None);
+
+        Assert.True(result.IsSuccess, result.Message);
+        var proofLog = await File.ReadAllTextAsync(proofLogPath);
+        Assert.Contains(
+            $"Port {_fixture.GatewayPort} is owned by openclaw-gateway.service (PID {pid}).",
+            proofLog,
+            StringComparison.Ordinal);
+    }
+
+    [E2EFact]
+    public async Task FullSetup_ForeignWslListener_IsRejectedBeforeGatewayStart()
+    {
+        var config = SetupConfig.LoadFromFile(_fixture.ConfigPath);
+        var port = GetFreeTcpPort();
+        var nodePath = $"/home/{config.Wsl.User}/.openclaw/tools/node/bin/node";
+        var start = await _fixture.RunInWslAsync(
+            $"""
+            nohup '{nodePath}' -e 'require("net").createServer().listen({port}, "127.0.0.1")' \
+              >/tmp/openclaw-foreign-listener-{port}.log 2>&1 </dev/null &
+            echo $!
+            """,
+            TimeSpan.FromSeconds(15),
+            inputViaStdin: true);
+        AssertCommandSucceeded(start, "start foreign WSL listener");
+        Assert.True(int.TryParse(start.Stdout.Trim(), out var foreignPid) && foreignPid > 0);
+
+        try
+        {
+            OpenClaw.SetupEngine.CommandResult? listeners = null;
+            for (var attempt = 0; attempt < 20; attempt++)
+            {
+                listeners = await _fixture.RunInWslAsync(
+                    $"ss -H -ltnp 'sport = :{port}'",
+                    TimeSpan.FromSeconds(15));
+                if (listeners.ExitCode == 0 &&
+                    listeners.Stdout.Contains($"pid={foreignPid},", StringComparison.Ordinal))
+                {
+                    break;
+                }
+                await Task.Delay(100);
+            }
+            var verifiedListeners = Assert.IsType<OpenClaw.SetupEngine.CommandResult>(listeners);
+            AssertCommandSucceeded(verifiedListeners, "inspect foreign WSL listener");
+            Assert.Contains($"pid={foreignPid},", verifiedListeners.Stdout, StringComparison.Ordinal);
+
+            config.GatewayPort = port;
+            var proofLogPath = Path.Combine(_fixture.ArtifactDir, "foreign-gateway-listener.jsonl");
+            using var logger = new SetupLogger(proofLogPath, LogLevel.Trace);
+            using var journal = new TransactionJournal(filePath: null, logger);
+            var context = new SetupContext(
+                config,
+                logger,
+                journal,
+                new CommandRunner(logger),
+                CancellationToken.None,
+                _fixture.DataDir,
+                _fixture.LocalAppDataRoot)
+            {
+                DistroName = _fixture.DistroName,
+            };
+
+            var result = await new StartGatewayStep().ExecuteAsync(context, CancellationToken.None);
+
+            Assert.False(result.IsSuccess);
+            Assert.Contains($"Port {port} is already in use by another process.", result.Message);
+            var proofLog = await File.ReadAllTextAsync(proofLogPath);
+            Assert.DoesNotContain("openclaw gateway start", proofLog, StringComparison.Ordinal);
+        }
+        finally
+        {
+            _ = await _fixture.RunInWslAsync(
+                $"kill {foreignPid} 2>/dev/null || true",
+                TimeSpan.FromSeconds(15));
+        }
+    }
+
+    private static int GetFreeTcpPort()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        return ((IPEndPoint)listener.LocalEndpoint).Port;
     }
 
     private static string ResolveNodeCommandsAllowKey()

--- a/tests/OpenClaw.E2ETests/Setup/SetupAndConnectTests.cs
+++ b/tests/OpenClaw.E2ETests/Setup/SetupAndConnectTests.cs
@@ -193,12 +193,34 @@ public class SetupAndConnectTests
             installResult = await new InstallGatewayServiceStep().ExecuteAsync(
                 context,
                 CancellationToken.None);
+            Assert.True(installResult.IsSuccess, installResult.Message);
+
+            var listenerDeadline = DateTimeOffset.UtcNow.AddSeconds(30);
+            OpenClaw.SetupEngine.CommandResult? listeners = null;
+            while (DateTimeOffset.UtcNow < listenerDeadline)
+            {
+                listeners = await _fixture.RunInWslAsync(
+                    $"ss -H -ltnp 'sport = :{_fixture.GatewayPort}'",
+                    TimeSpan.FromSeconds(15));
+                if (listeners.ExitCode == 0 &&
+                    !string.IsNullOrWhiteSpace(listeners.Stdout))
+                {
+                    break;
+                }
+
+                await Task.Delay(250);
+            }
+            var observedListeners = Assert.IsType<OpenClaw.SetupEngine.CommandResult>(listeners);
+            AssertCommandSucceeded(observedListeners, "wait for installed gateway listener");
+            Assert.False(
+                string.IsNullOrWhiteSpace(observedListeners.Stdout),
+                "The installed gateway service did not open its configured listener.");
+
             startResult = await new StartGatewayStep().ExecuteAsync(
                 context,
                 CancellationToken.None);
         }
 
-        Assert.True(installResult.IsSuccess, installResult.Message);
         Assert.True(startResult.IsSuccess, startResult.Message);
 
         var mainPid = await _fixture.RunInWslAsync(

--- a/tests/OpenClaw.E2ETests/Setup/SetupAndConnectTests.cs
+++ b/tests/OpenClaw.E2ETests/Setup/SetupAndConnectTests.cs
@@ -172,27 +172,10 @@ public class SetupAndConnectTests
     [E2EFact]
     public async Task FullSetup_AlreadyRunningGateway_IsRecognizedAsServiceOwned()
     {
-        var listeners = await _fixture.RunInWslAsync(
-            $"ss -H -ltnp 'sport = :{_fixture.GatewayPort}'",
-            TimeSpan.FromSeconds(15));
-        AssertCommandSucceeded(listeners, "inspect running gateway listeners");
-
-        var mainPid = await _fixture.RunInWslAsync(
-            "systemctl --user show openclaw-gateway.service -p MainPID --value",
-            TimeSpan.FromSeconds(15));
-        AssertCommandSucceeded(mainPid, "read gateway service MainPID");
-
-        var parsedMainPid = mainPid.Stdout.Trim();
-        Assert.True(int.TryParse(parsedMainPid, out var pid) && pid > 0, $"Invalid gateway MainPID: {parsedMainPid}");
-        var listenerPids = Regex.Matches(listeners.Stdout, @"pid=(\d+),")
-            .Select(match => int.Parse(match.Groups[1].Value))
-            .ToArray();
-        Assert.NotEmpty(listenerPids);
-        Assert.All(listenerPids, listenerPid => Assert.Equal(pid, listenerPid));
-
         var proofLogPath = Path.Combine(_fixture.ArtifactDir, "service-owned-gateway-start.jsonl");
         var config = SetupConfig.LoadFromFile(_fixture.ConfigPath);
-        StepResult result;
+        StepResult installResult;
+        StepResult startResult;
         using (var logger = new SetupLogger(proofLogPath, LogLevel.Trace))
         using (var journal = new TransactionJournal(filePath: null, logger))
         {
@@ -207,10 +190,24 @@ public class SetupAndConnectTests
             {
                 DistroName = _fixture.DistroName,
             };
-            result = await new StartGatewayStep().ExecuteAsync(context, CancellationToken.None);
+            installResult = await new InstallGatewayServiceStep().ExecuteAsync(
+                context,
+                CancellationToken.None);
+            startResult = await new StartGatewayStep().ExecuteAsync(
+                context,
+                CancellationToken.None);
         }
 
-        Assert.True(result.IsSuccess, result.Message);
+        Assert.True(installResult.IsSuccess, installResult.Message);
+        Assert.True(startResult.IsSuccess, startResult.Message);
+
+        var mainPid = await _fixture.RunInWslAsync(
+            "systemctl --user show openclaw-gateway.service -p MainPID --value",
+            TimeSpan.FromSeconds(15));
+        AssertCommandSucceeded(mainPid, "read gateway service MainPID");
+        var parsedMainPid = mainPid.Stdout.Trim();
+        Assert.True(int.TryParse(parsedMainPid, out var pid) && pid > 0, $"Invalid gateway MainPID: {parsedMainPid}");
+
         var proofLog = await File.ReadAllTextAsync(proofLogPath);
         Assert.Contains(
             $"Port {_fixture.GatewayPort} is owned by openclaw-gateway.service (PID {pid}).",

--- a/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
@@ -4080,6 +4080,100 @@ public class SetupStepsTests : IDisposable
             decision.Result.Message);
     }
 
+    [Theory]
+    [InlineData("node", "321", true)]
+    [InlineData("openclaw-gateway", "321", true)]
+    [InlineData("node", "999", false)]
+    [InlineData("other-openclaw", "999", false)]
+    [InlineData("python3", "0", false)]
+    [InlineData("node", "", false)]
+    public async Task StartGateway_AfterFreePortAndInstall_RequiresServiceOwnedListener(
+        string processName, string mainPid, bool expectedSuccess)
+    {
+        var port = GetFreeTcpPort();
+        var installed = false;
+        var commands = new FakeCommandRunner(
+            _ => throw new InvalidOperationException("Unexpected Windows command"),
+            (_, command, _) =>
+            {
+                if (command.Contains("openclaw gateway install --force"))
+                {
+                    installed = true;
+                    return Ok();
+                }
+                Assert.True(installed);
+                return command switch
+                {
+                    var value when value == $"ss -H -ltnp 'sport = :{port}'" =>
+                        Ok($"LISTEN 0 511 127.0.0.1:{port} 0.0.0.0:* users:((\"{processName}\",pid=321,fd=22))"),
+                    "systemctl --user show openclaw-gateway.service -p MainPID --value" => Ok(mainPid),
+                    var value when value.Contains("openclaw gateway start") => Ok(),
+                    var value when value.Contains("curl -s") => Ok("200"),
+                    _ => throw new InvalidOperationException($"Unexpected command: {command}"),
+                };
+            });
+        var ctx = CreateContext(new SetupConfig { GatewayPort = port }, commands);
+        ctx.DistroName = "test-distro";
+
+        Assert.True((await new PreflightPortStep().ExecuteAsync(ctx, CancellationToken.None)).IsSuccess);
+        Assert.True((await new InstallGatewayServiceStep().ExecuteAsync(ctx, CancellationToken.None)).IsSuccess);
+        var result = await new StartGatewayStep().ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(expectedSuccess, result.IsSuccess);
+        Assert.All(commands.WslCalls, call => Assert.Equal(ctx.DistroName, call.DistroName));
+        if (!expectedSuccess)
+        {
+            Assert.Contains($"Port {port} is already in use by another process.", result.Message);
+            Assert.Contains($"Owning process: {processName}.", result.Message);
+            Assert.DoesNotContain(commands.WslCalls, call => call.Command.Contains("openclaw gateway start") || call.Command.Contains("curl -s"));
+        }
+    }
+
+    [Theory]
+    [InlineData("", "0", 0, true)]
+    [InlineData("LISTEN 0 511 127.0.0.1:18789 *:*", "321", 0, false)]
+    [InlineData("LISTEN 0 511 127.0.0.1:18789 *:* users:((\"node\",pid=321,fd=22))\nLISTEN 0 511 [::1]:18789 *:* users:((\"python3\",pid=999,fd=23))", "321", 0, false)]
+    [InlineData("LISTEN 0 511 127.0.0.1:18789 *:* users:((\"node\",pid=321,fd=22),(\"python3\",pid=999,fd=23))", "321", 0, false)]
+    [InlineData("", "321", 1, false)]
+    public async Task StartGateway_PortInspection_RejectsUnownedOrUnreadableListeners(
+        string listeners, string mainPid, int inspectionExitCode, bool expectedSuccess)
+    {
+        var commands = new FakeCommandRunner(_ => Ok(), (_, command, _) => command switch
+        {
+            var value when value.StartsWith("ss -H") => new CommandResult(inspectionExitCode, listeners, "", TimeSpan.Zero, false),
+            var value when value.StartsWith("systemctl --user show") => Ok(mainPid),
+            var value when value.Contains("openclaw gateway start") => Ok(),
+            var value when value.Contains("curl -s") => Ok("200"),
+            _ => throw new InvalidOperationException($"Unexpected command: {command}"),
+        });
+        var ctx = CreateContext(commands: commands);
+        ctx.DistroName = "test-distro";
+
+        var result = await new StartGatewayStep().ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(expectedSuccess, result.IsSuccess);
+    }
+
+    [Fact]
+    public async Task PreflightPort_ForeignListener_BlocksBeforeServiceInstall()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0) { ExclusiveAddressUse = true };
+        listener.Start();
+        var commands = new FakeCommandRunner(_ => throw new InvalidOperationException("Must not install"));
+        var ctx = CreateContext(new SetupConfig { GatewayPort = ((IPEndPoint)listener.LocalEndpoint).Port }, commands);
+
+        var result = await new PreflightPortStep().ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains("already in use", result.Message);
+        if (OperatingSystem.IsWindows())
+        {
+            using var process = System.Diagnostics.Process.GetCurrentProcess();
+            Assert.Contains(process.ProcessName, result.Message);
+        }
+        Assert.Empty(commands.WslCalls);
+    }
+
     [Fact]
     public async Task StartGateway_RestartUsesRestartCommandAndWaitsForHealth()
     {
@@ -4102,7 +4196,7 @@ public class SetupStepsTests : IDisposable
         Assert.True(result.IsSuccess, result.Message);
         Assert.DoesNotContain(
             commands.WslCalls,
-            call => call.Command.Contains("ss -tlnp"));
+            call => call.Command.StartsWith("ss "));
         Assert.Contains(
             commands.WslCalls,
             call => call.Command.Contains("openclaw gateway restart"));

--- a/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
@@ -4081,14 +4081,14 @@ public class SetupStepsTests : IDisposable
     }
 
     [Theory]
-    [InlineData("node", "321", true)]
-    [InlineData("openclaw-gateway", "321", true)]
-    [InlineData("node", "999", false)]
-    [InlineData("other-openclaw", "999", false)]
-    [InlineData("python3", "0", false)]
-    [InlineData("node", "", false)]
+    [InlineData("node", "321", true, null)]
+    [InlineData("openclaw-gateway", "321", true, null)]
+    [InlineData("node", "999", false, "already in use by another process")]
+    [InlineData("other-openclaw", "999", false, "already in use by another process")]
+    [InlineData("python3", "0", false, "valid MainPID")]
+    [InlineData("node", "", false, "valid MainPID")]
     public async Task StartGateway_AfterFreePortAndInstall_RequiresServiceOwnedListener(
-        string processName, string mainPid, bool expectedSuccess)
+        string processName, string mainPid, bool expectedSuccess, string? expectedFailure)
     {
         var port = GetFreeTcpPort();
         var installed = false;
@@ -4123,25 +4123,43 @@ public class SetupStepsTests : IDisposable
         Assert.All(commands.WslCalls, call => Assert.Equal(ctx.DistroName, call.DistroName));
         if (!expectedSuccess)
         {
-            Assert.Contains($"Port {port} is already in use by another process.", result.Message);
-            Assert.Contains($"Owning process: {processName}.", result.Message);
+            Assert.Contains(expectedFailure!, result.Message);
             Assert.DoesNotContain(commands.WslCalls, call => call.Command.Contains("openclaw gateway start") || call.Command.Contains("curl -s"));
         }
     }
 
     [Theory]
-    [InlineData("", "0", 0, true)]
-    [InlineData("LISTEN 0 511 127.0.0.1:18789 *:*", "321", 0, false)]
-    [InlineData("LISTEN 0 511 127.0.0.1:18789 *:* users:((\"node\",pid=321,fd=22))\nLISTEN 0 511 [::1]:18789 *:* users:((\"python3\",pid=999,fd=23))", "321", 0, false)]
-    [InlineData("LISTEN 0 511 127.0.0.1:18789 *:* users:((\"node\",pid=321,fd=22),(\"python3\",pid=999,fd=23))", "321", 0, false)]
-    [InlineData("", "321", 1, false)]
+    [InlineData("", "0", 0, 0, true, null)]
+    [InlineData("LISTEN 0 511 127.0.0.1:18789 *:* users:((\"node\",pid=321,fd=22))\nLISTEN 0 511 [::1]:18789 *:* users:((\"node\",pid=321,fd=23))", "321", 0, 0, true, null)]
+    [InlineData("LISTEN 0 511 127.0.0.1:18789 *:*", "321", 0, 0, false, "Could not determine which process owns")]
+    [InlineData("LISTEN 0 511 127.0.0.1:18789 *:* users:((\"node\",pid=321,fd=22))\nLISTEN 0 511 [::1]:18789 *:* users:((\"python3\",pid=999,fd=23))", "321", 0, 0, false, "Listener PIDs outside openclaw-gateway.service: 999")]
+    [InlineData("LISTEN 0 511 127.0.0.1:18789 *:* users:((\"node\",pid=321,fd=22),(\"python3\",pid=999,fd=23))", "321", 0, 0, false, "Listener PIDs outside openclaw-gateway.service: 999")]
+    [InlineData("LISTEN 0 511 127.0.0.1:18789 *:* users:((\"node\",pid=321,fd=22))", "321", 1, 0, false, "ss unavailable")]
+    [InlineData("LISTEN 0 511 127.0.0.1:18789 *:* users:((\"node\",pid=321,fd=22))", "321", 0, 1, false, "service unavailable")]
+    [InlineData("LISTEN 0 511 127.0.0.1:18789 *:* users:((\"node\",pid=321,fd=22))", "abc", 0, 0, false, "valid MainPID: abc")]
+    [InlineData("LISTEN 0 511 127.0.0.1:18789 *:* users:((\"node\",pid=321,fd=22))", "-1", 0, 0, false, "valid MainPID: -1")]
     public async Task StartGateway_PortInspection_RejectsUnownedOrUnreadableListeners(
-        string listeners, string mainPid, int inspectionExitCode, bool expectedSuccess)
+        string listeners,
+        string mainPid,
+        int inspectionExitCode,
+        int serviceExitCode,
+        bool expectedSuccess,
+        string? expectedMessage)
     {
         var commands = new FakeCommandRunner(_ => Ok(), (_, command, _) => command switch
         {
-            var value when value.StartsWith("ss -H") => new CommandResult(inspectionExitCode, listeners, "", TimeSpan.Zero, false),
-            var value when value.StartsWith("systemctl --user show") => Ok(mainPid),
+            var value when value.StartsWith("ss -H") => new CommandResult(
+                inspectionExitCode,
+                listeners,
+                inspectionExitCode == 0 ? "" : "ss unavailable",
+                TimeSpan.Zero,
+                false),
+            var value when value.StartsWith("systemctl --user show") => new CommandResult(
+                serviceExitCode,
+                mainPid,
+                serviceExitCode == 0 ? "" : "service unavailable",
+                TimeSpan.Zero,
+                false),
             var value when value.Contains("openclaw gateway start") => Ok(),
             var value when value.Contains("curl -s") => Ok("200"),
             _ => throw new InvalidOperationException($"Unexpected command: {command}"),
@@ -4152,6 +4170,8 @@ public class SetupStepsTests : IDisposable
         var result = await new StartGatewayStep().ExecuteAsync(ctx, CancellationToken.None);
 
         Assert.Equal(expectedSuccess, result.IsSuccess);
+        if (!expectedSuccess)
+            Assert.Contains(expectedMessage!, result.Message);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Current-main replacement for #1349 (fix(setup): recognize the gateway service on its own port after install), preserving Peter Steinberger's diagnosis and PID-based ownership design without carrying the stale September 7 branch history.

The installer may start `openclaw-gateway.service` before `StartGatewayStep`. The real listener process is commonly named `node`, so process-name matching falsely reports that setup's own service is a foreign port conflict.

This replacement:

- queries the exact configured listener with `ss -H -ltnp 'sport = :<port>'`;
- requires a positive systemd user-service `MainPID`;
- accepts the occupied port only when every parsed listener PID exactly matches that `MainPID`;
- fails closed for command failure, invalid service state, missing ownership, or mixed/foreign listeners;
- surfaces distinct diagnostics and captured command details for those failure classes;
- includes process names and foreign PIDs in genuine conflict messages;
- exercises the production `InstallGatewayServiceStep` followed by `StartGatewayStep` in the real WSL E2E path.

## Required proof pools

- `windows-wsl-gateway-e2e`: required for the real install-service, listener-ownership, health, pairing, and setup path.
- `windows-wsl-mxc`: requested setup/connect closeout. Local and prior Azure attempts are blocked because no available host combines working WSL setup with the required unaugmented MXC BaseContainer tier.

## Validation

Current head: `e5684501`.

- focused `StartGateway` and `PreflightPort` tests: 20 passed
- `.\build.ps1`: passed
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore`: 3,944 passed, 32 environment-gated skips
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore`: 2,865 passed
- `dotnet test .\tests\OpenClaw.SetupEngine.Tests\OpenClaw.SetupEngine.Tests.csproj --no-restore`: 1,134 passed
- `dotnet build .\tests\OpenClaw.E2ETests\OpenClaw.E2ETests.csproj -c Debug -r win-x64 --no-restore`: passed, 0 warnings/errors
- `git diff --check`: passed
- final autoreview against current `origin/main`: clean, no actionable findings, confidence 0.87

Two unrelated baseline timing tests each failed once during repeated local full-suite runs: `McpHttpServerTests.Dispose_DuringInFlightHandler_DoesNotSurfaceObjectDisposedException` and `OpenClawChatDataProviderTests.QueuedSend_LifecycleStartBeforeAck_PromotesByIdempotencyKey`. Each passed five consecutive focused reruns; the final complete closeout above is green.

The first hosted run also hit unrelated tray integration failures in `CanvasNavigate_ReturnsNavigated` and `SystemRun_Where_ReturnsExpectedOutput`. Neither surface is changed by this five-file setup PR.

## Real behavior proof

Prior exact-head #1349 proof on Gateway `2026.6.34` passed both production-path behaviors:

- service-owned listeners were accepted only when every listener PID matched `MainPID`;
- a foreign WSL Node listener was rejected before `openclaw gateway start`.

This replacement rebases the behavior onto `main` after #1312 (improve(setup): install latest stable Gateway from npm) and #1381 (fix(setup): complete npm latest Gateway landing). Its E2E reruns `openclaw gateway install --force` through `InstallGatewayServiceStep`, waits only until a listener exists, then invokes `StartGatewayStep`, which remains the code that proves ownership. The first hosted run exposed and fixed an E2E timing gap where the step ran before the installed service had opened its port.

Local `.\scripts\validate-mxc-e2e.ps1` remains blocked before distro creation because WSL cannot attach its temporary `swap.vhdx` (`E_ACCESSDENIED`). The ownership behavior itself is covered by the current production-path unit tests and must pass the hosted setup/connect shard before merge.

## Adversarial review

- Codex review: no CRITICAL, HIGH, MEDIUM, or LOW correctness/security findings.
- Opus review: no fail-open path; accepted improvements for distinct diagnostics, service-query/dual-stack/invalid-PID coverage, and the real install→start E2E sequence.
- Rejected as out of scope: replacing exact `MainPID` equality with speculative future cgroup topology support, and changing the separate runtime provenance service in this setup-only PR.

## Security impact

No credential authority changes. The check runs before bootstrap minting and pairing. Unknown, unreadable, or conflicting listeners remain blocked; process names are diagnostics only and never authorize ownership.

Supersedes #1349 (fix(setup): recognize the gateway service on its own port after install).