### PR TITLE
fix(local-ai): add non-destructive recovery

### DIFF
--- a/src/OpenClaw.Connection/GatewayRecord.cs
+++ b/src/OpenClaw.Connection/GatewayRecord.cs
@@ -113,7 +113,7 @@ public static class GatewayRecordEditing
         return result;
     }
 
-    internal static bool AreEquivalentLoopbackEndpoints(string? left, string? right)
+    public static bool AreEquivalentLoopbackEndpoints(string? left, string? right)
     {
         if (!Uri.TryCreate(left, UriKind.Absolute, out var leftUri) ||
             !Uri.TryCreate(right, UriKind.Absolute, out var rightUri) ||
@@ -179,6 +179,16 @@ public static class GatewayRecordEditing
         }
 
         return distro;
+    }
+
+    public static bool IsSetupManagedLocalRecord(GatewayRecord record)
+    {
+        if (record.SshTunnel is not null)
+            return false;
+
+        return ResolveManagedDistroName(record) is not null &&
+            (record.IsLocal ||
+             OpenClaw.Shared.LocalGatewayUrlClassifier.IsLocalGatewayUrl(record.Url));
     }
 
     private static string? ParseLegacyManagedDistroName(string? friendlyName)

--- a/src/OpenClaw.SetupEngine.UI/Pages/CapabilitiesPage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/CapabilitiesPage.xaml.cs
@@ -36,6 +36,7 @@ public sealed partial class CapabilitiesPage : Page
     private readonly LocalAiSetupAvailabilityCoordinator _localAiAvailability = new();
     private bool _treatBundledAllOnAsPlaceholder;
     private bool _forceLocalAiNetworkingConsent;
+    private bool _localAiRecoveryOnly;
     private CancellationTokenSource? _tailscaleStatusCancellation;
     private int _tailscaleStatusGeneration;
     private int _step = 1;
@@ -74,7 +75,8 @@ public sealed partial class CapabilitiesPage : Page
 
     protected override void OnNavigatedTo(NavigationEventArgs e)
     {
-        _config = e.Parameter as SetupConfig ?? new SetupConfig();
+        var args = e.Parameter as CapabilitiesPageArgs;
+        _config = args?.Config ?? e.Parameter as SetupConfig ?? new SetupConfig();
         // The tray always registers device.info/status with Node Mode. Keep the
         // setup declaration and gateway allowlist aligned with that runtime contract.
         _config.Capabilities.Device = true;
@@ -105,7 +107,10 @@ public sealed partial class CapabilitiesPage : Page
         TailscaleAuthModeSelector.SelectedIndex = _config.Tailscale.AuthMode == TailscaleAuthMode.AuthKey ? 1 : 0;
         UpdateTailscaleOptions();
         var previewPage = SetupPreview.RequestedPage;
-        var localAiReviewPreview = previewPage is "capabilities-review" or "capabilities-review-consent";
+        var localAiReviewPreview =
+            args?.StartAtLocalAiReview == true ||
+            previewPage is "capabilities-review" or "capabilities-review-consent";
+        _localAiRecoveryOnly = args?.StartAtLocalAiReview == true;
         _forceLocalAiNetworkingConsent = previewPage == "capabilities-review-consent";
         if (localAiReviewPreview)
             _config.LocalAi.Enabled = true;
@@ -214,6 +219,12 @@ public sealed partial class CapabilitiesPage : Page
 
     private void Back_Click(object sender, RoutedEventArgs e)
     {
+        if (_localAiRecoveryOnly)
+        {
+            SetupWindow.Active?.NavigateToWelcome(back: true);
+            return;
+        }
+
         if (_step <= 1)
         {
             // First capability step — step back to the Welcome screen.
@@ -781,8 +792,9 @@ public sealed partial class CapabilitiesPage : Page
         // below immediately, without needing Continue to advance on incomplete information.
         PrimaryButton.IsEnabled =
             _step != 3 ||
-            LocalAiToggle.IsOn != true ||
-            (_localAiSelectionEligible &&
+            (!_localAiRecoveryOnly && LocalAiToggle.IsOn != true) ||
+            (LocalAiToggle.IsOn == true &&
+             _localAiSelectionEligible &&
              (!_localAiNetworkingConsentRequired || LocalAiNetworkingConsentCheckBox.IsChecked == true));
     }
 

--- a/src/OpenClaw.SetupEngine.UI/Pages/CapabilitiesPage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/CapabilitiesPage.xaml.cs
@@ -37,6 +37,7 @@ public sealed partial class CapabilitiesPage : Page
     private bool _treatBundledAllOnAsPlaceholder;
     private bool _forceLocalAiNetworkingConsent;
     private bool _localAiRecoveryOnly;
+    private bool _localAiRecoveryModelPinned;
     private CancellationTokenSource? _tailscaleStatusCancellation;
     private int _tailscaleStatusGeneration;
     private int _step = 1;
@@ -111,6 +112,7 @@ public sealed partial class CapabilitiesPage : Page
             args?.StartAtLocalAiReview == true ||
             previewPage is "capabilities-review" or "capabilities-review-consent";
         _localAiRecoveryOnly = args?.StartAtLocalAiReview == true;
+        _localAiRecoveryModelPinned = args?.PinLocalAiModel == true;
         _forceLocalAiNetworkingConsent = previewPage == "capabilities-review-consent";
         if (localAiReviewPreview)
             _config.LocalAi.Enabled = true;
@@ -341,16 +343,26 @@ public sealed partial class CapabilitiesPage : Page
                 // model instead of leaving setup stuck on a known-incompatible selection. A
                 // merely busy GPU (EligibleButBusy) is not reconciled away: the same model would
                 // still work once the GPU frees up, and CanInstall already covers that case.
-                if (_config!.LocalAi.SelectedModelId is { } selectedModelId &&
-                    !LocalInferenceEligibility.Evaluate(_localAiHardware, selectedModelId).CanInstall)
+                if (_config!.LocalAi.SelectedModelId is { } selectedModelId)
                 {
-                    _config.LocalAi.SelectedModelId = null;
+                    LocalInferenceEligibilityResult selectedEligibility =
+                        LocalInferenceEligibility.Evaluate(_localAiHardware, selectedModelId);
+                    if (_localAiRecoveryModelPinned)
+                    {
+                        eligibility = selectedEligibility;
+                    }
+                    else if (!selectedEligibility.CanInstall)
+                    {
+                        _config.LocalAi.SelectedModelId = null;
+                    }
                 }
                 _config.LocalAi.SelectedModelId ??= _localAiRecommendedModelId ?? deviceEligibility.Plan.Model.Id;
 
-                eligibility = LocalInferenceEligibility.Evaluate(
-                    _localAiHardware,
-                    _config.LocalAi.SelectedModelId);
+                eligibility ??= LocalInferenceEligibility.Evaluate(
+                        _localAiHardware,
+                        _config.LocalAi.SelectedModelId);
+                if (_localAiRecoveryModelPinned && !eligibility.CanInstall)
+                    hardwareReason = DescribeLocalAiUnavailable(eligibility);
             }
         }
         catch (Exception ex)
@@ -480,16 +492,17 @@ public sealed partial class CapabilitiesPage : Page
     /// descendant's own IsEnabled value; setting LocalAiToggle.IsEnabled back to true alone would
     /// not make it clickable. Availability being merely pending (Checking/ProbeUnknown), not yet a
     /// definitive result, must not remove the user's only way out, so this restores hit-testing on
-    /// the shared container and re-enables just the toggle: turning Local AI off unblocks Continue
-    /// via the existing LocalAiToggle.IsOn != true branch, instead of ever letting Continue itself
-    /// bypass an as-yet-undetermined WSL networking-consent requirement. The other Local AI
-    /// controls (model selector, consent checkbox) stay genuinely non-interactive because their
-    /// own IsEnabled is still false, independent of the container's hit-testability.
+    /// the shared container and re-enables just the toggle outside recovery: turning Local AI off
+    /// unblocks Continue via the existing LocalAiToggle.IsOn != true branch, instead of ever
+    /// letting Continue itself bypass an as-yet-undetermined WSL networking-consent requirement.
+    /// Recovery requires Local AI to remain selected, so its toggle stays disabled. The other
+    /// Local AI controls (model selector, consent checkbox) stay genuinely non-interactive because
+    /// their own IsEnabled is still false, independent of the container's hit-testability.
     /// </summary>
     private void RestoreLocalAiToggleAsPendingStateEscapeHatch()
     {
         LocalAiOptionContent.IsHitTestVisible = true;
-        LocalAiToggle.IsEnabled = true;
+        LocalAiToggle.IsEnabled = !_localAiRecoveryOnly;
     }
 
     private void ShowLocalAiUnavailable(LocalAiSetupAvailabilitySnapshot snapshot)
@@ -581,8 +594,8 @@ public sealed partial class CapabilitiesPage : Page
     {
         LocalAiOptionContent.IsHitTestVisible = isAvailable;
         LocalAiOptionContent.Opacity = isAvailable ? 1 : 0.55;
-        LocalAiToggle.IsEnabled = isAvailable;
-        LocalAiModelSelector.IsEnabled = isAvailable;
+        LocalAiToggle.IsEnabled = isAvailable && !_localAiRecoveryOnly;
+        LocalAiModelSelector.IsEnabled = isAvailable && !_localAiRecoveryModelPinned;
         LocalAiNetworkingConsentCheckBox.IsEnabled = isAvailable;
         AutomationProperties.SetHelpText(
             LocalAiOptionContent,

--- a/src/OpenClaw.SetupEngine.UI/Pages/CapabilitiesPageArgs.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/CapabilitiesPageArgs.cs
@@ -1,0 +1,3 @@
+namespace OpenClaw.SetupEngine.UI.Pages;
+
+internal sealed record CapabilitiesPageArgs(SetupConfig Config, bool StartAtLocalAiReview);

--- a/src/OpenClaw.SetupEngine.UI/Pages/CapabilitiesPageArgs.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/CapabilitiesPageArgs.cs
@@ -1,3 +1,6 @@
 namespace OpenClaw.SetupEngine.UI.Pages;
 
-internal sealed record CapabilitiesPageArgs(SetupConfig Config, bool StartAtLocalAiReview);
+internal sealed record CapabilitiesPageArgs(
+    SetupConfig Config,
+    bool StartAtLocalAiReview,
+    bool PinLocalAiModel);

--- a/src/OpenClaw.SetupEngine.UI/Pages/ProgressPage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/ProgressPage.xaml.cs
@@ -14,6 +14,7 @@ namespace OpenClaw.SetupEngine.UI.Pages;
 internal sealed record ProgressPageArgs(
     SetupConfig Config,
     bool ShowMilestoneOnly,
+    bool LocalAiRecoveryOnly,
     string DataDir,
     string LocalDataDir);
 
@@ -29,6 +30,8 @@ public sealed partial class ProgressPage : Page
     private string _dataDir = null!;
     private string _localDataDir = null!;
     private Uri? _tailscaleAuthorizationUri;
+    private HashSet<string> _activeStepIds = [];
+    private bool _localAiRecoveryOnly;
     private const int MaxLogLines = 200;
 
     internal bool IsPipelineRunning => _runCts != null && !_pipelineFinished;
@@ -50,7 +53,7 @@ public sealed partial class ProgressPage : Page
         ("local-ai-wsl", "Verify Local AI access", ["verify-local-ai-wsl"]),
         ("tailscale-auth", "Connect Tailscale", ["install-tailscale", "authorize-tailscale"]),
         ("configure", "Configure gateway", ["configure-gateway", "configure-local-ai-gateway", "install-service"]),
-        ("start", "Start gateway", ["start-gateway", "mint-token"]),
+        ("start", "Start gateway", ["start-gateway", "restart-gateway", "mint-token"]),
         ("tailscale-serve", "Publish with Tailscale", ["finalize-tailscale-serve"]),
         ("pairing", "Pair device", ["pair-operator", "pair-node", "verify-e2e"]),
         ("finish", "Finish setup", ["run-wizard", "start-keepalive"]),
@@ -68,6 +71,10 @@ public sealed partial class ProgressPage : Page
         _config = args?.Config ?? e.Parameter as SetupConfig ?? new SetupConfig();
         _dataDir = args?.DataDir ?? SetupContext.ResolveDataDir();
         _localDataDir = args?.LocalDataDir ?? SetupContext.ResolveLocalDataDir();
+        _localAiRecoveryOnly = args?.LocalAiRecoveryOnly == true;
+        _activeStepIds = BuildSteps(_config, _localAiRecoveryOnly)
+            .Select(step => step.Id)
+            .ToHashSet(StringComparer.Ordinal);
         TitleText.Text = _config.LocalAi.Enabled ? "Setting up OpenClaw and Local AI" : "Setting up OpenClaw";
         SubtitleText.Text = _config.LocalAi.Enabled
             ? "Preparing the gateway and Local AI"
@@ -140,7 +147,8 @@ public sealed partial class ProgressPage : Page
                 showDetailProgress: groupId is "local-ai-engine" or "local-ai-model");
             _rows[groupId] = row;
             StepsPanel.Children.Add(row.Element);
-            if (_config?.LocalAi.Enabled != true && IsLocalAiOnlyGroup(stepIds))
+            if (!_activeStepIds.Overlaps(stepIds) ||
+                (_config?.LocalAi.Enabled != true && IsLocalAiOnlyGroup(stepIds)))
                 row.Element.Visibility = Visibility.Collapsed;
         }
     }
@@ -188,7 +196,7 @@ public sealed partial class ProgressPage : Page
             ctx.ExternalAuthorizationPresenter = new ProgressAuthorizationPresenter(DispatcherQueue, ShowTailscaleAuthorization);
             ctx.DetailProgress = new DirectProgress<SetupDetailProgressEvent>(OnDetailProgress);
 
-            var steps = BuildSteps(config);
+            var steps = BuildSteps(config, _localAiRecoveryOnly);
             _pipeline = new SetupPipeline(steps);
             _pipeline.StepProgress += OnStepProgress;
 
@@ -298,7 +306,7 @@ public sealed partial class ProgressPage : Page
                 _completedSteps.Add(e.StepId);
 
                 // If all steps in this group are done, mark group done
-                if (group.StepIds.All(id => _completedSteps.Contains(id)))
+                if (group.StepIds.Where(_activeStepIds.Contains).All(id => _completedSteps.Contains(id)))
                     row.SetStatus(StepStatus.Done);
             }
         });
@@ -379,8 +387,10 @@ public sealed partial class ProgressPage : Page
         MilestoneStatusText.Text = "Another setup task is still active. Wait for it to finish, then start OpenClaw onboard.";
     }
 
-    private static List<SetupStep> BuildSteps(SetupConfig config)
-        => SetupStepFactory.BuildDefaultSteps()
+    private static List<SetupStep> BuildSteps(SetupConfig config, bool localAiRecoveryOnly = false)
+        => (localAiRecoveryOnly
+                ? SetupStepFactory.BuildLocalAiRecoverySteps()
+                : SetupStepFactory.BuildDefaultSteps())
             .Where(step => step is not RunGatewayWizardStep)
             .Where(step => config.SkipWizard || step is not WindowsNodeBootstrapContextStep)
             .ToList();

--- a/src/OpenClaw.SetupEngine.UI/SetupWindow.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/SetupWindow.xaml.cs
@@ -29,6 +29,12 @@ public sealed partial class SetupWindow : Window
     private readonly object _localAiHardwareProbeLock = new();
     private Task<HostHardwareInfo>? _localAiHardwareProbeTask;
     private readonly WslViabilityProbe _wslViabilityProbe = new(InspectWslViabilityAsync);
+    private bool _startAtLocalAiRecoveryReview;
+    private bool _defaultLocalAiEnabled;
+    private bool _defaultSkipWizard;
+    private string _defaultDistroName = null!;
+    private int _defaultGatewayPort;
+    private string? _defaultGatewayUrl;
 
     public static SetupWindow? Active { get; private set; }
 
@@ -47,21 +53,25 @@ public sealed partial class SetupWindow : Window
         _setupLock is not null &&
         RootFrame.Content is not ProgressPage { IsPipelineRunning: true } &&
         RootFrame.Content is not WizardPage;
-
     [DllImport("user32.dll")]
     private static extern uint GetDpiForWindow(IntPtr hwnd);
 
     public SetupWindow(
         string? configPath = null,
         bool startAtGatewayInstalledMilestone = false,
+        bool startAtLocalAiRecoveryReview = false,
         string? dataDir = null,
         string? localDataDir = null,
         string? distroNameOverride = null,
         int? gatewayPortOverride = null,
+        string? localAiRecoveryGatewayId = null,
+        string? localAiRecoveryDistroName = null,
+        int? localAiRecoveryGatewayPort = null,
         string[]? commandLineArgs = null)
     {
         _dataDir = dataDir ?? SetupContext.ResolveDataDir();
         _localDataDir = localDataDir ?? SetupContext.ResolveLocalDataDir();
+        _startAtLocalAiRecoveryReview = startAtLocalAiRecoveryReview;
         InitializeComponent();
         Active = this;
 
@@ -168,7 +178,25 @@ public sealed partial class SetupWindow : Window
             return;
         }
         _config.ApplyUiDefaults(rollbackOnFailure: setupArguments.RollbackOnFailure);
-        if (startAtGatewayInstalledMilestone)
+        _defaultLocalAiEnabled = _config.LocalAi.Enabled;
+        _defaultSkipWizard = _config.SkipWizard;
+        _defaultDistroName = _config.DistroName;
+        _defaultGatewayPort = _config.GatewayPort;
+        _defaultGatewayUrl = _config.GatewayUrl;
+        if (startAtLocalAiRecoveryReview)
+        {
+            _config.LocalAiRecoveryGatewayId = localAiRecoveryGatewayId;
+            if (!string.IsNullOrWhiteSpace(localAiRecoveryDistroName))
+                _config.DistroName = localAiRecoveryDistroName;
+            if (localAiRecoveryGatewayPort is > 0 and <= 65535)
+            {
+                _config.GatewayPort = localAiRecoveryGatewayPort.Value;
+                _config.GatewayUrl = null;
+            }
+            _config.LocalAi.Enabled = true;
+            _config.SkipWizard = true;
+        }
+        if (startAtGatewayInstalledMilestone || startAtLocalAiRecoveryReview)
         {
             _persistStartupPreferenceOnComplete = false;
             _showStartupPreferenceOnComplete = false;
@@ -189,12 +217,18 @@ public sealed partial class SetupWindow : Window
 
         if (startAtGatewayInstalledMilestone)
             NavigateToGatewayInstalledMilestone();
+        else if (startAtLocalAiRecoveryReview)
+            NavigateToCapabilities();
         else
             NavigateTo(typeof(SecurityNoticePage), _config);
     }
 
     public void NavigateToSecurityNotice(bool back = false) => NavigateTo(typeof(SecurityNoticePage), _config, back);
-    public void NavigateToWelcome(bool back = false) => NavigateTo(typeof(WelcomePage), _config, back);
+    public void NavigateToWelcome(bool back = false)
+    {
+        ResetLocalAiRecoveryMode();
+        NavigateTo(typeof(WelcomePage), _config, back);
+    }
     public bool IsWelcomeInstallSelected => _isWelcomeInstallSelected;
     public void SetWelcomeInstallSelected(bool installSelected) => _isWelcomeInstallSelected = installSelected;
 
@@ -227,13 +261,16 @@ public sealed partial class SetupWindow : Window
     }
 
     public void NavigateToAdvancedSetup() => NavigateTo(typeof(AdvancedSetupPage), _config);
-    public void NavigateToCapabilities() => NavigateTo(typeof(CapabilitiesPage), _config);
+    public void NavigateToCapabilities() =>
+        NavigateTo(
+            typeof(CapabilitiesPage),
+            new CapabilitiesPageArgs(_config, _startAtLocalAiRecoveryReview));
     public void NavigateToProgress() => NavigateTo(typeof(ProgressPage), CreateProgressPageArgs(showMilestoneOnly: false));
     public void NavigateToGatewayInstalledMilestone() =>
         NavigateTo(typeof(ProgressPage), CreateProgressPageArgs(showMilestoneOnly: true));
 
     private ProgressPageArgs CreateProgressPageArgs(bool showMilestoneOnly) =>
-        new(_config, showMilestoneOnly, _dataDir, _localDataDir);
+        new(_config, showMilestoneOnly, _startAtLocalAiRecoveryReview, _dataDir, _localDataDir);
 
     public bool TryNavigateToGatewayInstalledMilestone()
     {
@@ -244,6 +281,22 @@ public sealed partial class SetupWindow : Window
         _showStartupPreferenceOnComplete = false;
         NavigateToGatewayInstalledMilestone();
         return true;
+    }
+
+    private void ResetLocalAiRecoveryMode()
+    {
+        if (!_startAtLocalAiRecoveryReview)
+            return;
+
+        _startAtLocalAiRecoveryReview = false;
+        _config.LocalAiRecoveryGatewayId = null;
+        _config.DistroName = _defaultDistroName;
+        _config.GatewayPort = _defaultGatewayPort;
+        _config.GatewayUrl = _defaultGatewayUrl;
+        _config.LocalAi.Enabled = _defaultLocalAiEnabled;
+        _config.SkipWizard = _defaultSkipWizard;
+        _persistStartupPreferenceOnComplete = true;
+        _showStartupPreferenceOnComplete = true;
     }
 
     public bool TryNavigateToWizard(bool back = false)

--- a/src/OpenClaw.SetupEngine.UI/SetupWindow.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/SetupWindow.xaml.cs
@@ -4,6 +4,7 @@ using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Animation;
+using OpenClaw.Connection.LocalAi;
 using OpenClaw.Shared.Inference;
 using OpenClaw.SetupEngine.UI.Pages;
 using System.Runtime.InteropServices;
@@ -30,11 +31,8 @@ public sealed partial class SetupWindow : Window
     private Task<HostHardwareInfo>? _localAiHardwareProbeTask;
     private readonly WslViabilityProbe _wslViabilityProbe = new(InspectWslViabilityAsync);
     private bool _startAtLocalAiRecoveryReview;
-    private bool _defaultLocalAiEnabled;
-    private bool _defaultSkipWizard;
-    private string _defaultDistroName = null!;
-    private int _defaultGatewayPort;
-    private string? _defaultGatewayUrl;
+    private bool _pinLocalAiRecoveryModel;
+    private LocalAiRecoveryConfigurationBaseline _localAiRecoveryBaseline = null!;
 
     public static SetupWindow? Active { get; private set; }
 
@@ -67,6 +65,8 @@ public sealed partial class SetupWindow : Window
         string? localAiRecoveryGatewayId = null,
         string? localAiRecoveryDistroName = null,
         int? localAiRecoveryGatewayPort = null,
+        string? localAiRecoveryModelId = null,
+        int? localAiRecoveryRequestedPort = null,
         string[]? commandLineArgs = null)
     {
         _dataDir = dataDir ?? SetupContext.ResolveDataDir();
@@ -178,11 +178,7 @@ public sealed partial class SetupWindow : Window
             return;
         }
         _config.ApplyUiDefaults(rollbackOnFailure: setupArguments.RollbackOnFailure);
-        _defaultLocalAiEnabled = _config.LocalAi.Enabled;
-        _defaultSkipWizard = _config.SkipWizard;
-        _defaultDistroName = _config.DistroName;
-        _defaultGatewayPort = _config.GatewayPort;
-        _defaultGatewayUrl = _config.GatewayUrl;
+        _localAiRecoveryBaseline = LocalAiRecoveryConfigurationBaseline.Capture(_config);
         if (startAtLocalAiRecoveryReview)
         {
             _config.LocalAiRecoveryGatewayId = localAiRecoveryGatewayId;
@@ -193,8 +189,19 @@ public sealed partial class SetupWindow : Window
                 _config.GatewayPort = localAiRecoveryGatewayPort.Value;
                 _config.GatewayUrl = null;
             }
+            if (!string.IsNullOrWhiteSpace(localAiRecoveryModelId))
+            {
+                _config.LocalAi.SelectedModelId = localAiRecoveryModelId;
+                _pinLocalAiRecoveryModel = true;
+            }
+            if (localAiRecoveryRequestedPort is { } requestedPort &&
+                LocalAiPortPolicy.TryValidate(requestedPort, out _))
+            {
+                _config.LocalAi.Port = requestedPort;
+            }
             _config.LocalAi.Enabled = true;
             _config.SkipWizard = true;
+            _config.RollbackOnFailure = true;
         }
         if (startAtGatewayInstalledMilestone || startAtLocalAiRecoveryReview)
         {
@@ -264,7 +271,10 @@ public sealed partial class SetupWindow : Window
     public void NavigateToCapabilities() =>
         NavigateTo(
             typeof(CapabilitiesPage),
-            new CapabilitiesPageArgs(_config, _startAtLocalAiRecoveryReview));
+            new CapabilitiesPageArgs(
+                _config,
+                _startAtLocalAiRecoveryReview,
+                _pinLocalAiRecoveryModel));
     public void NavigateToProgress() => NavigateTo(typeof(ProgressPage), CreateProgressPageArgs(showMilestoneOnly: false));
     public void NavigateToGatewayInstalledMilestone() =>
         NavigateTo(typeof(ProgressPage), CreateProgressPageArgs(showMilestoneOnly: true));
@@ -277,6 +287,7 @@ public sealed partial class SetupWindow : Window
         if (!CanNavigateToGatewayInstalledMilestone)
             return false;
 
+        ResetLocalAiRecoveryMode();
         _persistStartupPreferenceOnComplete = false;
         _showStartupPreferenceOnComplete = false;
         NavigateToGatewayInstalledMilestone();
@@ -289,12 +300,9 @@ public sealed partial class SetupWindow : Window
             return;
 
         _startAtLocalAiRecoveryReview = false;
+        _pinLocalAiRecoveryModel = false;
         _config.LocalAiRecoveryGatewayId = null;
-        _config.DistroName = _defaultDistroName;
-        _config.GatewayPort = _defaultGatewayPort;
-        _config.GatewayUrl = _defaultGatewayUrl;
-        _config.LocalAi.Enabled = _defaultLocalAiEnabled;
-        _config.SkipWizard = _defaultSkipWizard;
+        _localAiRecoveryBaseline.Restore(_config);
         _persistStartupPreferenceOnComplete = true;
         _showStartupPreferenceOnComplete = true;
     }

