### PR TITLE
fix(chat): make snapshot delivery race-free

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Chat/ChatConversationState.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ChatConversationState.cs
@@ -107,6 +107,8 @@ internal sealed class ChatConversationState
     {
         lock (_gate)
         {
+            if (_disposed)
+                return null;
             return _presentation.RememberSelectedThread(threadId);
         }
     }
@@ -350,6 +352,8 @@ internal sealed class ChatConversationState
     {
         lock (_gate)
         {
+            if (_disposed)
+                return new(BuildSnapshotLocked(context), []);
             var previousUsage = _presentation.SnapshotUsage();
             _presentation.ReplaceSessions(sessions);
             var currentSessions = _presentation.SessionSnapshot();
@@ -387,6 +391,8 @@ internal sealed class ChatConversationState
     {
         lock (_gate)
         {
+            if (_disposed)
+                return BuildSnapshotLocked(context);
             _presentation.ApplyModels(models);
             return BuildSnapshotLocked(context);
         }
@@ -437,7 +443,8 @@ internal sealed class ChatConversationState
     {
         lock (_gate)
         {
-            return _presentation.IsCommandCatalogEpochCurrent(epoch)
+            return !_disposed &&
+                   _presentation.IsCommandCatalogEpochCurrent(epoch)
                 ? BuildSnapshotLocked(context)
                 : null;
         }

--- a/src/OpenClaw.Tray.WinUI/Chat/ChatStatePersistence.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ChatStatePersistence.cs
@@ -12,6 +12,8 @@ internal sealed class ChatStatePersistence : IDisposable
     private readonly string _lastStatePath;
     private readonly string _abortedIdsPath;
     private readonly TimeSpan _lastStateSaveDelay;
+    private readonly Action? _beforeLastStateSaveForTesting;
+    private readonly Action? _beforeSelectedStateSaveForTesting;
     private readonly Dictionary<string, HashSet<string>> _abortedIds;
     private readonly Dictionary<string, Dictionary<string, long>>
         _abortedIdGenerations;
@@ -24,12 +26,17 @@ internal sealed class ChatStatePersistence : IDisposable
     internal ChatStatePersistence(
         string? lastStatePath = null,
         TimeSpan? lastStateSaveDelay = null,
-        string? abortedIdsPath = null)
+        string? abortedIdsPath = null,
+        Action? beforeLastStateSaveForTesting = null,
+        Action? beforeSelectedStateSaveForTesting = null)
     {
         _lastStatePath = !string.IsNullOrWhiteSpace(lastStatePath)
             ? lastStatePath
             : ChatMetadataStore.LastChatStateFilePath;
         _lastStateSaveDelay = lastStateSaveDelay ?? TimeSpan.FromSeconds(2);
+        _beforeLastStateSaveForTesting = beforeLastStateSaveForTesting;
+        _beforeSelectedStateSaveForTesting =
+            beforeSelectedStateSaveForTesting;
         _abortedIdsPath = !string.IsNullOrWhiteSpace(abortedIdsPath)
             ? abortedIdsPath
             : ChatMetadataStore.AbortedIdsFilePath;
@@ -204,39 +211,29 @@ internal sealed class ChatStatePersistence : IDisposable
 
     internal void SaveSelectedState(OpenClawChatDataProvider.LastChatState state)
     {
-        Timer? timer;
-        lock (_gate)
-        {
-            timer = _lastStateSaveTimer;
-            _lastStateSaveTimer = null;
-            _lastStateSaveVersion++;
-            _lastState = state;
-        }
-        timer?.Dispose();
-        SaveLastChatState(state, _lastStatePath);
-    }
-
-    internal void DebounceSnapshot(ChatDataSnapshot snapshot)
-    {
-        var defaultThread = snapshot.DefaultThreadId is { } defaultId
-            ? Array.Find(snapshot.Threads, thread => thread.Id == defaultId)
-            : snapshot.Threads.FirstOrDefault();
-        if (defaultThread is null && snapshot.AvailableModels.Length == 0)
-            return;
-
+        _beforeSelectedStateSaveForTesting?.Invoke();
         lock (_gate)
         {
             if (_disposed)
                 return;
-            var previous = _lastState;
-            var state = new OpenClawChatDataProvider.LastChatState
-            {
-                DefaultThreadId = snapshot.DefaultThreadId ?? previous?.DefaultThreadId,
-                ThreadTitle = defaultThread?.Title ?? previous?.ThreadTitle,
-                Model = defaultThread?.Model ?? previous?.Model,
-                ModelProvider = defaultThread?.ModelProvider ?? previous?.ModelProvider,
-                AvailableModels = snapshot.AvailableModels.ToArray(),
-            };
+            var timer = _lastStateSaveTimer;
+            _lastStateSaveTimer = null;
+            _lastStateSaveVersion++;
+            _lastState = state;
+            timer?.Dispose();
+            SaveLastChatStateLocked(state);
+        }
+    }
+
+    internal void DebounceSnapshot(ChatDataSnapshot snapshot)
+    {
+        lock (_gate)
+        {
+            if (_disposed)
+                return;
+            var state = CreateLastChatState(snapshot, _lastState);
+            if (state is null)
+                return;
             _lastState = state;
             var version = ++_lastStateSaveVersion;
             _lastStateSaveTimer?.Dispose();
@@ -246,6 +243,27 @@ internal sealed class ChatStatePersistence : IDisposable
                 _lastStateSaveDelay,
                 Timeout.InfiniteTimeSpan);
         }
+    }
+
+    internal void SaveFinalSnapshot(ChatDataSnapshot snapshot)
+    {
+        Timer? timer;
+        lock (_gate)
+        {
+            if (_disposed)
+                return;
+            _disposed = true;
+            var state = CreateLastChatState(snapshot, _lastState);
+            _lastStateSaveVersion++;
+            timer = _lastStateSaveTimer;
+            _lastStateSaveTimer = null;
+            if (state is not null)
+            {
+                _lastState = state;
+                SaveLastChatStateLocked(state);
+            }
+        }
+        timer?.Dispose();
     }
 
     public void Dispose()
@@ -362,10 +380,37 @@ internal sealed class ChatStatePersistence : IDisposable
         {
             if (_disposed || version != _lastStateSaveVersion)
                 return;
-            SaveLastChatState(state, _lastStatePath);
+            SaveLastChatStateLocked(state);
             _lastStateSaveTimer?.Dispose();
             _lastStateSaveTimer = null;
         }
+    }
+
+    private void SaveLastChatStateLocked(
+        OpenClawChatDataProvider.LastChatState state)
+    {
+        _beforeLastStateSaveForTesting?.Invoke();
+        SaveLastChatState(state, _lastStatePath);
+    }
+
+    private static OpenClawChatDataProvider.LastChatState? CreateLastChatState(
+        ChatDataSnapshot snapshot,
+        OpenClawChatDataProvider.LastChatState? previous)
+    {
+        var defaultThread = snapshot.DefaultThreadId is { } defaultId
+            ? Array.Find(snapshot.Threads, thread => thread.Id == defaultId)
+            : snapshot.Threads.FirstOrDefault();
+        if (defaultThread is null && snapshot.AvailableModels.Length == 0)
+            return null;
+
+        return new OpenClawChatDataProvider.LastChatState
+        {
+            DefaultThreadId = snapshot.DefaultThreadId ?? previous?.DefaultThreadId,
+            ThreadTitle = defaultThread?.Title ?? previous?.ThreadTitle,
+            Model = defaultThread?.Model ?? previous?.Model,
+            ModelProvider = defaultThread?.ModelProvider ?? previous?.ModelProvider,
+            AvailableModels = snapshot.AvailableModels.ToArray(),
+        };
     }
 
     private static void SaveLastChatState(

--- a/src/OpenClaw.Tray.WinUI/Chat/ChatStatePersistence.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ChatStatePersistence.cs
@@ -12,8 +12,8 @@ internal sealed class ChatStatePersistence : IDisposable
     private readonly string _lastStatePath;
     private readonly string _abortedIdsPath;
     private readonly TimeSpan _lastStateSaveDelay;
-    private readonly Action? _beforeLastStateSaveForTesting;
-    private readonly Action? _beforeSelectedStateSaveForTesting;
+    private Action? _beforeLastStateSaveForTesting;
+    private Action? _beforeSelectedStateSaveForTesting;
     private readonly Dictionary<string, HashSet<string>> _abortedIds;
     private readonly Dictionary<string, Dictionary<string, long>>
         _abortedIdGenerations;
@@ -51,6 +51,16 @@ internal sealed class ChatStatePersistence : IDisposable
                 StringComparer.Ordinal),
             StringComparer.Ordinal);
     }
+
+#if OPENCLAW_TRAY_TESTS
+    internal void SetTestHooks(
+        Action? beforeLastStateSave,
+        Action? beforeSelectedStateSave)
+    {
+        _beforeLastStateSaveForTesting = beforeLastStateSave;
+        _beforeSelectedStateSaveForTesting = beforeSelectedStateSave;
+    }
+#endif
 
     internal OpenClawChatDataProvider.LastChatState? InitialLastChatState { get; }
 

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
@@ -102,6 +102,13 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
 #if OPENCLAW_TRAY_TESTS
     internal Action<ChatDataSnapshot>? BeforePublishForTests { get; set; }
     internal Action? BeforePublishDrainForTests { get; set; }
