### PR TITLE
feat(shared): add safe Hugging Face cache primitives

### DIFF
--- a/src/OpenClaw.Shared/IO/WindowsPathSafety.cs
+++ b/src/OpenClaw.Shared/IO/WindowsPathSafety.cs
@@ -1,0 +1,63 @@
+namespace OpenClaw.Shared.IO;
+
+/// <summary>
+/// Shared Windows path primitives for callers that apply their own ownership and
+/// reparse-point policies.
+/// </summary>
+public static class WindowsPathSafety
+{
+    public const int MaximumComponentLength = 255;
+
+    private const StringComparison PathComparison = StringComparison.OrdinalIgnoreCase;
+
+    /// <summary>Returns a fully qualified path without a trailing directory separator.</summary>
+    public static string NormalizePath(string path) =>
+        Path.TrimEndingDirectorySeparator(Path.GetFullPath(path));
+
+    /// <summary>Compares normalized Windows paths using ordinal, case-insensitive semantics.</summary>
+    public static bool PathEquals(string? left, string? right) =>
+        string.Equals(left, right, PathComparison);
+
+    /// <summary>Returns whether a normalized path equals or is nested beneath a normalized root.</summary>
+    public static bool IsSameOrDescendant(string candidate, string root) =>
+        PathEquals(candidate, root) || IsStrictDescendant(candidate, root);
+
+    /// <summary>Returns whether a normalized path is nested beneath a normalized root.</summary>
+    public static bool IsStrictDescendant(string candidate, string root) =>
+        candidate.StartsWith(EnsureTrailingDirectorySeparator(root), PathComparison);
+
+    public static string EnsureTrailingDirectorySeparator(string path) =>
+        Path.EndsInDirectorySeparator(path) ? path : path + Path.DirectorySeparatorChar;
+
+    /// <summary>Returns whether a value is safe to use as one Windows path segment.</summary>
+    public static bool IsSafeSegment(string? value) =>
+        !string.IsNullOrWhiteSpace(value) &&
+        value.Length <= MaximumComponentLength &&
+        string.Equals(value, value.Trim(), StringComparison.Ordinal) &&
+        value is not "." and not ".." &&
+        !value.EndsWith('.') &&
+        !Path.IsPathRooted(value) &&
+        value.IndexOfAny(Path.GetInvalidFileNameChars()) < 0 &&
+        !value.Contains(Path.DirectorySeparatorChar) &&
+        !value.Contains(Path.AltDirectorySeparatorChar) &&
+        !IsWindowsDeviceName(value);
+
+    /// <summary>Returns whether a segment names a reserved Windows device.</summary>
+    public static bool IsWindowsDeviceName(string segment)
+    {
+        ArgumentNullException.ThrowIfNull(segment);
+
+        string baseName = segment.Split('.')[0];
+        return baseName.Equals("CON", StringComparison.OrdinalIgnoreCase) ||
+               baseName.Equals("PRN", StringComparison.OrdinalIgnoreCase) ||
+               baseName.Equals("AUX", StringComparison.OrdinalIgnoreCase) ||
+               baseName.Equals("NUL", StringComparison.OrdinalIgnoreCase) ||
+               IsNumberedDevice(baseName, "COM") ||
+               IsNumberedDevice(baseName, "LPT");
+    }
+
+    private static bool IsNumberedDevice(string value, string prefix) =>
+        value.Length == 4 &&
+        value.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) &&
+        value[3] is >= '1' and <= '9' or '\u00b9' or '\u00b2' or '\u00b3';
+}