--- a/src/OpenClaw.SetupEngine/ExistingConfigDetector.cs
+++ b/src/OpenClaw.SetupEngine/ExistingConfigDetector.cs
@@ -25,14 +25,19 @@ public sealed class ExistingConfigDetector
     public static ExistingConfig Detect(
         string dataDir,
         string targetDistroName,
-        string? localDataDir = null)
+        string? localDataDir = null,
+        string? expectedLocalGatewayId = null)
     {
         localDataDir ??= SetupContext.ResolveLocalDataDir();
         var registry = new GatewayRegistry(dataDir);
         registry.Load();
         var all = registry.GetAll();
 
-        var localRecord = all.FirstOrDefault(r => r.IsLocal && r.SshTunnel == null);
+        var localRecord = string.IsNullOrWhiteSpace(expectedLocalGatewayId)
+            ? all.FirstOrDefault(r => r.IsLocal && r.SshTunnel == null)
+            : all.FirstOrDefault(r =>
+                string.Equals(r.Id, expectedLocalGatewayId, StringComparison.Ordinal) &&
+                GatewayRecordEditing.IsSetupManagedLocalRecord(r));
         var preserved = all.Where(r => !r.IsLocal || r.SshTunnel != null).ToList();
 
         var logger = new SetupLogger(filePath: null, LogLevel.Warn);

--- a/src/OpenClaw.SetupEngine/LocalAiGatewayConfiguration.cs
+++ b/src/OpenClaw.SetupEngine/LocalAiGatewayConfiguration.cs
@@ -215,6 +215,8 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
         CommandResult currentResult = await CaptureStateAsync(ctx, ct);
         if (currentResult.ExitCode != 0 || currentResult.TimedOut)
         {
+            if (ctx.LocalAiRecoveryProviderTransition)
+                ctx.LocalAiRecoveryReceiptRollbackAllowed = false;
             ctx.Logger.Warn("Could not inspect the Local AI gateway configuration during rollback; preserving it.");
             return;
         }
@@ -226,6 +228,8 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
         }
         catch (Exception ex) when (ex is FormatException or JsonException or InvalidDataException)
         {
+            if (ctx.LocalAiRecoveryProviderTransition)
+                ctx.LocalAiRecoveryReceiptRollbackAllowed = false;
             ctx.Logger.Warn($"Could not validate Local AI gateway rollback state; preserving it ({ex.GetType().Name}).");
             return;
         }
@@ -253,6 +257,8 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
                 ctx.LocalAiResolvedInstall!) ||
             !JsonEquals(current.PrimaryModelJson!, expectedPrimary))
         {
+            if (ctx.LocalAiRecoveryProviderTransition)
+                ctx.LocalAiRecoveryReceiptRollbackAllowed = false;
             ctx.Logger.Warn("Local AI gateway settings changed after setup; preserving the newer values.");
             return;
         }
@@ -273,6 +279,14 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
             CommandResult restore = await ApplyBatchAsync(ctx, restoreBatch, "LOCAL_AI_GATEWAY_RESTORED", ct);
             if (restore.ExitCode != 0 || restore.TimedOut)
             {
+                if (recoveryOriginal is not null)
+                {
+                    await ReconcileFailedRecoveryRestoreAsync(
+                        ctx,
+                        prior,
+                        recoveryOriginal,
+                        ct).ConfigureAwait(false);
+                }
                 ctx.Logger.Warn("Restoring the previous Local AI gateway settings failed.");
                 return;
             }
@@ -292,6 +306,66 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
             if (result.ExitCode != 0 || result.TimedOut)
                 ctx.Logger.Warn("Removing setup-created Local AI gateway settings failed.");
         }
+    }
+
+    private static async Task ReconcileFailedRecoveryRestoreAsync(
+        SetupContext ctx,
+        LocalAiGatewayPriorState prior,
+        LocalAiResolvedInstall recoveryOriginal,
+        CancellationToken ct)
+    {
+        CommandResult observedResult = await CaptureStateAsync(ctx, ct).ConfigureAwait(false);
+        if (observedResult.ExitCode != 0 || observedResult.TimedOut)
+        {
+            ctx.LocalAiRecoveryReceiptRollbackAllowed = false;
+            ctx.Logger.Warn(
+                "The Local AI provider rollback outcome could not be inspected; preserving the replacement receipt.");
+            return;
+        }
+
+        LocalAiGatewayPriorState observed;
+        try
+        {
+            observed = ParseSnapshot(observedResult.Stdout);
+        }
+        catch (Exception ex) when (ex is FormatException or JsonException or InvalidDataException)
+        {
+            ctx.LocalAiRecoveryReceiptRollbackAllowed = false;
+            ctx.Logger.Warn(
+                $"The Local AI provider rollback outcome was invalid; preserving the replacement receipt ({ex.GetType().Name}).");
+            return;
+        }
+
+        bool originalRestored =
+            observed.ProviderExisted &&
+            prior.ProviderExisted &&
+            LocalAiGatewayProviderDefinition.MatchesProviderJson(
+                observed.ProviderJson!,
+                recoveryOriginal) &&
+            observed.PrimaryModelExisted == prior.PrimaryModelExisted &&
+            (!observed.PrimaryModelExisted ||
+                JsonEquals(observed.PrimaryModelJson!, prior.PrimaryModelJson!));
+        if (originalRestored)
+        {
+            ctx.LocalAiRecoveryReceiptRollbackAllowed = true;
+            return;
+        }
+
+        bool replacementRetained =
+            observed.ProviderExisted &&
+            observed.PrimaryModelExisted &&
+            ctx.LocalAiResolvedInstall is { } replacement &&
+            LocalAiGatewayProviderDefinition.MatchesProviderJson(
+                observed.ProviderJson!,
+                replacement) &&
+            JsonEquals(
+                observed.PrimaryModelJson!,
+                JsonSerializer.Serialize(
+                    LocalAiGatewayProviderDefinition.BuildPrimaryModel(replacement)));
+        ctx.LocalAiRecoveryReceiptRollbackAllowed = false;
+        ctx.Logger.Warn(replacementRetained
+            ? "The replacement Local AI gateway route remains active; preserving its endpoint receipt."
+            : "The Local AI provider rollback was incomplete; preserving the replacement receipt for manual recovery.");
     }
 
     private static async Task RemoveManagedStateForUninstallAsync(

--- a/src/OpenClaw.SetupEngine/LocalAiGatewayConfiguration.cs
+++ b/src/OpenClaw.SetupEngine/LocalAiGatewayConfiguration.cs
@@ -108,6 +108,7 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
             prior.PrimaryModelExisted &&
             JsonEquals(prior.PrimaryModelJson!, expectedPrimary);
         string? fallbackModel;
+        bool recoveryProviderTransition = false;
         if (prior.ProviderExisted)
         {
             bool matchesCurrentInstall = install.Endpoint is not null &&
@@ -132,8 +133,7 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
                 return StepResult.Fail(
                     "The existing llamacpp gateway route is not the exact companion-managed configuration; preserving it.");
             }
-            if (matchesRecoveryInstall)
-                ctx.LocalAiRecoveryProviderTransition = true;
+            recoveryProviderTransition = matchesRecoveryInstall;
             fallbackModel = install.Manifest.GatewayFallbackModel;
         }
         else if (retainedManagedPrimary)
@@ -153,6 +153,11 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
         else
         {
             fallbackModel = null;
+        }
+        if (ctx.LocalAiRecoveryOriginalInstall is not null &&
+            (recoveryProviderTransition || !prior.ProviderExisted))
+        {
+            ctx.LocalAiRecoveryProviderTransition = true;
         }
         ctx.LocalAiGatewayPriorState ??= prior;
 
@@ -241,11 +246,11 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
             ? ctx.LocalAiRecoveryOriginalInstall
             : null;
         if (recoveryOriginal is not null &&
-            current.ProviderExisted &&
-            prior.ProviderExisted &&
-            LocalAiGatewayProviderDefinition.MatchesProviderJson(
-                current.ProviderJson!,
-                recoveryOriginal) &&
+            current.ProviderExisted == prior.ProviderExisted &&
+            (!current.ProviderExisted ||
+                LocalAiGatewayProviderDefinition.MatchesProviderJson(
+                    current.ProviderJson!,
+                    recoveryOriginal)) &&
             current.PrimaryModelExisted == prior.PrimaryModelExisted &&
             (!current.PrimaryModelExisted ||
                 JsonEquals(current.PrimaryModelJson!, prior.PrimaryModelJson!)))
@@ -268,7 +273,7 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
         }
 
         string restoreBatch;
-        if (recoveryOriginal is not null)
+        if (recoveryOriginal is not null && prior.ProviderExisted)
         {
             restoreBatch = LocalAiGatewayConfigBuilder.BuildRecoveryRestoreBatchJson(
                 prior,
@@ -294,8 +299,6 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
                 ctx.Logger.Warn("Restoring the previous Local AI gateway settings failed.");
                 return;
             }
-            if (recoveryOriginal is not null)
-                ctx.LocalAiRecoveryReceiptRollbackAllowed = true;
         }
 
         var unset = new List<string>(2);
@@ -310,8 +313,21 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
                 ctx.DistroName!, script, TimeSpan.FromMinutes(2), ct: ct,
                 user: ctx.Config.Wsl.User, inputViaStdin: true);
             if (result.ExitCode != 0 || result.TimedOut)
+            {
+                if (recoveryOriginal is not null)
+                {
+                    await ReconcileFailedRecoveryRestoreAsync(
+                        ctx,
+                        prior,
+                        recoveryOriginal,
+                        ct).ConfigureAwait(false);
+                }
                 ctx.Logger.Warn("Removing setup-created Local AI gateway settings failed.");
+                return;
+            }
         }
+        if (recoveryOriginal is not null)
+            ctx.LocalAiRecoveryReceiptRollbackAllowed = true;
     }
 
     private static async Task ReconcileFailedRecoveryRestoreAsync(
@@ -343,11 +359,11 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
         }
 
         bool originalRestored =
-            observed.ProviderExisted &&
-            prior.ProviderExisted &&
-            LocalAiGatewayProviderDefinition.MatchesProviderJson(
-                observed.ProviderJson!,
-                recoveryOriginal) &&
+            observed.ProviderExisted == prior.ProviderExisted &&
+            (!observed.ProviderExisted ||
+                LocalAiGatewayProviderDefinition.MatchesProviderJson(
+                    observed.ProviderJson!,
+                    recoveryOriginal)) &&
             observed.PrimaryModelExisted == prior.PrimaryModelExisted &&
             (!observed.PrimaryModelExisted ||
                 JsonEquals(observed.PrimaryModelJson!, prior.PrimaryModelJson!));

--- a/src/OpenClaw.SetupEngine/LocalAiGatewayConfiguration.cs
+++ b/src/OpenClaw.SetupEngine/LocalAiGatewayConfiguration.cs
@@ -51,6 +51,23 @@ internal static class LocalAiGatewayConfigBuilder
         LocalAiGatewayProviderDefinition.BuildPrimaryModel(
             context.LocalAiResolvedInstall
                 ?? throw new InvalidOperationException("The Local AI install receipt is required."));
+
+    public static string BuildRecoveryRestoreBatchJson(
+        LocalAiGatewayPriorState prior,
+        LocalAiResolvedInstall originalInstall)
+    {
+        ArgumentNullException.ThrowIfNull(prior);
+        ArgumentNullException.ThrowIfNull(originalInstall);
+        using JsonDocument provider = JsonDocument.Parse(
+            LocalAiGatewayProviderDefinition.BuildProviderJson(originalInstall));
+        using JsonDocument primary = JsonDocument.Parse(prior.PrimaryModelJson!);
+        object[] operations =
+        [
+            new { path = ProviderPath, value = (object)provider.RootElement.Clone() },
+            new { path = PrimaryModelPath, value = (object)primary.RootElement.Clone() },
+        ];
+        return JsonSerializer.Serialize(operations);
+    }
 }
 
 public sealed class ConfigureLocalAiGatewayStep : SetupStep
@@ -69,6 +86,7 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
     {
         if (ctx.LocalAiResolvedInstall is null || ctx.LocalAiEligibility?.Plan is null)
             return StepResult.Terminal("Local AI gateway configuration requires a qualified install receipt.");
+        ctx.LocalAiRecoveryProviderTransition = false;
 
         CommandResult snapshotResult = await CaptureStateAsync(ctx, ct);
         if (snapshotResult.ExitCode != 0 || snapshotResult.TimedOut)
@@ -93,14 +111,29 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
         string? fallbackModel;
         if (prior.ProviderExisted)
         {
-            if (install.Endpoint is null ||
-                !LocalAiGatewayProviderDefinition.MatchesProviderJson(prior.ProviderJson!, install) ||
+            bool matchesCurrentInstall = install.Endpoint is not null &&
+                LocalAiGatewayProviderDefinition.MatchesProviderJson(prior.ProviderJson!, install);
+            bool matchesRecoveryInstall = false;
+            if (!matchesCurrentInstall &&
+                ctx.LocalAiRecoveryOriginalInstall is { Endpoint: not null } originalInstall)
+            {
+                string originalPrimary = JsonSerializer.Serialize(
+                    LocalAiGatewayProviderDefinition.BuildPrimaryModel(originalInstall));
+                matchesRecoveryInstall =
+                    LocalAiGatewayProviderDefinition.MatchesProviderJson(
+                        prior.ProviderJson!,
+                        originalInstall) &&
+                    JsonEquals(originalPrimary, expectedPrimary);
+            }
+
+            if ((!matchesCurrentInstall && !matchesRecoveryInstall) ||
                 !prior.PrimaryModelExisted ||
                 !JsonEquals(prior.PrimaryModelJson!, expectedPrimary))
             {
                 return StepResult.Fail(
                     "The existing llamacpp gateway route is not the exact companion-managed configuration; preserving it.");
             }
+            ctx.LocalAiRecoveryProviderTransition = matchesRecoveryInstall;
             fallbackModel = install.Manifest.GatewayFallbackModel;
         }
         else if (retainedManagedPrimary)
@@ -196,6 +229,24 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
             return;
         }
 
+        LocalAiResolvedInstall? recoveryOriginal = ctx.LocalAiRecoveryProviderTransition
+            ? ctx.LocalAiRecoveryOriginalInstall
+            : null;
+        if (recoveryOriginal is not null &&
+            current.ProviderExisted &&
+            prior.ProviderExisted &&
+            LocalAiGatewayProviderDefinition.MatchesProviderJson(
+                current.ProviderJson!,
+                recoveryOriginal) &&
+            current.PrimaryModelExisted == prior.PrimaryModelExisted &&
+            (!current.PrimaryModelExisted ||
+                JsonEquals(current.PrimaryModelJson!, prior.PrimaryModelJson!)))
+        {
+            if (await RestoreRecoveryManifestAsync(ctx, recoveryOriginal, ct).ConfigureAwait(false))
+                ctx.LocalAiRecoveryProviderTransition = false;
+            return;
+        }
+
         string expectedPrimary = JsonSerializer.Serialize(LocalAiGatewayConfigBuilder.ExpectedPrimaryModel(ctx));
         if (!current.ProviderExisted || !current.PrimaryModelExisted ||
             !LocalAiGatewayProviderDefinition.MatchesProviderJson(
@@ -207,12 +258,31 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
             return;
         }
 
-        string restoreBatch = LocalAiGatewayConfigBuilder.BuildRestoreBatchJson(prior);
+        string restoreBatch;
+        if (recoveryOriginal is not null)
+        {
+            restoreBatch = LocalAiGatewayConfigBuilder.BuildRecoveryRestoreBatchJson(
+                prior,
+                recoveryOriginal);
+        }
+        else
+        {
+            restoreBatch = LocalAiGatewayConfigBuilder.BuildRestoreBatchJson(prior);
+        }
         if (restoreBatch != "[]")
         {
             CommandResult restore = await ApplyBatchAsync(ctx, restoreBatch, "LOCAL_AI_GATEWAY_RESTORED", ct);
             if (restore.ExitCode != 0 || restore.TimedOut)
+            {
                 ctx.Logger.Warn("Restoring the previous Local AI gateway settings failed.");
+                return;
+            }
+        }
+
+        if (recoveryOriginal is not null)
+        {
+            if (await RestoreRecoveryManifestAsync(ctx, recoveryOriginal, ct).ConfigureAwait(false))
+                ctx.LocalAiRecoveryProviderTransition = false;
         }
 
         var unset = new List<string>(2);
@@ -228,6 +298,26 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
                 user: ctx.Config.Wsl.User, inputViaStdin: true);
             if (result.ExitCode != 0 || result.TimedOut)
                 ctx.Logger.Warn("Removing setup-created Local AI gateway settings failed.");
+        }
+    }
+
+    private static async Task<bool> RestoreRecoveryManifestAsync(
+        SetupContext ctx,
+        LocalAiResolvedInstall recoveryOriginal,
+        CancellationToken ct)
+    {
+        try
+        {
+            var store = new LocalAiManifestStore(new LocalAiPaths(ctx.LocalDataDir));
+            await store.SaveAsync(recoveryOriginal.Manifest, ct).ConfigureAwait(false);
+            ctx.LocalAiResolvedInstall = store.ResolveAndValidate(recoveryOriginal.Manifest);
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidDataException)
+        {
+            ctx.Logger.Warn(
+                $"Restoring the previous Local AI endpoint receipt failed ({ex.GetType().Name}).");
+            return false;
         }
     }
 

--- a/src/OpenClaw.SetupEngine/LocalAiGatewayConfiguration.cs
+++ b/src/OpenClaw.SetupEngine/LocalAiGatewayConfiguration.cs
@@ -86,7 +86,6 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
     {
         if (ctx.LocalAiResolvedInstall is null || ctx.LocalAiEligibility?.Plan is null)
             return StepResult.Terminal("Local AI gateway configuration requires a qualified install receipt.");
-        ctx.LocalAiRecoveryProviderTransition = false;
 
         CommandResult snapshotResult = await CaptureStateAsync(ctx, ct);
         if (snapshotResult.ExitCode != 0 || snapshotResult.TimedOut)
@@ -133,7 +132,8 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
                 return StepResult.Fail(
                     "The existing llamacpp gateway route is not the exact companion-managed configuration; preserving it.");
             }
-            ctx.LocalAiRecoveryProviderTransition = matchesRecoveryInstall;
+            if (matchesRecoveryInstall)
+                ctx.LocalAiRecoveryProviderTransition = true;
             fallbackModel = install.Manifest.GatewayFallbackModel;
         }
         else if (retainedManagedPrimary)
@@ -154,6 +154,7 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
         {
             fallbackModel = null;
         }
+        ctx.LocalAiGatewayPriorState ??= prior;
 
         ctx.LocalAiGatewayPriorState = retainedManagedPrimary
             ? prior with
@@ -242,8 +243,6 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
             (!current.PrimaryModelExisted ||
                 JsonEquals(current.PrimaryModelJson!, prior.PrimaryModelJson!)))
         {
-            if (await RestoreRecoveryManifestAsync(ctx, recoveryOriginal, ct).ConfigureAwait(false))
-                ctx.LocalAiRecoveryProviderTransition = false;
             return;
         }
 
@@ -279,12 +278,6 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
             }
         }
 
-        if (recoveryOriginal is not null)
-        {
-            if (await RestoreRecoveryManifestAsync(ctx, recoveryOriginal, ct).ConfigureAwait(false))
-                ctx.LocalAiRecoveryProviderTransition = false;
-        }
-
         var unset = new List<string>(2);
         if (!prior.PrimaryModelExisted)
             unset.Add($"openclaw config unset {LocalAiGatewayConfigBuilder.PrimaryModelPath}");
@@ -298,26 +291,6 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
                 user: ctx.Config.Wsl.User, inputViaStdin: true);
             if (result.ExitCode != 0 || result.TimedOut)
                 ctx.Logger.Warn("Removing setup-created Local AI gateway settings failed.");
-        }
-    }
-
-    private static async Task<bool> RestoreRecoveryManifestAsync(
-        SetupContext ctx,
-        LocalAiResolvedInstall recoveryOriginal,
-        CancellationToken ct)
-    {
-        try
-        {
-            var store = new LocalAiManifestStore(new LocalAiPaths(ctx.LocalDataDir));
-            await store.SaveAsync(recoveryOriginal.Manifest, ct).ConfigureAwait(false);
-            ctx.LocalAiResolvedInstall = store.ResolveAndValidate(recoveryOriginal.Manifest);
-            return true;
-        }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidDataException)
-        {
-            ctx.Logger.Warn(
-                $"Restoring the previous Local AI endpoint receipt failed ({ex.GetType().Name}).");
-            return false;
         }
     }
 

--- a/src/OpenClaw.SetupEngine/LocalAiGatewayConfiguration.cs
+++ b/src/OpenClaw.SetupEngine/LocalAiGatewayConfiguration.cs
@@ -81,6 +81,10 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
     public override string Id => "configure-local-ai-gateway";
     public override string DisplayName => "Connect gateway to Local AI";
     public override bool CanSkip(SetupContext ctx) => !ctx.Config.LocalAi.Enabled;
+    public override TimeSpan GetRollbackTimeout(SetupContext ctx) =>
+        ctx.LocalAiRecoveryOriginalInstall is null
+            ? base.GetRollbackTimeout(ctx)
+            : TimeSpan.FromSeconds(Math.Max(ctx.Config.RollbackTimeoutSeconds, 420));
 
     public override async Task<StepResult> ExecuteAsync(SetupContext ctx, CancellationToken ct)
     {
@@ -159,17 +163,17 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
         {
             ctx.LocalAiRecoveryProviderTransition = true;
         }
-        ctx.LocalAiGatewayPriorState ??= prior;
-
-        ctx.LocalAiGatewayPriorState = retainedManagedPrimary
-            ? prior with
-            {
-                PrimaryModelExisted = fallbackModel is not null,
-                PrimaryModelJson = fallbackModel is null
-                    ? null
-                    : JsonSerializer.Serialize(fallbackModel),
-            }
-            : prior;
+        LocalAiGatewayPriorState rollbackPrior =
+            retainedManagedPrimary && ctx.LocalAiRecoveryOriginalInstall is null
+                ? prior with
+                {
+                    PrimaryModelExisted = fallbackModel is not null,
+                    PrimaryModelJson = fallbackModel is null
+                        ? null
+                        : JsonSerializer.Serialize(fallbackModel),
+                }
+                : prior;
+        ctx.LocalAiGatewayPriorState ??= rollbackPrior;
 
         if (!string.Equals(
                 install.Manifest.GatewayFallbackModel,

--- a/src/OpenClaw.SetupEngine/LocalAiGatewayConfiguration.cs
+++ b/src/OpenClaw.SetupEngine/LocalAiGatewayConfiguration.cs
@@ -212,6 +212,9 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
         if (ctx.LocalAiGatewayPriorState is not { } prior)
             return;
 
+        if (ctx.LocalAiRecoveryProviderTransition)
+            ctx.LocalAiRecoveryReceiptRollbackAllowed = false;
+
         CommandResult currentResult = await CaptureStateAsync(ctx, ct);
         if (currentResult.ExitCode != 0 || currentResult.TimedOut)
         {
@@ -247,6 +250,7 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
             (!current.PrimaryModelExisted ||
                 JsonEquals(current.PrimaryModelJson!, prior.PrimaryModelJson!)))
         {
+            ctx.LocalAiRecoveryReceiptRollbackAllowed = true;
             return;
         }
 
@@ -290,6 +294,8 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
                 ctx.Logger.Warn("Restoring the previous Local AI gateway settings failed.");
                 return;
             }
+            if (recoveryOriginal is not null)
+                ctx.LocalAiRecoveryReceiptRollbackAllowed = true;
         }
 
         var unset = new List<string>(2);

--- a/src/OpenClaw.SetupEngine/LocalAiInstallReconciler.cs
+++ b/src/OpenClaw.SetupEngine/LocalAiInstallReconciler.cs
@@ -7,9 +7,11 @@ internal sealed record LocalAiReconcileResult(
     bool Reused,
     LocalAiResolvedInstall? ResolvedInstall,
     LlamaRuntimeInstallResult? RuntimeInstall,
-    HuggingFaceModelInstallResult? ModelInstall)
+    HuggingFaceModelInstallResult? ModelInstall,
+    LocalAiResolvedInstall? OriginalInstall = null)
 {
-    public static LocalAiReconcileResult NotInstalled { get; } = new(false, null, null, null);
+    public static LocalAiReconcileResult NotInstalled { get; } =
+        new(false, null, null, null);
 }
 
 internal interface ILocalAiModelFileVerifier
@@ -27,9 +29,9 @@ internal sealed class LocalAiModelFileVerifier : ILocalAiModelFileVerifier
 }
 
 /// <summary>
-/// Reuses only an installation claimed by a complete manifest that still
-/// matches the selected immutable catalog recipe and passes on-disk checks.
-/// Unclaimed paths remain the responsibility of the individual acquirers.
+/// Reuses an installation only when its manifest, runtime, and model still match
+/// the selected immutable recipe. Recovery may retain a matching receipt while
+/// the individual acquirers repair incomplete runtime or model assets.
 /// </summary>
 internal sealed class LocalAiInstallReconciler
 {
@@ -53,7 +55,8 @@ internal sealed class LocalAiInstallReconciler
         string localDataDirectory,
         LocalInferencePlan plan,
         string selectedGpuId,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        bool allowIncompleteInstallation = false)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(localDataDirectory);
         ArgumentNullException.ThrowIfNull(plan);
@@ -75,18 +78,24 @@ internal sealed class LocalAiInstallReconciler
         LlamaRuntimeInspection inspection = await _runtimeInspector
             .InspectAsync(Path.GetDirectoryName(install.ExecutablePath)!, cancellationToken)
             .ConfigureAwait(false);
-        if (!inspection.IsValid)
+        bool modelIsValid = await _modelVerifier
+            .VerifyAsync(install.ModelPath, plan.Model.Weights, cancellationToken)
+            .ConfigureAwait(false);
+        if (!inspection.IsValid || !modelIsValid)
         {
-            throw new InvalidDataException(
-                inspection.Error ?? "The managed llama-server runtime no longer passes validation.");
-        }
+            if (!allowIncompleteInstallation)
+            {
+                throw new InvalidDataException(!inspection.IsValid
+                    ? inspection.Error ?? "The managed llama-server runtime no longer passes validation."
+                    : "The managed Local AI model no longer matches its pinned size and SHA-256 digest.");
+            }
 
-        if (!await _modelVerifier
-                .VerifyAsync(install.ModelPath, plan.Model.Weights, cancellationToken)
-                .ConfigureAwait(false))
-        {
-            throw new InvalidDataException(
-                "The managed Local AI model no longer matches its pinned size and SHA-256 digest.");
+            return new LocalAiReconcileResult(
+                Reused: false,
+                ResolvedInstall: null,
+                RuntimeInstall: inspection.IsValid ? CreateRuntimeInstall(install) : null,
+                ModelInstall: modelIsValid ? CreateModelInstall(install) : null,
+                OriginalInstall: install);
         }
 
         if (migrateLegacyGpuId)