+    internal void SetPersistenceTestHooks(
+        Action? beforeLastStateSave,
+        Action? beforeSelectedStateSave) =>
+        _persistence.SetTestHooks(
+            beforeLastStateSave,
+            beforeSelectedStateSave);
+
     internal bool PublishDisposedForTests
     {
         get
@@ -133,8 +140,6 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         string? attachmentMetaCacheFilePath = null,
         string? lastChatStateFilePath = null,
         TimeSpan? lastChatStateSaveDelay = null,
-        Action? lastStateSaveReservedForTesting = null,
-        Action? beforeSelectedStateSaveForTesting = null,
         Func<TimeSpan, CancellationToken, Func<Task>, Task>? historyRetryScheduler = null,
         Action? historyFailureReservedForTesting = null,
         Func<Func<Task>, Task>? deferredAbortScheduler = null)
@@ -148,9 +153,7 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
             attachmentMetaCacheFilePath);
         _persistence = new ChatStatePersistence(
             lastChatStateFilePath,
-            lastChatStateSaveDelay,
-            beforeLastStateSaveForTesting: lastStateSaveReservedForTesting,
-            beforeSelectedStateSaveForTesting: beforeSelectedStateSaveForTesting);
+            lastChatStateSaveDelay);
         _state = new ChatConversationState(
             bridge.CurrentStatus,
             _persistence.InitialLastChatState,

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
@@ -1919,7 +1919,7 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
     {
         try
         {
-            _post!(DrainPendingPublish);
+            TryPostFenced(DrainPendingPublish);
         }
         catch
         {
@@ -2115,25 +2115,29 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
             return;
         }
 
-        lock (_publishGate)
+        TryPostFenced(() => Deliver(callback));
+    }
+
+    private bool TryPostFenced(Action callback)
+    {
+        if (!TryBeginDelivery(out var threadId))
+            return false;
+
+        try
         {
-            if (_publishDisposed)
-                return;
+            _post!(callback);
+            return true;
         }
-        _post(() => Deliver(callback));
+        finally
+        {
+            EndDelivery(threadId);
+        }
     }
 
     private void Deliver(Action callback)
     {
-        var threadId = Environment.CurrentManagedThreadId;
-        lock (_publishGate)
-        {
-            if (_publishDisposed)
-                return;
-            _activeDeliveries++;
-            _deliveryDepthByThread[threadId] =
-                _deliveryDepthByThread.GetValueOrDefault(threadId) + 1;
-        }
+        if (!TryBeginDelivery(out var threadId))
+            return;
 
         try
         {
@@ -2141,16 +2145,35 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         }
         finally
         {
-            lock (_publishGate)
-            {
-                _activeDeliveries--;
-                var depth = _deliveryDepthByThread[threadId] - 1;
-                if (depth == 0)
-                    _deliveryDepthByThread.Remove(threadId);
-                else
-                    _deliveryDepthByThread[threadId] = depth;
-                Monitor.PulseAll(_publishGate);
-            }
+            EndDelivery(threadId);
+        }
+    }
+
+    private bool TryBeginDelivery(out int threadId)
+    {
+        threadId = Environment.CurrentManagedThreadId;
+        lock (_publishGate)
+        {
+            if (_publishDisposed)
+                return false;
+            _activeDeliveries++;
+            _deliveryDepthByThread[threadId] =
+                _deliveryDepthByThread.GetValueOrDefault(threadId) + 1;
+            return true;
+        }
+    }
+
+    private void EndDelivery(int threadId)
+    {
+        lock (_publishGate)
+        {
+            _activeDeliveries--;
+            var depth = _deliveryDepthByThread[threadId] - 1;
+            if (depth == 0)
+                _deliveryDepthByThread.Remove(threadId);
+            else
+                _deliveryDepthByThread[threadId] = depth;
+            Monitor.PulseAll(_publishGate);
         }
     }
 

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
@@ -2,6 +2,7 @@ using System.Buffers;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Runtime.ExceptionServices;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using OpenClaw.Chat;
@@ -78,6 +79,14 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
     private readonly ChatHistoryLoader _historyLoader;
     private readonly Action<Action>? _post;
     private readonly Func<Func<Task>, Task> _deferredAbortScheduler;
+    private readonly object _publishGate = new();
+    private readonly Dictionary<int, int> _deliveryDepthByThread = [];
+    private readonly ManualResetEventSlim _disposeCompleted = new();
+    private readonly List<ChatProviderNotification> _pendingPublishNotifications = [];
+    private ChatDataSnapshot? _pendingPublishSnapshot;
+    private int _activeDeliveries;
+    private bool _publishScheduled;
+    private bool _publishDisposed;
 
     /// <summary>Whether any thread is in an aborted state (suppress TTS/notifications).</summary>
     public bool IsResponseSuppressed => _state.IsResponseSuppressed;
@@ -89,6 +98,19 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
 
     public event EventHandler<ChatDataChangedEventArgs>? Changed;
     public event EventHandler<ChatProviderNotificationEventArgs>? NotificationRequested;
+
+#if OPENCLAW_TRAY_TESTS
+    internal Action<ChatDataSnapshot>? BeforePublishForTests { get; set; }
+    internal Action? BeforePublishDrainForTests { get; set; }
+    internal bool PublishDisposedForTests
+    {
+        get
+        {
+            lock (_publishGate)
+                return _publishDisposed;
+        }
+    }
+#endif
 
     /// <param name="bridge">Adapter wrapping the live gateway client.</param>
     /// <param name="post">
@@ -111,6 +133,8 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         string? attachmentMetaCacheFilePath = null,
         string? lastChatStateFilePath = null,
         TimeSpan? lastChatStateSaveDelay = null,
+        Action? lastStateSaveReservedForTesting = null,
+        Action? beforeSelectedStateSaveForTesting = null,
         Func<TimeSpan, CancellationToken, Func<Task>, Task>? historyRetryScheduler = null,
         Action? historyFailureReservedForTesting = null,
         Func<Func<Task>, Task>? deferredAbortScheduler = null)
@@ -124,7 +148,9 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
             attachmentMetaCacheFilePath);
         _persistence = new ChatStatePersistence(
             lastChatStateFilePath,
-            lastChatStateSaveDelay);
+            lastChatStateSaveDelay,
+            beforeLastStateSaveForTesting: lastStateSaveReservedForTesting,
+            beforeSelectedStateSaveForTesting: beforeSelectedStateSaveForTesting);
         _state = new ChatConversationState(
             bridge.CurrentStatus,
             _persistence.InitialLastChatState,
@@ -547,9 +573,14 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
             Logger.Warn($"[Queue] chat.send failed threadId='{threadId}' queuedMessageId='{request.Id}' sendRunId='{request.SendRunId}': {ex.Message}");
             // Surface as an error in the timeline + notification, while the
             // failed queue card keeps the attempted text visible for retry/edit.
-            Publish(failure.Snapshot!);
-            RaiseNotification(new ChatProviderNotification(
-                ChatProviderNotificationKind.Error, threadId, LocalizationHelper.GetString("Chat_Notification_SendFailed"), ex.Message));
+            Publish(
+                failure.Snapshot!,
+                new ChatProviderNotification(
+                    ChatProviderNotificationKind.Error,
+                    threadId,
+                    LocalizationHelper.GetString(
+                        "Chat_Notification_SendFailed"),
+                    ex.Message));
             TryDispatchNextQueuedSend(threadId);
             if (rethrow)
                 throw;
@@ -639,9 +670,15 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
             {
                 _state.RollbackAbort(threadId, runId);
                 Logger.Warn($"[ABORT] chat.abort failed, cleared suppression: {ex.Message}");
-                RaiseNotification(new ChatProviderNotification(
-                    ChatProviderNotificationKind.Error, threadId, LocalizationHelper.GetString("Chat_Notification_AbortFailed"), ex.Message));
-                ApplyEventAndPublish(threadId, new ChatTurnEndEvent());
+                ApplyEventAndPublish(
+                    threadId,
+                    new ChatTurnEndEvent(),
+                    notification: new ChatProviderNotification(
+                        ChatProviderNotificationKind.Error,
+                        threadId,
+                        LocalizationHelper.GetString(
+                            "Chat_Notification_AbortFailed"),
+                        ex.Message));
                 return;
             }
 
@@ -720,26 +757,19 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
             if (snapshot is null)
                 return;
             if (result.PublishSnapshot)
-            {
-                Changed?.Invoke(this, new ChatDataChangedEventArgs(snapshot));
-                if (snapshot.Threads.Length > 0 ||
-                    snapshot.AvailableModels.Length > 0)
-                {
-                    _persistence.DebounceSnapshot(snapshot);
-                }
-            }
-            if (result.Notification is not null)
-            {
-                NotificationRequested?.Invoke(
-                    this,
-                    new ChatProviderNotificationEventArgs(result.Notification));
-            }
+                DeliverPublishBatch(
+                    snapshot,
+                    result.Notification is null
+                        ? []
+                        : [result.Notification]);
+            else if (result.Notification is not null)
+                DeliverPublishBatch(
+                    snapshot,
+                    [result.Notification],
+                    publishSnapshot: false);
         }
 
-        if (_post is null)
-            Deliver();
-        else
-            _post(Deliver);
+        QueueFencedDelivery(Deliver);
     }
 
     public Task SetThreadSuspendedAsync(string threadId, bool suspended, CancellationToken cancellationToken = default)
@@ -879,13 +909,10 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
                 epoch,
                 ProjectionContext());
             if (snapshot is not null)
-                Changed?.Invoke(this, new ChatDataChangedEventArgs(snapshot));
+                DeliverPublishBatch(snapshot, []);
         }
 
-        if (_post is null)
-            Deliver();
-        else
-            _post(Deliver);
+        QueueFencedDelivery(Deliver);
     }
 
     public Task SetPermissionModeAsync(string threadId, bool allowAll, CancellationToken cancellationToken = default)