--- a/src/OpenClaw.Shared/Inference/Catalog/HuggingFaceHubCache.cs
+++ b/src/OpenClaw.Shared/Inference/Catalog/HuggingFaceHubCache.cs
@@ -1,0 +1,762 @@
+using Microsoft.Win32.SafeHandles;
+using OpenClaw.Shared.IO;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace OpenClaw.Shared.Inference.Catalog;
+
+/// <summary>
+/// Resolves and validates paths in the standard Hugging Face hub cache layout.
+/// </summary>
+/// <remarks>
+/// Read and mutation validation are intentionally separate. Reads may follow a
+/// standard snapshot symlink into the same repository's blobs directory. This type
+/// deliberately does not expose a validate-then-mutate API because returning a path
+/// cannot make a later filesystem mutation race-free. Existing files are never
+/// considered reusable based on their path alone. Call
+/// <see cref="TryOpenVerifiedCacheFileAsync"/> with pinned size and SHA-256 evidence.
+/// </remarks>
+public static class HuggingFaceHubCache
+{
+    private const uint OpenExisting = 3;
+    private const uint FileFlagBackupSemantics = 0x02000000;
+    private const int HashBufferSize = 1024 * 1024;
+    private const string HubCacheEnvironmentVariable = "HF_HUB_CACHE";
+    private const string LegacyHubCacheEnvironmentVariable = "HUGGINGFACE_HUB_CACHE";
+    private const string HubHomeEnvironmentVariable = "HF_HOME";
+    private const string XdgCacheHomeEnvironmentVariable = "XDG_CACHE_HOME";
+
+    private enum CacheEntryKind
+    {
+        Blob,
+        Snapshot,
+    }
+
+    /// <summary>
+    /// Resolves the cache root using Hugging Face precedence: <c>HF_HUB_CACHE</c>,
+    /// <c>HUGGINGFACE_HUB_CACHE</c>, <c>HF_HOME\hub</c>,
+    /// <c>XDG_CACHE_HOME\huggingface\hub</c>, then
+    /// <c>%USERPROFILE%\.cache\huggingface\hub</c>.
+    /// </summary>
+    public static string ResolveCacheRoot() =>
+        ResolveCacheRoot(
+            Environment.GetEnvironmentVariable,
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            Environment.ExpandEnvironmentVariables);
+
+    internal static string ResolveCacheRoot(
+        Func<string, string?> getEnvironmentVariable,
+        string userProfile,
+        Func<string, string>? expandEnvironmentVariables = null)
+    {
+        ArgumentNullException.ThrowIfNull(getEnvironmentVariable);
+        expandEnvironmentVariables ??= Environment.ExpandEnvironmentVariables;
+
+        string? explicitCache = NullIfWhiteSpace(getEnvironmentVariable(HubCacheEnvironmentVariable))
+            ?? NullIfWhiteSpace(getEnvironmentVariable(LegacyHubCacheEnvironmentVariable));
+        if (explicitCache is not null)
+            return NormalizeConfiguredPath(explicitCache, userProfile, expandEnvironmentVariables);
+
+        string? hubHome = NullIfWhiteSpace(getEnvironmentVariable(HubHomeEnvironmentVariable));
+        if (hubHome is not null)
+            return WindowsPathSafety.NormalizePath(
+                Path.Combine(
+                    NormalizeConfiguredPath(hubHome, userProfile, expandEnvironmentVariables),
+                    "hub"));
+
+        string? xdgCacheHome = NullIfWhiteSpace(getEnvironmentVariable(XdgCacheHomeEnvironmentVariable));
+        if (xdgCacheHome is not null)
+        {
+            return WindowsPathSafety.NormalizePath(
+                Path.Combine(
+                    NormalizeConfiguredPath(xdgCacheHome, userProfile, expandEnvironmentVariables),
+                    "huggingface",
+                    "hub"));
+        }
+
+        if (string.IsNullOrWhiteSpace(userProfile))
+            throw new InvalidOperationException("The user profile directory is unavailable.");
+
+        return WindowsPathSafety.NormalizePath(
+            Path.Combine(userProfile, ".cache", "huggingface", "hub"));
+    }
+
+    /// <summary>
+    /// Computes the snapshot file path and its same-directory <c>.partial</c>
+    /// download path for one immutable repository revision.
+    /// </summary>
+    public static bool TryGetSnapshotPaths(
+        string cacheRoot,
+        string repositoryId,
+        string revision,
+        string relativePath,
+        out string snapshotPath,
+        out string partialPath,
+        out string error)
+    {
+        snapshotPath = "";
+        partialPath = "";
+
+        if (!TryNormalizeRoot(cacheRoot, out string normalizedRoot, out error) ||
+            !TryValidateRepositoryId(repositoryId, out string owner, out string repository, out error) ||
+            !TryValidateRevision(revision, out error) ||
+            !TryGetRelativePathSegments(relativePath, out string[] relativeSegments, out error))
+        {
+            return false;
+        }
+
+        try
+        {
+            string repositoryDirectory = Path.Combine(
+                normalizedRoot,
+                $"models--{owner}--{repository}");
+            string snapshotDirectory = Path.Combine(
+                repositoryDirectory,
+                "snapshots",
+                revision);
+            snapshotPath = WindowsPathSafety.NormalizePath(
+                Path.Combine([snapshotDirectory, .. relativeSegments]));
+            partialPath = WindowsPathSafety.NormalizePath(snapshotPath + ".partial");
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            snapshotPath = "";
+            partialPath = "";
+            error = $"Invalid Hugging Face hub cache path: {ex.Message}";
+            return false;
+        }
+
+        if (!WindowsPathSafety.IsStrictDescendant(snapshotPath, normalizedRoot) ||
+            !WindowsPathSafety.IsStrictDescendant(partialPath, normalizedRoot))
+        {
+            snapshotPath = "";
+            partialPath = "";
+            error = "The Hugging Face snapshot path escaped the hub cache root.";
+            return false;
+        }
+
+        error = "";
+        return true;
+    }
+
+    /// <summary>
+    /// Computes the content-addressed blob path used by Hugging Face for an LFS
+    /// artifact. The file at this path still requires pinned integrity verification.
+    /// </summary>
+    public static bool TryGetBlobPath(
+        string cacheRoot,
+        string repositoryId,
+        Sha256Digest sha256,
+        out string blobPath,
+        out string error)
+    {
+        ArgumentNullException.ThrowIfNull(sha256);
+        blobPath = "";
+
+        if (!TryNormalizeRoot(cacheRoot, out string normalizedRoot, out error) ||
+            !TryValidateRepositoryId(repositoryId, out string owner, out string repository, out error))
+        {
+            return false;
+        }
+
+        try
+        {
+            blobPath = WindowsPathSafety.NormalizePath(
+                Path.Combine(
+                    normalizedRoot,
+                    $"models--{owner}--{repository}",
+                    "blobs",
+                    sha256.Value));
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            blobPath = "";
+            error = $"Invalid Hugging Face hub cache path: {ex.Message}";
+            return false;
+        }
+
+        if (!WindowsPathSafety.IsStrictDescendant(blobPath, normalizedRoot))
+        {
+            blobPath = "";
+            error = "The Hugging Face blob path escaped the hub cache root.";
+            return false;
+        }
+
+        error = "";
+        return true;
+    }
+
+    /// <summary>
+    /// Opens a snapshot or blob entry for a caller that will verify its pinned
+    /// integrity. Standard snapshot symlinks are accepted only when the opened handle
+    /// resolves into the same repository's blobs directory.
+    /// </summary>
+    internal static bool TryOpenReadPath(
+        string cacheRoot,
+        string candidatePath,
+        out FileStream? stream,
+        out string validatedPath,
+        out string error)
+    {
+        stream = null;
+        validatedPath = "";
+
+        if (!TryNormalizeCacheEntry(
+                cacheRoot,
+                candidatePath,
+                out string normalizedRoot,
+                out string normalizedPath,
+                out CacheEntryKind entryKind,
+                out string repositoryDirectory,
+                out error) ||
+            !TryRejectReparsePointDescendants(
+                normalizedRoot,
+                normalizedPath,
+                includeTarget: false,
+                out error))
+        {
+            return false;
+        }
+
+        try
+        {
+            FileAttributes attributes = File.GetAttributes(normalizedPath);
+            stream = new FileStream(
+                normalizedPath,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.Read,
+                HashBufferSize,
+                FileOptions.Asynchronous | FileOptions.SequentialScan);
+
+            string finalPath = GetFinalPathFromHandle(stream.SafeFileHandle, normalizedPath);
+            string finalRoot = GetFinalDirectoryPath(normalizedRoot);
+            if (!WindowsPathSafety.IsStrictDescendant(finalPath, finalRoot))
+            {
+                error = $"Hugging Face cache path '{normalizedPath}' resolves outside the hub cache root.";
+                stream.Dispose();
+                stream = null;
+                return false;
+            }
+
+            if ((attributes & FileAttributes.ReparsePoint) != 0 &&
+                !TryValidateSnapshotLink(
+                    normalizedRoot,
+                    normalizedPath,
+                    finalRoot,
+                    finalPath,
+                    entryKind,
+                    repositoryDirectory,
+                    out error))
+            {
+                stream.Dispose();
+                stream = null;
+                return false;
+            }
+
+            validatedPath = normalizedPath;
+            error = "";
+            return true;
+        }
+        catch (Exception ex) when (
+            ex is IOException or
+                UnauthorizedAccessException or
+                System.Security.SecurityException or
+                NotSupportedException)
+        {
+            stream?.Dispose();
+            stream = null;
+            error = $"Cannot safely open Hugging Face hub cache path '{normalizedPath}': {ex.Message}";
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Returns an open stream only when a safely opened snapshot or blob matches the
+    /// pinned size and SHA-256 digest. The stream is rewound to position zero so a
+    /// caller can copy from the same verified handle, including across volumes.
+    /// The caller owns the returned stream.
+    /// </summary>
+    public static async Task<FileStream?> TryOpenVerifiedCacheFileAsync(
+        string cacheRoot,
+        string candidatePath,
+        long expectedSizeBytes,
+        Sha256Digest expectedSha256,
+        IProgress<long>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (expectedSizeBytes <= 0)
+            throw new ArgumentOutOfRangeException(nameof(expectedSizeBytes), "Expected size must be positive.");
+        ArgumentNullException.ThrowIfNull(expectedSha256);
+
+        if (!TryOpenReadPath(
+                cacheRoot,
+                candidatePath,
+                out FileStream? stream,
+                out _,
+                out _))
+        {
+            return null;
+        }
+
+        bool returnStream = false;
+        try
+        {
+            FileStream verifiedStream = stream!;
+            if (verifiedStream.Length != expectedSizeBytes)
+                return null;
+
+            using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+            var buffer = new byte[HashBufferSize];
+            long completed = 0;
+            progress?.Report(completed);
+            while (true)
+            {
+                int read = await verifiedStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+                if (read == 0)
+                    break;
+
+                hash.AppendData(buffer, 0, read);
+                completed += read;
+                progress?.Report(completed);
+            }
+
+            if (completed != expectedSizeBytes ||
+                !CryptographicOperations.FixedTimeEquals(
+                    hash.GetHashAndReset(),
+                    Convert.FromHexString(expectedSha256.Value)))
+            {
+                return null;
+            }
+
+            verifiedStream.Position = 0;
+            returnStream = true;
+            return verifiedStream;
+        }
+        catch (Exception ex) when (
+            ex is IOException or
+                UnauthorizedAccessException or
+                System.Security.SecurityException or
+                NotSupportedException)
+        {
+            return null;
+        }
+        finally
+        {
+            if (!returnStream)
+                await stream!.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    private static bool TryValidateSnapshotLink(
+        string normalizedRoot,
+        string normalizedPath,
+        string finalRoot,
+        string finalPath,
+        CacheEntryKind entryKind,
+        string repositoryDirectory,
+        out string error)
+    {
+        if (entryKind != CacheEntryKind.Snapshot ||
+            new FileInfo(normalizedPath).LinkTarget is null)
+        {
+            error = $"Refusing to read '{normalizedPath}' because it is an unsupported reparse point.";
+            return false;
+        }
+
+        string blobsDirectory = WindowsPathSafety.NormalizePath(
+            Path.Combine(repositoryDirectory, "blobs"));
+        if (!Directory.Exists(blobsDirectory))
+        {
+            error = "The Hugging Face snapshot link has no repository blobs directory.";
+            return false;
+        }
+
+        if (!TryRejectReparsePointDescendants(
+                normalizedRoot,
+                blobsDirectory,
+                includeTarget: true,
+                out error))
+        {
+            return false;
+        }
+
+        string finalBlobsDirectory = GetFinalDirectoryPath(blobsDirectory);
+        if (!WindowsPathSafety.IsStrictDescendant(finalBlobsDirectory, finalRoot) ||
+            !WindowsPathSafety.IsStrictDescendant(finalPath, finalBlobsDirectory))
+        {
+            error = $"Hugging Face snapshot link '{normalizedPath}' does not resolve into its repository blobs directory.";
+            return false;
+        }
+
+        error = "";
+        return true;
+    }
+
+    private static bool TryNormalizeCacheEntry(
+        string cacheRoot,
+        string candidatePath,
+        out string normalizedRoot,
+        out string normalizedPath,
+        out CacheEntryKind entryKind,
+        out string repositoryDirectory,
+        out string error)
+    {
+        entryKind = default;
+        repositoryDirectory = "";
+        if (!TryNormalizeContainedPath(
+                cacheRoot,
+                candidatePath,
+                out normalizedRoot,
+                out normalizedPath,
+                out error))
+        {
+            return false;
+        }
+
+        string[] segments = Path.GetRelativePath(normalizedRoot, normalizedPath).Split(
+            [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
+            StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length < 3 || !TryValidateRepositoryDirectoryName(segments[0]))
+        {
+            error = "The path is not a valid Hugging Face repository cache entry.";
+            return false;
+        }
+
+        repositoryDirectory = WindowsPathSafety.NormalizePath(
+            Path.Combine(normalizedRoot, segments[0]));
+        if (string.Equals(segments[1], "blobs", StringComparison.Ordinal) &&
+            segments.Length == 3 &&
+            WindowsPathSafety.IsSafeSegment(segments[2]))
+        {
+            entryKind = CacheEntryKind.Blob;
+            error = "";
+            return true;
+        }
+
+        if (string.Equals(segments[1], "snapshots", StringComparison.Ordinal) &&
+            segments.Length >= 4 &&
+            PinnedArtifactValidation.IsLowerHex(segments[2], 40) &&
+            segments.Skip(3).All(WindowsPathSafety.IsSafeSegment))
+        {
+            entryKind = CacheEntryKind.Snapshot;
+            error = "";
+            return true;
+        }
+
+        error = "The path is not a valid Hugging Face blob or pinned snapshot entry.";
+        return false;
+    }
+
+    private static bool TryNormalizeContainedPath(
+        string cacheRoot,
+        string candidatePath,
+        out string normalizedRoot,
+        out string normalizedPath,
+        out string error)
+    {
+        normalizedRoot = "";
+        normalizedPath = "";
+        if (!TryNormalizeRoot(cacheRoot, out normalizedRoot, out error))
+            return false;
+
+        if (string.IsNullOrWhiteSpace(candidatePath) || !Path.IsPathFullyQualified(candidatePath))
+        {
+            error = "The Hugging Face cache path must be fully qualified.";
+            return false;
+        }
+
+        try
+        {
+            normalizedPath = WindowsPathSafety.NormalizePath(candidatePath);
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            error = $"Invalid Hugging Face hub cache path: {ex.Message}";
+            return false;
+        }
+
+        if (!WindowsPathSafety.IsStrictDescendant(normalizedPath, normalizedRoot))
+        {
+            error = $"Hugging Face cache path '{normalizedPath}' is not contained within the hub cache root.";
+            return false;
+        }
+
+        error = "";
+        return true;
+    }
+
+    private static bool TryNormalizeRoot(
+        string cacheRoot,
+        out string normalizedRoot,
+        out string error)
+    {
+        normalizedRoot = "";
+        if (string.IsNullOrWhiteSpace(cacheRoot) || !Path.IsPathFullyQualified(cacheRoot))
+        {
+            error = "The Hugging Face hub cache root must be fully qualified.";
+            return false;
+        }
+
+        try
+        {
+            normalizedRoot = WindowsPathSafety.NormalizePath(cacheRoot);
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            error = $"Invalid Hugging Face hub cache path: {ex.Message}";
+            return false;
+        }
+
+        error = "";
+        return true;
+    }
+
+    private static bool TryValidateRepositoryId(
+        string repositoryId,
+        out string owner,
+        out string repository,
+        out string error)
+    {
+        owner = "";
+        repository = "";
+        string[] segments = repositoryId?.Split('/') ?? [];
+        if (repositoryId is null ||
+            repositoryId.Length > 96 ||
+            segments.Length != 2 ||
+            segments.Any(segment => !IsValidRepositorySegment(segment)))
+        {
+            error = "A Hugging Face repository id must contain exactly two safe path segments.";
+            return false;
+        }
+
+        owner = segments[0];
+        repository = segments[1];
+        error = "";
+        return true;
+    }
+
+    private static bool IsValidRepositorySegment(string segment) =>
+        WindowsPathSafety.IsSafeSegment(segment) &&
+        segment.All(character =>
+            char.IsAsciiLetterOrDigit(character) || character is '-' or '_' or '.') &&
+        segment[0] is not '-' and not '.' &&
+        segment[^1] is not '-' and not '.' &&
+        !segment.Contains("--", StringComparison.Ordinal) &&
+        !segment.Contains("..", StringComparison.Ordinal);
+
+    private static bool TryValidateRepositoryDirectoryName(string value)
+    {
+        const string prefix = "models--";
+        if (!value.StartsWith(prefix, StringComparison.Ordinal))
+            return false;
+
+        string[] segments = value[prefix.Length..].Split(
+            "--",
+            StringSplitOptions.None);
+        return segments.Length == 2 &&
+            segments.All(IsValidRepositorySegment) &&
+            $"{segments[0]}/{segments[1]}".Length <= 96;
+    }
+
+    private static bool TryValidateRevision(string revision, out string error)
+    {
+        if (!PinnedArtifactValidation.IsLowerHex(revision, 40))
+        {
+            error = "A Hugging Face revision must contain exactly 40 lowercase hexadecimal characters.";
+            return false;
+        }
+
+        error = "";
+        return true;
+    }
+
+    private static bool TryGetRelativePathSegments(
+        string relativePath,
+        out string[] segments,
+        out string error)
+    {
+        segments = [];
+        if (string.IsNullOrWhiteSpace(relativePath) ||
+            relativePath.Contains('\\') ||
+            relativePath.StartsWith('/') ||
+            relativePath.EndsWith('/'))
+        {
+            error = "The Hugging Face artifact path must be a normalized relative path.";
+            return false;
+        }
+
+        segments = relativePath.Split('/');
+        if (segments.Any(segment => !WindowsPathSafety.IsSafeSegment(segment)))
+        {
+            segments = [];
+            error = "The Hugging Face artifact path contains an unsafe Windows path segment.";
+            return false;
+        }
+
+        if (segments[^1].Length + ".partial".Length > WindowsPathSafety.MaximumComponentLength)
+        {
+            segments = [];
+            error = "The Hugging Face artifact file name is too long for its partial download suffix.";
+            return false;
+        }
+
+        error = "";
+        return true;
+    }
+
+    private static bool TryRejectReparsePointDescendants(
+        string normalizedRoot,
+        string normalizedPath,
+        bool includeTarget,
+        out string error)
+    {
+        string[] segments = Path.GetRelativePath(normalizedRoot, normalizedPath).Split(
+            [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
+            StringSplitOptions.RemoveEmptyEntries);
+        int count = includeTarget ? segments.Length : Math.Max(0, segments.Length - 1);
+        string current = normalizedRoot;
+        for (int index = 0; index < count; index++)
+        {
+            current = Path.Combine(current, segments[index]);
+            if (!TryRejectReparsePoint(current, out error))
+                return false;
+        }
+
+        error = "";
+        return true;
+    }
+
+    private static bool TryRejectReparsePoint(string path, out string error)
+    {
+        try
+        {
+            if ((File.GetAttributes(path) & FileAttributes.ReparsePoint) != 0)
+            {
+                error = $"Refusing to operate on '{path}' because it is a reparse point.";
+                return false;
+            }
+        }
+        catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
+        {
+            error = "";
+            return true;
+        }
+        catch (Exception ex) when (
+            ex is IOException or
+                UnauthorizedAccessException or
+                System.Security.SecurityException)
+        {
+            error = $"Cannot verify Hugging Face hub cache path '{path}': {ex.Message}";
+            return false;
+        }
+
+        error = "";
+        return true;
+    }
+
+    private static string GetFinalDirectoryPath(string path)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            FileSystemInfo? resolved = new DirectoryInfo(path).ResolveLinkTarget(returnFinalTarget: true);
+            return WindowsPathSafety.NormalizePath(resolved?.FullName ?? path);
+        }
+
+        using SafeFileHandle handle = CreateFileW(
+            path,
+            0,
+            FileShare.ReadWrite | FileShare.Delete,
+            IntPtr.Zero,
+            OpenExisting,
+            FileFlagBackupSemantics,
+            IntPtr.Zero);
+        if (handle.IsInvalid)
+            throw new IOException($"Cannot open directory '{path}' (Win32 error {Marshal.GetLastWin32Error()}).");
+
+        return GetFinalPathFromHandle(handle, path);
+    }
+
+    private static string GetFinalPathFromHandle(SafeFileHandle handle, string fallbackPath)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            FileSystemInfo? resolved = new FileInfo(fallbackPath).ResolveLinkTarget(returnFinalTarget: true);
+            return WindowsPathSafety.NormalizePath(resolved?.FullName ?? fallbackPath);
+        }
+
+        int capacity = 512;
+        while (capacity <= 32_768)
+        {
+            var builder = new StringBuilder(capacity);
+            uint length = GetFinalPathNameByHandleW(handle, builder, (uint)builder.Capacity, 0);
+            if (length == 0)
+            {
+                throw new IOException(
+                    $"Cannot resolve a Hugging Face cache handle (Win32 error {Marshal.GetLastWin32Error()}).");
+            }
+
+            if (length < builder.Capacity)
+                return WindowsPathSafety.NormalizePath(NormalizeFinalPath(builder.ToString()));
+
+            capacity = checked((int)length + 1);
+        }
+
+        throw new IOException("A resolved Hugging Face cache path exceeded the supported length.");
+    }
+
+    private static string NormalizeFinalPath(string path)
+    {
+        const string extendedPrefix = @"\\?\";
+        const string extendedUncPrefix = @"\\?\UNC\";
+        if (path.StartsWith(extendedUncPrefix, StringComparison.OrdinalIgnoreCase))
+            return @"\\" + path[extendedUncPrefix.Length..];
+
+        return path.StartsWith(extendedPrefix, StringComparison.OrdinalIgnoreCase)
+            ? path[extendedPrefix.Length..]
+            : path;
+    }
+
+    private static string NormalizeConfiguredPath(
+        string path,
+        string userProfile,
+        Func<string, string> expandEnvironmentVariables)
+    {
+        string expanded = path;
+        if (path == "~" ||
+            path.StartsWith($"~{Path.DirectorySeparatorChar}", StringComparison.Ordinal) ||
+            path.StartsWith($"~{Path.AltDirectorySeparatorChar}", StringComparison.Ordinal))
+        {
+            if (string.IsNullOrWhiteSpace(userProfile))
+                throw new InvalidOperationException("The user profile directory is unavailable.");
+
+            expanded = path.Length == 1
+                ? userProfile
+                : Path.Combine(userProfile, path[2..]);
+        }
+
+        expanded = expandEnvironmentVariables(expanded);
+        return WindowsPathSafety.NormalizePath(expanded);
+    }
+
+    private static string? NullIfWhiteSpace(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value;
+
+    [DllImport("kernel32.dll", EntryPoint = "CreateFileW", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern SafeFileHandle CreateFileW(
+        string fileName,
+        uint desiredAccess,
+        FileShare shareMode,
+        IntPtr securityAttributes,
+        uint creationDisposition,
+        uint flagsAndAttributes,
+        IntPtr templateFile);
+
+    [DllImport("kernel32.dll", EntryPoint = "GetFinalPathNameByHandleW", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern uint GetFinalPathNameByHandleW(
+        SafeFileHandle file,
+        StringBuilder filePath,
+        uint filePathLength,
+        uint flags);
+}

--- a/tests/OpenClaw.Shared.Tests/HuggingFaceHubCacheTests.cs
+++ b/tests/OpenClaw.Shared.Tests/HuggingFaceHubCacheTests.cs
@@ -1,0 +1,389 @@
+using OpenClaw.Shared.Inference.Catalog;
+using OpenClaw.Shared.IO;
+using OpenClaw.TestSupport;
+using System.Security.Cryptography;
+
+namespace OpenClaw.Shared.Tests;
+
+public sealed class HuggingFaceHubCacheTests
+{
+    [Fact]
+    public void ResolveCacheRoot_UsesHuggingFacePrecedence()
+    {
+        string resolved = HuggingFaceHubCache.ResolveCacheRoot(
+            name => name switch
+            {
+                "HF_HUB_CACHE" => @"C:\explicit",
+                "HUGGINGFACE_HUB_CACHE" => @"C:\legacy",
+                "HF_HOME" => @"C:\home",
+                "XDG_CACHE_HOME" => @"C:\xdg",
+                _ => null,
+            },
+            @"C:\profile");
+
+        Assert.Equal(@"C:\explicit", resolved);
+    }
+
+    [Fact]
+    public void ResolveCacheRoot_FallsBackThroughLegacyHomeXdgAndProfile()
+    {
+        Assert.Equal(
+            @"C:\legacy",
+            HuggingFaceHubCache.ResolveCacheRoot(
+                name => name == "HUGGINGFACE_HUB_CACHE" ? @"C:\legacy" : null,
+                @"C:\profile"));
+        Assert.Equal(
+            Path.Combine(@"C:\home", "hub"),
+            HuggingFaceHubCache.ResolveCacheRoot(
+                name => name == "HF_HOME" ? @"C:\home" : null,
+                @"C:\profile"));
+        Assert.Equal(
+            Path.Combine(@"C:\xdg", "huggingface", "hub"),
+            HuggingFaceHubCache.ResolveCacheRoot(
+                name => name == "XDG_CACHE_HOME" ? @"C:\xdg" : null,
+                @"C:\profile"));
+        Assert.Equal(
+            Path.Combine(@"C:\profile", ".cache", "huggingface", "hub"),
+            HuggingFaceHubCache.ResolveCacheRoot(_ => null, @"C:\profile"));
+    }
+
+    [Fact]
+    public void ResolveCacheRoot_ExpandsUserProfilePrefix()
+    {
+        string resolved = HuggingFaceHubCache.ResolveCacheRoot(
+            name => name == "HF_HUB_CACHE" ? @"~\hf-cache" : null,
+            @"C:\profile");
+
+        Assert.Equal(Path.Combine(@"C:\profile", "hf-cache"), resolved);
+    }
+
+    [Fact]
+    public void ResolveCacheRoot_ExpandsWindowsEnvironmentVariables()
+    {
+        string resolved = HuggingFaceHubCache.ResolveCacheRoot(
+            name => name == "HF_HUB_CACHE" ? @"%CACHE_ROOT%\hub" : null,
+            @"C:\profile",
+            value => value.Replace("%CACHE_ROOT%", @"D:\shared", StringComparison.Ordinal));
+
+        Assert.Equal(Path.Combine(@"D:\shared", "hub"), resolved);
+    }
+
+    [Fact]
+    public void TryGetSnapshotPaths_SupportsSafeNestedRelativePath()
+    {
+        using var temp = new TempDirectory();
+
+        bool success = HuggingFaceHubCache.TryGetSnapshotPaths(
+            temp.Path,
+            "unsloth/Qwen3.8-27B-GGUF",
+            new string('a', 40),
+            "weights/model.gguf",
+            out string snapshotPath,
+            out string partialPath,
+            out string error);
+
+        Assert.True(success, error);
+        string expected = Path.Combine(
+            temp.Path,
+            "models--unsloth--Qwen3.8-27B-GGUF",
+            "snapshots",
+            new string('a', 40),
+            "weights",
+            "model.gguf");
+        Assert.Equal(expected, snapshotPath);
+        Assert.Equal(expected + ".partial", partialPath);
+    }
+
+    [Theory]
+    [InlineData("owner")]
+    [InlineData("owner/repo/extra")]
+    [InlineData("owner/CON")]
+    [InlineData("owner/repo--other")]
+    [InlineData(".owner/repo")]
+    public void TryGetSnapshotPaths_RejectsUnsafeRepositoryId(string repositoryId)
+    {
+        bool success = HuggingFaceHubCache.TryGetSnapshotPaths(
+            @"C:\cache",
+            repositoryId,
+            new string('a', 40),
+            "model.gguf",
+            out string snapshotPath,
+            out string partialPath,
+            out string error);
+
+        Assert.False(success);
+        Assert.Empty(snapshotPath);
+        Assert.Empty(partialPath);
+        Assert.NotEmpty(error);
+    }
+
+    [Theory]
+    [InlineData("abc")]
+    [InlineData("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")]
+    [InlineData("gggggggggggggggggggggggggggggggggggggggg")]
+    public void TryGetSnapshotPaths_RejectsUnpinnedRevision(string revision)
+    {
+        bool success = HuggingFaceHubCache.TryGetSnapshotPaths(
+            @"C:\cache",
+            "owner/repo",
+            revision,
+            "model.gguf",
+            out _,
+            out _,
+            out string error);
+
+        Assert.False(success);
+        Assert.NotEmpty(error);
+    }
+
+    [Theory]
+    [InlineData("../model.gguf")]
+    [InlineData("folder/../model.gguf")]
+    [InlineData("folder//model.gguf")]
+    [InlineData(@"folder\model.gguf")]
+    [InlineData("/model.gguf")]
+    [InlineData("folder/CON")]
+    [InlineData("model.gguf:stream")]
+    public void TryGetSnapshotPaths_RejectsUnsafeRelativePath(string relativePath)
+    {
+        bool success = HuggingFaceHubCache.TryGetSnapshotPaths(
+            @"C:\cache",
+            "owner/repo",
+            new string('a', 40),
+            relativePath,
+            out string snapshotPath,
+            out string partialPath,
+            out string error);
+
+        Assert.False(success);
+        Assert.Empty(snapshotPath);
+        Assert.Empty(partialPath);
+        Assert.NotEmpty(error);
+    }
+
+    [Fact]
+    public void TryGetSnapshotPaths_ReservesComponentLengthForPartialSuffix()
+    {
+        string fileName = new('a', WindowsPathSafety.MaximumComponentLength - ".partial".Length + 1);
+
+        bool success = HuggingFaceHubCache.TryGetSnapshotPaths(
+            @"C:\cache",
+            "owner/repo",
+            new string('a', 40),
+            fileName,
+            out string snapshotPath,
+            out string partialPath,
+            out string error);
+
+        Assert.False(success);
+        Assert.Empty(snapshotPath);
+        Assert.Empty(partialPath);
+        Assert.NotEmpty(error);
+    }
+
+    [Fact]
+    public void TryGetBlobPath_UsesPinnedDigestWithoutTrustingExistingContent()
+    {
+        bool success = HuggingFaceHubCache.TryGetBlobPath(
+            @"C:\cache",
+            "owner/repo",
+            new Sha256Digest(new string('b', 64)),
+            out string blobPath,
+            out string error);
+
+        Assert.True(success, error);
+        Assert.Equal(
+            Path.Combine(
+                @"C:\cache",
+                "models--owner--repo",
+                "blobs",
+                new string('b', 64)),
+            blobPath);
+    }
+
+    [Fact]
+    public async Task TryOpenVerifiedCacheFileAsync_RequiresPinnedSizeAndDigest()
+    {
+        using var temp = new TempDirectory();
+        byte[] content = "verified model"u8.ToArray();
+        string snapshotPath = CreateSnapshotFile(temp.Path, content);
+        var digest = new Sha256Digest(Convert.ToHexString(SHA256.HashData(content)).ToLowerInvariant());
+
+        await using FileStream? verified = await HuggingFaceHubCache.TryOpenVerifiedCacheFileAsync(
+            temp.Path,
+            snapshotPath,
+            content.Length,
+            digest);
+        Assert.NotNull(verified);
+        Assert.Equal(0, verified.Position);
+        Assert.Equal(content, await ReadAllBytesAsync(verified));
+
+        Assert.Null(await HuggingFaceHubCache.TryOpenVerifiedCacheFileAsync(
+            temp.Path,
+            snapshotPath,
+            content.Length + 1,
+            digest));
+        Assert.Null(await HuggingFaceHubCache.TryOpenVerifiedCacheFileAsync(
+            temp.Path,
+            snapshotPath,
+            content.Length,
+            new Sha256Digest(new string('b', 64))));
+    }
+
+    [Fact]
+    public async Task TryOpenVerifiedCacheFileAsync_AcceptsVerifiedBlob()
+    {
+        using var temp = new TempDirectory();
+        byte[] content = "verified blob"u8.ToArray();
+        var digest = new Sha256Digest(Convert.ToHexString(SHA256.HashData(content)).ToLowerInvariant());
+        Assert.True(HuggingFaceHubCache.TryGetBlobPath(
+            temp.Path,
+            "owner/repo",
+            digest,
+            out string blobPath,
+            out string error), error);
+        Directory.CreateDirectory(Path.GetDirectoryName(blobPath)!);
+        await File.WriteAllBytesAsync(blobPath, content);
+
+        await using FileStream? verified = await HuggingFaceHubCache.TryOpenVerifiedCacheFileAsync(
+            temp.Path,
+            blobPath,
+            content.Length,
+            digest);
+
+        Assert.NotNull(verified);
+    }
+
+    [SymbolicLinkFact]
+    public async Task SnapshotRead_AcceptsOnlySameRepositoryBlobSymlink()
+    {
+        using var cache = new TempDirectory();
+        using var outside = new TempDirectory();
+        byte[] content = "verified linked model"u8.ToArray();
+        var digest = new Sha256Digest(Convert.ToHexString(SHA256.HashData(content)).ToLowerInvariant());
+        string repository = Path.Combine(cache.Path, "models--owner--repo");
+        string snapshots = Path.Combine(repository, "snapshots", new string('a', 40));
+        string blobs = Path.Combine(repository, "blobs");
+        string blobPath = Path.Combine(blobs, digest.Value);
+        string snapshotPath = Path.Combine(snapshots, "model.gguf");
+        Directory.CreateDirectory(snapshots);
+        Directory.CreateDirectory(blobs);
+        await File.WriteAllBytesAsync(blobPath, content);
+        File.CreateSymbolicLink(snapshotPath, Path.GetRelativePath(snapshots, blobPath));
+
+        await using FileStream? verified = await HuggingFaceHubCache.TryOpenVerifiedCacheFileAsync(
+            cache.Path,
+            snapshotPath,
+            content.Length,
+            digest);
+        Assert.NotNull(verified);
+
+        File.Delete(snapshotPath);
+        string outsidePath = Path.Combine(outside.Path, "model.gguf");
+        await File.WriteAllBytesAsync(outsidePath, content);
+        File.CreateSymbolicLink(snapshotPath, outsidePath);
+
+        Assert.Null(await HuggingFaceHubCache.TryOpenVerifiedCacheFileAsync(
+            cache.Path,
+            snapshotPath,
+            content.Length,
+            digest));
+    }
+
+    [SymbolicLinkFact]
+    public async Task TryOpenVerifiedCacheFileAsync_RejectsReparsePointAncestor()
+    {
+        using var cache = new TempDirectory();
+        using var outside = new TempDirectory();
+        string repositoryLink = Path.Combine(cache.Path, "models--owner--repo");
+        string outsideSnapshot = Path.Combine(
+            outside.Path,
+            "snapshots",
+            new string('a', 40));
+        Directory.CreateDirectory(outsideSnapshot);
+        Directory.CreateSymbolicLink(repositoryLink, outside.Path);
+        string candidate = Path.Combine(
+            repositoryLink,
+            "snapshots",
+            new string('a', 40),
+            "model.gguf");
+        byte[] content = "untrusted model"u8.ToArray();
+        await File.WriteAllBytesAsync(Path.Combine(outsideSnapshot, "model.gguf"), content);
+        var digest = new Sha256Digest(Convert.ToHexString(SHA256.HashData(content)).ToLowerInvariant());
+
+        FileStream? verified = await HuggingFaceHubCache.TryOpenVerifiedCacheFileAsync(
+            cache.Path,
+            candidate,
+            content.Length,
+            digest);
+
+        Assert.Null(verified);
+    }
+
+    private static string CreateSnapshotFile(string cacheRoot, byte[] content)
+    {
+        Assert.True(HuggingFaceHubCache.TryGetSnapshotPaths(
+            cacheRoot,
+            "owner/repo",
+            new string('a', 40),
+            "model.gguf",
+            out string snapshotPath,
+            out _,
+            out string error), error);
+        Directory.CreateDirectory(Path.GetDirectoryName(snapshotPath)!);
+        File.WriteAllBytes(snapshotPath, content);
+        return snapshotPath;
+    }
+
+    private static async Task<byte[]> ReadAllBytesAsync(Stream stream)
+    {
+        using var buffer = new MemoryStream();
+        await stream.CopyToAsync(buffer);
+        return buffer.ToArray();
+    }
+}
+
+internal static class SymbolicLinkTestSupport
+{
+    private static readonly Lazy<bool> s_isAvailable = new(Probe, isThreadSafe: true);
+
+    public static bool IsAvailable => s_isAvailable.Value;
+
+    private static bool Probe()
+    {
+        string directory = Path.Combine(Path.GetTempPath(), $"openclaw-symlink-probe-{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(directory);
+            string target = Path.Combine(directory, "target");
+            File.WriteAllText(target, "probe");
+            File.CreateSymbolicLink(Path.Combine(directory, "link"), target);
+            return true;
+        }
+        catch (Exception ex) when (
+            ex is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+        {
+            return false;
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                // A failed capability probe must not fail the test host.
+            }
+        }
+    }
+}
+
+internal sealed class SymbolicLinkFactAttribute : FactAttribute
+{
+    public SymbolicLinkFactAttribute()
+    {
+        if (!SymbolicLinkTestSupport.IsAvailable)
+            Skip = "Creating symbolic links requires Windows Developer Mode or elevation.";
+    }
+}

--- a/tests/OpenClaw.Shared.Tests/WindowsPathSafetyTests.cs
+++ b/tests/OpenClaw.Shared.Tests/WindowsPathSafetyTests.cs
@@ -1,0 +1,57 @@
+using OpenClaw.Shared.IO;
+
+namespace OpenClaw.Shared.Tests;
+
+public sealed class WindowsPathSafetyTests
+{
+    [Theory]
+    [InlineData("model.gguf")]
+    [InlineData("Qwen3.8-27B_GGUF")]
+    [InlineData("folder name")]
+    public void IsSafeSegment_AcceptsOrdinarySegments(string value)
+    {
+        Assert.True(WindowsPathSafety.IsSafeSegment(value));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData(".")]
+    [InlineData("..")]
+    [InlineData(" model")]
+    [InlineData("model ")]
+    [InlineData("model.")]
+    [InlineData("dir/model")]
+    [InlineData(@"dir\model")]
+    [InlineData("model:stream")]
+    [InlineData("CON")]
+    [InlineData("com1.gguf")]
+    [InlineData("COM\u00b9")]
+    [InlineData("com\u00b2.gguf")]
+    [InlineData("LPT9")]
+    [InlineData("LPT\u00b3.txt")]
+    public void IsSafeSegment_RejectsUnsafeWindowsSegments(string value)
+    {
+        Assert.False(WindowsPathSafety.IsSafeSegment(value));
+    }
+
+    [Fact]
+    public void IsSafeSegment_RejectsOverlongComponent()
+    {
+        Assert.True(WindowsPathSafety.IsSafeSegment(
+            new string('a', WindowsPathSafety.MaximumComponentLength)));
+        Assert.False(WindowsPathSafety.IsSafeSegment(
+            new string('a', WindowsPathSafety.MaximumComponentLength + 1)));
+    }
+
+    [Fact]
+    public void Containment_DoesNotTreatSiblingPrefixAsDescendant()
+    {
+        string root = WindowsPathSafety.NormalizePath(@"C:\cache\models");
+        string child = WindowsPathSafety.NormalizePath(@"C:\cache\models\file.gguf");
+        string siblingPrefix = WindowsPathSafety.NormalizePath(@"C:\cache\models-other\file.gguf");
+
+        Assert.True(WindowsPathSafety.IsStrictDescendant(child, root));
+        Assert.False(WindowsPathSafety.IsStrictDescendant(siblingPrefix, root));
+    }
+}


### PR DESCRIPTION
Related: #1288

## What Problem This Solves

The Local AI replacement train needs a safe, reusable way to locate and read standard Hugging Face hub-cache entries before setup, migration, manifests, or runtime behavior can move to that cache.

## Why This Change Was Made

This is **layer 1** replacing the shared portion of #1288 (feat(local-ai): store downloaded models in the standard HF hub cache). It lands only independently valuable `OpenClaw.Shared` path and verified-read primitives. Later layers will own model acquisition, cross-volume materialization, legacy migration, manifest compatibility, setup reconciliation, and runtime routing.

The API deliberately does not expose a validate-then-mutate path contract. A returned string cannot authorize a race-free later mutation. Instead, verified reads return the same rewound file handle that was safely opened and hashed, so a later layer can copy from that handle across volumes without reopening the path.

## User Impact

No product behavior changes in this layer. Developers gain a tested foundation for standard Hugging Face cache interoperability without committing setup or migration code to a same-volume hard-link strategy.

## Evidence

- Standard cache-root precedence covers `HF_HUB_CACHE`, `HUGGINGFACE_HUB_CACHE`, `HF_HOME`, `XDG_CACHE_HOME`, and the user-profile default.
- Focused tests exercise nested relative paths, repository/revision validation, Windows reserved device aliases, component limits, real snapshot symlinks, sibling/outside-target rejection, and pinned size/SHA-256 verification.
- Live cross-volume proof copied 27 bytes from a verified handle on `C:\` to `D:\`; the destination hash matched the pin.
- Autoreview accepted and drove fixes for superscript COM/LPT aliases and component/`.partial` length limits.
- Rubber-duck review drove Windows environment expansion and removal of the unsafe validate-then-mutate API.
- Final review suggestions for `CONIN$`/`CONOUT$` and `CON .gguf` were rejected after Microsoft documentation review and live Windows file-creation proof showed they are valid ordinary path components.

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs or instructions
- [x] Tests or validation
- [x] Security hardening
- [ ] Chore or infrastructure

## Scope

- [ ] Tray or WinUI UX
- [ ] Windows node capability
- [ ] Local MCP or `winnode`
- [ ] Gateway, connection, or pairing
- [ ] Setup or onboarding
- [x] Permissions, privacy, or security
- [x] Tests, CI, or docs

## Required proof pools

- `none`: this Shared-only path and verified-read layer requires no capacity-dependent host class. Focused tests create and validate real Windows symbolic links, and the live proof copies from the verified handle across local volumes.

## Validation

- `.\build.ps1`: passed, all 5 projects built.
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore --filter "FullyQualifiedName~HuggingFaceHubCacheTests|FullyQualifiedName~WindowsPathSafetyTests"`: passed, 47/47.
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore`: passed, 3,991 passed and 32 skipped.
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore`: passed, 2,865/2,865.
- Autoreview command: `python .agents\skills\autoreview\scripts\autoreview --mode local --prompt <layer-1 scope>`.
- Rubber-duck review: completed twice, with accepted findings fixed and final unsupported device-name suggestion rejected using Microsoft documentation plus live Windows behavior.

## Real Behavior Proof

- Environment tested: Windows 11 x64, .NET SDK 10.0.401.
- PR head or commit tested: `6cd0f147`.
- Exact steps or command run: loaded the built `OpenClaw.Shared.dll`, created a pinned snapshot under a temporary `C:\` cache, called `TryOpenVerifiedCacheFileAsync`, then copied from the returned rewound stream to a temporary `D:\` destination.
- Evidence after fix: `SourceVolume=C:\`, `DestinationVolume=D:\`, `Bytes=27`, `HashMatches=True`, `CopiedFromVerifiedHandle=True`.
- Observed result: the same safely opened and SHA-256-verified handle supported a cross-volume copy without reopening or trusting the pathname.
- Screenshot or artifact links verified? N/A
- Not verified or blocked: setup, migration, manifest, runtime, and tray behavior are intentionally deferred to later replacement layers.

## Security Impact

- New permissions or capabilities? No
- Secrets or tokens handling changed? No
- New or changed network calls? No
- Command or tool execution surface changed? No
- Data access scope changed? No
- If any answer is `Yes`, explain the risk and mitigation: N/A

## Compatibility and Migration

- Backward compatible? Yes
- Config or environment changes? No
- Migration needed? No
- If yes, list the exact upgrade steps: N/A

## Review Conversations

- [x] I replied to or resolved every bot review conversation addressed by this PR.
- [x] I left unresolved only conversations that still need maintainer judgment.