@@ -99,22 +108,32 @@ internal sealed class LocalAiInstallReconciler
             install = manifestStore.ResolveAndValidate(migratedManifest);
         }
 
-        IReadOnlyList<LocalAiVerifiedArchive> verifiedArchives = install.Manifest.RuntimeAssets
-            .Select(asset => new LocalAiVerifiedArchive(asset.FileName, asset.SizeBytes, asset.Sha256))
-            .ToArray();
-        var runtimeInstall = new LlamaRuntimeInstallResult(
+        return new LocalAiReconcileResult(
+            true,
+            install,
+            CreateRuntimeInstall(install),
+            CreateModelInstall(install));
+    }
+
+    private static LlamaRuntimeInstallResult CreateRuntimeInstall(LocalAiResolvedInstall install) =>
+        new(
             Path.GetDirectoryName(install.ExecutablePath)!,
             install.ExecutablePath,
             LlamaRuntimeInstallDisposition.ReusedVerified,
             CreatedThisRun: false,
-            verifiedArchives,
+            install.Manifest.RuntimeAssets
+                .Select(asset => new LocalAiVerifiedArchive(
+                    asset.FileName,
+                    asset.SizeBytes,
+                    asset.Sha256))
+                .ToArray(),
             Rollback: null);
-        var modelInstall = new HuggingFaceModelInstallResult(
+
+    private static HuggingFaceModelInstallResult CreateModelInstall(LocalAiResolvedInstall install) =>
+        new(
             install.ModelPath,
             HuggingFaceModelInstallDisposition.ReusedVerified,
             CreatedThisRun: false);
-        return new LocalAiReconcileResult(true, install, runtimeInstall, modelInstall);
-    }
 
     private static void ValidateRecipeMatch(
         LocalAiResolvedInstall install,

--- a/src/OpenClaw.SetupEngine/LocalAiRecoveryPolicy.cs
+++ b/src/OpenClaw.SetupEngine/LocalAiRecoveryPolicy.cs
@@ -148,20 +148,29 @@ public sealed class PreserveLocalAiRecoveryGatewayStep : SetupStep
         Exception? receiptError = null;
         if (ctx.LocalAiRecoveryOriginalInstall is { } originalInstall)
         {
-            try
+            if (!ctx.LocalAiRecoveryReceiptRollbackAllowed)
             {
-                var store = new LocalAiManifestStore(new LocalAiPaths(ctx.LocalDataDir));
-                await store.SaveAsync(originalInstall.Manifest, ct).ConfigureAwait(false);
-                ctx.LocalAiResolvedInstall = store.ResolveAndValidate(originalInstall.Manifest);
-                ctx.LocalAiRecoveryProviderTransition = false;
-                ctx.LocalAiGatewayPriorState = null;
-            }
-            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidDataException)
-            {
-                receiptError = ex;
                 ctx.Logger.Warn(
-                    $"Restoring the previous Local AI endpoint receipt failed ({ex.GetType().Name}).");
+                    "The previous Local AI endpoint receipt was not restored because gateway provider rollback did not complete.");
             }
+            else
+            {
+                try
+                {
+                    var store = new LocalAiManifestStore(new LocalAiPaths(ctx.LocalDataDir));
+                    await store.SaveAsync(originalInstall.Manifest, ct).ConfigureAwait(false);
+                    ctx.LocalAiResolvedInstall = store.ResolveAndValidate(originalInstall.Manifest);
+                }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidDataException)
+                {
+                    receiptError = ex;
+                    ctx.Logger.Warn(
+                        $"Restoring the previous Local AI endpoint receipt failed ({ex.GetType().Name}).");
+                }
+            }
+            ctx.LocalAiRecoveryProviderTransition = false;
+            ctx.LocalAiRecoveryReceiptRollbackAllowed = false;
+            ctx.LocalAiGatewayPriorState = null;
         }
 
         if (ctx.LocalAiRecoveryStoppedWsl)

--- a/src/OpenClaw.SetupEngine/LocalAiRecoveryPolicy.cs
+++ b/src/OpenClaw.SetupEngine/LocalAiRecoveryPolicy.cs
@@ -1,0 +1,156 @@
+using OpenClaw.Connection;
+
+namespace OpenClaw.SetupEngine;
+
+public static class LocalAiRecoveryPolicy
+{
+    public static bool CanRecoverExistingGateway(
+        ExistingConfigDetector.ExistingConfig existing,
+        string expectedGatewayId,
+        string targetDistroName,
+        string expectedGatewayUrl) =>
+        existing.HasLocalGateway &&
+        string.Equals(
+            existing.LocalGatewayId,
+            expectedGatewayId,
+            StringComparison.Ordinal) &&
+        existing.HasDistro &&
+        existing.DistroIsAppOwned &&
+        string.Equals(
+            existing.DistroName,
+            targetDistroName,
+            StringComparison.OrdinalIgnoreCase) &&
+        GatewayRecordEditing.AreEquivalentLoopbackEndpoints(
+            existing.LocalGatewayUrl,
+            expectedGatewayUrl);
+}
+
+public sealed class ValidateLocalAiRecoveryGatewayStep : SetupStep
+{
+    private readonly Func<string, string, string?, string?, ExistingConfigDetector.ExistingConfig> _detect;
+    private readonly Func<string, IReadOnlyList<GatewayRecord>> _loadGatewayRecords;
+    private readonly bool _finalCheck;
+
+    public ValidateLocalAiRecoveryGatewayStep(bool finalCheck = false)
+        : this(ExistingConfigDetector.Detect, LoadGatewayRecords, finalCheck)
+    {
+    }
+
+    internal ValidateLocalAiRecoveryGatewayStep(
+        Func<string, string, string?, string?, ExistingConfigDetector.ExistingConfig> detect,
+        Func<string, IReadOnlyList<GatewayRecord>> loadGatewayRecords,
+        bool finalCheck = false)
+    {
+        _detect = detect ?? throw new ArgumentNullException(nameof(detect));
+        _loadGatewayRecords =
+            loadGatewayRecords ?? throw new ArgumentNullException(nameof(loadGatewayRecords));
+        _finalCheck = finalCheck;
+    }
+
+    public override string Id => _finalCheck
+        ? "revalidate-local-ai-recovery-gateway"
+        : "validate-local-ai-recovery-gateway";
+    public override string DisplayName => _finalCheck
+        ? "Recheck gateway before Local AI recovery changes"
+        : "Verify existing gateway for Local AI recovery";
+    public override bool CanRetry => false;
+
+    public override Task<StepResult> ExecuteAsync(SetupContext ctx, CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+
+        var expectedGatewayId = ctx.Config.LocalAiRecoveryGatewayId;
+        if (string.IsNullOrWhiteSpace(expectedGatewayId))
+        {
+            return Task.FromResult(StepResult.Terminal(
+                "Local AI recovery is missing its managed gateway identity. Close recovery and retry."));
+        }
+
+        var owners = _loadGatewayRecords(ctx.DataDir)
+            .Where(record =>
+                GatewayRecordEditing.IsSetupManagedLocalRecord(record) &&
+                !string.IsNullOrWhiteSpace(record.Id) &&
+                !string.IsNullOrWhiteSpace(
+                    GatewayRecordEditing.ResolveManagedDistroName(record)))
+            .ToArray();
+        if (owners.Length != 1 ||
+            !string.Equals(owners[0].Id, expectedGatewayId, StringComparison.Ordinal) ||
+            !string.Equals(
+                GatewayRecordEditing.ResolveManagedDistroName(owners[0]),
+                ctx.Config.DistroName,
+                StringComparison.OrdinalIgnoreCase) ||
+            !GatewayRecordEditing.AreEquivalentLoopbackEndpoints(
+                owners[0].Url,
+                ctx.Config.EffectiveGatewayUrl))
+        {
+            return Task.FromResult(StepResult.Terminal(
+                "The managed gateway owner changed before Local AI recovery. Close recovery and review Connection settings."));
+        }
+
+        ExistingConfigDetector.ExistingConfig existing;
+        try
+        {
+            existing = _detect(
+                ctx.DataDir,
+                ctx.Config.DistroName,
+                ctx.LocalDataDir,
+                expectedGatewayId);
+        }
+        catch (Exception ex)
+        {
+            ctx.Logger.Warn($"Local AI recovery gateway inspection failed: {ex.Message}");
+            return Task.FromResult(StepResult.Terminal(
+                "OpenClaw could not safely verify the existing managed gateway. Close recovery and run full setup."));
+        }
+
+        return Task.FromResult(
+            LocalAiRecoveryPolicy.CanRecoverExistingGateway(
+                existing,
+                expectedGatewayId,
+                ctx.Config.DistroName,
+                ctx.Config.EffectiveGatewayUrl)
+                ? StepResult.Ok("Existing app-managed gateway verified for Local AI recovery.")
+                : StepResult.Terminal(
+                    "The existing app-managed gateway is unavailable. Close recovery and run full setup."));
+    }
+
+    private static IReadOnlyList<GatewayRecord> LoadGatewayRecords(string dataDir)
+    {
+        var registry = new GatewayRegistry(dataDir);
+        registry.Load();
+        return registry.GetAll();
+    }
+}
+
+public sealed class PreserveLocalAiRecoveryGatewayStep : SetupStep
+{
+    private readonly Func<SetupContext, CancellationToken, Task<StepResult>> _restart;
+
+    public PreserveLocalAiRecoveryGatewayStep()
+        : this(StartGatewayStep.RestartAndWaitForHealthAsync)
+    {
+    }
+
+    internal PreserveLocalAiRecoveryGatewayStep(
+        Func<SetupContext, CancellationToken, Task<StepResult>> restart) =>
+        _restart = restart ?? throw new ArgumentNullException(nameof(restart));
+
+    public override string Id => "preserve-local-ai-recovery-gateway";
+    public override string DisplayName => "Preserve gateway during Local AI recovery";
+    public override bool CanRetry => false;
+
+    public override Task<StepResult> ExecuteAsync(SetupContext ctx, CancellationToken ct) =>
+        Task.FromResult(StepResult.Ok("Gateway recovery guard armed."));
+
+    public override async Task RollbackAsync(SetupContext ctx, CancellationToken ct)
+    {
+        if (!ctx.LocalAiRecoveryStoppedWsl)
+            return;
+
+        StepResult restart = await _restart(ctx, ct);
+        if (!restart.IsSuccess)
+            throw new InvalidOperationException(restart.Message);
+
+        ctx.LocalAiRecoveryStoppedWsl = false;
+    }
+}

--- a/src/OpenClaw.SetupEngine/LocalAiRecoveryPolicy.cs
+++ b/src/OpenClaw.SetupEngine/LocalAiRecoveryPolicy.cs
@@ -1,4 +1,5 @@
 using OpenClaw.Connection;
+using OpenClaw.Connection.LocalAi;
 
 namespace OpenClaw.SetupEngine;
 
@@ -144,13 +145,39 @@ public sealed class PreserveLocalAiRecoveryGatewayStep : SetupStep
 
     public override async Task RollbackAsync(SetupContext ctx, CancellationToken ct)
     {
-        if (!ctx.LocalAiRecoveryStoppedWsl)
-            return;
+        Exception? receiptError = null;
+        if (ctx.LocalAiRecoveryOriginalInstall is { } originalInstall)
+        {
+            try
+            {
+                var store = new LocalAiManifestStore(new LocalAiPaths(ctx.LocalDataDir));
+                await store.SaveAsync(originalInstall.Manifest, ct).ConfigureAwait(false);
+                ctx.LocalAiResolvedInstall = store.ResolveAndValidate(originalInstall.Manifest);
+                ctx.LocalAiRecoveryProviderTransition = false;
+                ctx.LocalAiGatewayPriorState = null;
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidDataException)
+            {
+                receiptError = ex;
+                ctx.Logger.Warn(
+                    $"Restoring the previous Local AI endpoint receipt failed ({ex.GetType().Name}).");
+            }
+        }
 
-        StepResult restart = await _restart(ctx, ct);
-        if (!restart.IsSuccess)
-            throw new InvalidOperationException(restart.Message);
+        if (ctx.LocalAiRecoveryStoppedWsl)
+        {
+            StepResult restart = await _restart(ctx, ct);
+            if (!restart.IsSuccess)
+                throw new InvalidOperationException(restart.Message);
 
-        ctx.LocalAiRecoveryStoppedWsl = false;
+            ctx.LocalAiRecoveryStoppedWsl = false;
+        }
+
+        if (receiptError is not null)
+        {
+            throw new InvalidOperationException(
+                "The previous Local AI endpoint receipt could not be restored.",
+                receiptError);
+        }
     }
 }

--- a/src/OpenClaw.SetupEngine/LocalAiRecoveryPolicy.cs
+++ b/src/OpenClaw.SetupEngine/LocalAiRecoveryPolicy.cs
@@ -26,6 +26,40 @@ public static class LocalAiRecoveryPolicy
             expectedGatewayUrl);
 }
 
+internal sealed record LocalAiRecoveryConfigurationBaseline(
+    bool LocalAiEnabled,
+    string? LocalAiSelectedModelId,
+    int LocalAiPort,
+    bool RollbackOnFailure,
+    bool SkipWizard,
+    string DistroName,
+    int GatewayPort,
+    string? GatewayUrl)
+{
+    public static LocalAiRecoveryConfigurationBaseline Capture(SetupConfig config) =>
+        new(
+            config.LocalAi.Enabled,
+            config.LocalAi.SelectedModelId,
+            config.LocalAi.Port,
+            config.RollbackOnFailure,
+            config.SkipWizard,
+            config.DistroName,
+            config.GatewayPort,
+            config.GatewayUrl);
+
+    public void Restore(SetupConfig config)
+    {
+        config.LocalAi.Enabled = LocalAiEnabled;
+        config.LocalAi.SelectedModelId = LocalAiSelectedModelId;
+        config.LocalAi.Port = LocalAiPort;
+        config.RollbackOnFailure = RollbackOnFailure;
+        config.SkipWizard = SkipWizard;
+        config.DistroName = DistroName;
+        config.GatewayPort = GatewayPort;
+        config.GatewayUrl = GatewayUrl;
+    }
+}
+
 public sealed class ValidateLocalAiRecoveryGatewayStep : SetupStep
 {
     private readonly Func<string, string, string?, string?, ExistingConfigDetector.ExistingConfig> _detect;
@@ -77,8 +111,8 @@ public sealed class ValidateLocalAiRecoveryGatewayStep : SetupStep
         if (owners.Length != 1 ||
             !string.Equals(owners[0].Id, expectedGatewayId, StringComparison.Ordinal) ||
             !string.Equals(
-                GatewayRecordEditing.ResolveManagedDistroName(owners[0]),
-                ctx.Config.DistroName,
+                GatewayRecordEditing.ResolveManagedDistroName(owners[0])?.Trim(),
+                ctx.Config.DistroName.Trim(),
                 StringComparison.OrdinalIgnoreCase) ||
             !GatewayRecordEditing.AreEquivalentLoopbackEndpoints(
                 owners[0].Url,
@@ -139,6 +173,11 @@ public sealed class PreserveLocalAiRecoveryGatewayStep : SetupStep
     public override string Id => "preserve-local-ai-recovery-gateway";
     public override string DisplayName => "Preserve gateway during Local AI recovery";
     public override bool CanRetry => false;
+    // A cold WSL restart can consume two CLI attempts plus the full health window.
+    public override TimeSpan GetRollbackTimeout(SetupContext ctx) =>
+        TimeSpan.FromSeconds(Math.Max(
+            Math.Max(1, ctx.Config.RollbackTimeoutSeconds),
+            Math.Max(1, ctx.Config.Gateway.HealthTimeoutSeconds) + 75));
 
     public override Task<StepResult> ExecuteAsync(SetupContext ctx, CancellationToken ct) =>
         Task.FromResult(StepResult.Ok("Gateway recovery guard armed."));

--- a/src/OpenClaw.SetupEngine/LocalAiRecoveryPolicy.cs
+++ b/src/OpenClaw.SetupEngine/LocalAiRecoveryPolicy.cs
@@ -160,15 +160,20 @@ public sealed class ValidateLocalAiRecoveryGatewayStep : SetupStep
 public sealed class PreserveLocalAiRecoveryGatewayStep : SetupStep
 {
     private readonly Func<SetupContext, CancellationToken, Task<StepResult>> _restart;
+    private readonly Func<LocalAiResolvedInstall, CancellationToken, Task<bool>> _probeOriginalEndpoint;
 
     public PreserveLocalAiRecoveryGatewayStep()
-        : this(StartGatewayStep.RestartAndWaitForHealthAsync)
+        : this(StartGatewayStep.RestartAndWaitForHealthAsync, ProbeOriginalEndpointAsync)
     {
     }
 
     internal PreserveLocalAiRecoveryGatewayStep(
-        Func<SetupContext, CancellationToken, Task<StepResult>> restart) =>
+        Func<SetupContext, CancellationToken, Task<StepResult>> restart,
+        Func<LocalAiResolvedInstall, CancellationToken, Task<bool>>? probeOriginalEndpoint = null)
+    {
         _restart = restart ?? throw new ArgumentNullException(nameof(restart));
+        _probeOriginalEndpoint = probeOriginalEndpoint ?? ProbeOriginalEndpointAsync;
+    }
 
     public override string Id => "preserve-local-ai-recovery-gateway";
     public override string DisplayName => "Preserve gateway during Local AI recovery";
@@ -191,6 +196,12 @@ public sealed class PreserveLocalAiRecoveryGatewayStep : SetupStep
             {
                 ctx.Logger.Warn(
                     "The previous Local AI endpoint receipt was not restored because gateway provider rollback did not complete.");
+            }
+            else if (!await _probeOriginalEndpoint(originalInstall, ct).ConfigureAwait(false))
+            {
+                ctx.Logger.Warn(
+                    "The previous Local AI endpoint could not be verified as healthy; preserving the replacement " +
+                    "receipt instead of restoring a receipt for an endpoint that is not confirmed reachable.");
             }
             else
             {
@@ -227,5 +238,26 @@ public sealed class PreserveLocalAiRecoveryGatewayStep : SetupStep
                 "The previous Local AI endpoint receipt could not be restored.",
                 receiptError);
         }
+    }
+
+    /// <summary>
+    /// Confirms the original (pre-recovery) llama-server endpoint is actually alive before the
+    /// Gateway is pointed back at it. A stale manifest receipt alone cannot tell us whether the
+    /// original process is still running.
+    /// </summary>
+    private static async Task<bool> ProbeOriginalEndpointAsync(
+        LocalAiResolvedInstall original,
+        CancellationToken ct)
+    {
+        if (original.Endpoint is null)
+            return true;
+
+        using var client = new LlamaServerClient();
+        LlamaServerRouterProbeResult probe = await client.ProbeManagedModelAsync(
+            original.Endpoint,
+            original.Manifest.ModelAlias,
+            original.ModelPath,
+            ct).ConfigureAwait(false);
+        return probe.IsHealthy;
     }
 }

--- a/src/OpenClaw.SetupEngine/LocalAiSetupSteps.cs
+++ b/src/OpenClaw.SetupEngine/LocalAiSetupSteps.cs
@@ -161,6 +161,8 @@ public sealed class ConfigureLocalAiWslNetworkingStep : SetupStep
 
         try
         {
+            if (!string.IsNullOrWhiteSpace(ctx.Config.LocalAiRecoveryGatewayId))
+                ctx.LocalAiRecoveryStoppedWsl = true;
             CommandResult shutdown = await ShutdownWslAsync(ctx, ct);
             if (shutdown.ExitCode != 0 || shutdown.TimedOut)
             {
@@ -196,6 +198,8 @@ public sealed class ConfigureLocalAiWslNetworkingStep : SetupStep
                 CommandResult shutdown = await ShutdownWslAsync(ctx, ct);
                 if (shutdown.ExitCode != 0 || shutdown.TimedOut)
                     throw new InvalidOperationException("WSL could not be stopped to apply the restored configuration.");
+                if (!string.IsNullOrWhiteSpace(ctx.Config.LocalAiRecoveryGatewayId))
+                    ctx.LocalAiRecoveryStoppedWsl = true;
                 return;
             default:
                 throw new InvalidOperationException($"Unknown WSL configuration restore result: {restore}.");

--- a/src/OpenClaw.SetupEngine/LocalAiSetupSteps.cs
+++ b/src/OpenClaw.SetupEngine/LocalAiSetupSteps.cs
@@ -274,6 +274,8 @@ public sealed class ReconcileLocalAiInstallationStep : SetupStep
             ctx.LocalAiRuntimeInstall = result.RuntimeInstall;
             ctx.LocalAiModelInstall = result.ModelInstall;
             ctx.LocalAiPort = result.ResolvedInstall!.Manifest.RequestedPort;
+            if (!string.IsNullOrWhiteSpace(ctx.Config.LocalAiRecoveryGatewayId))
+                ctx.LocalAiRecoveryOriginalInstall = result.ResolvedInstall;
             return StepResult.Ok("Reused the verified managed Local AI installation.");
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)

--- a/src/OpenClaw.SetupEngine/LocalAiSetupSteps.cs
+++ b/src/OpenClaw.SetupEngine/LocalAiSetupSteps.cs
@@ -275,7 +275,10 @@ public sealed class ReconcileLocalAiInstallationStep : SetupStep
             ctx.LocalAiModelInstall = result.ModelInstall;
             ctx.LocalAiPort = result.ResolvedInstall!.Manifest.RequestedPort;
             if (!string.IsNullOrWhiteSpace(ctx.Config.LocalAiRecoveryGatewayId))
+            {
                 ctx.LocalAiRecoveryOriginalInstall = result.ResolvedInstall;
+                ctx.LocalAiRecoveryReceiptRollbackAllowed = true;
+            }
             return StepResult.Ok("Reused the verified managed Local AI installation.");
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)

--- a/src/OpenClaw.SetupEngine/LocalAiSetupSteps.cs
+++ b/src/OpenClaw.SetupEngine/LocalAiSetupSteps.cs
@@ -195,11 +195,11 @@ public sealed class ConfigureLocalAiWslNetworkingStep : SetupStep
             case WslGlobalConfigRestoreResult.InvalidBackup:
                 throw new InvalidDataException("The Local AI WSL configuration backup is invalid.");
             case WslGlobalConfigRestoreResult.Restored:
+                if (!string.IsNullOrWhiteSpace(ctx.Config.LocalAiRecoveryGatewayId))
+                    ctx.LocalAiRecoveryStoppedWsl = true;
                 CommandResult shutdown = await ShutdownWslAsync(ctx, ct);
                 if (shutdown.ExitCode != 0 || shutdown.TimedOut)
                     throw new InvalidOperationException("WSL could not be stopped to apply the restored configuration.");
-                if (!string.IsNullOrWhiteSpace(ctx.Config.LocalAiRecoveryGatewayId))
-                    ctx.LocalAiRecoveryStoppedWsl = true;
                 return;
             default:
                 throw new InvalidOperationException($"Unknown WSL configuration restore result: {restore}.");
@@ -265,20 +265,33 @@ public sealed class ReconcileLocalAiInstallationStep : SetupStep
         try
         {
             LocalAiReconcileResult result = await _reconciler
-                .ReconcileAsync(ctx.LocalDataDir, plan, selectedGpuId, ct)
+                .ReconcileAsync(
+                    ctx.LocalDataDir,
+                    plan,
+                    selectedGpuId,
+                    ct,
+                    allowIncompleteInstallation:
+                        !string.IsNullOrWhiteSpace(ctx.Config.LocalAiRecoveryGatewayId))
                 .ConfigureAwait(false);
+            if (!string.IsNullOrWhiteSpace(ctx.Config.LocalAiRecoveryGatewayId) &&
+                (result.ResolvedInstall ?? result.OriginalInstall) is { } originalInstall)
+            {
+                ctx.LocalAiRecoveryOriginalInstall = originalInstall;
+                ctx.LocalAiRecoveryReceiptRollbackAllowed = true;
+            }
             if (!result.Reused)
-                return StepResult.Skip("No completed managed Local AI installation was found.");
+            {
+                ctx.LocalAiRuntimeInstall = result.RuntimeInstall;
+                ctx.LocalAiModelInstall = result.ModelInstall;
+                return StepResult.Skip(result.OriginalInstall is null
+                    ? "No completed managed Local AI installation was found."
+                    : "The existing Local AI receipt was retained while incomplete assets are repaired.");
+            }
 
             ctx.LocalAiResolvedInstall = result.ResolvedInstall;
             ctx.LocalAiRuntimeInstall = result.RuntimeInstall;
             ctx.LocalAiModelInstall = result.ModelInstall;
             ctx.LocalAiPort = result.ResolvedInstall!.Manifest.RequestedPort;
-            if (!string.IsNullOrWhiteSpace(ctx.Config.LocalAiRecoveryGatewayId))
-            {
-                ctx.LocalAiRecoveryOriginalInstall = result.ResolvedInstall;
-                ctx.LocalAiRecoveryReceiptRollbackAllowed = true;
-            }
             return StepResult.Ok("Reused the verified managed Local AI installation.");
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
@@ -528,7 +541,10 @@ public sealed class PersistLocalAiManifestStep : SetupStep
             return StepResult.Terminal(portError ?? "The requested Local AI port is invalid.");
 
         var paths = new LocalAiPaths(ctx.LocalDataDir);
-        if (File.Exists(paths.ManifestPath))
+        bool replacesRecoveryReceipt =
+            ctx.LocalAiRecoveryOriginalInstall is not null &&
+            File.Exists(paths.ManifestPath);
+        if (File.Exists(paths.ManifestPath) && !replacesRecoveryReceipt)
             return StepResult.Terminal("A managed Local AI installation receipt already exists.");
 
         ImmutableArray<LocalAiAssetReceipt> runtimeAssets;
@@ -541,7 +557,7 @@ public sealed class PersistLocalAiManifestStep : SetupStep
             return StepResult.Terminal(ex.Message, ex);
         }
 
-        var manifest = new LocalAiInstallManifest
+        LocalAiInstallManifest manifest = new()
         {
             EngineVersion = LlamaRuntimeCatalog.ReleaseTag,
             Architecture = plan.Runtime.Architecture switch
@@ -573,13 +589,37 @@ public sealed class PersistLocalAiManifestStep : SetupStep
             DraftKeyCachePrecision = plan.Profile.DraftKeyCachePrecision,
             DraftValueCachePrecision = plan.Profile.DraftValueCachePrecision,
         };