@@ -1015,22 +1042,45 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
     {
         var transition = _state.DisposeState();
         if (!transition.IsFirstDispose)
+        {
+            if (IsDeliveringOnCurrentThread())
+                return ValueTask.CompletedTask;
+            _disposeCompleted.Wait();
+            WaitForInFlightDeliveries();
             return ValueTask.CompletedTask;
-        _telemetry.FinishAll(
-            ChatTelemetryOutcome.Canceled,
-            ChatTurnTelemetryReason.Disposed);
-        _historyLoader.Completed -= OnHistoryLoadCompleted;
-        _historyLoader.Dispose();
-        _metadataStore.Dispose();
-        _persistence.Dispose();
-        _bridge.StatusChanged -= OnStatusChanged;
-        _bridge.SessionsUpdated -= OnSessionsUpdated;
-        _bridge.SessionCommandCompleted -= OnSessionCommandCompleted;
-        _bridge.ChatMessageReceived -= OnChatMessageReceived;
-        _bridge.AgentEventReceived -= OnAgentEventReceived;
-        _bridge.ModelsListUpdated -= OnModelsListUpdated;
-        _bridge.Dispose();
-        return ValueTask.CompletedTask;
+        }
+
+        try
+        {
+            lock (_publishGate)
+            {
+                _publishDisposed = true;
+                _pendingPublishSnapshot = null;
+                _pendingPublishNotifications.Clear();
+                _publishScheduled = false;
+            }
+            WaitForInFlightDeliveries();
+            _persistence.SaveFinalSnapshot(_state.Snapshot(ProjectionContext()));
+            _telemetry.FinishAll(
+                ChatTelemetryOutcome.Canceled,
+                ChatTurnTelemetryReason.Disposed);
+            _historyLoader.Completed -= OnHistoryLoadCompleted;
+            _historyLoader.Dispose();
+            _metadataStore.Dispose();
+            _persistence.Dispose();
+            _bridge.StatusChanged -= OnStatusChanged;
+            _bridge.SessionsUpdated -= OnSessionsUpdated;
+            _bridge.SessionCommandCompleted -= OnSessionCommandCompleted;
+            _bridge.ChatMessageReceived -= OnChatMessageReceived;
+            _bridge.AgentEventReceived -= OnAgentEventReceived;
+            _bridge.ModelsListUpdated -= OnModelsListUpdated;
+            _bridge.Dispose();
+            return ValueTask.CompletedTask;
+        }
+        finally
+        {
+            _disposeCompleted.Set();
+        }
     }
 
     /// <summary>
@@ -1386,11 +1436,14 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         _telemetry.CompletePreparedTurn(completion);
         if (_state.SnapshotLatestAssistantUsage(threadId, ProjectionContext()) is { } latestUsage)
             Publish(latestUsage);
-        ApplyEventAndPublish(threadId, new ChatTurnEndEvent());
-        RaiseNotification(new ChatProviderNotification(
-            ChatProviderNotificationKind.TurnComplete,
+        ApplyEventAndPublish(
             threadId,
-            LocalizationHelper.GetString("Chat_Notification_AssistantReplied")));
+            new ChatTurnEndEvent(),
+            notification: new ChatProviderNotification(
+                ChatProviderNotificationKind.TurnComplete,
+                threadId,
+                LocalizationHelper.GetString(
+                    "Chat_Notification_AssistantReplied")));
         ScheduleQueuedSendDrain(threadId);
     }
 
@@ -1529,13 +1582,14 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
                     {
                         Logger.Warn(
                             $"[ABORT] Deferred chat.abort failed, cleared suppression: {ex.Message}");
-                        RaiseNotification(new ChatProviderNotification(
-                            ChatProviderNotificationKind.Error,
-                            threadId,
-                            LocalizationHelper.GetString(
-                                "Chat_Notification_AbortFailed"),
-                            ex.Message));
-                        Publish(rollbackSnapshot);
+                        Publish(
+                            rollbackSnapshot,
+                            new ChatProviderNotification(
+                                ChatProviderNotificationKind.Error,
+                                threadId,
+                                LocalizationHelper.GetString(
+                                    "Chat_Notification_AbortFailed"),
+                                ex.Message));
                         ScheduleQueuedSendDrain(threadId);
                     }
                     return;
@@ -1592,14 +1646,23 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         var title = LocalizationHelper.GetString("Chat_Notification_KeylessEventDropped");
         var message = LocalizationHelper.GetString("Chat_Notification_KeylessEventDroppedMessage");
 
-        RaiseNotification(new ChatProviderNotification(
+        var notification = new ChatProviderNotification(
             ChatProviderNotificationKind.Error,
             threadId ?? string.Empty,
             title,
-            message));
+            message);
 
         if (!string.IsNullOrWhiteSpace(threadId))
-            ApplyEventAndPublish(threadId, new ChatStatusEvent(message, ChatTone.Warning));
+        {
+            ApplyEventAndPublish(
+                threadId,
+                new ChatStatusEvent(message, ChatTone.Warning),
+                notification: notification);
+        }
+        else
+        {
+            RaiseNotification(notification);
+        }
     }
 
     private void RecordDroppedTerminalEvent(ChatTerminalEventDropReason reason)
@@ -1794,35 +1857,318 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
 
     internal static ChatEvent TruncateChatEvent(ChatEvent evt) => ChatContentFormatting.TruncateChatEvent(evt);
 
-    private void ApplyEventAndPublish(string threadId, ChatEvent evt, ChatEntryMetadata? meta = null)
+    private void ApplyEventAndPublish(
+        string threadId,
+        ChatEvent evt,
+        ChatEntryMetadata? meta = null,
+        ChatProviderNotification? notification = null)
     {
         var snapshot = _state.ApplyEvent(
             threadId,
             evt,
             meta,
             ProjectionContext());
-        Publish(snapshot);
+        Publish(snapshot, notification);
     }
 
     private ChatProjectionContext ProjectionContext() =>
         new(_bridge.MainSessionKey, _bridge.HasHandshakeSnapshot);
 