+        if (ctx.LocalAiRecoveryOriginalInstall is { } originalInstall)
+        {
+            manifest = originalInstall.Manifest with
+            {
+                EngineVersion = manifest.EngineVersion,
+                Architecture = manifest.Architecture,
+                RuntimeId = manifest.RuntimeId,
+                ModelCatalogId = manifest.ModelCatalogId,
+                SelectedGpuId = manifest.SelectedGpuId,
+                ExecutablePath = manifest.ExecutablePath,
+                RuntimeAssets = manifest.RuntimeAssets,
+                ModelPath = manifest.ModelPath,
+                ModelId = manifest.ModelId,
+                ModelAlias = manifest.ModelAlias,
+                ModelAsset = manifest.ModelAsset,
+                RequestedPort = manifest.RequestedPort,
+                Endpoint = null,
+                ContextLength = manifest.ContextLength,
+                KeyCachePrecision = manifest.KeyCachePrecision,
+                ValueCachePrecision = manifest.ValueCachePrecision,
+                DraftKeyCachePrecision = manifest.DraftKeyCachePrecision,
+                DraftValueCachePrecision = manifest.DraftValueCachePrecision,
+            };
+        }
 
         var store = new LocalAiManifestStore(paths);
         try
         {
             await store.SaveAsync(manifest, ct);
             ctx.LocalAiResolvedInstall = store.ResolveAndValidate(manifest);
-            ctx.LocalAiManifestCreatedThisRun = true;
+            ctx.LocalAiManifestCreatedThisRun = !replacesRecoveryReceipt;
             return StepResult.Ok("Recorded the verified llama-server and Hugging Face installation.");
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidDataException)

--- a/src/OpenClaw.SetupEngine/LocalAiSetupSteps.cs
+++ b/src/OpenClaw.SetupEngine/LocalAiSetupSteps.cs
@@ -822,8 +822,22 @@ public sealed class StartLocalAiRuntimeStep : SetupStep
         }
     }
 
-    public override Task RollbackAsync(SetupContext ctx, CancellationToken ct) =>
-        DisposeRuntimeAsync(ctx).AsTask();
+    public override Task RollbackAsync(SetupContext ctx, CancellationToken ct)
+    {
+        // During a recovery provider transition, ConfigureLocalAiGatewayStep's rollback (which
+        // runs before this step's rollback) sets LocalAiRecoveryReceiptRollbackAllowed only when
+        // it confirmed the Gateway no longer routes to this runtime's endpoint. If that could not
+        // be confirmed, the Gateway may still be pointed at this runtime; disposing it here would
+        // orphan the active route instead of the intended, coordinated rollback.
+        if (ctx.LocalAiRecoveryProviderTransition && !ctx.LocalAiRecoveryReceiptRollbackAllowed)
+        {
+            ctx.Logger.Warn(
+                "Keeping the replacement llama-server router running because the Gateway configuration " +
+                "rollback could not confirm it no longer routes to this endpoint.");
+            return Task.CompletedTask;
+        }
+        return DisposeRuntimeAsync(ctx).AsTask();
+    }
 
     private static ILocalAiRuntime CreateRuntime(SetupContext ctx)
     {

--- a/src/OpenClaw.SetupEngine/RestartGatewayStep.cs
+++ b/src/OpenClaw.SetupEngine/RestartGatewayStep.cs
@@ -1,0 +1,30 @@
+namespace OpenClaw.SetupEngine;
+
+public sealed class RestartGatewayStep : SetupStep
+{
+    private readonly Func<SetupContext, CancellationToken, Task<StepResult>> _restart;
+
+    public RestartGatewayStep()
+        : this(StartGatewayStep.RestartAndWaitForHealthAsync)
+    {
+    }
+
+    internal RestartGatewayStep(
+        Func<SetupContext, CancellationToken, Task<StepResult>> restart) =>
+        _restart = restart ?? throw new ArgumentNullException(nameof(restart));
+
+    public override string Id => "restart-gateway";
+    public override string DisplayName => "Restart gateway";
+    public override RetryPolicy Retry => new(MaxAttempts: 3, InitialDelay: TimeSpan.FromSeconds(3));
+
+    public override async Task<StepResult> ExecuteAsync(SetupContext ctx, CancellationToken ct)
+    {
+        if (!string.IsNullOrWhiteSpace(ctx.Config.LocalAiRecoveryGatewayId))
+            ctx.LocalAiRecoveryStoppedWsl = true;
+
+        StepResult result = await _restart(ctx, ct);
+        if (result.IsSuccess)
+            ctx.LocalAiRecoveryStoppedWsl = false;
+        return result;
+    }
+}

--- a/src/OpenClaw.SetupEngine/SetupContext.cs
+++ b/src/OpenClaw.SetupEngine/SetupContext.cs
@@ -34,6 +34,8 @@ public sealed class SetupConfig
     public Dictionary<string, string>? WizardAnswers { get; set; }
     [JsonIgnore]
     public bool UsesBundledDefaultConfig { get; set; }
+    [JsonIgnore]
+    public string? LocalAiRecoveryGatewayId { get; set; }
 
     // Nested config sections — everything is configurable
     public WslConfig Wsl { get; set; } = new();
@@ -521,6 +523,7 @@ public sealed class SetupContext
     internal LocalAiGpuLoadEvidence? LocalAiGpuLoadEvidence { get; set; }
     internal LocalAiGatewayPriorState? LocalAiGatewayPriorState { get; set; }
     internal bool IsUninstalling { get; set; }
+    internal bool LocalAiRecoveryStoppedWsl { get; set; }
 
     // Data directory for gateway registry and identity files
     public string DataDir { get; }

--- a/src/OpenClaw.SetupEngine/SetupContext.cs
+++ b/src/OpenClaw.SetupEngine/SetupContext.cs
@@ -516,6 +516,8 @@ public sealed class SetupContext
     internal LlamaRuntimeInstallResult? LocalAiRuntimeInstall { get; set; }
     internal HuggingFaceModelInstallResult? LocalAiModelInstall { get; set; }
     internal LocalAiResolvedInstall? LocalAiResolvedInstall { get; set; }
+    internal LocalAiResolvedInstall? LocalAiRecoveryOriginalInstall { get; set; }
+    internal bool LocalAiRecoveryProviderTransition { get; set; }
     internal bool LocalAiManifestCreatedThisRun { get; set; }
     internal ILocalAiRuntime? LocalAiRuntime { get; set; }
     internal HostHardwareInfo? LocalAiGpuBaseline { get; set; }

--- a/src/OpenClaw.SetupEngine/SetupContext.cs
+++ b/src/OpenClaw.SetupEngine/SetupContext.cs
@@ -518,6 +518,7 @@ public sealed class SetupContext
     internal LocalAiResolvedInstall? LocalAiResolvedInstall { get; set; }
     internal LocalAiResolvedInstall? LocalAiRecoveryOriginalInstall { get; set; }
     internal bool LocalAiRecoveryProviderTransition { get; set; }
+    internal bool LocalAiRecoveryReceiptRollbackAllowed { get; set; }
     internal bool LocalAiManifestCreatedThisRun { get; set; }
     internal ILocalAiRuntime? LocalAiRuntime { get; set; }
     internal HostHardwareInfo? LocalAiGpuBaseline { get; set; }

--- a/src/OpenClaw.SetupEngine/SetupPipeline.cs
+++ b/src/OpenClaw.SetupEngine/SetupPipeline.cs
@@ -51,6 +51,29 @@ public static class SetupStepFactory
         new WindowsNodeBootstrapContextStep(),
     ];
 
+    public static List<SetupStep> BuildLocalAiRecoverySteps() =>
+    [
+        new PreflightOsStep(),
+        new ValidateLocalAiRecoveryGatewayStep(),
+        new PreserveLocalAiRecoveryGatewayStep(),
+        new PreflightLocalAiHardwareStep(),
+        new PreflightWslStep(),
+        new EnsureWslPlatformStep(reusePreflightResult: true),
+        new ReconcileLocalAiInstallationStep(),
+        new AcquireLocalAiRuntimeStep(),
+        new AcquireLocalAiModelStep(),
+        new PersistLocalAiManifestStep(),
+        new StartLocalAiRuntimeStep(),
+        new CaptureLocalAiGpuBaselineStep(),
+        new VerifyLocalAiInferenceStep(),
+        new VerifyLocalAiGpuLoadStep(),
+        new ValidateLocalAiRecoveryGatewayStep(finalCheck: true),
+        new ConfigureLocalAiWslNetworkingStep(),
+        new VerifyLocalAiWslStep(),
+        new ConfigureLocalAiGatewayStep(),
+        new RestartGatewayStep(),
+    ];
+
     public static List<SetupStep> BuildDefaultSteps()
     {
         return

--- a/src/OpenClaw.SetupEngine/SetupPipeline.cs
+++ b/src/OpenClaw.SetupEngine/SetupPipeline.cs
@@ -12,6 +12,8 @@ public abstract class SetupStep
     public abstract Task<StepResult> ExecuteAsync(SetupContext ctx, CancellationToken ct);
 
     public virtual Task RollbackAsync(SetupContext ctx, CancellationToken ct) => Task.CompletedTask;
+    public virtual TimeSpan GetRollbackTimeout(SetupContext ctx) =>
+        TimeSpan.FromSeconds(Math.Max(1, ctx.Config.RollbackTimeoutSeconds));
     public virtual bool CanSkip(SetupContext ctx) => false;
     public virtual bool CanRetry => true;
     public virtual RetryPolicy Retry => RetryPolicy.Default;
@@ -423,8 +425,9 @@ public sealed class SetupPipeline
 
     private static async Task RunRollbackWithTimeout(SetupStep step, SetupContext ctx, CancellationToken ct)
     {
+        TimeSpan timeout = step.GetRollbackTimeout(ctx);
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        cts.CancelAfter(TimeSpan.FromSeconds(Math.Max(1, ctx.Config.RollbackTimeoutSeconds)));
+        cts.CancelAfter(timeout);
 
         try
         {
@@ -432,7 +435,8 @@ public sealed class SetupPipeline
         }
         catch (OperationCanceledException) when (!ct.IsCancellationRequested)
         {
-            throw new TimeoutException($"Rollback for step '{step.Id}' exceeded {ctx.Config.RollbackTimeoutSeconds}s.");
+            throw new TimeoutException(
+                $"Rollback for step '{step.Id}' exceeded {timeout.TotalSeconds:F0}s.");
         }
     }
 }

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -3916,6 +3916,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands, IPer
     void IAppCommands.ShowChat() => ShowChatWindow();
     void IAppCommands.CheckForUpdates() => _ = _updateCoordinator!.CheckForUpdatesUserInitiatedAsync();
     void IAppCommands.ShowOnboarding() => _ = ShowOnboardingAsync();
+    void IAppCommands.ShowLocalAiSetup() => _ = _windowManager?.ShowLocalAiSetupAsync();
     void IAppCommands.OpenLocalAiLogs() =>
         OpenFolder(new LocalAiPaths(AppIdentity.ResolveSetupLocalDataDirectory()).LogsDirectory, "Local AI logs");
     void IAppCommands.ShowGatewayWizard() => _ = ShowGatewayWizardAsync();

--- a/src/OpenClaw.Tray.WinUI/Presentation/LocalAiPageViewModel.cs
+++ b/src/OpenClaw.Tray.WinUI/Presentation/LocalAiPageViewModel.cs
@@ -193,7 +193,7 @@ internal sealed class LocalAiPageViewModel : INavigationAware, IDisposable, INot
     public Task<bool> StopAsync() => RunRuntimeActionAsync(CanStop, _runtime.StopAsync);
     public Task<bool> RestartAsync() => RunRuntimeActionAsync(CanRestart, _runtime.RestartAsync);
     public bool OpenLogs() => RunCommand(CanOpenLogs, _appCommands.OpenLocalAiLogs);
-    public bool RetrySetup() => RunCommand(CanRetrySetup, _appCommands.ShowOnboarding);
+    public bool RetrySetup() => RunCommand(CanRetrySetup, _appCommands.ShowLocalAiSetup);
     public bool ChangeModel() => RunCommand(CanChangeModel, _appCommands.ShowOnboarding);
     public bool RepairConnection() => RunCommand(CanRepairConnection, _appCommands.Reconnect);
     public bool OpenChat() => RunCommand(CanOpenChat, _appCommands.ShowChat);

--- a/src/OpenClaw.Tray.WinUI/Services/IAppCommands.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/IAppCommands.cs
@@ -17,6 +17,7 @@ internal interface IAppCommands
     void ShowChat();
     void CheckForUpdates();
     void ShowOnboarding();
+    void ShowLocalAiSetup();
     void OpenLocalAiLogs() { }
     void ShowGatewayWizard();
     void ShowConnectionStatus();

--- a/src/OpenClaw.Tray.WinUI/Services/IWindowManager.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/IWindowManager.cs
@@ -26,6 +26,7 @@ internal interface IWindowManager
     void ShowHub(string? navigateTo = null, bool activate = true);
     void ShowConnectionStatus();
     Task ShowOnboardingAsync();
+    Task ShowLocalAiSetupAsync();
     Task ShowGatewayWizardAsync();
     void CloseSetup();
     void ApplyThemeToOpenWindows();

--- a/src/OpenClaw.Tray.WinUI/Services/LocalAiGatewayDistroResolver.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/LocalAiGatewayDistroResolver.cs
@@ -115,7 +115,7 @@ internal sealed class LocalAiGatewayDistroResolver : ILocalAiGatewayDistroResolv
 
         GatewayRecord owner = owners[0];
         _gatewayId = owner.Id;
-        _distroName = owner.SetupManagedDistroName!.Trim();
+        _distroName = GatewayRecordEditing.ResolveManagedDistroName(owner)!.Trim();
     }
 
     public LocalAiGatewayDistroResolution Resolve()
@@ -132,7 +132,7 @@ internal sealed class LocalAiGatewayDistroResolver : ILocalAiGatewayDistroResolv
         if (owners.Count != 1 ||
             !string.Equals(owners[0].Id, _gatewayId, StringComparison.Ordinal) ||
             !string.Equals(
-                owners[0].SetupManagedDistroName?.Trim(),
+                GatewayRecordEditing.ResolveManagedDistroName(owners[0])?.Trim(),
                 _distroName,
                 StringComparison.Ordinal))
         {

--- a/src/OpenClaw.Tray.WinUI/Services/LocalAiGatewayDistroResolver.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/LocalAiGatewayDistroResolver.cs
@@ -19,6 +19,62 @@ internal interface ILocalAiGatewayDistroResolver
     LocalAiGatewayDistroResolution Resolve();
 }
 
+internal enum LocalAiSetupRoute
+{
+    Recovery,
+    Provision,
+    Blocked,
+}
+
+internal sealed record LocalAiRecoveryTarget(
+    string GatewayId,
+    string DistroName,
+    int GatewayPort);
+
+internal sealed record LocalAiSetupResolution(
+    LocalAiSetupRoute Route,
+    LocalAiRecoveryTarget? RecoveryTarget = null);
+
+internal static class LocalAiSetupRoutePolicy
+{
+    public static LocalAiSetupResolution Decide(
+        IReadOnlyList<GatewayRecord> owners,
+        bool hasLocalGateway,
+        string? localGatewayId,
+        bool hasDistro,
+        bool hasDistroDataDirectory,
+        bool distroIsAppOwned)
+    {
+        if (owners.Count == 1)
+        {
+            var owner = owners[0];
+            if (hasLocalGateway &&
+                string.Equals(localGatewayId, owners[0].Id, StringComparison.Ordinal) &&
+                hasDistro &&
+                distroIsAppOwned &&
+                Uri.TryCreate(owner.Url, UriKind.Absolute, out var uri) &&
+                uri.Port is > 0 and <= 65535)
+            {
+                return new(
+                    LocalAiSetupRoute.Recovery,
+                    new LocalAiRecoveryTarget(
+                        owner.Id,
+                        GatewayRecordEditing.ResolveManagedDistroName(owner)!.Trim(),
+                        uri.Port));
+            }
+
+            return new(LocalAiSetupRoute.Blocked);
+        }
+
+        return new(owners.Count == 0 &&
+            !hasLocalGateway &&
+            !hasDistro &&
+            !hasDistroDataDirectory
+                ? LocalAiSetupRoute.Provision
+                : LocalAiSetupRoute.Blocked);
+    }
+}
+
 /// <summary>
 /// Pins the singleton Local AI installation to the one explicitly setup-managed
 /// local WSL gateway in the loaded registry. Every resolution revalidates the
@@ -87,11 +143,12 @@ internal sealed class LocalAiGatewayDistroResolver : ILocalAiGatewayDistroResolv
         return LocalAiGatewayDistroResolution.Resolved(_distroName);
     }
 
-    private static IReadOnlyList<GatewayRecord> FindOwners(IEnumerable<GatewayRecord> records) =>
+    internal static IReadOnlyList<GatewayRecord> FindOwners(IEnumerable<GatewayRecord> records) =>
         records
             .Where(record =>
-                WslKeepAlivePolicy.IsSetupManagedLocalRecord(record) &&
+                GatewayRecordEditing.IsSetupManagedLocalRecord(record) &&
                 !string.IsNullOrWhiteSpace(record.Id) &&
-                !string.IsNullOrWhiteSpace(record.SetupManagedDistroName))
+                !string.IsNullOrWhiteSpace(
+                    GatewayRecordEditing.ResolveManagedDistroName(record)))
             .ToArray();
 }

--- a/src/OpenClaw.Tray.WinUI/Services/LocalAiGatewayDistroResolver.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/LocalAiGatewayDistroResolver.cs
@@ -29,7 +29,9 @@ internal enum LocalAiSetupRoute
 internal sealed record LocalAiRecoveryTarget(
     string GatewayId,
     string DistroName,
-    int GatewayPort);
+    int GatewayPort,
+    string? ModelCatalogId,
+    int? RequestedLocalAiPort);
 
 internal sealed record LocalAiSetupResolution(
     LocalAiSetupRoute Route,
@@ -43,7 +45,9 @@ internal static class LocalAiSetupRoutePolicy
         string? localGatewayId,
         bool hasDistro,
         bool hasDistroDataDirectory,
-        bool distroIsAppOwned)
+        bool distroIsAppOwned,
+        string? installedModelCatalogId = null,
+        int? installedRequestedLocalAiPort = null)
     {
         if (owners.Count == 1)
         {
@@ -53,14 +57,19 @@ internal static class LocalAiSetupRoutePolicy
                 hasDistro &&
                 distroIsAppOwned &&
                 Uri.TryCreate(owner.Url, UriKind.Absolute, out var uri) &&
-                uri.Port is > 0 and <= 65535)
+                uri.Port is > 0 and <= 65535 &&
+                GatewayRecordEditing.AreEquivalentLoopbackEndpoints(
+                    owner.Url,
+                    $"ws://127.0.0.1:{uri.Port}"))
             {
                 return new(
                     LocalAiSetupRoute.Recovery,
                     new LocalAiRecoveryTarget(
                         owner.Id,
                         GatewayRecordEditing.ResolveManagedDistroName(owner)!.Trim(),
-                        uri.Port));
+                        uri.Port,
+                        installedModelCatalogId,
+                        installedRequestedLocalAiPort));
             }
 
             return new(LocalAiSetupRoute.Blocked);

--- a/src/OpenClaw.Tray.WinUI/Services/WindowManager.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/WindowManager.cs
@@ -2,6 +2,7 @@ using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using OpenClaw.Connection;
+using OpenClaw.SetupEngine;
 using OpenClaw.Shared;
 using OpenClawTray.Helpers;
 using OpenClawTray.Presentation;