-    private void Publish(ChatDataSnapshot snapshot)
+    private void Publish(
+        ChatDataSnapshot snapshot,
+        ChatProviderNotification? notification = null)
     {
-        var args = new ChatDataChangedEventArgs(snapshot);
+#if OPENCLAW_TRAY_TESTS
+        BeforePublishForTests?.Invoke(snapshot);
+#endif
+
         if (_post is null)
         {
-            Changed?.Invoke(this, args);
+            Deliver(() =>
+                DeliverPublishBatch(
+                    snapshot,
+                    notification is null
+                        ? []
+                        : [notification]));
         }
         else
         {
-            _post(() => Changed?.Invoke(this, args));
+            bool shouldSchedule;
+            lock (_publishGate)
+            {
+                if (_publishDisposed)
+                    return;
+
+                _pendingPublishSnapshot = snapshot;
+                if (notification is not null)
+                    _pendingPublishNotifications.Add(notification);
+                shouldSchedule = !_publishScheduled;
+                if (shouldSchedule)
+                    _publishScheduled = true;
+            }
+
+            if (shouldSchedule)
+                PostPublishDrain();
+        }
+    }
+
+    private void PostPublishDrain()
+    {
+        try
+        {
+            _post!(DrainPendingPublish);
+        }
+        catch
+        {
+            lock (_publishGate)
+                _publishScheduled = false;
+            throw;
+        }
+    }
+
+    private void DrainPendingPublish()
+    {
+        ChatDataSnapshot? snapshot;
+        ChatProviderNotification[] notifications;
+        lock (_publishGate)
+        {
+            if (_publishDisposed)
+            {
+                _pendingPublishSnapshot = null;
+                _pendingPublishNotifications.Clear();
+                _publishScheduled = false;
+                return;
+            }
+
+            snapshot = _pendingPublishSnapshot;
+            _pendingPublishSnapshot = null;
+            notifications = _pendingPublishNotifications.ToArray();
+            _pendingPublishNotifications.Clear();
+            if (snapshot is null)
+            {
+                _publishScheduled = false;
+                return;
+            }
         }
 
-        // Debounce-save last-known UI state so the next launch can show
-        // meaningful labels while reconnecting instead of "Main session"/"model".
+        try
+        {
+            Deliver(() =>
+            {
+#if OPENCLAW_TRAY_TESTS
+                BeforePublishDrainForTests?.Invoke();
+#endif
+                // Coalescing follows authoritative state order, not caller arrival.
+                var authoritativeSnapshot =
+                    _state.Snapshot(ProjectionContext());
+                DeliverPublishBatch(
+                    authoritativeSnapshot,
+                    notifications);
+            });
+        }
+        finally
+        {
+            bool shouldSchedule;
+            lock (_publishGate)
+            {
+                if (_publishDisposed)
+                {
+                    _pendingPublishSnapshot = null;
+                    _pendingPublishNotifications.Clear();
+                    _publishScheduled = false;
+                    shouldSchedule = false;
+                }
+                else
+                {
+                    shouldSchedule = _pendingPublishSnapshot is not null;
+                    if (!shouldSchedule)
+                        _publishScheduled = false;
+                }
+            }
+
+            if (shouldSchedule)
+                PostPublishDrain();
+        }
+    }
+
+    private void DebounceSnapshot(ChatDataSnapshot snapshot)
+    {
         if (snapshot.Threads.Length > 0 || snapshot.AvailableModels.Length > 0)
             _persistence.DebounceSnapshot(snapshot);
+    }
+
+    private void DeliverSnapshot(ChatDataSnapshot snapshot)
+    {
+        Deliver(
+            () =>
+            {
+                var failure = InvokeChangedSubscribers(snapshot);
+                try
+                {
+                    DebounceSnapshot(snapshot);
+                }
+                catch (Exception ex)
+                {
+                    failure ??= ExceptionDispatchInfo.Capture(ex);
+                }
+                failure?.Throw();
+            });
+    }
+
+    private void DeliverPublishBatch(
+        ChatDataSnapshot snapshot,
+        IReadOnlyList<ChatProviderNotification> notifications,
+        bool publishSnapshot = true)
+    {
+        ExceptionDispatchInfo? failure = null;
+        if (publishSnapshot)
+        {
+            failure = InvokeChangedSubscribers(snapshot);
+            try
+            {
+                DebounceSnapshot(snapshot);
+            }
+            catch (Exception ex)
+            {
+                failure ??= ExceptionDispatchInfo.Capture(ex);
+            }
+        }
+
+        foreach (var notification in notifications)
+        {
+            if (IsPublishDisposed())
+                break;
+            var notificationFailure =
+                InvokeNotificationSubscribers(notification);
+            failure ??= notificationFailure;
+        }
+
+        failure?.Throw();
+    }
+
+    private ExceptionDispatchInfo? InvokeChangedSubscribers(
+        ChatDataSnapshot snapshot)
+    {
+        var handlers = Changed;
+        if (handlers is null)
+            return null;
+        var args = new ChatDataChangedEventArgs(snapshot);
+        foreach (EventHandler<ChatDataChangedEventArgs> handler in
+                 handlers.GetInvocationList())
+        {
+            if (IsPublishDisposed())
+                break;
+            try
+            {
+                handler(this, args);
+            }
+            catch (Exception ex)
+            {
+                return ExceptionDispatchInfo.Capture(ex);
+            }
+        }
+        return null;
+    }
+
+    private ExceptionDispatchInfo? InvokeNotificationSubscribers(
+        ChatProviderNotification notification)
+    {
+        var handlers = NotificationRequested;
+        if (handlers is null)
+            return null;
+        var args = new ChatProviderNotificationEventArgs(notification);
+        foreach (EventHandler<ChatProviderNotificationEventArgs> handler in
+                 handlers.GetInvocationList())
+        {
+            if (IsPublishDisposed())
+                break;
+            try
+            {
+                handler(this, args);
+            }
+            catch (Exception ex)
+            {
+                return ExceptionDispatchInfo.Capture(ex);
+            }
+        }
+        return null;
+    }
+
+    private bool IsPublishDisposed()
+    {
+        lock (_publishGate)
+            return _publishDisposed;
+    }
+
+    private void DeliverNotification(ChatProviderNotification notification) =>
+        Deliver(
+            () => InvokeNotificationSubscribers(notification)?.Throw());
+
+    private void QueueFencedDelivery(Action callback)
+    {
+        if (_post is null)
+        {
+            Deliver(callback);
+            return;
+        }
+
+        lock (_publishGate)
+        {
+            if (_publishDisposed)
+                return;
+        }
+        _post(() => Deliver(callback));
+    }
+
+    private void Deliver(Action callback)
+    {
+        var threadId = Environment.CurrentManagedThreadId;
+        lock (_publishGate)
+        {
+            if (_publishDisposed)
+                return;
+            _activeDeliveries++;
+            _deliveryDepthByThread[threadId] =
+                _deliveryDepthByThread.GetValueOrDefault(threadId) + 1;
+        }
+
+        try
+        {
+            callback();
+        }
+        finally
+        {
+            lock (_publishGate)
+            {
+                _activeDeliveries--;
+                var depth = _deliveryDepthByThread[threadId] - 1;
+                if (depth == 0)
+                    _deliveryDepthByThread.Remove(threadId);
+                else
+                    _deliveryDepthByThread[threadId] = depth;
+                Monitor.PulseAll(_publishGate);
+            }
+        }
+    }
+
+    private bool IsDeliveringOnCurrentThread()
+    {
+        lock (_publishGate)
+            return _deliveryDepthByThread.ContainsKey(Environment.CurrentManagedThreadId);
+    }
+
+    private void WaitForInFlightDeliveries()
+    {
+        lock (_publishGate)
+        {
+            var threadId = Environment.CurrentManagedThreadId;
+            var ownCallbackDepth = _deliveryDepthByThread.GetValueOrDefault(threadId);
+            while (_activeDeliveries > ownCallbackDepth)
+            {
+                Monitor.Wait(_publishGate);
+                ownCallbackDepth = _deliveryDepthByThread.GetValueOrDefault(threadId);
+            }
+        }
     }
 
     // ── Last-chat-state cache ──────────────────────────────────────────
@@ -1843,13 +2189,24 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
 
     private void RaiseNotification(ChatProviderNotification notification)
     {
-        var args = new ChatProviderNotificationEventArgs(notification);
         if (_post is null)
         {
-            NotificationRequested?.Invoke(this, args);
+            DeliverNotification(notification);
             return;
         }
-        _post(() => NotificationRequested?.Invoke(this, args));
+
+        lock (_publishGate)
+        {
+            if (_publishDisposed)
+                return;
+            if (_pendingPublishSnapshot is not null)
+            {
+                _pendingPublishNotifications.Add(notification);
+                return;
+            }
+        }
+        QueueFencedDelivery(() =>
+            InvokeNotificationSubscribers(notification)?.Throw());
     }
 
 }

--- a/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
@@ -281,11 +281,12 @@ public class OpenClawChatDataProviderTests
                 attachmentMetaCacheFilePath: attachmentMetaCachePath,
                 lastChatStateFilePath: lastChatStatePath,
                 lastChatStateSaveDelay: lastChatStateSaveDelay,
-                lastStateSaveReservedForTesting: lastStateSaveReservedForTesting,
-                beforeSelectedStateSaveForTesting: beforeSelectedStateSaveForTesting,
                 historyRetryScheduler: historyRetryScheduler,
                 historyFailureReservedForTesting: historyFailureReservedForTesting,
                 deferredAbortScheduler: deferredAbortScheduler);
+        provider.SetPersistenceTestHooks(
+            lastStateSaveReservedForTesting,
+            beforeSelectedStateSaveForTesting);
         var snapshots = new List<ChatDataSnapshot>();
         var notifications = new List<ChatProviderNotification>();
         provider.Changed += (_, e) => snapshots.Add(e.Snapshot);
@@ -5783,8 +5784,8 @@ public class OpenClawChatDataProviderTests
             lastChatStateFilePath: Path.Combine(
                 temp.DirectoryPath,
                 "last-chat-state.json"),
-            lastChatStateSaveDelay: TimeSpan.Zero,
-            lastStateSaveReservedForTesting: snapshotSaved.Set);
+            lastChatStateSaveDelay: TimeSpan.Zero);
+        provider.SetPersistenceTestHooks(snapshotSaved.Set, null);
         var notifications = new List<ChatProviderNotification>();
         provider.Changed += (_, _) =>
             throw new InvalidOperationException("snapshot subscriber failed");

--- a/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
@@ -6214,6 +6214,92 @@ public class OpenClawChatDataProviderTests
     }
 
     [Fact]