@@ -341,13 +342,89 @@ internal sealed class WindowManager : IWindowManager
 
     public async Task ShowOnboardingAsync()
     {
-        await EnsureSetupWindowAsync(startAtGatewayInstalledMilestone: false);
+        await EnsureSetupWindowAsync(
+            startAtGatewayInstalledMilestone: false,
+            localAiRecoveryTarget: null);
+    }
+
+    public async Task ShowLocalAiSetupAsync()
+    {
+        var resolution = await ResolveLocalAiSetupRouteAsync();
+        if (resolution.Route == LocalAiSetupRoute.Provision)
+        {
+            Logger.Info("Local AI recovery requires an existing app-managed gateway; opening full setup");
+            await ShowOnboardingAsync();
+            return;
+        }
+        if (resolution.Route == LocalAiSetupRoute.Blocked ||
+            resolution.RecoveryTarget is null)
+        {
+            Logger.Warn("Local AI setup could not safely identify one existing app-managed gateway");
+            _callbacks.GetAppNotificationService()?.Show(new AppNotification
+            {
+                Id = $"local-ai-setup-owner-{Guid.NewGuid():N}",
+                Title = "Local AI setup needs attention",
+                Message = "OpenClaw could not safely identify the managed WSL gateway. Review Connection settings before retrying setup.",
+                Severity = AppNotificationSeverity.Warning,
+                Source = "local-ai",
+                DedupeKey = "local-ai-setup-owner",
+                CreatedAt = DateTimeOffset.UtcNow,
+            });
+            ShowHub("connection");
+            return;
+        }
+
+        await ShowLocalAiSetupRecoveryAsync(resolution.RecoveryTarget);
+    }
+
+    private async Task<LocalAiSetupResolution> ResolveLocalAiSetupRouteAsync()
+    {
+        var registry = _callbacks.GetGatewayRegistry();
+        if (registry is null)
+            return new(LocalAiSetupRoute.Blocked);
+
+        try
+        {
+            var owners = LocalAiGatewayDistroResolver.FindOwners(registry.GetAll());
+            var distroName = owners.Count == 1
+                ? GatewayRecordEditing.ResolveManagedDistroName(owners[0])!.Trim()
+                : AppIdentity.SetupDistroName;
+            var existing = await Task.Run(() => ExistingConfigDetector.Detect(
+                AppIdentity.ResolveRoamingDataDirectory(),
+                distroName,
+                AppIdentity.ResolveSetupLocalDataDirectory(),
+                owners.Count == 1 ? owners[0].Id : null));
+            return LocalAiSetupRoutePolicy.Decide(
+                owners,
+                existing.HasLocalGateway,
+                existing.LocalGatewayId,
+                existing.HasDistro,
+                existing.HasDistroDataDirectory,
+                existing.DistroIsAppOwned);
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn($"Local AI recovery gateway inspection failed: {ex.Message}");
+            return new(LocalAiSetupRoute.Blocked);
+        }
+    }
+
+    private async Task ShowLocalAiSetupRecoveryAsync(LocalAiRecoveryTarget target)
+    {
+        var (setupWindow, created) = await EnsureSetupWindowAsync(
+            startAtGatewayInstalledMilestone: false,
+            localAiRecoveryTarget: target);
+        if (!_isShuttingDown && !created && setupWindow is { IsClosed: false })
+        {
+            Logger.Info("Setup window already open; leaving current setup page visible to avoid interrupting active setup");
+        }
     }
 
     public async Task ShowGatewayWizardAsync()
     {
         var (setupWindow, created) = await EnsureSetupWindowAsync(
-            startAtGatewayInstalledMilestone: true);
+            startAtGatewayInstalledMilestone: true,
+            localAiRecoveryTarget: null);
         if (!_isShuttingDown && !created && setupWindow is { IsClosed: false })
         {
             if (setupWindow.TryNavigateToGatewayInstalledMilestone())
@@ -362,7 +439,8 @@ internal sealed class WindowManager : IWindowManager
     }
 
     private async Task<(SetupWindow? Window, bool Created)> EnsureSetupWindowAsync(
-        bool startAtGatewayInstalledMilestone)
+        bool startAtGatewayInstalledMilestone,
+        LocalAiRecoveryTarget? localAiRecoveryTarget)
     {
         if (_isShuttingDown || _callbacks.GetSettings() is null)
         {
@@ -409,10 +487,14 @@ internal sealed class WindowManager : IWindowManager
         {
             setupWindow = new SetupWindow(
                 startAtGatewayInstalledMilestone: startAtGatewayInstalledMilestone,
+                startAtLocalAiRecoveryReview: localAiRecoveryTarget is not null,
                 dataDir: AppIdentity.ResolveRoamingDataDirectory(),
                 localDataDir: AppIdentity.ResolveSetupLocalDataDirectory(),
                 distroNameOverride: AppIdentity.SetupDistroName,
                 gatewayPortOverride: AppIdentity.SetupGatewayPort,
+                localAiRecoveryGatewayId: localAiRecoveryTarget?.GatewayId,
+                localAiRecoveryDistroName: localAiRecoveryTarget?.DistroName,
+                localAiRecoveryGatewayPort: localAiRecoveryTarget?.GatewayPort,
                 commandLineArgs: SetupWindowArgumentProjection.Project(
                     _callbacks.GetStartupArgs(),
                     _callbacks.IsDeepLinkArg,

--- a/src/OpenClaw.Tray.WinUI/Services/WindowManager.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/WindowManager.cs
@@ -2,6 +2,7 @@ using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using OpenClaw.Connection;
+using OpenClaw.Connection.LocalAi;
 using OpenClaw.SetupEngine;
 using OpenClaw.Shared;
 using OpenClawTray.Helpers;
@@ -394,13 +395,18 @@ internal sealed class WindowManager : IWindowManager
                 distroName,
                 AppIdentity.ResolveSetupLocalDataDirectory(),
                 owners.Count == 1 ? owners[0].Id : null));
+            LocalAiResolvedInstall? install = await new LocalAiManifestStore(
+                    new LocalAiPaths(AppIdentity.ResolveSetupLocalDataDirectory()))
+                .LoadAsync();
             return LocalAiSetupRoutePolicy.Decide(
                 owners,
                 existing.HasLocalGateway,
                 existing.LocalGatewayId,
                 existing.HasDistro,
                 existing.HasDistroDataDirectory,
-                existing.DistroIsAppOwned);
+                existing.DistroIsAppOwned,
+                install?.Manifest.ModelCatalogId,
+                install?.Manifest.RequestedPort);
         }
         catch (Exception ex)
         {
@@ -495,6 +501,8 @@ internal sealed class WindowManager : IWindowManager
                 localAiRecoveryGatewayId: localAiRecoveryTarget?.GatewayId,
                 localAiRecoveryDistroName: localAiRecoveryTarget?.DistroName,
                 localAiRecoveryGatewayPort: localAiRecoveryTarget?.GatewayPort,
+                localAiRecoveryModelId: localAiRecoveryTarget?.ModelCatalogId,
+                localAiRecoveryRequestedPort: localAiRecoveryTarget?.RequestedLocalAiPort,
                 commandLineArgs: SetupWindowArgumentProjection.Project(
                     _callbacks.GetStartupArgs(),
                     _callbacks.IsDeepLinkArg,

--- a/src/OpenClaw.Tray.WinUI/Services/WslKeepAlivePolicy.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/WslKeepAlivePolicy.cs
@@ -107,15 +107,9 @@ internal static class WslKeepAlivePolicy
     }
 
     public static bool IsSetupManagedLocalRecord(GatewayRecord record)
-    {
-        if (record.SshTunnel is not null)
-            return false;
-
-        if (GatewayRecordEditing.ResolveManagedDistroName(record) is not null)
-            return record.IsLocal || LocalGatewayUrlClassifier.IsLocalGatewayUrl(record.Url);
-
-        return IsLegacyDefaultSetupManagedLocalRecord(record);
-    }
+        => GatewayRecordEditing.IsSetupManagedLocalRecord(record) ||
+           (record.SshTunnel is null &&
+            IsLegacyDefaultSetupManagedLocalRecord(record));
 
     public static bool IsSameSetupManagedGateway(
         GatewayRecord expected,

--- a/tests/OpenClaw.SetupEngine.Tests/LocalAiGatewayUninstallTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/LocalAiGatewayUninstallTests.cs
@@ -177,6 +177,7 @@ public sealed class LocalAiGatewayUninstallTests
         var commands = new GatewayStateCommandRunner(originalProvider, primary);
         SetupContext context = CreateRecoveryContext(temp.Path, commands);
         context.LocalAiRecoveryOriginalInstall = original;
+        context.LocalAiRecoveryReceiptRollbackAllowed = true;
         LocalAiInstallManifest replacementManifest = original.Manifest with
         {
             Endpoint = "http://127.0.0.1:39876/v1",
@@ -211,6 +212,7 @@ public sealed class LocalAiGatewayUninstallTests
         var commands = new GatewayStateCommandRunner(driftedProvider, primary);
         SetupContext context = CreateRecoveryContext(temp.Path, commands);
         context.LocalAiRecoveryOriginalInstall = original;
+        context.LocalAiRecoveryReceiptRollbackAllowed = true;
         LocalAiInstallManifest replacementManifest = original.Manifest with
         {
             Endpoint = "http://127.0.0.1:39876/v1",
@@ -240,6 +242,7 @@ public sealed class LocalAiGatewayUninstallTests
         var commands = new GatewayStateCommandRunner(originalProvider, primary);
         SetupContext context = CreateRecoveryContext(temp.Path, commands);
         context.LocalAiRecoveryOriginalInstall = original;
+        context.LocalAiRecoveryReceiptRollbackAllowed = true;
         LocalAiInstallManifest replacementManifest = original.Manifest with
         {
             Endpoint = "http://127.0.0.1:39876/v1",
@@ -278,6 +281,7 @@ public sealed class LocalAiGatewayUninstallTests
         };
         SetupContext context = CreateRecoveryContext(temp.Path, commands);
         context.LocalAiRecoveryOriginalInstall = original;
+        context.LocalAiRecoveryReceiptRollbackAllowed = true;
         LocalAiInstallManifest replacementManifest = original.Manifest with
         {
             Endpoint = "http://127.0.0.1:39876/v1",
@@ -312,6 +316,7 @@ public sealed class LocalAiGatewayUninstallTests
             primaryJson: JsonSerializer.Serialize("openai/gpt-5"));
         SetupContext context = CreateRecoveryContext(temp.Path, commands);
         context.LocalAiRecoveryOriginalInstall = original;
+        context.LocalAiRecoveryReceiptRollbackAllowed = true;
         LocalAiInstallManifest replacementManifest = original.Manifest with
         {
             Endpoint = "http://127.0.0.1:39876/v1",
@@ -350,6 +355,7 @@ public sealed class LocalAiGatewayUninstallTests
         };
         SetupContext context = CreateRecoveryContext(temp.Path, commands);
         context.LocalAiRecoveryOriginalInstall = original;
+        context.LocalAiRecoveryReceiptRollbackAllowed = true;
         LocalAiInstallManifest replacementManifest = original.Manifest with
         {
             Endpoint = "http://127.0.0.1:39876/v1",
@@ -374,6 +380,99 @@ public sealed class LocalAiGatewayUninstallTests
         Assert.Equal(primary, commands.PrimaryJson);
         Assert.Equal(original.Endpoint, (await store.LoadAsync())!.Endpoint);
         Assert.False(context.LocalAiRecoveryProviderTransition);
+    }
+
+    [Fact]
+    public async Task Recovery_FailedProviderCompensationKeepsReplacementReceipt()
+    {
+        using var temp = new TempDirectory("local-ai-gateway-recovery-");
+        LocalAiResolvedInstall original = await SaveManifestAsync(temp.Path, "openai/gpt-5");
+        string originalProvider = LocalAiGatewayProviderDefinition.BuildProviderJson(original);
+        string primary = JsonSerializer.Serialize(
+            LocalAiGatewayProviderDefinition.BuildPrimaryModel(original));
+        var commands = new GatewayStateCommandRunner(originalProvider, primary);
+        SetupContext context = CreateRecoveryContext(temp.Path, commands);
+        context.Config.RollbackOnFailure = true;
+        context.LocalAiRecoveryOriginalInstall = original;
+        context.LocalAiRecoveryReceiptRollbackAllowed = true;
+        LocalAiInstallManifest replacementManifest = original.Manifest with
+        {
+            Endpoint = "http://127.0.0.1:39876/v1",
+        };
+        var store = new LocalAiManifestStore(new LocalAiPaths(temp.Path));
+        await store.SaveAsync(replacementManifest);
+        context.LocalAiResolvedInstall = store.ResolveAndValidate(replacementManifest);
+        var configure = new ConfigureLocalAiGatewayStep();
+        StepResult configured = await configure.ExecuteAsync(context, CancellationToken.None);
+        commands.FailRestoreBatchOnce = true;
+        var pipeline = new SetupPipeline(
+        [
+            new PreserveLocalAiRecoveryGatewayStep((_, _) =>
+                Task.FromResult(StepResult.Ok("not needed"))),
+            new DelegatingRollbackStep("configured", configure.RollbackAsync),
+            new DelegatingRollbackStep(
+                "fail",
+                (_, _) => Task.CompletedTask,
+                (_, _) => Task.FromResult(StepResult.Fail("forced failure"))),
+        ]);
+
+        PipelineResult result = await pipeline.RunAsync(context);
+
+        Assert.Equal(StepOutcome.Success, configured.Outcome);
+        Assert.Equal(PipelineOutcome.Failed, result.Outcome);
+        Assert.True(LocalAiGatewayProviderDefinition.MatchesProviderJson(
+            commands.ProviderJson!,
+            context.LocalAiResolvedInstall));
+        Assert.Equal(new Uri(replacementManifest.Endpoint!), (await store.LoadAsync())!.Endpoint);
+        Assert.False(context.LocalAiRecoveryProviderTransition);
+        Assert.False(context.LocalAiRecoveryReceiptRollbackAllowed);
+    }
+
+    [Fact]
+    public async Task Recovery_LostRollbackAcknowledgementRestoresOriginalReceipt()
+    {
+        using var temp = new TempDirectory("local-ai-gateway-recovery-");
+        LocalAiResolvedInstall original = await SaveManifestAsync(temp.Path, "openai/gpt-5");
+        string originalProvider = LocalAiGatewayProviderDefinition.BuildProviderJson(original);
+        string primary = JsonSerializer.Serialize(
+            LocalAiGatewayProviderDefinition.BuildPrimaryModel(original));
+        var commands = new GatewayStateCommandRunner(originalProvider, primary);
+        SetupContext context = CreateRecoveryContext(temp.Path, commands);
+        context.Config.RollbackOnFailure = true;
+        context.LocalAiRecoveryOriginalInstall = original;
+        context.LocalAiRecoveryReceiptRollbackAllowed = true;
+        LocalAiInstallManifest replacementManifest = original.Manifest with
+        {
+            Endpoint = "http://127.0.0.1:39876/v1",
+        };
+        var store = new LocalAiManifestStore(new LocalAiPaths(temp.Path));
+        await store.SaveAsync(replacementManifest);
+        context.LocalAiResolvedInstall = store.ResolveAndValidate(replacementManifest);
+        var configure = new ConfigureLocalAiGatewayStep();
+        StepResult configured = await configure.ExecuteAsync(context, CancellationToken.None);
+        commands.LoseRestoreAcknowledgementOnce = true;
+        var pipeline = new SetupPipeline(
+        [
+            new PreserveLocalAiRecoveryGatewayStep((_, _) =>
+                Task.FromResult(StepResult.Ok("not needed"))),
+            new DelegatingRollbackStep("configured", configure.RollbackAsync),
+            new DelegatingRollbackStep(
+                "fail",
+                (_, _) => Task.CompletedTask,
+                (_, _) => Task.FromResult(StepResult.Fail("forced failure"))),
+        ]);
+
+        PipelineResult result = await pipeline.RunAsync(context);
+
+        Assert.Equal(StepOutcome.Success, configured.Outcome);
+        Assert.Equal(PipelineOutcome.Failed, result.Outcome);
+        Assert.True(LocalAiGatewayProviderDefinition.MatchesProviderJson(
+            commands.ProviderJson!,
+            original));
+        Assert.Equal(primary, commands.PrimaryJson);
+        Assert.Equal(original.Endpoint, (await store.LoadAsync())!.Endpoint);
+        Assert.False(context.LocalAiRecoveryProviderTransition);
+        Assert.False(context.LocalAiRecoveryReceiptRollbackAllowed);
     }
 
     private static SetupContext CreateContext(string localDataDirectory, ICommandRunner commands)
@@ -474,6 +573,8 @@ public sealed class LocalAiGatewayUninstallTests
         public bool FailCapture { get; init; }
         public bool FailConfiguredBatchOnce { get; set; }
         public bool LoseConfiguredAcknowledgementOnce { get; set; }
+        public bool FailRestoreBatchOnce { get; set; }
+        public bool LoseRestoreAcknowledgementOnce { get; set; }
         public List<string> WslCalls { get; } = [];
 
         public Task<CommandResult> RunAsync(
@@ -499,6 +600,17 @@ public sealed class LocalAiGatewayUninstallTests
             WslCalls.Add(command);
             if (environment is not null && environment.Count == 1)
             {
+                if (FailRestoreBatchOnce &&
+                    command.Contains("LOCAL_AI_GATEWAY_RESTORED", StringComparison.Ordinal))
+                {
+                    FailRestoreBatchOnce = false;
+                    return Task.FromResult(new CommandResult(
+                        1,
+                        "",
+                        "gateway rollback failed",
+                        TimeSpan.Zero,
+                        TimedOut: false));
+                }
                 if (FailConfiguredBatchOnce &&
                     command.Contains("LOCAL_AI_GATEWAY_CONFIGURED", StringComparison.Ordinal))
                 {
@@ -521,6 +633,17 @@ public sealed class LocalAiGatewayUninstallTests
                         ProviderJson = value;
                     else if (path == LocalAiGatewayProviderDefinition.PrimaryModelPath)
                         PrimaryJson = value;
+                }
+                if (LoseRestoreAcknowledgementOnce &&
+                    command.Contains("LOCAL_AI_GATEWAY_RESTORED", StringComparison.Ordinal))
+                {
+                    LoseRestoreAcknowledgementOnce = false;
+                    return Task.FromResult(new CommandResult(
+                        1,
+                        "",
+                        "gateway rollback acknowledgement lost",
+                        TimeSpan.Zero,
+                        TimedOut: false));
                 }
                 if (LoseConfiguredAcknowledgementOnce &&
                     command.Contains("LOCAL_AI_GATEWAY_CONFIGURED", StringComparison.Ordinal))
@@ -579,5 +702,21 @@ public sealed class LocalAiGatewayUninstallTests
         private static string EncodeOrMissing(string? value) => value is null
             ? "MISSING"
             : Convert.ToBase64String(Encoding.UTF8.GetBytes(value));
+    }
+
+    private sealed class DelegatingRollbackStep(
+        string id,
+        Func<SetupContext, CancellationToken, Task> rollback,
+        Func<SetupContext, CancellationToken, Task<StepResult>>? execute = null) : SetupStep
+    {
+        public override string Id => id;
+        public override string DisplayName => id;
+        public override bool CanRetry => false;
+
+        public override Task<StepResult> ExecuteAsync(SetupContext ctx, CancellationToken ct) =>
+            execute?.Invoke(ctx, ct) ?? Task.FromResult(StepResult.Ok());
+
+        public override Task RollbackAsync(SetupContext ctx, CancellationToken ct) =>
+            rollback(ctx, ct);
     }
 }

--- a/tests/OpenClaw.SetupEngine.Tests/LocalAiGatewayUninstallTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/LocalAiGatewayUninstallTests.cs
@@ -254,8 +254,9 @@ public sealed class LocalAiGatewayUninstallTests
 
         StepResult result = await step.ExecuteAsync(context, CancellationToken.None);
         await step.RollbackAsync(context, CancellationToken.None);
-        await new PreserveLocalAiRecoveryGatewayStep((_, _) =>
-                Task.FromResult(StepResult.Ok("not needed")))
+        await new PreserveLocalAiRecoveryGatewayStep(
+                (_, _) => Task.FromResult(StepResult.Ok("not needed")),
+                (_, _) => Task.FromResult(true))
             .RollbackAsync(context, CancellationToken.None);
 
         Assert.Equal(StepOutcome.Success, result.Outcome);
@@ -289,8 +290,9 @@ public sealed class LocalAiGatewayUninstallTests
 
         StepResult result = await step.ExecuteAsync(context, CancellationToken.None);
         await step.RollbackAsync(context, CancellationToken.None);
-        await new PreserveLocalAiRecoveryGatewayStep((_, _) =>
-                Task.FromResult(StepResult.Ok("not needed")))
+        await new PreserveLocalAiRecoveryGatewayStep(
+                (_, _) => Task.FromResult(StepResult.Ok("not needed")),
+                (_, _) => Task.FromResult(true))
             .RollbackAsync(context, CancellationToken.None);
 
         Assert.Equal(StepOutcome.Success, result.Outcome);
@@ -326,8 +328,9 @@ public sealed class LocalAiGatewayUninstallTests
 
         StepResult result = await step.ExecuteAsync(context, CancellationToken.None);
         await step.RollbackAsync(context, CancellationToken.None);
-        await new PreserveLocalAiRecoveryGatewayStep((_, _) =>
-                Task.FromResult(StepResult.Ok("not needed")))
+        await new PreserveLocalAiRecoveryGatewayStep(
+                (_, _) => Task.FromResult(StepResult.Ok("not needed")),
+                (_, _) => Task.FromResult(true))
             .RollbackAsync(context, CancellationToken.None);
 
         Assert.Equal(StepOutcome.Failed, result.Outcome);
@@ -363,8 +366,9 @@ public sealed class LocalAiGatewayUninstallTests
             ProviderJson: null,
             PrimaryModelExisted: true,
             PrimaryModelJson: JsonSerializer.Serialize("openai/gpt-5"));
-        var step = new PreserveLocalAiRecoveryGatewayStep((_, _) =>
-            Task.FromResult(StepResult.Ok("not needed")));
+        var step = new PreserveLocalAiRecoveryGatewayStep(
+            (_, _) => Task.FromResult(StepResult.Ok("not needed")),
+            (_, _) => Task.FromResult(true));
 
         await step.RollbackAsync(context, CancellationToken.None);
 
@@ -401,8 +405,9 @@ public sealed class LocalAiGatewayUninstallTests
         StepResult first = await step.ExecuteAsync(context, CancellationToken.None);
         StepResult second = await step.ExecuteAsync(context, CancellationToken.None);
         await step.RollbackAsync(context, CancellationToken.None);
-        await new PreserveLocalAiRecoveryGatewayStep((_, _) =>
-                Task.FromResult(StepResult.Ok("not needed")))
+        await new PreserveLocalAiRecoveryGatewayStep(
+                (_, _) => Task.FromResult(StepResult.Ok("not needed")),
+                (_, _) => Task.FromResult(true))
             .RollbackAsync(context, CancellationToken.None);
 
         Assert.Equal(StepOutcome.Failed, first.Outcome);
@@ -486,8 +491,9 @@ public sealed class LocalAiGatewayUninstallTests
         commands.LoseRestoreAcknowledgementOnce = true;
         var pipeline = new SetupPipeline(
         [
-            new PreserveLocalAiRecoveryGatewayStep((_, _) =>
-                Task.FromResult(StepResult.Ok("not needed"))),
+            new PreserveLocalAiRecoveryGatewayStep(
+                (_, _) => Task.FromResult(StepResult.Ok("not needed")),
+                (_, _) => Task.FromResult(true)),
             new DelegatingRollbackStep("configured", configure.RollbackAsync),
             new DelegatingRollbackStep(
                 "fail",

--- a/tests/OpenClaw.SetupEngine.Tests/LocalAiGatewayUninstallTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/LocalAiGatewayUninstallTests.cs
@@ -268,6 +268,39 @@ public sealed class LocalAiGatewayUninstallTests
     }
 
     [Fact]
+    public async Task Recovery_RollbackPreservesEndpointCycleManagedPrimary()
+    {
+        using var temp = new TempDirectory("local-ai-gateway-recovery-");
+        LocalAiResolvedInstall original = await SaveManifestAsync(temp.Path, "openai/gpt-5");
+        string managedPrimary = JsonSerializer.Serialize(
+            LocalAiGatewayProviderDefinition.BuildPrimaryModel(original));
+        var commands = new GatewayStateCommandRunner(providerJson: null, managedPrimary);
+        SetupContext context = CreateRecoveryContext(temp.Path, commands);
+        context.LocalAiRecoveryOriginalInstall = original;
+        context.LocalAiRecoveryReceiptRollbackAllowed = true;
+        LocalAiInstallManifest replacementManifest = original.Manifest with
+        {
+            Endpoint = "http://127.0.0.1:39876/v1",
+        };
+        var store = new LocalAiManifestStore(new LocalAiPaths(temp.Path));
+        await store.SaveAsync(replacementManifest);
+        context.LocalAiResolvedInstall = store.ResolveAndValidate(replacementManifest);
+        var step = new ConfigureLocalAiGatewayStep();
+
+        StepResult result = await step.ExecuteAsync(context, CancellationToken.None);
+        await step.RollbackAsync(context, CancellationToken.None);
+        await new PreserveLocalAiRecoveryGatewayStep((_, _) =>
+                Task.FromResult(StepResult.Ok("not needed")))
+            .RollbackAsync(context, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.Success, result.Outcome);
+        Assert.Null(commands.ProviderJson);
+        Assert.Equal(managedPrimary, commands.PrimaryJson);
+        Assert.Equal(original.Endpoint, (await store.LoadAsync())!.Endpoint);
+        Assert.False(context.LocalAiRecoveryProviderTransition);
+    }
+
+    [Fact]
     public async Task Recovery_FailedProviderSwitchRestoresOriginalReceipt()
     {
         using var temp = new TempDirectory("local-ai-gateway-recovery-");

--- a/tests/OpenClaw.SetupEngine.Tests/LocalAiGatewayUninstallTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/LocalAiGatewayUninstallTests.cs
@@ -475,6 +475,52 @@ public sealed class LocalAiGatewayUninstallTests
         Assert.False(context.LocalAiRecoveryReceiptRollbackAllowed);
     }
 
+    [Fact]
+    public async Task Recovery_RollbackCancellationKeepsReplacementReceipt()
+    {
+        using var temp = new TempDirectory("local-ai-gateway-recovery-");
+        LocalAiResolvedInstall original = await SaveManifestAsync(temp.Path, "openai/gpt-5");
+        string originalProvider = LocalAiGatewayProviderDefinition.BuildProviderJson(original);
+        string primary = JsonSerializer.Serialize(
+            LocalAiGatewayProviderDefinition.BuildPrimaryModel(original));
+        var commands = new GatewayStateCommandRunner(originalProvider, primary);
+        SetupContext context = CreateRecoveryContext(temp.Path, commands);
+        context.Config.RollbackOnFailure = true;
+        context.LocalAiRecoveryOriginalInstall = original;
+        context.LocalAiRecoveryReceiptRollbackAllowed = true;
+        LocalAiInstallManifest replacementManifest = original.Manifest with
+        {
+            Endpoint = "http://127.0.0.1:39876/v1",
+        };
+        var store = new LocalAiManifestStore(new LocalAiPaths(temp.Path));
+        await store.SaveAsync(replacementManifest);
+        context.LocalAiResolvedInstall = store.ResolveAndValidate(replacementManifest);
+        var configure = new ConfigureLocalAiGatewayStep();
+        StepResult configured = await configure.ExecuteAsync(context, CancellationToken.None);
+        commands.ThrowOnNextCapture = true;
+        var pipeline = new SetupPipeline(
+        [
+            new PreserveLocalAiRecoveryGatewayStep((_, _) =>
+                Task.FromResult(StepResult.Ok("not needed"))),
+            new DelegatingRollbackStep("configured", configure.RollbackAsync),
+            new DelegatingRollbackStep(
+                "fail",
+                (_, _) => Task.CompletedTask,
+                (_, _) => Task.FromResult(StepResult.Fail("forced failure"))),
+        ]);
+
+        PipelineResult result = await pipeline.RunAsync(context);
+
+        Assert.Equal(StepOutcome.Success, configured.Outcome);
+        Assert.Equal(PipelineOutcome.Failed, result.Outcome);
+        Assert.True(LocalAiGatewayProviderDefinition.MatchesProviderJson(
+            commands.ProviderJson!,
+            context.LocalAiResolvedInstall));
+        Assert.Equal(new Uri(replacementManifest.Endpoint!), (await store.LoadAsync())!.Endpoint);
+        Assert.False(context.LocalAiRecoveryProviderTransition);
+        Assert.False(context.LocalAiRecoveryReceiptRollbackAllowed);
+    }
+
     private static SetupContext CreateContext(string localDataDirectory, ICommandRunner commands)
     {
         var config = new SetupConfig { LocalAi = new LocalAiConfig { Enabled = true } };
@@ -575,6 +621,7 @@ public sealed class LocalAiGatewayUninstallTests
         public bool LoseConfiguredAcknowledgementOnce { get; set; }
         public bool FailRestoreBatchOnce { get; set; }
         public bool LoseRestoreAcknowledgementOnce { get; set; }
+        public bool ThrowOnNextCapture { get; set; }
         public List<string> WslCalls { get; } = [];
 
         public Task<CommandResult> RunAsync(
@@ -682,6 +729,11 @@ public sealed class LocalAiGatewayUninstallTests
                     "",
                     TimeSpan.Zero,
                     TimedOut: false));
+            }
+            if (ThrowOnNextCapture)
+            {
+                ThrowOnNextCapture = false;
+                throw new OperationCanceledException(ct);
             }
             if (FailCapture)
             {

--- a/tests/OpenClaw.SetupEngine.Tests/LocalAiGatewayUninstallTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/LocalAiGatewayUninstallTests.cs
@@ -166,6 +166,136 @@ public sealed class LocalAiGatewayUninstallTests
             command.Contains("LOCAL_AI_GATEWAY_UNSET", StringComparison.Ordinal));
     }
 
+    [Fact]
+    public async Task Recovery_ReplacesExactManagedProviderAfterAutomaticPortChanges()
+    {
+        using var temp = new TempDirectory("local-ai-gateway-recovery-");
+        LocalAiResolvedInstall original = await SaveManifestAsync(temp.Path, "openai/gpt-5");
+        string originalProvider = LocalAiGatewayProviderDefinition.BuildProviderJson(original);
+        string primary = JsonSerializer.Serialize(
+            LocalAiGatewayProviderDefinition.BuildPrimaryModel(original));
+        var commands = new GatewayStateCommandRunner(originalProvider, primary);
+        SetupContext context = CreateRecoveryContext(temp.Path, commands);
+        context.LocalAiRecoveryOriginalInstall = original;
+        LocalAiInstallManifest replacementManifest = original.Manifest with
+        {
+            Endpoint = "http://127.0.0.1:39876/v1",
+        };
+        var store = new LocalAiManifestStore(new LocalAiPaths(temp.Path));
+        await store.SaveAsync(replacementManifest);
+        context.LocalAiResolvedInstall = store.ResolveAndValidate(replacementManifest);
+        var step = new ConfigureLocalAiGatewayStep();
+
+        StepResult result = await step.ExecuteAsync(context, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.Success, result.Outcome);
+        Assert.True(context.LocalAiRecoveryProviderTransition);
+        Assert.True(LocalAiGatewayProviderDefinition.MatchesProviderJson(
+            commands.ProviderJson!,
+            context.LocalAiResolvedInstall));
+        Assert.Equal(primary, commands.PrimaryJson);
+    }
+
+    [Fact]
+    public async Task Recovery_PreservesProviderThatMatchesNeitherEndpoint()
+    {
+        using var temp = new TempDirectory("local-ai-gateway-recovery-");
+        LocalAiResolvedInstall original = await SaveManifestAsync(temp.Path);
+        string driftedProvider = LocalAiGatewayProviderDefinition.BuildProviderJson(original)
+            .Replace(
+                "http://127.0.0.1:28765/v1",
+                "http://127.0.0.1:45555/v1",
+                StringComparison.Ordinal);
+        string primary = JsonSerializer.Serialize(
+            LocalAiGatewayProviderDefinition.BuildPrimaryModel(original));
+        var commands = new GatewayStateCommandRunner(driftedProvider, primary);
+        SetupContext context = CreateRecoveryContext(temp.Path, commands);
+        context.LocalAiRecoveryOriginalInstall = original;
+        LocalAiInstallManifest replacementManifest = original.Manifest with
+        {
+            Endpoint = "http://127.0.0.1:39876/v1",
+        };
+        context.LocalAiResolvedInstall = new LocalAiResolvedInstall(
+            replacementManifest,
+            original.ExecutablePath,
+            original.ModelPath,
+            new Uri(replacementManifest.Endpoint!));
+
+        StepResult result = await new ConfigureLocalAiGatewayStep()
+            .ExecuteAsync(context, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.Failed, result.Outcome);
+        Assert.Equal(driftedProvider, commands.ProviderJson);
+        Assert.Equal(primary, commands.PrimaryJson);
+    }
+
+    [Fact]
+    public async Task Recovery_RollbackRestoresOriginalProviderAndReceipt()
+    {
+        using var temp = new TempDirectory("local-ai-gateway-recovery-");
+        LocalAiResolvedInstall original = await SaveManifestAsync(temp.Path, "openai/gpt-5");
+        string originalProvider = LocalAiGatewayProviderDefinition.BuildProviderJson(original);
+        string primary = JsonSerializer.Serialize(
+            LocalAiGatewayProviderDefinition.BuildPrimaryModel(original));
+        var commands = new GatewayStateCommandRunner(originalProvider, primary);
+        SetupContext context = CreateRecoveryContext(temp.Path, commands);
+        context.LocalAiRecoveryOriginalInstall = original;
+        LocalAiInstallManifest replacementManifest = original.Manifest with
+        {
+            Endpoint = "http://127.0.0.1:39876/v1",
+        };
+        var store = new LocalAiManifestStore(new LocalAiPaths(temp.Path));
+        await store.SaveAsync(replacementManifest);
+        context.LocalAiResolvedInstall = store.ResolveAndValidate(replacementManifest);
+        var step = new ConfigureLocalAiGatewayStep();
+
+        StepResult result = await step.ExecuteAsync(context, CancellationToken.None);
+        await step.RollbackAsync(context, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.Success, result.Outcome);
+        Assert.True(LocalAiGatewayProviderDefinition.MatchesProviderJson(
+            commands.ProviderJson!,
+            original));
+        Assert.Equal(primary, commands.PrimaryJson);
+        Assert.Equal(original.Endpoint, (await store.LoadAsync())!.Endpoint);
+        Assert.False(context.LocalAiRecoveryProviderTransition);
+    }
+
+    [Fact]
+    public async Task Recovery_FailedProviderSwitchRestoresOriginalReceipt()
+    {
+        using var temp = new TempDirectory("local-ai-gateway-recovery-");
+        LocalAiResolvedInstall original = await SaveManifestAsync(temp.Path, "openai/gpt-5");
+        string originalProvider = LocalAiGatewayProviderDefinition.BuildProviderJson(original);
+        string primary = JsonSerializer.Serialize(
+            LocalAiGatewayProviderDefinition.BuildPrimaryModel(original));
+        var commands = new GatewayStateCommandRunner(originalProvider, primary)
+        {
+            FailConfiguredBatchOnce = true,
+        };
+        SetupContext context = CreateRecoveryContext(temp.Path, commands);
+        context.LocalAiRecoveryOriginalInstall = original;
+        LocalAiInstallManifest replacementManifest = original.Manifest with
+        {
+            Endpoint = "http://127.0.0.1:39876/v1",
+        };
+        var store = new LocalAiManifestStore(new LocalAiPaths(temp.Path));
+        await store.SaveAsync(replacementManifest);
+        context.LocalAiResolvedInstall = store.ResolveAndValidate(replacementManifest);
+        var step = new ConfigureLocalAiGatewayStep();
+
+        StepResult result = await step.ExecuteAsync(context, CancellationToken.None);
+        await step.RollbackAsync(context, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.Failed, result.Outcome);
+        Assert.True(LocalAiGatewayProviderDefinition.MatchesProviderJson(
+            commands.ProviderJson!,
+            original));
+        Assert.Equal(primary, commands.PrimaryJson);
+        Assert.Equal(original.Endpoint, (await store.LoadAsync())!.Endpoint);
+        Assert.False(context.LocalAiRecoveryProviderTransition);
+    }
+
     private static SetupContext CreateContext(string localDataDirectory, ICommandRunner commands)
     {
         var config = new SetupConfig { LocalAi = new LocalAiConfig { Enabled = true } };
@@ -177,6 +307,18 @@ public sealed class LocalAiGatewayUninstallTests
             commands,
             CancellationToken.None,
             localDataDir: localDataDirectory);
+    }
+
+    private static SetupContext CreateRecoveryContext(
+        string localDataDirectory,
+        ICommandRunner commands)
+    {
+        SetupContext context = CreateContext(localDataDirectory, commands);
+        context.Config.LocalAi.Enabled = true;
+        context.Config.LocalAiRecoveryGatewayId = "gateway-id";
+        context.DistroName = "OpenClawGateway";
+        context.LocalAiEligibility = LocalInferenceEligibility.Evaluate(CreateSparkHardware());
+        return context;
     }
 
     private static HostHardwareInfo CreateSparkHardware() => new(
@@ -250,6 +392,7 @@ public sealed class LocalAiGatewayUninstallTests
         public string? ProviderJson { get; private set; } = providerJson;
         public string? PrimaryJson { get; private set; } = primaryJson;
         public bool FailCapture { get; init; }
+        public bool FailConfiguredBatchOnce { get; set; }
         public List<string> WslCalls { get; } = [];
 
         public Task<CommandResult> RunAsync(
@@ -273,47 +416,46 @@ public sealed class LocalAiGatewayUninstallTests
         {
             ct.ThrowIfCancellationRequested();
             WslCalls.Add(command);
-            if (command.Contains("LOCAL_AI_GATEWAY_CONFIGURED", StringComparison.Ordinal))
+            if (environment is not null && environment.Count == 1)
             {
-                string encoded = Assert.Single(environment!).Value;
+                if (FailConfiguredBatchOnce &&
+                    command.Contains("LOCAL_AI_GATEWAY_CONFIGURED", StringComparison.Ordinal))
+                {
+                    FailConfiguredBatchOnce = false;
+                    return Task.FromResult(new CommandResult(
+                        1,
+                        "",
+                        "gateway configuration failed",
+                        TimeSpan.Zero,
+                        TimedOut: false));
+                }
+                string encoded = Assert.Single(environment).Value;
                 string batch = Encoding.UTF8.GetString(Convert.FromBase64String(encoded));
                 using JsonDocument document = JsonDocument.Parse(batch);
-                ProviderJson = document.RootElement[0].GetProperty("value").GetRawText();
-                PrimaryJson = document.RootElement[1].GetProperty("value").GetRawText();
+                foreach (JsonElement operation in document.RootElement.EnumerateArray())
+                {
+                    string path = operation.GetProperty("path").GetString()!;
+                    string value = operation.GetProperty("value").GetRawText();
+                    if (path == LocalAiGatewayProviderDefinition.ProviderPath)
+                        ProviderJson = value;
+                    else if (path == LocalAiGatewayProviderDefinition.PrimaryModelPath)
+                        PrimaryJson = value;
+                }
+                string marker =
+                    command.Contains("LOCAL_AI_GATEWAY_CONFIGURED", StringComparison.Ordinal)
+                        ? "LOCAL_AI_GATEWAY_CONFIGURED"
+                        : command.Contains("LOCAL_AI_GATEWAY_RESTORED", StringComparison.Ordinal)
+                            ? "LOCAL_AI_GATEWAY_RESTORED"
+                            : "LOCAL_AI_PRIMARY_RESTORED";
                 return Task.FromResult(new CommandResult(
                     0,
-                    "LOCAL_AI_GATEWAY_CONFIGURED",
+                    marker,
                     "",
                     TimeSpan.Zero,
                     TimedOut: false));
             }
-            if (command.Contains("LOCAL_AI_PRIMARY_RESTORED", StringComparison.Ordinal))
-            {
-                string encoded = Assert.Single(environment!).Value;
-                string batch = Encoding.UTF8.GetString(Convert.FromBase64String(encoded));
-                using JsonDocument document = JsonDocument.Parse(batch);
-                PrimaryJson = document.RootElement[0].GetProperty("value").GetRawText();
-                return Task.FromResult(new CommandResult(
-                    0,
-                    "LOCAL_AI_PRIMARY_RESTORED",
-                    "",
-                    TimeSpan.Zero,
-                    TimedOut: false));
-            }
-            if (command.Contains("LOCAL_AI_GATEWAY_RESTORED", StringComparison.Ordinal))
-            {
-                string encoded = Assert.Single(environment!).Value;
-                string batch = Encoding.UTF8.GetString(Convert.FromBase64String(encoded));
-                using JsonDocument document = JsonDocument.Parse(batch);
-                PrimaryJson = document.RootElement[0].GetProperty("value").GetRawText();
-                return Task.FromResult(new CommandResult(
-                    0,
-                    "LOCAL_AI_GATEWAY_RESTORED",
-                    "",
-                    TimeSpan.Zero,
-                    TimedOut: false));
-            }
-            if (command.Contains("LOCAL_AI_GATEWAY_UNSET", StringComparison.Ordinal))
+            if (command.Contains("LOCAL_AI_GATEWAY_UNSET", StringComparison.Ordinal) ||
+                command.Contains("openclaw config unset", StringComparison.Ordinal))
             {
                 if (command.Contains(LocalAiGatewayProviderDefinition.PrimaryModelPath, StringComparison.Ordinal))
                     PrimaryJson = null;

--- a/tests/OpenClaw.SetupEngine.Tests/LocalAiGatewayUninstallTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/LocalAiGatewayUninstallTests.cs
@@ -521,6 +521,50 @@ public sealed class LocalAiGatewayUninstallTests
         Assert.False(context.LocalAiRecoveryReceiptRollbackAllowed);
     }
 
+    [Fact]
+    public async Task Recovery_ProviderCreationRollbackCancellationKeepsReplacementReceipt()
+    {
+        using var temp = new TempDirectory("local-ai-gateway-recovery-");
+        LocalAiResolvedInstall original = await SaveManifestAsync(temp.Path, "openai/gpt-5");
+        string fallback = JsonSerializer.Serialize("openai/gpt-5");
+        var commands = new GatewayStateCommandRunner(providerJson: null, primaryJson: fallback);
+        SetupContext context = CreateRecoveryContext(temp.Path, commands);
+        context.Config.RollbackOnFailure = true;
+        context.LocalAiRecoveryOriginalInstall = original;
+        context.LocalAiRecoveryReceiptRollbackAllowed = true;
+        LocalAiInstallManifest replacementManifest = original.Manifest with
+        {
+            Endpoint = "http://127.0.0.1:39876/v1",
+        };
+        var store = new LocalAiManifestStore(new LocalAiPaths(temp.Path));
+        await store.SaveAsync(replacementManifest);
+        context.LocalAiResolvedInstall = store.ResolveAndValidate(replacementManifest);
+        var configure = new ConfigureLocalAiGatewayStep();
+        StepResult configured = await configure.ExecuteAsync(context, CancellationToken.None);
+        commands.ThrowOnNextCapture = true;
+        var pipeline = new SetupPipeline(
+        [
+            new PreserveLocalAiRecoveryGatewayStep((_, _) =>
+                Task.FromResult(StepResult.Ok("not needed"))),
+            new DelegatingRollbackStep("configured", configure.RollbackAsync),
+            new DelegatingRollbackStep(
+                "fail",
+                (_, _) => Task.CompletedTask,
+                (_, _) => Task.FromResult(StepResult.Fail("forced failure"))),
+        ]);
+
+        PipelineResult result = await pipeline.RunAsync(context);
+
+        Assert.Equal(StepOutcome.Success, configured.Outcome);
+        Assert.Equal(PipelineOutcome.Failed, result.Outcome);
+        Assert.True(LocalAiGatewayProviderDefinition.MatchesProviderJson(
+            commands.ProviderJson!,
+            context.LocalAiResolvedInstall));
+        Assert.Equal(new Uri(replacementManifest.Endpoint!), (await store.LoadAsync())!.Endpoint);
+        Assert.False(context.LocalAiRecoveryProviderTransition);
+        Assert.False(context.LocalAiRecoveryReceiptRollbackAllowed);
+    }
+
     private static SetupContext CreateContext(string localDataDirectory, ICommandRunner commands)
     {
         var config = new SetupConfig { LocalAi = new LocalAiConfig { Enabled = true } };

--- a/tests/OpenClaw.SetupEngine.Tests/LocalAiGatewayUninstallTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/LocalAiGatewayUninstallTests.cs
@@ -251,6 +251,9 @@ public sealed class LocalAiGatewayUninstallTests
 
         StepResult result = await step.ExecuteAsync(context, CancellationToken.None);
         await step.RollbackAsync(context, CancellationToken.None);
+        await new PreserveLocalAiRecoveryGatewayStep((_, _) =>
+                Task.FromResult(StepResult.Ok("not needed")))
+            .RollbackAsync(context, CancellationToken.None);
 
         Assert.Equal(StepOutcome.Success, result.Outcome);
         Assert.True(LocalAiGatewayProviderDefinition.MatchesProviderJson(
@@ -286,8 +289,85 @@ public sealed class LocalAiGatewayUninstallTests
 
         StepResult result = await step.ExecuteAsync(context, CancellationToken.None);
         await step.RollbackAsync(context, CancellationToken.None);
+        await new PreserveLocalAiRecoveryGatewayStep((_, _) =>
+                Task.FromResult(StepResult.Ok("not needed")))
+            .RollbackAsync(context, CancellationToken.None);
 
         Assert.Equal(StepOutcome.Failed, result.Outcome);
+        Assert.True(LocalAiGatewayProviderDefinition.MatchesProviderJson(
+            commands.ProviderJson!,
+            original));
+        Assert.Equal(primary, commands.PrimaryJson);
+        Assert.Equal(original.Endpoint, (await store.LoadAsync())!.Endpoint);
+        Assert.False(context.LocalAiRecoveryProviderTransition);
+    }
+
+    [Fact]
+    public async Task Recovery_FailureBeforeProviderConfigurationRestoresOriginalReceipt()
+    {
+        using var temp = new TempDirectory("local-ai-gateway-recovery-");
+        LocalAiResolvedInstall original = await SaveManifestAsync(temp.Path, "openai/gpt-5");
+        var commands = new GatewayStateCommandRunner(
+            providerJson: null,
+            primaryJson: JsonSerializer.Serialize("openai/gpt-5"));
+        SetupContext context = CreateRecoveryContext(temp.Path, commands);
+        context.LocalAiRecoveryOriginalInstall = original;
+        LocalAiInstallManifest replacementManifest = original.Manifest with
+        {
+            Endpoint = "http://127.0.0.1:39876/v1",
+        };
+        var store = new LocalAiManifestStore(new LocalAiPaths(temp.Path));
+        await store.SaveAsync(replacementManifest);
+        context.LocalAiResolvedInstall = store.ResolveAndValidate(replacementManifest);
+        context.LocalAiRecoveryProviderTransition = true;
+        context.LocalAiGatewayPriorState = new(
+            ProviderExisted: false,
+            ProviderJson: null,
+            PrimaryModelExisted: true,
+            PrimaryModelJson: JsonSerializer.Serialize("openai/gpt-5"));
+        var step = new PreserveLocalAiRecoveryGatewayStep((_, _) =>
+            Task.FromResult(StepResult.Ok("not needed")));
+
+        await step.RollbackAsync(context, CancellationToken.None);
+
+        Assert.Equal(original.Endpoint, (await store.LoadAsync())!.Endpoint);
+        Assert.Equal(original.Endpoint, context.LocalAiResolvedInstall!.Endpoint);
+        Assert.False(context.LocalAiRecoveryProviderTransition);
+        Assert.Null(context.LocalAiGatewayPriorState);
+    }
+
+    [Fact]
+    public async Task Recovery_RetryPreservesOriginalProviderRollbackBaseline()
+    {
+        using var temp = new TempDirectory("local-ai-gateway-recovery-");
+        LocalAiResolvedInstall original = await SaveManifestAsync(temp.Path, "openai/gpt-5");
+        string originalProvider = LocalAiGatewayProviderDefinition.BuildProviderJson(original);
+        string primary = JsonSerializer.Serialize(
+            LocalAiGatewayProviderDefinition.BuildPrimaryModel(original));
+        var commands = new GatewayStateCommandRunner(originalProvider, primary)
+        {
+            LoseConfiguredAcknowledgementOnce = true,
+        };
+        SetupContext context = CreateRecoveryContext(temp.Path, commands);
+        context.LocalAiRecoveryOriginalInstall = original;
+        LocalAiInstallManifest replacementManifest = original.Manifest with
+        {
+            Endpoint = "http://127.0.0.1:39876/v1",
+        };
+        var store = new LocalAiManifestStore(new LocalAiPaths(temp.Path));
+        await store.SaveAsync(replacementManifest);
+        context.LocalAiResolvedInstall = store.ResolveAndValidate(replacementManifest);
+        var step = new ConfigureLocalAiGatewayStep();
+
+        StepResult first = await step.ExecuteAsync(context, CancellationToken.None);
+        StepResult second = await step.ExecuteAsync(context, CancellationToken.None);
+        await step.RollbackAsync(context, CancellationToken.None);
+        await new PreserveLocalAiRecoveryGatewayStep((_, _) =>
+                Task.FromResult(StepResult.Ok("not needed")))
+            .RollbackAsync(context, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.Failed, first.Outcome);
+        Assert.Equal(StepOutcome.Success, second.Outcome);
         Assert.True(LocalAiGatewayProviderDefinition.MatchesProviderJson(
             commands.ProviderJson!,
             original));
@@ -393,6 +473,7 @@ public sealed class LocalAiGatewayUninstallTests
         public string? PrimaryJson { get; private set; } = primaryJson;
         public bool FailCapture { get; init; }
         public bool FailConfiguredBatchOnce { get; set; }
+        public bool LoseConfiguredAcknowledgementOnce { get; set; }
         public List<string> WslCalls { get; } = [];
 
         public Task<CommandResult> RunAsync(
@@ -440,6 +521,17 @@ public sealed class LocalAiGatewayUninstallTests
                         ProviderJson = value;
                     else if (path == LocalAiGatewayProviderDefinition.PrimaryModelPath)
                         PrimaryJson = value;
+                }
+                if (LoseConfiguredAcknowledgementOnce &&
+                    command.Contains("LOCAL_AI_GATEWAY_CONFIGURED", StringComparison.Ordinal))
+                {
+                    LoseConfiguredAcknowledgementOnce = false;
+                    return Task.FromResult(new CommandResult(
+                        1,
+                        "",
+                        "gateway configuration acknowledgement lost",
+                        TimeSpan.Zero,
+                        TimedOut: false));
                 }
                 string marker =
                     command.Contains("LOCAL_AI_GATEWAY_CONFIGURED", StringComparison.Ordinal)

--- a/tests/OpenClaw.SetupEngine.Tests/LocalAiInstallRecoveryTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/LocalAiInstallRecoveryTests.cs
@@ -5,6 +5,7 @@ using System.Net.Http.Headers;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using OpenClaw.Connection.LocalAi;
+using OpenClaw.Shared.Inference;
 using OpenClaw.Shared.Inference.Catalog;
 
 namespace OpenClaw.SetupEngine.Tests;
@@ -536,6 +537,117 @@ public sealed class LocalAiInstallRecoveryTests
     }
 
     [Fact]
+    public async Task Reconciler_RecoveryRetainsReceiptWhileMissingModelIsRepaired()
+    {
+        using var temp = new TempDirectory();
+        LocalInferencePlan plan = CatalogPlan();
+        const string gpuId = "GPU-0";
+        var paths = new LocalAiPaths(temp.Path);
+        var store = new LocalAiManifestStore(paths);
+        LocalAiInstallManifest manifest = CreateManifest(temp.Path, plan, gpuId);
+        await store.SaveAsync(manifest);
+        var reconciler = new LocalAiInstallReconciler(
+            new ValidRuntimeInspector(),
+            new RejectingModelVerifier());
+
+        LocalAiReconcileResult result = await reconciler.ReconcileAsync(
+            temp.Path,
+            plan,
+            gpuId,
+            CancellationToken.None,
+            allowIncompleteInstallation: true);
+
+        Assert.False(result.Reused);
+        Assert.NotNull(result.OriginalInstall);
+        Assert.Equal(manifest.Endpoint, result.OriginalInstall!.Manifest.Endpoint);
+        Assert.NotNull(result.RuntimeInstall);
+        Assert.Null(result.ModelInstall);
+        Assert.True(File.Exists(paths.ManifestPath));
+    }
+
+    [Fact]
+    public async Task ReconcileStep_RecoveryPinsIncompleteReceiptAsRollbackBaseline()
+    {
+        using var temp = new TempDirectory();
+        LocalInferencePlan plan = CatalogPlan();
+        const string gpuId = "GPU-0";
+        LocalAiInstallManifest manifest = CreateManifest(temp.Path, plan, gpuId);
+        await new LocalAiManifestStore(new LocalAiPaths(temp.Path)).SaveAsync(manifest);
+        var context = CreateContext(temp.Path, confirmDestructive: false);
+        context.Config.LocalAi.Enabled = true;
+        context.Config.LocalAiRecoveryGatewayId = "gateway-id";
+        context.LocalAiEligibility = new LocalInferenceEligibilityResult(
+            LocalInferenceEligibilityStatus.Eligible,
+            LocalInferenceEligibilityFailureCode.None,
+            LocalInferenceSelectionFailureCode.None,
+            plan,
+            new GpuInfo(GpuVendor.Nvidia, "Test GPU", StableId: gpuId),
+            RequiredTotalMemoryBytes: 0,
+            DetectedTotalMemoryBytes: 0,
+            RequiredFreeMemoryBytes: 0,
+            AvailableFreeMemoryBytes: 0);
+        var step = new ReconcileLocalAiInstallationStep(new LocalAiInstallReconciler(
+            new ValidRuntimeInspector(),
+            new RejectingModelVerifier()));
+
+        StepResult result = await step.ExecuteAsync(context, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.Skipped, result.Outcome);
+        Assert.Equal(manifest.Endpoint, context.LocalAiRecoveryOriginalInstall?.Manifest.Endpoint);
+        Assert.True(context.LocalAiRecoveryReceiptRollbackAllowed);
+        Assert.NotNull(context.LocalAiRuntimeInstall);
+        Assert.Null(context.LocalAiModelInstall);
+    }
+
+    [Fact]
+    public async Task RecoveryPipeline_RewritesIncompleteReceiptAfterModelRepair()
+    {
+        using var temp = new TempDirectory();
+        LocalInferencePlan plan = CatalogPlan();
+        const string gpuId = "GPU-0";
+        LocalAiInstallManifest manifest = CreateManifest(temp.Path, plan, gpuId) with
+        {
+            RequestedPort = 18803,
+            GatewayFallbackModel = "openai/gpt-5",
+        };
+        var store = new LocalAiManifestStore(new LocalAiPaths(temp.Path));
+        await store.SaveAsync(manifest);
+        LocalAiResolvedInstall original = (await store.LoadAsync())!;
+        var context = CreateContext(temp.Path, confirmDestructive: false);
+        context.Config.LocalAi.Enabled = true;
+        context.Config.LocalAiRecoveryGatewayId = "gateway-id";
+        context.LocalAiPort = manifest.RequestedPort;
+        context.LocalAiEligibility = new LocalInferenceEligibilityResult(
+            LocalInferenceEligibilityStatus.Eligible,
+            LocalInferenceEligibilityFailureCode.None,
+            LocalInferenceSelectionFailureCode.None,
+            plan,
+            new GpuInfo(GpuVendor.Nvidia, "Test GPU", StableId: gpuId),
+            RequiredTotalMemoryBytes: 0,
+            DetectedTotalMemoryBytes: 0,
+            RequiredFreeMemoryBytes: 0,
+            AvailableFreeMemoryBytes: 0);
+        var pipeline = new SetupPipeline(
+        [
+            new ReconcileLocalAiInstallationStep(new LocalAiInstallReconciler(
+                new ValidRuntimeInspector(),
+                new RejectingModelVerifier())),
+            new CompleteModelRepairStep(original.ModelPath),
+            new PersistLocalAiManifestStep(),
+        ]);
+
+        PipelineResult result = await pipeline.RunAsync(context);
+
+        Assert.Equal(PipelineOutcome.Success, result.Outcome);
+        LocalAiResolvedInstall repaired = (await store.LoadAsync())!;
+        Assert.Null(repaired.Endpoint);
+        Assert.Equal(manifest.RequestedPort, repaired.Manifest.RequestedPort);
+        Assert.Equal(manifest.GatewayFallbackModel, repaired.Manifest.GatewayFallbackModel);
+        Assert.Equal(manifest.InstalledAtUtc, repaired.Manifest.InstalledAtUtc);
+        Assert.False(context.LocalAiManifestCreatedThisRun);
+    }
+
+    [Fact]
     public async Task FreshProcessUninstall_RemovesCanonicalLocalAiRoot()
     {
         using var temp = new TempDirectory();
@@ -867,6 +979,29 @@ public sealed class LocalAiInstallRecoveryTests
             string path,
             PinnedArtifact artifact,
             CancellationToken cancellationToken) => Task.FromResult(true);
+    }
+
+    private sealed class RejectingModelVerifier : ILocalAiModelFileVerifier
+    {
+        public Task<bool> VerifyAsync(
+            string path,
+            PinnedArtifact artifact,
+            CancellationToken cancellationToken) => Task.FromResult(false);
+    }
+
+    private sealed class CompleteModelRepairStep(string modelPath) : SetupStep
+    {
+        public override string Id => "complete-model-repair";
+        public override string DisplayName => "Complete model repair";
+
+        public override Task<StepResult> ExecuteAsync(SetupContext ctx, CancellationToken ct)
+        {
+            ctx.LocalAiModelInstall = new HuggingFaceModelInstallResult(
+                modelPath,
+                HuggingFaceModelInstallDisposition.Downloaded,
+                CreatedThisRun: true);
+            return Task.FromResult(StepResult.Ok("Model repaired."));
+        }
     }
 
     private sealed class TempDirectory : IDisposable

--- a/tests/OpenClaw.SetupEngine.Tests/LocalAiRecoveryConfigurationBaselineTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/LocalAiRecoveryConfigurationBaselineTests.cs
@@ -1,0 +1,51 @@
+namespace OpenClaw.SetupEngine.Tests;
+
+public sealed class LocalAiRecoveryConfigurationBaselineTests
+{
+    [Fact]
+    public void Restore_BackToWelcomeReturnsSubsequentNormalSetupToOriginalValues() =>
+        AssertRestoreReturnsOriginalValues();
+
+    [Fact]
+    public void Restore_GatewayInstalledMilestoneReturnsSubsequentNormalSetupToOriginalValues() =>
+        AssertRestoreReturnsOriginalValues();
+
+    private static void AssertRestoreReturnsOriginalValues()
+    {
+        var config = new SetupConfig
+        {
+            DistroName = "Original Distro",
+            GatewayPort = 18789,
+            GatewayUrl = "ws://127.0.0.1:18789",
+            RollbackOnFailure = false,
+            SkipWizard = false,
+            LocalAi = new LocalAiConfig
+            {
+                Enabled = false,
+                SelectedModelId = "original-model",
+                Port = 18803,
+            },
+        };
+        LocalAiRecoveryConfigurationBaseline baseline =
+            LocalAiRecoveryConfigurationBaseline.Capture(config);
+        config.DistroName = "Recovery Distro";
+        config.GatewayPort = 28889;
+        config.GatewayUrl = null;
+        config.RollbackOnFailure = true;
+        config.SkipWizard = true;
+        config.LocalAi.Enabled = true;
+        config.LocalAi.SelectedModelId = "recovery-model";
+        config.LocalAi.Port = 28803;
+
+        baseline.Restore(config);
+
+        Assert.Equal("Original Distro", config.DistroName);
+        Assert.Equal(18789, config.GatewayPort);
+        Assert.Equal("ws://127.0.0.1:18789", config.GatewayUrl);
+        Assert.False(config.RollbackOnFailure);
+        Assert.False(config.SkipWizard);
+        Assert.False(config.LocalAi.Enabled);
+        Assert.Equal("original-model", config.LocalAi.SelectedModelId);
+        Assert.Equal(18803, config.LocalAi.Port);
+    }
+}

--- a/tests/OpenClaw.SetupEngine.Tests/LocalAiWslNetworkingConsentTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/LocalAiWslNetworkingConsentTests.cs
@@ -60,6 +60,62 @@ public sealed class LocalAiWslNetworkingConsentTests
         Assert.Empty(commands.Invocations);
     }
 
+    [Fact]
+    public async Task Step_RecoveryShutdown_ArmsGatewayRollbackRestart()
+    {
+        using var temp = new TempDirectory("local-ai-recovery-shutdown-");
+        var commands = new SuccessfulCommandRunner();
+        SetupContext context = CreateContext(temp.Path, consent: true, commands);
+        context.Config.LocalAiRecoveryGatewayId = "gateway-id";
+        var step = new ConfigureLocalAiWslNetworkingStep(_ => new ChangedManager());
+
+        StepResult result = await step.ExecuteAsync(context, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.Success, result.Outcome);
+        Assert.True(context.LocalAiRecoveryStoppedWsl);
+        Assert.Equal(["wsl.exe --shutdown"], commands.Invocations);
+    }
+
+    [Theory]
+    [InlineData(1, false)]
+    [InlineData(-1, true)]
+    public async Task Step_RecoveryShutdownFailure_StillArmsGatewayRollbackRestart(
+        int exitCode,
+        bool timedOut)
+    {
+        using var temp = new TempDirectory("local-ai-recovery-shutdown-fail-");
+        var commands = new SuccessfulCommandRunner(new CommandResult(
+            exitCode,
+            string.Empty,
+            "failed",
+            TimeSpan.Zero,
+            timedOut));
+        SetupContext context = CreateContext(temp.Path, consent: true, commands);
+        context.Config.LocalAiRecoveryGatewayId = "gateway-id";
+        var step = new ConfigureLocalAiWslNetworkingStep(_ => new ChangedManager());
+
+        StepResult result = await step.ExecuteAsync(context, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.Failed, result.Outcome);
+        Assert.True(context.LocalAiRecoveryStoppedWsl);
+    }
+
+    [Fact]
+    public async Task Step_RecoveryShutdownCancellation_StillArmsGatewayRollbackRestart()
+    {
+        using var temp = new TempDirectory("local-ai-recovery-shutdown-cancel-");
+        using var cts = new CancellationTokenSource();
+        var commands = new CancelingCommandRunner(cts);
+        SetupContext context = CreateContext(temp.Path, consent: true, commands);
+        context.Config.LocalAiRecoveryGatewayId = "gateway-id";
+        var step = new ConfigureLocalAiWslNetworkingStep(_ => new ChangedManager());
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => step.ExecuteAsync(context, cts.Token));
+
+        Assert.True(context.LocalAiRecoveryStoppedWsl);
+    }
+
     private static SetupContext CreateContext(
         string localDataDirectory,
         bool consent,
@@ -121,6 +177,69 @@ public sealed class LocalAiWslNetworkingConsentTests
         }
     }
 
+    private sealed class SuccessfulCommandRunner(
+        CommandResult? result = null) : ICommandRunner
+    {
+        public List<string> Invocations { get; } = [];
+
+        public Task<CommandResult> RunAsync(
+            string executable,
+            string[] arguments,
+            TimeSpan timeout,
+            IReadOnlyDictionary<string, string>? environment = null,
+            string? workingDirectory = null,
+            string? stdinInput = null,
+            CancellationToken ct = default,
+            Stream? stdinStream = null)
+        {
+            Invocations.Add($"{Path.GetFileName(executable)} {string.Join(' ', arguments)}");
+            return Task.FromResult(result ?? new CommandResult(
+                0,
+                string.Empty,
+                string.Empty,
+                TimeSpan.Zero,
+                TimedOut: false));
+        }
+
+        public Task<CommandResult> RunInWslAsync(
+            string distroName,
+            string command,
+            TimeSpan timeout,
+            IReadOnlyDictionary<string, string>? environment = null,
+            CancellationToken ct = default,
+            string? user = null,
+            bool inputViaStdin = false) =>
+            throw new NotSupportedException();
+    }
+
+    private sealed class CancelingCommandRunner(
+        CancellationTokenSource cancellation) : ICommandRunner
+    {
+        public Task<CommandResult> RunAsync(
+            string executable,
+            string[] arguments,
+            TimeSpan timeout,
+            IReadOnlyDictionary<string, string>? environment = null,
+            string? workingDirectory = null,
+            string? stdinInput = null,
+            CancellationToken ct = default,
+            Stream? stdinStream = null)
+        {
+            cancellation.Cancel();
+            throw new OperationCanceledException(ct);
+        }
+
+        public Task<CommandResult> RunInWslAsync(
+            string distroName,
+            string command,
+            TimeSpan timeout,
+            IReadOnlyDictionary<string, string>? environment = null,
+            CancellationToken ct = default,
+            string? user = null,
+            bool inputViaStdin = false) =>
+            throw new NotSupportedException();
+    }
+
     private sealed class RecordingManager(string configPath) : IWslGlobalConfigManager
     {
         public bool ApplyCalled { get; private set; }
@@ -140,5 +259,17 @@ public sealed class LocalAiWslNetworkingConsentTests
             RestoreCalled = true;
             return WslGlobalConfigRestoreResult.NoBackup;
         }
+
+    }
+
+    private sealed class ChangedManager : IWslGlobalConfigManager
+    {
+        public WslGlobalConfigStatus Inspect() => new(Exists: false, IsMirrored: false);
+
+        public WslGlobalConfigApplyResult ApplyMirroredNetworking() =>
+            new(Changed: true, RollbackMetadata: null);
+
+        public WslGlobalConfigRestoreResult RestoreIfUnchanged() =>
+            WslGlobalConfigRestoreResult.NoBackup;
     }
 }

--- a/tests/OpenClaw.SetupEngine.Tests/LocalAiWslNetworkingConsentTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/LocalAiWslNetworkingConsentTests.cs
@@ -116,6 +116,54 @@ public sealed class LocalAiWslNetworkingConsentTests
         Assert.True(context.LocalAiRecoveryStoppedWsl);
     }
 
+    [Theory]
+    [InlineData(0, false)]
+    [InlineData(1, false)]
+    [InlineData(-1, true)]
+    public async Task Rollback_RecoveryShutdown_ArmsGatewayRestartBeforeCommandCompletes(
+        int exitCode,
+        bool timedOut)
+    {
+        using var temp = new TempDirectory("local-ai-recovery-rollback-shutdown-");
+        var commands = new SuccessfulCommandRunner(new CommandResult(
+            exitCode,
+            string.Empty,
+            exitCode == 0 ? string.Empty : "failed",
+            TimeSpan.Zero,
+            timedOut));
+        SetupContext context = CreateContext(temp.Path, consent: true, commands);
+        context.Config.LocalAiRecoveryGatewayId = "gateway-id";
+        var step = new ConfigureLocalAiWslNetworkingStep(_ => new RestoredManager());
+
+        if (exitCode == 0 && !timedOut)
+        {
+            await step.RollbackAsync(context, CancellationToken.None);
+        }
+        else
+        {
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => step.RollbackAsync(context, CancellationToken.None));
+        }
+
+        Assert.True(context.LocalAiRecoveryStoppedWsl);
+    }
+
+    [Fact]
+    public async Task Rollback_RecoveryShutdownCancellation_StillArmsGatewayRestart()
+    {
+        using var temp = new TempDirectory("local-ai-recovery-rollback-cancel-");
+        using var cts = new CancellationTokenSource();
+        var commands = new CancelingCommandRunner(cts);
+        SetupContext context = CreateContext(temp.Path, consent: true, commands);
+        context.Config.LocalAiRecoveryGatewayId = "gateway-id";
+        var step = new ConfigureLocalAiWslNetworkingStep(_ => new RestoredManager());
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => step.RollbackAsync(context, cts.Token));
+
+        Assert.True(context.LocalAiRecoveryStoppedWsl);
+    }
+
     private static SetupContext CreateContext(
         string localDataDirectory,
         bool consent,
@@ -271,5 +319,16 @@ public sealed class LocalAiWslNetworkingConsentTests
 
         public WslGlobalConfigRestoreResult RestoreIfUnchanged() =>
             WslGlobalConfigRestoreResult.NoBackup;
+    }
+
+    private sealed class RestoredManager : IWslGlobalConfigManager
+    {
+        public WslGlobalConfigStatus Inspect() => new(Exists: true, IsMirrored: true);
+
+        public WslGlobalConfigApplyResult ApplyMirroredNetworking() =>
+            new(Changed: false, RollbackMetadata: null);
+
+        public WslGlobalConfigRestoreResult RestoreIfUnchanged() =>
+            WslGlobalConfigRestoreResult.Restored;
     }
 }

--- a/tests/OpenClaw.SetupEngine.Tests/SetupPipelineTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupPipelineTests.cs
@@ -147,6 +147,106 @@ public class SetupPipelineTests
     }
 
     [Fact]
+    public void BuildLocalAiRecoverySteps_PreservesExistingWslGateway()
+    {
+        var steps = SetupStepFactory.BuildLocalAiRecoverySteps();
+
+        Assert.DoesNotContain(steps, step => step is ValidateDistroInstallPathStep);
+        Assert.Equal(2, steps.Count(step => step is ValidateLocalAiRecoveryGatewayStep));
+        Assert.Contains(steps, step => step is PreserveLocalAiRecoveryGatewayStep);
+        Assert.DoesNotContain(steps, step => step is CleanupStaleDistroStep);
+        Assert.DoesNotContain(steps, step => step is CleanupStaleGatewayStep);
+        Assert.DoesNotContain(steps, step => step is CreateWslInstanceStep);
+        Assert.DoesNotContain(steps, step => step is ConfigureWslInstanceStep);
+        Assert.DoesNotContain(steps, step => step is InstallCliStep);
+        Assert.Contains(steps, step => step is AcquireLocalAiRuntimeStep);
+        Assert.Contains(steps, step => step is AcquireLocalAiModelStep);
+        Assert.Contains(steps, step => step is VerifyLocalAiWslStep);
+        Assert.IsType<ConfigureLocalAiGatewayStep>(steps[^2]);
+        Assert.IsType<RestartGatewayStep>(steps[^1]);
+        Assert.True(
+            steps.FindIndex(step => step is ValidateLocalAiRecoveryGatewayStep) <
+            steps.FindIndex(step => step is AcquireLocalAiRuntimeStep));
+        Assert.True(
+            steps.FindIndex(step => step is PreserveLocalAiRecoveryGatewayStep) <
+            steps.FindIndex(step => step is ConfigureLocalAiWslNetworkingStep));
+        Assert.IsType<ValidateLocalAiRecoveryGatewayStep>(
+            steps[steps.FindIndex(step => step is ConfigureLocalAiWslNetworkingStep) - 1]);
+    }
+
+    [Fact]
+    public async Task ValidateLocalAiRecoveryGateway_MissingDistro_BlocksBeforeRecovery()
+    {
+        var context = CreateContext(LocalAiRecoveryConfig());
+        var step = new ValidateLocalAiRecoveryGatewayStep(
+            (_, _, _, _) => ExistingLocalAiGateway(hasDistro: false, appOwned: false),
+            _ => [ManagedGatewayRecord()]);
+
+        var result = await step.ExecuteAsync(context, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.FailedTerminal, result.Outcome);
+        Assert.Contains("run full setup", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ValidateLocalAiRecoveryGateway_AppOwnedDistro_AllowsRecovery()
+    {
+        var context = CreateContext(LocalAiRecoveryConfig());
+        var step = new ValidateLocalAiRecoveryGatewayStep(
+            (_, _, _, _) => ExistingLocalAiGateway(hasDistro: true, appOwned: true),
+            _ => [ManagedGatewayRecord()]);
+
+        var result = await step.ExecuteAsync(context, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.Success, result.Outcome);
+    }
+
+    [Fact]
+    public async Task ValidateLocalAiRecoveryGateway_OwnerDrift_BlocksBeforeRecovery()
+    {
+        var context = CreateContext(LocalAiRecoveryConfig());
+        var step = new ValidateLocalAiRecoveryGatewayStep(
+            (_, _, _, _) => ExistingLocalAiGateway(hasDistro: true, appOwned: true),
+            _ => [ManagedGatewayRecord() with { Id = "replacement-gateway" }]);
+
+        var result = await step.ExecuteAsync(context, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.FailedTerminal, result.Outcome);
+        Assert.Contains("owner changed", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task PreserveLocalAiRecoveryGateway_RestartsAfterWslShutdown()
+    {
+        var context = CreateContext(LocalAiRecoveryConfig());
+        context.LocalAiRecoveryStoppedWsl = true;
+        var restartCalls = 0;
+        var step = new PreserveLocalAiRecoveryGatewayStep((_, _) =>
+        {
+            restartCalls++;
+            return Task.FromResult(StepResult.Ok("restarted"));
+        });
+
+        await step.RollbackAsync(context, CancellationToken.None);
+
+        Assert.Equal(1, restartCalls);
+        Assert.False(context.LocalAiRecoveryStoppedWsl);
+    }
+
+    [Fact]
+    public async Task RestartGatewayStep_FailureArmsRecoveryRollbackRestart()
+    {
+        var context = CreateContext(LocalAiRecoveryConfig());
+        var step = new RestartGatewayStep((_, _) =>
+            Task.FromResult(StepResult.Fail("restart failed")));
+
+        StepResult result = await step.ExecuteAsync(context, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.Failed, result.Outcome);
+        Assert.True(context.LocalAiRecoveryStoppedWsl);
+    }
+
+    [Fact]
     public void LocalAiDisabled_SkipsEveryLocalAiMutation()
     {
         var ctx = CreateContext(new SetupConfig
@@ -174,6 +274,36 @@ public class SetupPipelineTests
         Assert.False(steps.Single(step => step is PreflightWslStep).CanSkip(ctx));
         Assert.False(steps.Single(step => step is EnsureWslPlatformStep).CanSkip(ctx));
     }
+
+    private static ExistingConfigDetector.ExistingConfig ExistingLocalAiGateway(
+        bool hasDistro,
+        bool appOwned) =>
+        new(
+            HasLocalGateway: true,
+            LocalGatewayId: "gateway-id",
+            LocalGatewayUrl: "ws://127.0.0.1:18789",
+            HasDistro: hasDistro,
+            HasDistroDataDirectory: hasDistro,
+            DistroIsAppOwned: appOwned,
+            DistroName: hasDistro ? "OpenClawGateway" : null,
+            HasIdentityFiles: true,
+            PreservedGatewayCount: 0,
+            PreservedGatewayNames: []);
+
+    private static SetupConfig LocalAiRecoveryConfig() => new()
+    {
+        DistroName = "OpenClawGateway",
+        GatewayPort = 18789,
+        LocalAiRecoveryGatewayId = "gateway-id",
+    };
+
+    private static OpenClaw.Connection.GatewayRecord ManagedGatewayRecord() => new()
+    {
+        Id = "gateway-id",
+        Url = "ws://127.0.0.1:18789",
+        IsLocal = true,
+        SetupManagedDistroName = "OpenClawGateway",
+    };
 
     [Theory]
     [InlineData(false)]

--- a/tests/OpenClaw.SetupEngine.Tests/SetupPipelineTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupPipelineTests.cs
@@ -1,3 +1,6 @@
+using System.Collections.Immutable;
+using OpenClaw.Connection.LocalAi;
+
 namespace OpenClaw.SetupEngine.Tests;
 
 public class SetupPipelineTests
@@ -285,6 +288,180 @@ public class SetupPipelineTests
 
         Assert.Equal(StepOutcome.Failed, result.Outcome);
         Assert.True(context.LocalAiRecoveryStoppedWsl);
+    }
+
+    /// <summary>
+    /// Regression guard for a rollback race: if the Gateway could not be confirmed switched back
+    /// to the original (A) endpoint, the replacement (B) runtime must be kept alive rather than
+    /// disposed, otherwise the Gateway is left routing to a dead process.
+    /// </summary>
+    [Fact]
+    public async Task StartLocalAiRuntimeStep_KeepsReplacementRuntimeWhenGatewayRollbackUnconfirmed()
+    {
+        var context = CreateContext(LocalAiRecoveryConfig());
+        context.LocalAiRecoveryProviderTransition = true;
+        context.LocalAiRecoveryReceiptRollbackAllowed = false;
+        var runtime = new DisposeTrackingRuntime();
+        context.LocalAiRuntime = runtime;
+        var step = new StartLocalAiRuntimeStep(_ => runtime);
+
+        await step.RollbackAsync(context, CancellationToken.None);
+
+        Assert.Equal(0, runtime.DisposeCalls);
+        Assert.NotNull(context.LocalAiRuntime);
+    }
+
+    [Fact]
+    public async Task StartLocalAiRuntimeStep_DisposesRuntimeWhenGatewayRollbackConfirmed()
+    {
+        var context = CreateContext(LocalAiRecoveryConfig());
+        context.LocalAiRecoveryProviderTransition = true;
+        context.LocalAiRecoveryReceiptRollbackAllowed = true;
+        var runtime = new DisposeTrackingRuntime();
+        context.LocalAiRuntime = runtime;
+        var step = new StartLocalAiRuntimeStep(_ => runtime);
+
+        await step.RollbackAsync(context, CancellationToken.None);
+
+        Assert.Equal(1, runtime.DisposeCalls);
+        Assert.Null(context.LocalAiRuntime);
+    }
+
+    [Fact]
+    public async Task StartLocalAiRuntimeStep_DisposesRuntimeOutsideRecoveryTransition()
+    {
+        var context = CreateContext(LocalAiRecoveryConfig());
+        context.LocalAiRecoveryProviderTransition = false;
+        context.LocalAiRecoveryReceiptRollbackAllowed = false;
+        var runtime = new DisposeTrackingRuntime();
+        context.LocalAiRuntime = runtime;
+        var step = new StartLocalAiRuntimeStep(_ => runtime);
+
+        await step.RollbackAsync(context, CancellationToken.None);
+
+        Assert.Equal(1, runtime.DisposeCalls);
+        Assert.Null(context.LocalAiRuntime);
+    }
+
+    /// <summary>
+    /// Regression guard: a stale manifest receipt is not enough to prove the original (A)
+    /// endpoint is still alive. Rollback must probe it before pointing the Gateway back at it.
+    /// </summary>
+    [Fact]
+    public async Task PreserveLocalAiRecoveryGateway_PreservesReplacementReceiptWhenOriginalEndpointUnhealthy()
+    {
+        var context = CreateContext(LocalAiRecoveryConfig());
+        LocalAiResolvedInstall originalInstall = CreateLocalAiResolvedInstall(context.LocalDataDir, port: 18801);
+        LocalAiResolvedInstall replacementInstall = CreateLocalAiResolvedInstall(context.LocalDataDir, port: 18802);
+        context.LocalAiRecoveryOriginalInstall = originalInstall;
+        context.LocalAiRecoveryReceiptRollbackAllowed = true;
+        context.LocalAiResolvedInstall = replacementInstall;
+        var probedEndpoints = new List<Uri?>();
+        var step = new PreserveLocalAiRecoveryGatewayStep(
+            (_, _) => Task.FromResult(StepResult.Ok("restarted")),
+            (install, _) =>
+            {
+                probedEndpoints.Add(install.Endpoint);
+                return Task.FromResult(false);
+            });
+
+        await step.RollbackAsync(context, CancellationToken.None);
+
+        Assert.Equal([originalInstall.Endpoint], probedEndpoints);
+        Assert.Same(replacementInstall, context.LocalAiResolvedInstall);
+        Assert.False(context.LocalAiRecoveryReceiptRollbackAllowed);
+        Assert.False(context.LocalAiRecoveryProviderTransition);
+    }
+
+    [Fact]
+    public async Task PreserveLocalAiRecoveryGateway_RestoresReceiptWhenOriginalEndpointHealthy()
+    {
+        var context = CreateContext(LocalAiRecoveryConfig());
+        LocalAiResolvedInstall originalInstall = CreateLocalAiResolvedInstall(context.LocalDataDir, port: 18801);
+        context.LocalAiRecoveryOriginalInstall = originalInstall;
+        context.LocalAiRecoveryReceiptRollbackAllowed = true;
+        context.LocalAiResolvedInstall = CreateLocalAiResolvedInstall(context.LocalDataDir, port: 18802);
+        var step = new PreserveLocalAiRecoveryGatewayStep(
+            (_, _) => Task.FromResult(StepResult.Ok("restarted")),
+            (_, _) => Task.FromResult(true));
+
+        await step.RollbackAsync(context, CancellationToken.None);
+
+        Assert.NotNull(context.LocalAiResolvedInstall);
+        Assert.Equal(originalInstall.Manifest.ModelAlias, context.LocalAiResolvedInstall!.Manifest.ModelAlias);
+        Assert.Equal(originalInstall.Endpoint, context.LocalAiResolvedInstall!.Endpoint);
+    }
+
+    private sealed class DisposeTrackingRuntime : ILocalAiRuntime
+    {
+        public int DisposeCalls { get; private set; }
+
+        public LocalAiRuntimeSnapshot Snapshot => throw new NotSupportedException();
+
+        public Task<LocalAiRuntimeSnapshot> EnsureStartedAsync(CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<LocalAiRuntimeSnapshot> StopAsync(CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<LocalAiRuntimeSnapshot> RestartAsync(CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<LocalAiRuntimeSnapshot> RefreshAsync(CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public event EventHandler<LocalAiRuntimeSnapshotChangedEventArgs>? StateChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            DisposeCalls++;
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private static LocalAiResolvedInstall CreateLocalAiResolvedInstall(string localDataDirectory, int port)
+    {
+        var paths = new LocalAiPaths(localDataDirectory);
+        const string revision = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        string executableRelative = Path.Combine("engines", "llama-server", "b1", "win-x64", "llama-server.exe");
+        string modelRelative = Path.Combine("models", "model.gguf");
+        var manifest = new LocalAiInstallManifest
+        {
+            EngineVersion = "b1",
+            Architecture = "x64",
+            RuntimeId = "llama-server-b1-win-x64-cpu",
+            ModelCatalogId = "test-model",
+            SelectedGpuId = "CPU",
+            ExecutablePath = executableRelative,
+            RuntimeAssets = ImmutableArray.Create(new LocalAiAssetReceipt
+            {
+                FileName = "llama-server.exe",
+                SourceUrl = "https://github.com/example/example/releases/download/b1/llama-server.exe",
+                SizeBytes = 1,
+                Sha256 = new string('a', 64),
+            }),
+            ModelPath = modelRelative,
+            ModelId = $"owner/repo@{revision}",
+            ModelAlias = "test-model",
+            ModelAsset = new LocalAiAssetReceipt
+            {
+                FileName = "model.gguf",
+                SourceUrl = $"https://huggingface.co/owner/repo/resolve/{revision}/model.gguf",
+                SizeBytes = 1,
+                Sha256 = new string('a', 64),
+            },
+            Endpoint = $"http://127.0.0.1:{port}/v1",
+            ContextLength = 4096,
+        };
+        return new LocalAiResolvedInstall(
+            manifest,
+            Path.Combine(paths.RootDirectory, executableRelative),
+            Path.Combine(paths.RootDirectory, modelRelative),
+            new Uri(manifest.Endpoint!));
     }
 
     [Fact]

--- a/tests/OpenClaw.SetupEngine.Tests/SetupPipelineTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupPipelineTests.cs
@@ -216,6 +216,19 @@ public class SetupPipelineTests
     }
 
     [Fact]
+    public async Task ValidateLocalAiRecoveryGateway_TrimsEffectiveDistroName()
+    {
+        var context = CreateContext(LocalAiRecoveryConfig());
+        var step = new ValidateLocalAiRecoveryGatewayStep(
+            (_, _, _, _) => ExistingLocalAiGateway(hasDistro: true, appOwned: true),
+            _ => [ManagedGatewayRecord() with { SetupManagedDistroName = " OpenClawGateway " }]);
+
+        var result = await step.ExecuteAsync(context, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.Success, result.Outcome);
+    }
+
+    [Fact]
     public async Task PreserveLocalAiRecoveryGateway_RestartsAfterWslShutdown()
     {
         var context = CreateContext(LocalAiRecoveryConfig());
@@ -231,6 +244,34 @@ public class SetupPipelineTests
 
         Assert.Equal(1, restartCalls);
         Assert.False(context.LocalAiRecoveryStoppedWsl);
+    }
+
+    [Fact]
+    public async Task PreserveLocalAiRecoveryGateway_UsesGatewayRestartRollbackBudget()
+    {
+        SetupConfig config = LocalAiRecoveryConfig();
+        config.RollbackOnFailure = true;
+        config.RollbackTimeoutSeconds = 1;
+        config.Gateway.HealthTimeoutSeconds = 1;
+        var context = CreateContext(config);
+        context.LocalAiRecoveryStoppedWsl = true;
+        var pipeline = new SetupPipeline([
+            new PreserveLocalAiRecoveryGatewayStep(async (_, ct) =>
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(1_100), ct);
+                return StepResult.Ok("restarted");
+            }),
+            new MockStep("failure", (_, _) => Task.FromResult(StepResult.Fail("fail"))),
+        ]);
+
+        PipelineResult result = await pipeline.RunAsync(context);
+
+        Assert.Equal(PipelineOutcome.Failed, result.Outcome);
+        Assert.False(context.LocalAiRecoveryStoppedWsl);
+        Assert.Contains(
+            context.Journal.Entries,
+            entry => entry.StepId == "preserve-local-ai-recovery-gateway" &&
+                     entry.Event == "rollback_ok");
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/LocalAiGatewayProviderCoordinatorTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalAiGatewayProviderCoordinatorTests.cs
@@ -432,6 +432,100 @@ public sealed class LocalAiGatewayProviderCoordinatorTests
     }
 
     [Fact]
+    public void LocalAiSetupRoute_UsesUniqueManagedOwnerEvenWhenItIsNotActive()
+    {
+        GatewayRecord owner = ManagedRecord("managed", "CustomGateway") with
+        {
+            Url = "ws://127.0.0.1:29999",
+        };
+        IReadOnlyList<GatewayRecord> owners =
+            LocalAiGatewayDistroResolver.FindOwners([owner]);
+
+        LocalAiSetupResolution resolution = LocalAiSetupRoutePolicy.Decide(
+            owners,
+            hasLocalGateway: true,
+            localGatewayId: owner.Id,
+            hasDistro: true,
+            hasDistroDataDirectory: true,
+            distroIsAppOwned: true);
+
+        Assert.Equal(LocalAiSetupRoute.Recovery, resolution.Route);
+        Assert.Equal("managed", resolution.RecoveryTarget?.GatewayId);
+        Assert.Equal("CustomGateway", resolution.RecoveryTarget?.DistroName);
+        Assert.Equal(29999, resolution.RecoveryTarget?.GatewayPort);
+    }
+
+    [Fact]
+    public void LocalAiSetupRoute_AcceptsLegacyManagedOwner()
+    {
+        GatewayRecord owner = new()
+        {
+            Id = "legacy-managed",
+            Url = "ws://localhost:18789",
+            IsLocal = true,
+            FriendlyName = "Local (LegacyGateway)",
+        };
+        IReadOnlyList<GatewayRecord> owners =
+            LocalAiGatewayDistroResolver.FindOwners([owner]);
+
+        LocalAiSetupResolution resolution = LocalAiSetupRoutePolicy.Decide(
+            owners,
+            hasLocalGateway: true,
+            localGatewayId: owner.Id,
+            hasDistro: true,
+            hasDistroDataDirectory: true,
+            distroIsAppOwned: true);
+
+        Assert.Equal(LocalAiSetupRoute.Recovery, resolution.Route);
+        Assert.Equal("LegacyGateway", resolution.RecoveryTarget?.DistroName);
+    }
+
+    [Fact]
+    public void LocalAiSetupRoute_ProvisionsOnlyWhenManagedGatewayIsConclusivelyAbsent()
+    {
+        LocalAiSetupResolution resolution = LocalAiSetupRoutePolicy.Decide(
+            owners: [],
+            hasLocalGateway: false,
+            localGatewayId: null,
+            hasDistro: false,
+            hasDistroDataDirectory: false,
+            distroIsAppOwned: false);
+
+        Assert.Equal(LocalAiSetupRoute.Provision, resolution.Route);
+        Assert.Null(resolution.RecoveryTarget);
+    }
+
+    [Fact]
+    public void LocalAiSetupRoute_BlocksAmbiguousOrStaleOwnership()
+    {
+        IReadOnlyList<GatewayRecord> ambiguousOwners =
+        [
+            ManagedRecord("managed-a", "GatewayA"),
+            ManagedRecord("managed-b", "GatewayB"),
+        ];
+        Assert.Equal(
+            LocalAiSetupRoute.Blocked,
+            LocalAiSetupRoutePolicy.Decide(
+                ambiguousOwners,
+                hasLocalGateway: true,
+                localGatewayId: "managed-a",
+                hasDistro: true,
+                hasDistroDataDirectory: true,
+                distroIsAppOwned: true).Route);
+
+        GatewayRecord staleOwner = ManagedRecord("managed", "OpenClawGateway");
+        Assert.Equal(
+            LocalAiSetupRoute.Blocked,
+            LocalAiSetupRoutePolicy.Decide(
+                [staleOwner],
+                hasLocalGateway: true,
+                localGatewayId: staleOwner.Id,
+                hasDistro: false,
+                hasDistroDataDirectory: true,
+                distroIsAppOwned: true).Route);
+    }
+
+    [Fact]
     public async Task Publish_AmbiguousManagedGatewayOwners_FailsWithoutWslCommand()
     {
         LocalAiResolvedInstall install = Install(28_773);

--- a/tests/OpenClaw.Tray.Tests/LocalAiGatewayProviderCoordinatorTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalAiGatewayProviderCoordinatorTests.cs
@@ -481,6 +481,24 @@ public sealed class LocalAiGatewayProviderCoordinatorTests
     }
 
     [Fact]
+    public void DistroResolver_ResolvesLegacyManagedOwner()
+    {
+        GatewayRecord owner = new()
+        {
+            Id = "legacy-managed",
+            Url = "ws://localhost:18789",
+            IsLocal = true,
+            FriendlyName = "Local (LegacyGateway)",
+        };
+        var resolver = new LocalAiGatewayDistroResolver(CreateRegistry(owner));
+
+        LocalAiGatewayDistroResolution resolution = resolver.Resolve();
+
+        Assert.True(resolution.Success);
+        Assert.Equal("LegacyGateway", resolution.DistroName);
+    }
+
+    [Fact]
     public void LocalAiSetupRoute_ProvisionsOnlyWhenManagedGatewayIsConclusivelyAbsent()
     {
         LocalAiSetupResolution resolution = LocalAiSetupRoutePolicy.Decide(

--- a/tests/OpenClaw.Tray.Tests/LocalAiGatewayProviderCoordinatorTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalAiGatewayProviderCoordinatorTests.cs
@@ -447,12 +447,16 @@ public sealed class LocalAiGatewayProviderCoordinatorTests
             localGatewayId: owner.Id,
             hasDistro: true,
             hasDistroDataDirectory: true,
-            distroIsAppOwned: true);
+            distroIsAppOwned: true,
+            installedModelCatalogId: LocalModelCatalog.Qwen38_27BModelId,
+            installedRequestedLocalAiPort: 28888);
 
         Assert.Equal(LocalAiSetupRoute.Recovery, resolution.Route);
         Assert.Equal("managed", resolution.RecoveryTarget?.GatewayId);
         Assert.Equal("CustomGateway", resolution.RecoveryTarget?.DistroName);
         Assert.Equal(29999, resolution.RecoveryTarget?.GatewayPort);
+        Assert.Equal(LocalModelCatalog.Qwen38_27BModelId, resolution.RecoveryTarget?.ModelCatalogId);
+        Assert.Equal(28888, resolution.RecoveryTarget?.RequestedLocalAiPort);
     }
 
     [Fact]
@@ -474,10 +478,52 @@ public sealed class LocalAiGatewayProviderCoordinatorTests
             localGatewayId: owner.Id,
             hasDistro: true,
             hasDistroDataDirectory: true,
-            distroIsAppOwned: true);
+            distroIsAppOwned: true,
+            installedModelCatalogId: LocalModelCatalog.Qwen38_27BModelId);
 
         Assert.Equal(LocalAiSetupRoute.Recovery, resolution.Route);
         Assert.Equal("LegacyGateway", resolution.RecoveryTarget?.DistroName);
+    }
+
+    [Theory]
+    [InlineData("http://127.0.0.1:18789")]
+    [InlineData("ws://127.0.0.1:18789/path")]
+    [InlineData("ws://127.0.0.1:18789?query=1")]
+    public void LocalAiSetupRoute_BlocksNonCanonicalManagedEndpoint(string url)
+    {
+        GatewayRecord owner = ManagedRecord("managed", "OpenClawGateway") with
+        {
+            Url = url,
+        };
+
+        LocalAiSetupResolution resolution = LocalAiSetupRoutePolicy.Decide(
+            [owner],
+            hasLocalGateway: true,
+            localGatewayId: owner.Id,
+            hasDistro: true,
+            hasDistroDataDirectory: true,
+            distroIsAppOwned: true,
+            installedModelCatalogId: LocalModelCatalog.Qwen38_27BModelId);
+
+        Assert.Equal(LocalAiSetupRoute.Blocked, resolution.Route);
+    }
+
+    [Fact]
+    public void LocalAiSetupRoute_RecoversManagedGatewayWithoutAnInstalledModelReceipt()
+    {
+        GatewayRecord owner = ManagedRecord("managed", "OpenClawGateway");
+
+        LocalAiSetupResolution resolution = LocalAiSetupRoutePolicy.Decide(
+            [owner],
+            hasLocalGateway: true,
+            localGatewayId: owner.Id,
+            hasDistro: true,
+            hasDistroDataDirectory: true,
+            distroIsAppOwned: true);
+
+        Assert.Equal(LocalAiSetupRoute.Recovery, resolution.Route);
+        Assert.Null(resolution.RecoveryTarget?.ModelCatalogId);
+        Assert.Null(resolution.RecoveryTarget?.RequestedLocalAiPort);
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/LocalAiSetupUxContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalAiSetupUxContractTests.cs
@@ -570,9 +570,11 @@ public sealed class LocalAiSetupUxContractTests
         // on the toggle being off, or requires a fully resolved, eligible, consented state.
         string primaryButtonMethod = ExtractMethod(source, "private void UpdatePrimaryButtonState");
         Assert.DoesNotContain("_localAiAvailability", primaryButtonMethod);
-        Assert.Contains("LocalAiToggle.IsOn != true ||", primaryButtonMethod);
         Assert.Contains(
-            "(_localAiSelectionEligible &&\r\n             (!_localAiNetworkingConsentRequired || LocalAiNetworkingConsentCheckBox.IsChecked == true));",
+            "(!_localAiRecoveryOnly && LocalAiToggle.IsOn != true) ||",
+            primaryButtonMethod);
+        Assert.Contains(
+            "(LocalAiToggle.IsOn == true &&\r\n             _localAiSelectionEligible &&\r\n             (!_localAiNetworkingConsentRequired || LocalAiNetworkingConsentCheckBox.IsChecked == true));",
             primaryButtonMethod);
     }
 

--- a/tests/OpenClaw.Tray.Tests/LocalAiSetupUxContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalAiSetupUxContractTests.cs
@@ -236,10 +236,14 @@ public sealed class LocalAiSetupUxContractTests
             "LocalInferenceEligibilityResult deviceEligibility = LocalInferenceEligibility.Evaluate(_localAiHardware);",
             "if (!deviceEligibility.CanInstall || deviceEligibility.Plan is null || deviceEligibility.SelectedGpu is null)",
             "hardwareReason = DescribeLocalAiUnavailable(deviceEligibility);",
-            "!LocalInferenceEligibility.Evaluate(_localAiHardware, selectedModelId).CanInstall",
+            "LocalInferenceEligibilityResult selectedEligibility =",
+            "LocalInferenceEligibility.Evaluate(_localAiHardware, selectedModelId);",
+            "if (_localAiRecoveryModelPinned)",
+            "eligibility = selectedEligibility;",
+            "else if (!selectedEligibility.CanInstall)",
             "_config.LocalAi.SelectedModelId = null;",
             "_config.LocalAi.SelectedModelId ??= _localAiRecommendedModelId ?? deviceEligibility.Plan.Model.Id;",
-            "eligibility = LocalInferenceEligibility.Evaluate(",
+            "eligibility ??= LocalInferenceEligibility.Evaluate(",
             "_config.LocalAi.SelectedModelId);");
     }
 