+    public async Task DisposeAsync_WaitsForPublishPostInvocation()
+    {
+        var bridge = new FakeBridge { Sessions = [MainSession()] };
+        using var postEntered = new ManualResetEventSlim();
+        using var releasePost = new ManualResetEventSlim();
+        var queued = new ConcurrentQueue<Action>();
+        var provider = new OpenClawChatDataProvider(
+            bridge,
+            post: callback =>
+            {
+                postEntered.Set();
+                Assert.True(releasePost.Wait(TimeSpan.FromSeconds(10)));
+                queued.Enqueue(callback);
+            });
+
+        var publishTask = Task.Factory.StartNew(
+            () => bridge.RaiseStatus(ConnectionStatus.Connecting),
+            CancellationToken.None,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default);
+        Assert.True(postEntered.Wait(TimeSpan.FromSeconds(10)));
+        var disposeTask = Task.Run(async () => await provider.DisposeAsync());
+        Assert.True(
+            SpinWait.SpinUntil(
+                () => provider.PublishDisposedForTests,
+                TimeSpan.FromSeconds(10)));
+        Assert.False(disposeTask.IsCompleted);
+        Assert.False(bridge.IsDisposed);
+
+        releasePost.Set();
+        await publishTask;
+        await disposeTask;
+
+        Assert.True(bridge.IsDisposed);
+        AssertSingleQueuedAction(queued)();
+    }
+
+    [Fact]
+    public async Task DisposeAsync_WaitsForFencedCallbackPostInvocation()
+    {
+        var bridge = new FakeBridge
+        {
+            Sessions = [MainSession()],
+            CurrentStatus = ConnectionStatus.Connected,
+            CommandCatalogResult = new CommandCatalog
+            {
+                IsSupported = true,
+                Commands = [new GatewayCommand { Name = "status", NativeName = "/status" }],
+            },
+        };
+        using var postEntered = new ManualResetEventSlim();
+        using var releasePost = new ManualResetEventSlim();
+        var queued = new ConcurrentQueue<Action>();
+        var provider = new OpenClawChatDataProvider(
+            bridge,
+            post: callback =>
+            {
+                postEntered.Set();
+                Assert.True(releasePost.Wait(TimeSpan.FromSeconds(10)));
+                queued.Enqueue(callback);
+            });
+
+        var catalogTask = Task.Factory.StartNew(
+                () => provider.EnsureCommandCatalogAsync(),
+                CancellationToken.None,
+                TaskCreationOptions.LongRunning,
+                TaskScheduler.Default)
+            .Unwrap();
+        Assert.True(postEntered.Wait(TimeSpan.FromSeconds(10)));
+        var disposeTask = Task.Run(async () => await provider.DisposeAsync());
+        Assert.True(
+            SpinWait.SpinUntil(
+                () => provider.PublishDisposedForTests,
+                TimeSpan.FromSeconds(10)));
+        Assert.False(disposeTask.IsCompleted);
+        Assert.False(bridge.IsDisposed);
+
+        releasePost.Set();
+        await catalogTask;
+        await disposeTask;
+
+        Assert.True(bridge.IsDisposed);
+        AssertSingleQueuedAction(queued)();
+    }
+
+    [Fact]
     public async Task DisposeAsync_WaitsForInFlightHistoryNotificationCallback()
     {
         var bridge = new FakeBridge

--- a/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
@@ -261,6 +261,8 @@ public class OpenClawChatDataProviderTests
             string? attachmentMetaCachePath = null,
             string? lastChatStatePath = null,
             TimeSpan? lastChatStateSaveDelay = null,
+            Action? lastStateSaveReservedForTesting = null,
+            Action? beforeSelectedStateSaveForTesting = null,
             Func<TimeSpan, CancellationToken, Func<Task>, Task>? historyRetryScheduler = null,
             Action? historyFailureReservedForTesting = null,
             Func<Func<Task>, Task>? deferredAbortScheduler = null,
@@ -269,6 +271,7 @@ public class OpenClawChatDataProviderTests
         var bridge = new FakeBridge { Sessions = initial ?? Array.Empty<SessionInfo>() };
         var provider = toolMetaCachePath is null && attachmentMetaCachePath is null && lastChatStatePath is null &&
             lastChatStateSaveDelay is null && historyRetryScheduler is null && historyFailureReservedForTesting is null &&
+            lastStateSaveReservedForTesting is null && beforeSelectedStateSaveForTesting is null &&
             deferredAbortScheduler is null && post is null
             ? new OpenClawChatDataProvider(bridge)
             : new OpenClawChatDataProvider(
@@ -278,6 +281,8 @@ public class OpenClawChatDataProviderTests
                 attachmentMetaCacheFilePath: attachmentMetaCachePath,
                 lastChatStateFilePath: lastChatStatePath,
                 lastChatStateSaveDelay: lastChatStateSaveDelay,
+                lastStateSaveReservedForTesting: lastStateSaveReservedForTesting,
+                beforeSelectedStateSaveForTesting: beforeSelectedStateSaveForTesting,
                 historyRetryScheduler: historyRetryScheduler,
                 historyFailureReservedForTesting: historyFailureReservedForTesting,
                 deferredAbortScheduler: deferredAbortScheduler);
@@ -2021,6 +2026,7 @@ public class OpenClawChatDataProviderTests
         Assert.Single(posted);
 
         bridge.RaiseAgent(MakeAgentEvent("lifecycle", """{"phase":"start"}""", runId: "run-1"));
+        Assert.Single(posted);
 
         foreach (var action in posted)
             action();
@@ -5475,16 +5481,808 @@ public class OpenClawChatDataProviderTests
         var bridge = new FakeBridge { Sessions = new[] { MainSession() } };
         var queued = new List<Action>();
         var provider = new OpenClawChatDataProvider(bridge, post: a => queued.Add(a));
-        var snapshots = new List<ChatDataSnapshot>();
-        provider.Changed += (_, e) => snapshots.Add(e.Snapshot);
+        var deliveries = new List<string>();
+        provider.Changed += (_, _) => deliveries.Add("snapshot");
+        provider.NotificationRequested += (_, _) => deliveries.Add("notification");
 
         bridge.RaiseChat(new ChatMessageInfo { SessionKey = "main", Role = "assistant", Text = "x", State = "final" });
 
-        // Snapshot was queued, not invoked immediately.
-        Assert.Empty(snapshots);
-        Assert.NotEmpty(queued);
+        Assert.Empty(deliveries);
+        Assert.Single(queued);
         foreach (var a in queued) a();
-        Assert.NotEmpty(snapshots);
+        Assert.Equal(["snapshot", "notification"], deliveries);
+    }
+
+    [Fact]
+    public async Task PostDelegate_CoalescesBurstToLatestSnapshotPerDrain()
+    {
+        var bridge = new FakeBridge { Sessions = [MainSession()] };
+        var queued = new ConcurrentQueue<Action>();
+        var postCount = 0;
+        var provider = new OpenClawChatDataProvider(
+            bridge,
+            post: action =>
+            {
+                Interlocked.Increment(ref postCount);
+                queued.Enqueue(action);
+            });
+        var snapshots = new List<ChatDataSnapshot>();
+        provider.Changed += (_, args) => snapshots.Add(args.Snapshot);
+        await using (provider)
+        {
+            bridge.RaiseStatus(ConnectionStatus.Connecting);
+            bridge.RaiseStatus(ConnectionStatus.Connected);
+            bridge.RaiseStatus(ConnectionStatus.Disconnected);
+
+            Assert.Equal(1, Volatile.Read(ref postCount));
+            AssertSingleQueuedAction(queued)();
+
+            var snapshot = Assert.Single(snapshots);
+            Assert.Equal(ConnectionStatus.Disconnected.ToString(), snapshot.ConnectionStatus);
+            Assert.Empty(queued);
+        }
+    }
+
+    [Fact]
+    public async Task PostDelegate_PublishesDuringCallbackScheduleExactlyOneFollowUpDrain()
+    {
+        var bridge = new FakeBridge { Sessions = [MainSession()] };
+        var queued = new ConcurrentQueue<Action>();
+        var postCount = 0;
+        var provider = new OpenClawChatDataProvider(
+            bridge,
+            post: action =>
+            {
+                Interlocked.Increment(ref postCount);
+                queued.Enqueue(action);
+            });
+        var snapshots = new List<ChatDataSnapshot>();
+        provider.Changed += (_, args) =>
+        {
+            snapshots.Add(args.Snapshot);
+            if (snapshots.Count == 1)
+            {
+                bridge.RaiseStatus(ConnectionStatus.Connected);
+                bridge.RaiseStatus(ConnectionStatus.Disconnected);
+            }
+        };
+        await using (provider)
+        {
+            bridge.RaiseStatus(ConnectionStatus.Connecting);
+            Assert.Equal(1, Volatile.Read(ref postCount));
+
+            AssertSingleQueuedAction(queued)();
+
+            Assert.Equal(2, Volatile.Read(ref postCount));
+            AssertSingleQueuedAction(queued)();
+
+            Assert.Equal(2, snapshots.Count);
+            Assert.Equal("Connecting…", snapshots[0].ConnectionStatus);
+            Assert.Equal(ConnectionStatus.Disconnected.ToString(), snapshots[1].ConnectionStatus);
+            Assert.Empty(queued);
+        }
+    }
+
+    [Fact]
+    public async Task PostDelegate_ConcurrentBurstDoesNotLoseFinalSnapshot()
+    {
+        var bridge = new FakeBridge { Sessions = [MainSession()] };
+        var queued = new ConcurrentQueue<Action>();
+        var postCount = 0;
+        var provider = new OpenClawChatDataProvider(
+            bridge,
+            post: action =>
+            {
+                Interlocked.Increment(ref postCount);
+                queued.Enqueue(action);
+            });
+        var snapshots = new ConcurrentQueue<ChatDataSnapshot>();
+        provider.Changed += (_, args) => snapshots.Enqueue(args.Snapshot);
+        await using (provider)
+        {
+            Parallel.For(
+                0,
+                512,
+                index => bridge.RaiseStatus(
+                    index % 2 == 0
+                        ? ConnectionStatus.Connecting
+                        : ConnectionStatus.Connected));
+            bridge.RaiseStatus(ConnectionStatus.Disconnected);
+
+            Assert.Equal(1, Volatile.Read(ref postCount));
+            AssertSingleQueuedAction(queued)();
+
+            var snapshot = Assert.Single(snapshots);
+            Assert.Equal(ConnectionStatus.Disconnected.ToString(), snapshot.ConnectionStatus);
+            Assert.Empty(queued);
+        }
+    }
+
+    [Fact]
+    public async Task PostDelegate_OutOfOrderPublishArrivalUsesAuthoritativeFinalSnapshot()
+    {
+        var bridge = new FakeBridge { Sessions = [MainSession()] };
+        var queued = new ConcurrentQueue<Action>();
+        var postCount = 0;
+        var provider = new OpenClawChatDataProvider(
+            bridge,
+            post: action =>
+            {
+                Interlocked.Increment(ref postCount);
+                queued.Enqueue(action);
+            });
+        using var olderSnapshotBuilt = new ManualResetEventSlim();
+        using var releaseOlderPublish = new ManualResetEventSlim();
+        provider.BeforePublishForTests = snapshot =>
+        {
+            if (snapshot.ConnectionStatus == "Connecting…")
+            {
+                olderSnapshotBuilt.Set();
+                Assert.True(releaseOlderPublish.Wait(TimeSpan.FromSeconds(10)));
+            }
+        };
+        var snapshots = new List<ChatDataSnapshot>();
+        provider.Changed += (_, args) => snapshots.Add(args.Snapshot);
+        await using (provider)
+        {
+            var olderPublish = Task.Run(
+                () => bridge.RaiseStatus(ConnectionStatus.Connecting));
+            Assert.True(olderSnapshotBuilt.Wait(TimeSpan.FromSeconds(10)));
+
+            bridge.RaiseStatus(ConnectionStatus.Disconnected);
+            releaseOlderPublish.Set();
+            await olderPublish;
+
+            Assert.Equal(1, Volatile.Read(ref postCount));
+            AssertSingleQueuedAction(queued)();
+
+            var snapshot = Assert.Single(snapshots);
+            Assert.Equal(
+                ConnectionStatus.Disconnected.ToString(),
+                snapshot.ConnectionStatus);
+            Assert.Empty(queued);
+        }
+    }
+
+    [Fact]
+    public async Task PostDelegate_RapidToolAndSessionBurstUsesOneDrainAndKeepsFinalSnapshot()
+    {
+        const int toolCount = 64;
+        var bridge = new FakeBridge { Sessions = [MainSession()] };
+        var queued = new ConcurrentQueue<Action>();
+        var postCount = 0;
+        var provider = new OpenClawChatDataProvider(
+            bridge,
+            post: action =>
+            {
+                Interlocked.Increment(ref postCount);
+                queued.Enqueue(action);
+            });
+        var snapshots = new List<ChatDataSnapshot>();
+        provider.Changed += (_, args) => snapshots.Add(args.Snapshot);
+        await using (provider)
+        {
+            await provider.LoadAsync();
+            for (var index = 0; index < toolCount; index++)
+            {
+                var command = $"echo {index}";
+                bridge.RaiseAgent(MakeAgentEvent(
+                    "tool",
+                    JsonSerializer.Serialize(new
+                    {
+                        phase = "start",
+                        name = "powershell",
+                        args = new { command },
+                    })));
+                bridge.RaiseAgent(MakeAgentEvent(
+                    "tool",
+                    JsonSerializer.Serialize(new
+                    {
+                        phase = "result",
+                        name = "powershell",
+                        args = new { command },
+                    })));
+
+                if (index % 8 == 0)
+                {
+                    bridge.RaiseSessions(
+                    [
+                        new SessionInfo
+                        {
+                            Key = "main",
+                            IsMain = true,
+                            DisplayName = $"Main session {index}",
+                            Status = "active",
+                        },
+                    ]);
+                }
+            }
+
+            bridge.RaiseSessions(
+            [
+                new SessionInfo
+                {
+                    Key = "main",
+                    IsMain = true,
+                    DisplayName = "Final session",
+                    Status = "active",
+                },
+            ]);
+
+            Assert.Equal(1, Volatile.Read(ref postCount));
+            AssertSingleQueuedAction(queued)();
+
+            var snapshot = Assert.Single(snapshots);
+            Assert.Equal("Final session", Assert.Single(snapshot.Threads).Title);
+            Assert.Equal(
+                toolCount,
+                snapshot.Timelines["main"].Entries.Count(
+                    entry => entry.Kind == ChatTimelineItemKind.ToolCall));
+            Assert.All(
+                snapshot.Timelines["main"].Entries.Where(
+                    entry => entry.Kind == ChatTimelineItemKind.ToolCall),
+                entry => Assert.Equal(ChatToolCallStatus.Success, entry.ToolResult));
+            Assert.Empty(queued);
+        }
+    }
+
+    [Fact]
+    public async Task PostDelegate_DrainLeaseFencesAuthoritativeSnapshotRebuild()
+    {
+        var bridge = new FakeBridge { Sessions = [MainSession()] };
+        var queued = new ConcurrentQueue<Action>();
+        var provider = new OpenClawChatDataProvider(bridge, post: queued.Enqueue);
+        using var drainEntered = new ManualResetEventSlim();
+        using var releaseDrain = new ManualResetEventSlim();
+        provider.BeforePublishDrainForTests = () =>
+        {
+            drainEntered.Set();
+            Assert.True(releaseDrain.Wait(TimeSpan.FromSeconds(10)));
+        };
+
+        bridge.RaiseStatus(ConnectionStatus.Connecting);
+        var drain = AssertSingleQueuedAction(queued);
+        var drainTask = Task.Factory.StartNew(
+            drain,
+            CancellationToken.None,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default);
+        Assert.True(drainEntered.Wait(TimeSpan.FromSeconds(10)));
+        var disposeTask = Task.Factory.StartNew(
+            () => provider.DisposeAsync().AsTask().GetAwaiter().GetResult(),
+            CancellationToken.None,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default);
+        Assert.True(
+            SpinWait.SpinUntil(
+                () => provider.PublishDisposedForTests,
+                TimeSpan.FromSeconds(10)));
+        Assert.False(disposeTask.IsCompleted);
+        Assert.False(bridge.IsDisposed);
+
+        releaseDrain.Set();
+        await drainTask;
+        await disposeTask;
+
+        Assert.True(bridge.IsDisposed);
+    }
+
+    [Fact]
+    public async Task PostDelegate_ThrowingSnapshotSubscriberDoesNotDropNotification()
+    {
+        using var temp = new TempDirectory();
+        var bridge = new FakeBridge { Sessions = [MainSession()] };
+        var queued = new ConcurrentQueue<Action>();
+        using var snapshotSaved = new ManualResetEventSlim();
+        var provider = new OpenClawChatDataProvider(
+            bridge,
+            post: queued.Enqueue,
+            toolMetaCacheFilePath: Path.Combine(
+                temp.DirectoryPath,
+                "tool-metadata.json"),
+            lastChatStateFilePath: Path.Combine(
+                temp.DirectoryPath,
+                "last-chat-state.json"),
+            lastChatStateSaveDelay: TimeSpan.Zero,
+            lastStateSaveReservedForTesting: snapshotSaved.Set);
+        var notifications = new List<ChatProviderNotification>();
+        provider.Changed += (_, _) =>
+            throw new InvalidOperationException("snapshot subscriber failed");
+        provider.NotificationRequested +=
+            (_, args) => notifications.Add(args.Notification);
+        await provider.LoadAsync();
+
+        bridge.RaiseChat(new ChatMessageInfo
+        {
+            SessionKey = "main",
+            Role = "assistant",
+            Text = "done",
+            State = "final",
+        });
+        var drain = AssertSingleQueuedAction(queued);
+
+        Assert.Throws<InvalidOperationException>(drain);
+        Assert.Single(
+            notifications,
+            notification =>
+                notification.Kind ==
+                ChatProviderNotificationKind.TurnComplete);
+        Assert.True(snapshotSaved.Wait(TimeSpan.FromSeconds(10)));
+
+        await provider.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task InlinePost_ThrowingSnapshotSubscriberDoesNotDropPairedNotification()
+    {
+        var bridge = new FakeBridge { Sessions = [MainSession()] };
+        var provider = new OpenClawChatDataProvider(
+            bridge,
+            post: action => action());
+        var notifications = new List<ChatProviderNotification>();
+        provider.Changed += (_, _) =>
+            throw new InvalidOperationException("snapshot subscriber failed");
+        provider.NotificationRequested +=
+            (_, args) => notifications.Add(args.Notification);
+
+        var snapshot = await provider.LoadAsync();
+        var notification = new ChatProviderNotification(
+            ChatProviderNotificationKind.TurnComplete,
+            "main",
+            "done");
+        var publish = typeof(OpenClawChatDataProvider).GetMethod(
+            "Publish",
+            System.Reflection.BindingFlags.Instance |
+            System.Reflection.BindingFlags.NonPublic);
+        var failure = Assert.Throws<System.Reflection.TargetInvocationException>(
+            () => publish!.Invoke(provider, [snapshot, notification]));
+        Assert.IsType<InvalidOperationException>(failure.InnerException);
+        Assert.Single(
+            notifications,
+            delivered =>
+                delivered.Kind ==
+                ChatProviderNotificationKind.TurnComplete);
+
+        await provider.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task PostDelegate_DisposalFromSnapshotSubscriberStopsBatchedNotification()
+    {
+        var bridge = new FakeBridge { Sessions = [MainSession()] };
+        var queued = new ConcurrentQueue<Action>();
+        var provider = new OpenClawChatDataProvider(bridge, post: queued.Enqueue);
+        var notifications = new List<ChatProviderNotification>();
+        provider.Changed +=
+            (_, _) => provider.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        provider.NotificationRequested +=
+            (_, args) => notifications.Add(args.Notification);
+
+        bridge.RaiseChat(new ChatMessageInfo
+        {
+            SessionKey = "main",
+            Role = "assistant",
+            Text = "done",
+            State = "final",
+        });
+        AssertSingleQueuedAction(queued)();
+
+        Assert.Empty(notifications);
+        Assert.True(bridge.IsDisposed);
+    }
+
+    [Fact]
+    public void DirectDelivery_DisposalFromFirstSubscriberStopsLaterSubscribers()
+    {
+        var bridge = new FakeBridge { Sessions = [MainSession()] };
+        var provider = new OpenClawChatDataProvider(bridge);
+        var laterSubscriberCalls = 0;
+        provider.Changed +=
+            (_, _) => provider.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        provider.Changed +=
+            (_, _) => Interlocked.Increment(ref laterSubscriberCalls);
+
+        bridge.RaiseStatus(ConnectionStatus.Connecting);
+
+        Assert.Equal(0, Volatile.Read(ref laterSubscriberCalls));
+        Assert.True(bridge.IsDisposed);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_DropsQueuedChangedDeliveryAndFuturePublishes()
+    {
+        var bridge = new FakeBridge { Sessions = [MainSession()] };
+        var queued = new ConcurrentQueue<Action>();
+        var provider = new OpenClawChatDataProvider(bridge, post: queued.Enqueue);
+        var snapshots = new List<ChatDataSnapshot>();
+        provider.Changed += (_, args) => snapshots.Add(args.Snapshot);
+
+        bridge.RaiseStatus(ConnectionStatus.Connecting);
+        var queuedBeforeDispose = AssertSingleQueuedAction(queued);
+
+        await provider.DisposeAsync();
+        queuedBeforeDispose();
+        bridge.RaiseStatus(ConnectionStatus.Connected);
+
+        Assert.Empty(snapshots);
+        Assert.Empty(queued);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_WaitsForInFlightChangedCallback()
+    {
+        var bridge = new FakeBridge { Sessions = [MainSession()] };
+        var provider = new OpenClawChatDataProvider(bridge);
+        using var callbackEntered = new ManualResetEventSlim();
+        using var releaseCallback = new ManualResetEventSlim();
+        provider.Changed += (_, _) =>
+        {
+            callbackEntered.Set();
+            Assert.True(releaseCallback.Wait(TimeSpan.FromSeconds(10)));
+        };
+
+        var publishTask = Task.Run(
+            () => bridge.RaiseStatus(ConnectionStatus.Connecting));
+        Assert.True(callbackEntered.Wait(TimeSpan.FromSeconds(10)));
+        var disposeTask = Task.Run(async () => await provider.DisposeAsync());
+        Assert.True(
+            SpinWait.SpinUntil(
+                () => provider.PublishDisposedForTests,
+                TimeSpan.FromSeconds(10)));
+        Assert.False(disposeTask.IsCompleted);
+        Assert.False(bridge.IsDisposed);
+
+        releaseCallback.Set();
+        await publishTask;
+        await disposeTask;
+
+        Assert.True(bridge.IsDisposed);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_FromChangedCallbackDoesNotDeadlock()
+    {
+        var bridge = new FakeBridge { Sessions = [MainSession()] };
+        var provider = new OpenClawChatDataProvider(bridge);
+        provider.Changed += (_, _) => provider.DisposeAsync().AsTask().GetAwaiter().GetResult();
+
+        await Task.Run(
+            () => bridge.RaiseStatus(ConnectionStatus.Connecting))
+            .WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.True(bridge.IsDisposed);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_ConcurrentExternalAndCallbackDisposalDoesNotDeadlock()
+    {
+        var bridge = new FakeBridge { Sessions = [MainSession()] };
+        var provider = new OpenClawChatDataProvider(bridge);
+        using var callbackEntered = new ManualResetEventSlim();
+        using var allowCallbackDispose = new ManualResetEventSlim();
+        provider.Changed += (_, _) =>
+        {
+            callbackEntered.Set();
+            Assert.True(allowCallbackDispose.Wait(TimeSpan.FromSeconds(10)));
+            provider.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        };
+
+        var publishTask = Task.Run(
+            () => bridge.RaiseStatus(ConnectionStatus.Connecting));
+        Assert.True(callbackEntered.Wait(TimeSpan.FromSeconds(10)));
+        var externalDispose = Task.Run(async () => await provider.DisposeAsync());
+        Assert.True(
+            SpinWait.SpinUntil(
+                () => provider.PublishDisposedForTests,
+                TimeSpan.FromSeconds(10)));
+
+        allowCallbackDispose.Set();
+        await publishTask.WaitAsync(TimeSpan.FromSeconds(10));
+        await externalDispose.WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.True(bridge.IsDisposed);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_PersistsAuthoritativeSnapshotWhenQueuedDeliveryIsDropped()
+    {
+        using var temp = new TempDirectory();
+        var statePath = Path.Combine(temp.DirectoryPath, "last-chat-state.json");
+        var queued = new ConcurrentQueue<Action>();
+        var (bridge, provider, snapshots, _) = CreateProvider(
+            lastChatStatePath: statePath,
+            lastChatStateSaveDelay: TimeSpan.FromDays(1),
+            post: queued.Enqueue);
+        bridge.RaiseSessions(
+        [
+            new SessionInfo
+            {
+                Key = "main",
+                IsMain = true,
+                DisplayName = "Final session",
+                Status = "active",
+            },
+        ]);
+        Assert.Single(queued);
+
+        await provider.DisposeAsync();
+
+        Assert.Empty(snapshots);
+        var persisted = OpenClawChatDataProvider.LoadLastChatState(statePath);
+        Assert.Equal("Final session", persisted?.ThreadTitle);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_FinalSnapshotWinsOverOlderSelectedStateSave()
+    {
+        using var temp = new TempDirectory();
+        var statePath = Path.Combine(temp.DirectoryPath, "last-chat-state.json");
+        using var oldSaveEntered = new ManualResetEventSlim();
+        using var releaseOldSave = new ManualResetEventSlim();
+        var queued = new ConcurrentQueue<Action>();
+        var blockNextSave = 1;
+        var (bridge, provider, _, _) = CreateProvider(
+            [
+                new SessionInfo
+                {
+                    Key = "old",
+                    IsMain = true,
+                    DisplayName = "Old session",
+                    Status = "active",
+                },
+            ],
+            lastChatStatePath: statePath,
+            lastChatStateSaveDelay: TimeSpan.FromDays(1),
+            post: queued.Enqueue,
+            lastStateSaveReservedForTesting: () =>
+            {
+                if (Interlocked.Exchange(ref blockNextSave, 0) != 1)
+                    return;
+                oldSaveEntered.Set();
+                Assert.True(releaseOldSave.Wait(TimeSpan.FromSeconds(10)));
+            });
+        await provider.LoadAsync();
+
+        var oldSave = Task.Factory.StartNew(
+            () => provider.RememberSelectedThread("old"),
+            CancellationToken.None,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default);
+        Assert.True(oldSaveEntered.Wait(TimeSpan.FromSeconds(10)));
+        bridge.RaiseSessions(
+        [
+            new SessionInfo
+            {
+                Key = "final",
+                IsMain = true,
+                DisplayName = "Final session",
+                Status = "active",
+            },
+        ]);
+        var dispose = Task.Factory.StartNew(
+            () => provider.DisposeAsync().AsTask().GetAwaiter().GetResult(),
+            CancellationToken.None,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default);
+        Assert.False(dispose.IsCompleted);
+
+        releaseOldSave.Set();
+        await oldSave;
+        await dispose;
+
+        var persisted = OpenClawChatDataProvider.LoadLastChatState(statePath);
+        Assert.Equal("Final session", persisted?.ThreadTitle);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_FinalSnapshotRejectsSelectedStateWaitingOutsidePersistenceFence()
+    {
+        using var temp = new TempDirectory();
+        var statePath = Path.Combine(temp.DirectoryPath, "last-chat-state.json");
+        using var staleSaveReady = new ManualResetEventSlim();
+        using var releaseStaleSave = new ManualResetEventSlim();
+        var (bridge, provider, _, _) = CreateProvider(
+            [
+                new SessionInfo
+                {
+                    Key = "old",
+                    IsMain = true,
+                    DisplayName = "Old session",
+                    Status = "active",
+                },
+            ],
+            lastChatStatePath: statePath,
+            beforeSelectedStateSaveForTesting: () =>
+            {
+                staleSaveReady.Set();
+                Assert.True(releaseStaleSave.Wait(TimeSpan.FromSeconds(10)));
+            });
+        await provider.LoadAsync();
+
+        var staleSave = Task.Factory.StartNew(
+            () => provider.RememberSelectedThread("old"),
+            CancellationToken.None,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default);
+        Assert.True(staleSaveReady.Wait(TimeSpan.FromSeconds(10)));
+        bridge.RaiseSessions(
+        [
+            new SessionInfo
+            {
+                Key = "final",
+                IsMain = true,
+                DisplayName = "Final session",
+                Status = "active",
+            },
+        ]);
+
+        await provider.DisposeAsync();
+        releaseStaleSave.Set();
+        await staleSave;
+
+        var persisted = OpenClawChatDataProvider.LoadLastChatState(statePath);
+        Assert.Equal("Final session", persisted?.ThreadTitle);
+    }
+
+    [Fact]
+    public void ConversationState_DisposalRejectsPersistenceRelevantPresentationMutations()
+    {
+        var state = new ChatConversationState(
+            ConnectionStatus.Connected,
+            lastChatState: null,
+            seedModels: null);
+        var context = new ChatProjectionContext(
+            "old",
+            HasHandshakeSnapshot: true);
+        var before = state.Load(
+        [
+            new SessionInfo
+            {
+                Key = "old",
+                IsMain = true,
+                DisplayName = "Old session",
+                Status = "active",
+            },
+        ],
+        context);
+        state.DisposeState();
+
+        Assert.Null(state.RememberSelectedThread("new"));
+        var sessionsAfterDispose = state.ApplySessions(
+        [
+            new SessionInfo
+            {
+                Key = "new",
+                IsMain = true,
+                DisplayName = "New session",
+                Status = "active",
+            },
+        ],
+        new ChatProjectionContext("new", HasHandshakeSnapshot: true));
+        var modelsAfterDispose = state.ApplyModels(
+            new ModelsListInfo
+            {
+                Models =
+                [
+                    new ModelInfo
+                    {
+                        Id = "new-model",
+                        Name = "New model",
+                    },
+                ],
+            },
+            context);
+
+        var after = state.Snapshot(context);
+        Assert.Equal(
+            before.Threads.Select(thread => thread.Id),
+            sessionsAfterDispose.Snapshot.Threads.Select(thread => thread.Id));
+        Assert.Equal(before.AvailableModels, modelsAfterDispose.AvailableModels);
+        Assert.Equal(
+            before.Threads.Select(thread => thread.Id),
+            after.Threads.Select(thread => thread.Id));
+        Assert.Equal(before.AvailableModels, after.AvailableModels);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_DropsQueuedCommandCatalogDelivery()
+    {
+        var bridge = new FakeBridge
+        {
+            Sessions = [MainSession()],
+            CurrentStatus = ConnectionStatus.Connected,
+            CommandCatalogResult = new CommandCatalog
+            {
+                IsSupported = true,
+                Commands = [new GatewayCommand { Name = "status", NativeName = "/status" }],
+            },
+        };
+        var queued = new ConcurrentQueue<Action>();
+        var provider = new OpenClawChatDataProvider(bridge, post: queued.Enqueue);
+        var snapshots = new List<ChatDataSnapshot>();
+        provider.Changed += (_, args) => snapshots.Add(args.Snapshot);
+
+        await provider.EnsureCommandCatalogAsync();
+        var queuedBeforeDispose = AssertSingleQueuedAction(queued);
+
+        await provider.DisposeAsync();
+        queuedBeforeDispose();
+
+        Assert.Empty(snapshots);
+        Assert.Empty(queued);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_WaitsForInFlightHistoryNotificationCallback()
+    {
+        var bridge = new FakeBridge
+        {
+            Sessions = [MainSession()],
+            CurrentStatus = ConnectionStatus.Connected,
+            HistoryBehavior = _ => Task.FromException<ChatHistoryInfo>(
+                new InvalidOperationException("history unavailable")),
+        };
+        var provider = new OpenClawChatDataProvider(bridge);
+        using var callbackEntered = new ManualResetEventSlim();
+        using var releaseCallback = new ManualResetEventSlim();
+        provider.NotificationRequested += (_, _) =>
+        {
+            callbackEntered.Set();
+            Assert.True(releaseCallback.Wait(TimeSpan.FromSeconds(10)));
+        };
+
+        var loadTask = Task.Run(() => provider.LoadHistoryAsync("main"));
+        Assert.True(callbackEntered.Wait(TimeSpan.FromSeconds(10)));
+        var disposeTask = Task.Run(async () => await provider.DisposeAsync());
+        Assert.True(
+            SpinWait.SpinUntil(
+                () => provider.PublishDisposedForTests,
+                TimeSpan.FromSeconds(10)));
+        Assert.False(disposeTask.IsCompleted);
+
+        releaseCallback.Set();
+        await loadTask;
+        await disposeTask;
+
+        Assert.True(bridge.IsDisposed);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_WaitsForInFlightCommandCatalogCallback()
+    {
+        var bridge = new FakeBridge
+        {
+            Sessions = [MainSession()],
+            CurrentStatus = ConnectionStatus.Connected,
+            CommandCatalogResult = new CommandCatalog
+            {
+                IsSupported = true,
+                Commands = [new GatewayCommand { Name = "status", NativeName = "/status" }],
+            },
+        };
+        var provider = new OpenClawChatDataProvider(bridge);
+        using var callbackEntered = new ManualResetEventSlim();
+        using var releaseCallback = new ManualResetEventSlim();
+        provider.Changed += (_, _) =>
+        {
+            callbackEntered.Set();
+            Assert.True(releaseCallback.Wait(TimeSpan.FromSeconds(10)));
+        };
+
+        var catalogTask = Task.Run(() => provider.EnsureCommandCatalogAsync());
+        Assert.True(callbackEntered.Wait(TimeSpan.FromSeconds(10)));
+        var disposeTask = Task.Run(async () => await provider.DisposeAsync());
+        Assert.True(
+            SpinWait.SpinUntil(
+                () => provider.PublishDisposedForTests,
+                TimeSpan.FromSeconds(10)));
+        Assert.False(disposeTask.IsCompleted);
+
+        releaseCallback.Set();
+        await catalogTask;
+        await disposeTask;
+
+        Assert.True(bridge.IsDisposed);
     }
 
     [Fact]
@@ -9572,7 +10370,7 @@ public class OpenClawChatDataProviderTests
     }
 
     [Fact]
-    public async Task Disconnect_DropsHistoryDeliveryQueuedAfterNewerStatusSnapshot()
+    public async Task Disconnect_QueuedHistoryDeliveryCannotSupersedeLatestStatusDrain()
     {
         var deliveries = new List<Action>();
         var bridge = new FakeBridge
@@ -9599,10 +10397,11 @@ public class OpenClawChatDataProviderTests
         bridge.RaiseStatus(ConnectionStatus.Disconnected);
         Assert.Equal(2, deliveries.Count);
 
-        // Model a dispatcher race where disconnect is delivered before the
-        // history callback that was queued from an earlier connection state.
-        deliveries[1]();
+        // The first callback is history commit work, not a snapshot drain. It
+        // observes the advanced connection generation and drops its stale result.
+        // The second callback is the coalesced snapshot drain.
         deliveries[0]();
+        deliveries[1]();
 
         var snapshot = Assert.Single(snapshots);
         Assert.Equal(ConnectionStatus.Disconnected.ToString(), snapshot.ConnectionStatus);
@@ -13505,7 +14304,7 @@ public class OpenClawChatDataProviderTests
     }
 
     [Fact]
-    public async Task LoadHistoryAsync_QueuedDeliveryDropsAfterResetGenerationAdvances()
+    public async Task LoadHistoryAsync_QueuedDeliveryCannotSupersedeLatestResetGenerationDrain()
     {
         using var temp = new TempDirectory();
         var bridge = new FakeBridge
@@ -13548,8 +14347,8 @@ public class OpenClawChatDataProviderTests
             });
             Assert.Equal(2, deliveries.Count);
 
-            deliveries[1]();
             deliveries[0]();
+            deliveries[1]();
 
             var snapshot = Assert.Single(snapshots);
             Assert.Empty(snapshot.Timelines["main"].Entries);
@@ -13691,6 +14490,13 @@ public class OpenClawChatDataProviderTests
            snapshot.QueuedMessagesByThread.TryGetValue(threadId, out var queued)
             ? queued
             : Array.Empty<ChatQueuedMessage>();
+
+    private static Action AssertSingleQueuedAction(ConcurrentQueue<Action> queued)
+    {
+        Assert.True(queued.TryDequeue(out var action));
+        Assert.Empty(queued);
+        return action;
+    }
 
     private static ISet<string> GetQueuedDrainScheduledThreads(OpenClawChatDataProvider provider)
     {


### PR DESCRIPTION
Supersedes #1301 (fix(chat): make snapshot coalescing race-free) with a maintainer-owned replacement rebuilt on current `main`.

## What changed

`OpenClawChatDataProvider` remains the facade and event-publication owner. `ChatHistoryLoader` continues to own history request, retry, and rebuild mechanics, while `ChatMetadataStore` continues to own correlation and metadata persistence.

- Coalesces producer bursts into one dispatcher drain that publishes the latest authoritative chat snapshot.
- Preserves snapshot-associated notification ordering and callback-time reentrancy.
- Routes history completion and command-catalog callbacks through the same disposal-aware delivery fence.
- Tracks dispatcher posting and callback delivery as in-flight work so disposal cannot tear down the bridge while either is active.
- Rejects queued and future delivery after disposal, including later multicast subscribers.
- Serializes selected-state, debounce, and final-state persistence so stale saves cannot overwrite the shutdown snapshot.
- Preserves the existing provider constructor contract; new persistence race hooks remain test-only.
- Adds deterministic concurrency and disposal tests using gates and explicit queues, without sleeps.

## Ownership and invariant

- Old owner: `OpenClawChatDataProvider` directly posted independent snapshot callbacks without a unified lifecycle fence.
- New owner: `OpenClawChatDataProvider` still owns publication, now through one coalesced, disposal-aware delivery state machine.
- Preserved invariant: `ChatConversationState` remains authoritative, history mechanics stay in `ChatHistoryLoader`, metadata stays in `ChatMetadataStore`, and consumers receive the latest state without post-disposal callbacks.

## Required proof pools

- `windows-winui-interactive`: Not verified / blocked. This change is an internal publication and disposal synchronization repair with no intended visual delta. Current-head behavior is covered by deterministic unit tests rather than a meaningful screenshot.

## Validation

Current base: `4064eb9c230d2eb12bb8cf9162247453d89447bb`

Current head: `7f0db3b444a9bf011fd7e396b12ea063d9649c06`

- `.\build.ps1`: passed.
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore`: 3,991 passed, 32 skipped.
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore`: 2,888 passed.
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore --filter "FullyQualifiedName~OpenClawChatDataProviderTests"`: 419 passed.
- `git diff --check`: passed.

## Real behavior proof

Deterministic tests prove:

- one drain per producer burst with the latest authoritative snapshot;
- exactly one follow-up drain for callback-time publication;
- no stale overwrite from out-of-order producers or persistence races;
- queued history and command-catalog delivery is dropped after disposal;
- disposal waits for active snapshot, notification, history, catalog, and dispatcher-post work;
- callback-initiated and concurrent disposal complete without deadlock;
- subscriber exceptions do not discard persistence or later paired notifications.

No visible UI change is claimed.

## Review

- Rubber-duck review: no blocking findings. Non-blocking dispatcher-shutdown/drop observations were not expanded because the production `Action<Action>` posting contract cannot report enqueue rejection and that behavior is outside this disposal-race replacement.
- Autoreview accepted and fixed two findings: preserve the existing constructor contract, and fence actual dispatcher-post invocation against disposal.
- Final command: `python .agents\skills\autoreview\scripts\autoreview --mode branch --base origin/main --stream-engine-output`.
- Final autoreview: clean, no accepted/actionable findings; patch correct at 0.90 confidence.