@@ -531,11 +535,12 @@ public sealed class LocalAiSetupUxContractTests
 
     /// <summary>
     /// Setup step 3 must never dead-end: while Local AI availability is still pending
-    /// (Checking/ProbeUnknown), the toggle must stay interactive even though every other
-    /// Local AI control is disabled, so turning Local AI off is always an escape hatch. Continue
-    /// itself must never bypass eligibility or an as-yet-undetermined WSL networking-consent
-    /// requirement merely because availability hasn't resolved yet — that would let a fast user
-    /// leave step 3 before the consent checkbox is even known to be required.
+    /// (Checking/ProbeUnknown), the toggle must stay interactive outside recovery even though
+    /// every other Local AI control is disabled, so turning Local AI off is an escape hatch.
+    /// Recovery requires Local AI and keeps the toggle disabled. Continue itself must never bypass
+    /// eligibility or an as-yet-undetermined WSL networking-consent requirement merely because
+    /// availability hasn't resolved yet — that would let a fast user leave step 3 before the
+    /// consent checkbox is even known to be required.
     /// </summary>
     [Fact]
     public void CapabilitiesReview_PendingAvailabilityIsEscapedByToggleNotByBypassingContinue()
@@ -552,7 +557,7 @@ public sealed class LocalAiSetupUxContractTests
         AssertInOrder(
             restoreMethod,
             "LocalAiOptionContent.IsHitTestVisible = true;",
-            "LocalAiToggle.IsEnabled = true;");
+            "LocalAiToggle.IsEnabled = !_localAiRecoveryOnly;");
 
         string checkingMethod = ExtractMethod(source, "private void ShowLocalAiAvailabilityChecking");
         AssertInOrder(

--- a/tests/OpenClaw.Tray.Tests/Presentation/LocalAiPageViewModelTests.cs
+++ b/tests/OpenClaw.Tray.Tests/Presentation/LocalAiPageViewModelTests.cs
@@ -636,7 +636,7 @@ public sealed class LocalAiPageViewModelTests
     [Theory]
     [InlineData(LocalAiModelAvailabilityState.Unknown)]
     [InlineData(LocalAiModelAvailabilityState.NotInstalled)]
-    public void MissingModel_KeepsRetrySetupAndDoesNotOfferChangeModel(
+    public void MissingModel_UsesLocalAiSetupRouteAndDoesNotOfferChangeModel(
         LocalAiModelAvailabilityState modelState)
     {
         using var harness = new LocalAiHarness(modelState);
@@ -649,7 +649,8 @@ public sealed class LocalAiPageViewModelTests
         Assert.True(harness.ViewModel.RetrySetup());
 
         Assert.Equal(0, harness.Commands.ShowGatewayWizardCount);
-        Assert.Equal(1, harness.Commands.ShowOnboardingCount);
+        Assert.Equal(0, harness.Commands.ShowOnboardingCount);
+        Assert.Equal(1, harness.Commands.ShowLocalAiSetupCount);
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/Presentation/PresentationTestDoubles.cs
+++ b/tests/OpenClaw.Tray.Tests/Presentation/PresentationTestDoubles.cs
@@ -67,6 +67,7 @@ internal sealed class FakeAppCommands : IAppCommands, IDisposable
     public int ReconnectCount { get; private set; }
     public int ShowChatCount { get; private set; }
     public int ShowOnboardingCount { get; private set; }
+    public int ShowLocalAiSetupCount { get; private set; }
     public int OpenLocalAiLogsCount { get; private set; }
 
     public void ClearOperationLog() => _operationLog.Clear();
@@ -79,6 +80,7 @@ internal sealed class FakeAppCommands : IAppCommands, IDisposable
     public void ShowChat() => ShowChatCount++;
     public void CheckForUpdates() { }
     public void ShowOnboarding() => ShowOnboardingCount++;
+    public void ShowLocalAiSetup() => ShowLocalAiSetupCount++;
     public void ShowGatewayWizard() => ShowGatewayWizardCount++;
     public void OpenLocalAiLogs() => OpenLocalAiLogsCount++;
     public void ShowConnectionStatus() { }
@@ -148,6 +150,7 @@ internal sealed class SelfWritingAppCommands : IAppCommands
     public void ShowChat() { }
     public void CheckForUpdates() { }
     public void ShowOnboarding() { }
+    public void ShowLocalAiSetup() { }
     public void ShowGatewayWizard() { }
     public void ShowConnectionStatus() { }
     public void NotifySettingsSaved() { }

--- a/tests/OpenClaw.Tray.Tests/WindowManagerTests.cs
+++ b/tests/OpenClaw.Tray.Tests/WindowManagerTests.cs
@@ -49,6 +49,58 @@ public sealed class WindowManagerTests
     }
 
     [Fact]
+    public void LocalAiSetup_ChoosesRecoveryOnlyAfterManagedGatewayProof()
+    {
+        var manager = ReadManager();
+
+        Assert.Contains("public async Task ShowLocalAiSetupAsync()", manager);
+        Assert.Contains("LocalAiGatewayDistroResolver.FindOwners(", manager);
+        Assert.Contains("ExistingConfigDetector.Detect(", manager);
+        Assert.Contains("LocalAiSetupRoutePolicy.Decide(", manager);
+        AssertInOrder(
+            manager,
+            "if (resolution.Route == LocalAiSetupRoute.Provision)",
+            "await ShowOnboardingAsync();",
+            "if (resolution.Route == LocalAiSetupRoute.Blocked",
+            "await ShowLocalAiSetupRecoveryAsync(");
+    }
+
+    [Fact]
+    public void LocalAiRecoveryMode_IsNotAppliedToAnExistingSetupWindow()
+    {
+        var manager = ReadManager();
+        var setupWindow = File.ReadAllText(Path.Combine(
+            TestRepositoryPaths.GetRepositoryRoot(),
+            "src",
+            "OpenClaw.SetupEngine.UI",
+            "SetupWindow.xaml.cs"));
+
+        Assert.DoesNotContain("TryNavigateToOnboardingStart", manager);
+        Assert.DoesNotContain("TryNavigateToLocalAiRecoveryReview", manager);
+        Assert.Contains("private void ResetLocalAiRecoveryMode()", setupWindow);
+        AssertInOrder(
+            setupWindow,
+            "public void NavigateToWelcome(bool back = false)",
+            "ResetLocalAiRecoveryMode();",
+            "NavigateTo(typeof(WelcomePage), _config, back);");
+        Assert.Contains("_config.LocalAi.Enabled = true;", setupWindow);
+        Assert.Contains("_config.SkipWizard = true;", setupWindow);
+
+        var capabilities = File.ReadAllText(Path.Combine(
+            TestRepositoryPaths.GetRepositoryRoot(),
+            "src",
+            "OpenClaw.SetupEngine.UI",
+            "Pages",
+            "CapabilitiesPage.xaml.cs"));
+        AssertInOrder(
+            capabilities,
+            "private void Back_Click(object sender, RoutedEventArgs e)",
+            "if (_localAiRecoveryOnly)",
+            "SetupWindow.Active?.NavigateToWelcome(back: true);",
+            "return;");
+    }
+
+    [Fact]
     public void CloseForShutdown_GatesCreationAndClosesOwnedWindowsOnce()
     {
         var manager = ReadManager();

--- a/tests/OpenClaw.Tray.Tests/WindowManagerTests.cs
+++ b/tests/OpenClaw.Tray.Tests/WindowManagerTests.cs
@@ -56,6 +56,8 @@ public sealed class WindowManagerTests
         Assert.Contains("public async Task ShowLocalAiSetupAsync()", manager);
         Assert.Contains("LocalAiGatewayDistroResolver.FindOwners(", manager);
         Assert.Contains("ExistingConfigDetector.Detect(", manager);
+        Assert.Contains("new LocalAiManifestStore(", manager);
+        Assert.Contains("install?.Manifest.ModelCatalogId", manager);
         Assert.Contains("LocalAiSetupRoutePolicy.Decide(", manager);
         AssertInOrder(
             manager,
@@ -83,8 +85,20 @@ public sealed class WindowManagerTests
             "public void NavigateToWelcome(bool back = false)",
             "ResetLocalAiRecoveryMode();",
             "NavigateTo(typeof(WelcomePage), _config, back);");
+        AssertInOrder(
+            setupWindow,
+            "public bool TryNavigateToGatewayInstalledMilestone()",
+            "ResetLocalAiRecoveryMode();",
+            "NavigateToGatewayInstalledMilestone();");
         Assert.Contains("_config.LocalAi.Enabled = true;", setupWindow);
         Assert.Contains("_config.SkipWizard = true;", setupWindow);
+        Assert.Contains("_config.RollbackOnFailure = true;", setupWindow);
+        Assert.Contains("_config.LocalAi.SelectedModelId = localAiRecoveryModelId;", setupWindow);
+        Assert.Contains("_localAiRecoveryBaseline.Restore(_config);", setupWindow);
+        Assert.Contains("localAiRecoveryModelId: localAiRecoveryTarget?.ModelCatalogId", manager);
+        Assert.Contains(
+            "localAiRecoveryRequestedPort: localAiRecoveryTarget?.RequestedLocalAiPort",
+            manager);
 
         var capabilities = File.ReadAllText(Path.Combine(
             TestRepositoryPaths.GetRepositoryRoot(),
@@ -98,6 +112,18 @@ public sealed class WindowManagerTests
             "if (_localAiRecoveryOnly)",
             "SetupWindow.Active?.NavigateToWelcome(back: true);",
             "return;");
+        Assert.Contains(
+            "LocalAiModelSelector.IsEnabled = isAvailable && !_localAiRecoveryModelPinned;",
+            capabilities);
+        Assert.Contains(
+            "LocalAiToggle.IsEnabled = isAvailable && !_localAiRecoveryOnly;",
+            capabilities);
+        AssertInOrder(
+            capabilities,
+            "if (_localAiRecoveryModelPinned)",
+            "eligibility = selectedEligibility;",
+            "else if (!selectedEligibility.CanInstall)",
+            "_config.LocalAi.SelectedModelId = null;");
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

Replaces #1357 (Add non-destructive Local AI recovery), supersedes #1342 (Add recovery flow for local AI setup), and fixes #1307.

Local AI **Retry setup or download** could enter the destructive-capable onboarding pipeline, recreate an existing app-owned WSL gateway, or dead-end when the gateway was exact but the Local AI receipt was missing or incomplete.

## Fix

- route Local AI retry through an owner-aware setup command
- select non-destructive recovery only when exactly one setup-managed local gateway, exact registry ID, effective managed distro, and canonical loopback gateway endpoint/port are proven
- carry the exact gateway ID, distro, gateway port, receipt model, and requested Local AI port into recovery
- keep receipt-less retries for an exact managed owner in the non-destructive recovery pipeline while allowing the current catalog recommendation to be selected
- pin the receipt model and port when a structurally valid receipt exists
- validate ownership before acquisition and again immediately before WSL/provider mutation
- exclude gateway cleanup, distro creation/configuration, CLI install, and service install from recovery
- retain the original receipt as the rollback baseline while repairing incomplete runtime/model assets
- rewrite repaired receipts conservatively, preserving schema-4 cache migration fields, requested port, fallback model, and original install timestamp while clearing the unverified endpoint
- preserve the first provider/primary rollback snapshot across retries and #1390 endpoint-restart lifecycle states
- restore the original provider, primary model, and receipt only when compensation proves the original live route
- retain the replacement receipt when provider rollback is unproven
- arm WSL restart recovery before shutdown, force rollback-on-failure, and provide recovery-sized rollback budgets
- disable the Local AI toggle during recovery and restore every recovery-only config override when Back or the gateway-installed milestone exits to normal setup

## Integrated dependencies

- #1390 (fix(local-ai): keep routing safe across endpoint restarts) is integrated from `621f4100f8b40ac84e844bcc39b01fe03a2238bb`.
- #1388 (feat(local-ai): add verified legacy model cache migration) is integrated from `3ce56b8902d558a2d43a1308b4d61ccbf6856274`.
- #1397 (feat(local-ai): safely use the standard Hugging Face hub cache) is integrated from current `origin/main` `7dab793673ff00a43fd74259ed83321894ef601e`.
- The expected `LocalAiGatewayProviderCoordinatorTests` overlap was resolved without weakening either lifecycle contract.

Current head: `c9dee4102e2a8f22bb0d7edea081c3d52f357abc`, including current `origin/main` `7dab793673ff00a43fd74259ed83321894ef601e`.

## Required proof pools

- `windows-wsl-dgx-blackwell`: **Not verified / blocked.** The available RTX 4080 SUPER exposes 16,376 MiB, below the approximately 22.2 GiB minimum for the smallest current new-install catalog recipe.
- `windows-winui-interactive`: **Not verified / blocked.** The current-catalog hardware gate correctly prevents an enabled recovery review on this host, so no current-head enabled recovery-page screenshot/video is claimed.
- `windows-wsl-gateway-e2e`: **Not verified / blocked for the real recovery transaction.** Hyper-V firewall policy blocks WSL-to-Windows loopback without elevation, so no real existing-gateway provider replacement, restart, inference, and receipt-compensation transaction is claimed.

## Validation

Current-head local validation:

- `.\build.ps1`: passed
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore`: 3,991 passed, 32 skipped
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore`: 2,908 passed
- `dotnet test .\tests\OpenClaw.SetupEngine.Tests\OpenClaw.SetupEngine.Tests.csproj --no-restore`: 1,186 passed, 1 environment-dependent cross-volume test skipped
- focused `LocalAiInstallRecoveryTests`: 44 passed, 1 environment-dependent cross-volume test skipped
- focused Local AI Connection migration/lifecycle tests: 110 passed, 1 environment-dependent cross-volume test skipped
- `dotnet test .\tests\OpenClaw.Connection.Tests\OpenClaw.Connection.Tests.csproj --no-restore`: 793 passed, 1 environment-dependent cross-volume test skipped
## Reviews

- Final autoreview: clean, no accepted/actionable findings. One valid finding was fixed so schema-4 reconciliation verifies the retained legacy compatibility copy and routes a missing or corrupt copy through safe rematerialization. One cold-refresh finding was rejected after confirming a new runtime service returns before probing and a live managed process already owns a verified model lease.
- Final rubber-duck review: clean, no actionable issues. It independently confirmed the compatibility-copy fix, exact pre-recovery receipt preservation, schema-4 active cache identity, independent runtime/model repair, and the rejected cold-refresh invariant.
- ClawSweeper remains advisory rather than the merge authority; local tests and independent code review are the landing evidence.
## Real behavior proof

Current-head automated coverage establishes:

- exact-owner routing for receipt-backed and receipt-less recovery
- visible fail-closed handling for ambiguous, stale, or drifted gateway ownership
- two ownership checks before mutation and absence of destructive provisioning steps
- receipt model/port propagation and current-recommendation selection only when no receipt exists
- incomplete receipt reconciliation through repair and persistence
- schema-4 cache-field and original timestamp preservation
- exact provider replacement, lost-acknowledgement handling, first-snapshot pinning, endpoint-cycle rollback, and conservative receipt restoration
- WSL restart arming, per-step rollback budgets, forced rollback, recovery toggle/model gating, and full config restoration on both recovery exits

Prior host evidence is intentionally not counted as current-catalog recovery proof: pinned legacy Qwen3.5 9B and llama.cpp `b10655` loaded successfully, but that does not satisfy the current catalog or enabled WinUI recovery gate.

**Not verified / blocked:** current-catalog native inference, enabled recovery-page interactive proof, real WSL-to-Windows reachability, and a live existing-gateway provider/restart/receipt recovery transaction. Keep this PR draft with `status: 📣 needs proof` until `windows-wsl-dgx-blackwell` and interactive proof are available or a maintainer explicitly accepts the scoped proof gap.

## Ownership notes

- old owner: Local AI Retry entered general onboarding and its destructive-capable default pipeline
- new owner: `WindowManager.ShowLocalAiSetupAsync` selects provision/recovery/blocked routing; `BuildLocalAiRecoverySteps` owns the exact-owner non-destructive transaction
- preserved invariant: gateway/provider lifecycle remains compatible with #1390, and legacy cache migration receipts remain compatible with #1388

## Security impact

No new credentials or permissions. Recovery fails closed on ambiguous ownership and binds WSL/provider mutation to one revalidated registry owner, distro, canonical loopback endpoint/port, and retained receipt.