### PR TITLE
fix(mxc): bound termination and output drain cleanup

### DIFF
--- a/src/OpenClaw.Shared/Mxc/MxcExecutor.cs
+++ b/src/OpenClaw.Shared/Mxc/MxcExecutor.cs
@@ -1,4 +1,6 @@
+using System.ComponentModel;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -13,7 +15,11 @@ public sealed class MxcExecutor
 {
     private const int DefaultStdoutCapBytes = 40_000;
     private const int DefaultStderrCapBytes = 5_000;
+    internal const int ProcessTreeKillWorkerLimit = 8;
     private static readonly TimeSpan s_defaultCleanupTimeout = TimeSpan.FromMilliseconds(500);
+    private static readonly SemaphoreSlim s_processTreeKillWorkers = new(
+        ProcessTreeKillWorkerLimit,
+        ProcessTreeKillWorkerLimit);
 
     private readonly string _wxcExePath;
     private readonly int _stdoutCapBytes;
@@ -122,47 +128,15 @@ public sealed class MxcExecutor
         // ArgumentList avoids the manual-quoting trap that bites Process.Arguments
         // (each entry is escaped per Win32 CommandLineToArgvW rules by the BCL).
         foreach (var arg in arguments) startInfo.ArgumentList.Add(arg);
-        using var process = _processFactory(startInfo)
+        var process = _processFactory(startInfo)
             ?? throw new InvalidOperationException("Process factory returned null.");
+        var processOwnedByKillWorker = false;
+        var processRelease = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var processStarted = false;
+        RedirectedOutputCapture? stdout = null;
+        RedirectedOutputCapture? stderr = null;
 
-        var stdoutBuilder = new StringBuilder();
-        var stderrBuilder = new StringBuilder();
-        // StringBuilder is not thread-safe; the async event handlers can fire
-        // concurrently with each other and with the post-kill ToString() read.
-        var outLock = new object();
-        var errLock = new object();
         var processExited = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var stdoutClosed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var stderrClosed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        process.OutputDataReceived += (_, e) =>
-        {
-            if (e.Data is null)
-            {
-                stdoutClosed.TrySetResult();
-                return;
-            }
-
-            lock (outLock)
-            {
-                if (stdoutBuilder.Length < _stdoutCapBytes * 2)
-                    stdoutBuilder.AppendLine(e.Data);
-            }
-        };
-        process.ErrorDataReceived += (_, e) =>
-        {
-            if (e.Data is null)
-            {
-                stderrClosed.TrySetResult();
-                return;
-            }
-
-            lock (errLock)
-            {
-                if (stderrBuilder.Length < _stderrCapBytes * 2)
-                    stderrBuilder.AppendLine(e.Data);
-            }
-        };
         process.EnableRaisingEvents = true;
         process.Exited += (_, _) => processExited.TrySetResult();
 
@@ -170,8 +144,16 @@ public sealed class MxcExecutor
         try
         {
             process.Start();
-            process.BeginOutputReadLine();
-            process.BeginErrorReadLine();
+            processStarted = true;
+            var processId = process.Id;
+            stdout = new RedirectedOutputCapture(
+                GetRedirectedPipe(process.StandardOutput),
+                process.StandardOutput.CurrentEncoding,
+                GetCaptureLimit(_stdoutCapBytes));
+            stderr = new RedirectedOutputCapture(
+                GetRedirectedPipe(process.StandardError),
+                process.StandardError.CurrentEncoding,
+                GetCaptureLimit(_stderrCapBytes));
             if (process.HasExited)
                 processExited.TrySetResult();
 
@@ -188,51 +170,93 @@ public sealed class MxcExecutor
 
             if (!completed)
             {
-                try { _processTreeKiller(process); }
-                catch (Exception ex) { Trace.WriteLine($"MxcExecutor: process kill (cancellation path) failed: {ex.Message}"); }
-                if (!await WaitForCleanupAsync(processExited.Task, stdoutClosed.Task, stderrClosed.Task, _cleanupTimeout))
-                    Trace.WriteLine($"MxcExecutor: cancellation cleanup timed out (pid={process.Id}).");
+                if (!await KillProcessTreeWithTimeoutAsync(
+                        process,
+                        processRelease.Task,
+                        () => processOwnedByKillWorker = true))
+                {
+                    Trace.WriteLine($"MxcExecutor: process kill (cancellation path) timed out or failed (pid={processId}).");
+                }
+                var cleanupCompleted = await WaitForCleanupAsync(
+                        processExited.Task,
+                        stdout.Completion,
+                        stderr.Completion,
+                        _cleanupTimeout);
+                if (!cleanupCompleted)
+                {
+                    Trace.WriteLine($"MxcExecutor: cancellation cleanup timed out (pid={processId}).");
+                }
 
+                var cancelledOutput = cleanupCompleted
+                    ? stdout.Output
+                    : (await StopOutputCapturesAsync(stdout, stderr, _cleanupTimeout)).Stdout;
                 sw.Stop();
-                string capturedOut;
-                lock (outLock) { capturedOut = stdoutBuilder.ToString(); }
                 return new MxcResult
                 {
                     Success = false,
                     ExitCode = -1,
-                    Output = Truncate(capturedOut, _stdoutCapBytes),
+                    Output = Truncate(cancelledOutput, _stdoutCapBytes),
                     Error = "Execution was cancelled.",
                     TimedOut = true,
                     DurationMs = sw.ElapsedMilliseconds,
                 };
             }
 
-            // Normal completion keeps the established lossless drain behavior.
-            // The bounded cleanup exists specifically for cancellation, where
-            // availability takes precedence over waiting indefinitely for a
-            // launcher or inherited pipe handle that ignored termination.
-            try { process.WaitForExit(); }
-            catch (Exception ex) { Trace.WriteLine($"MxcExecutor: post-exit drain failed: {ex.Message}"); }
+            // The launcher exited, but a descendant may still hold an inherited
+            // stdout/stderr write handle. Bound the drain so a completed launcher
+            // cannot pin the node invocation slot indefinitely.
+            var outputDrained = await WaitForCleanupAsync(
+                    processExited.Task,
+                    stdout.Completion,
+                    stderr.Completion,
+                    _cleanupTimeout);
+            if (!outputDrained)
+            {
+                Trace.WriteLine($"MxcExecutor: post-exit output drain timed out (pid={processId}).");
+            }
 
+            var output = outputDrained
+                ? (Stdout: stdout.Output, Stderr: stderr.Output)
+                : await StopOutputCapturesAsync(stdout, stderr, _cleanupTimeout);
             sw.Stop();
-            string outRaw, errRaw;
-            lock (outLock) { outRaw = stdoutBuilder.ToString().Trim(); }
-            lock (errLock) { errRaw = stderrBuilder.ToString().Trim(); }
-            var stdout = Truncate(outRaw, _stdoutCapBytes);
-            var stderr = Truncate(errRaw, _stderrCapBytes);
+            var capturedOut = Truncate(output.Stdout.Trim(), _stdoutCapBytes);
+            var capturedError = Truncate(output.Stderr.Trim(), _stderrCapBytes);
 
             return new MxcResult
             {
                 Success = process.ExitCode == 0,
                 ExitCode = process.ExitCode,
-                Output = string.IsNullOrEmpty(stdout) ? null : stdout,
-                Error = string.IsNullOrEmpty(stderr) ? null : stderr,
+                Output = string.IsNullOrEmpty(capturedOut) ? null : capturedOut,
+                Error = string.IsNullOrEmpty(capturedError) ? null : capturedError,
                 TimedOut = false,
                 DurationMs = sw.ElapsedMilliseconds,
             };
         }
         catch (Exception ex)
         {
+            if (processStarted)
+            {
+                try
+                {
+                    if (!processOwnedByKillWorker)
+                    {
+                        _ = await KillProcessTreeWithTimeoutAsync(
+                            process,
+                            processRelease.Task,
+                            () => processOwnedByKillWorker = true);
+                    }
+                    if (stdout is not null)
+                        _ = await stdout.StopAndSnapshotAsync(_cleanupTimeout);
+                    if (stderr is not null)
+                        _ = await stderr.StopAndSnapshotAsync(_cleanupTimeout);
+                }
+                catch (Exception cleanupException)
+                {
+                    Trace.WriteLine(
+                        $"MxcExecutor: post-failure cleanup failed: {cleanupException.Message}");
+                }
+            }
+
             sw.Stop();
             return new MxcResult
             {
@@ -242,7 +266,128 @@ public sealed class MxcExecutor
                 DurationMs = sw.ElapsedMilliseconds,
             };
         }
+        finally
+        {
+            processRelease.TrySetResult();
+            if (!processOwnedByKillWorker)
+                process.Dispose();
+        }
     }
+
+    private static FileStream GetRedirectedPipe(StreamReader reader) =>
+        reader.BaseStream as FileStream
+        ?? throw new InvalidOperationException("Redirected process stream is not a file-backed pipe.");
+
+    private static int GetCaptureLimit(int resultLimit) =>
+        resultLimit > int.MaxValue / 2 ? int.MaxValue : resultLimit * 2;
+
+    private static async Task<(string Stdout, string Stderr)> StopOutputCapturesAsync(
+        RedirectedOutputCapture stdout,
+        RedirectedOutputCapture stderr,
+        TimeSpan timeout)
+    {
+        var stdoutTask = stdout.StopAndSnapshotAsync(timeout);
+        var stderrTask = stderr.StopAndSnapshotAsync(timeout);
+        await Task.WhenAll(stdoutTask, stderrTask);
+        return (await stdoutTask, await stderrTask);
+    }
+
+    internal async Task<bool> KillProcessTreeWithTimeoutAsync(
+        Process process,
+        Task? processRelease = null,
+        Action? transferProcessOwnership = null)
+    {
+        var processId = process.Id;
+        var timeoutStarted = Stopwatch.GetTimestamp();
+        if (!await s_processTreeKillWorkers.WaitAsync(_cleanupTimeout))
+        {
+            Trace.WriteLine(
+                $"MxcExecutor: timed out waiting for process kill worker capacity " +
+                $"(limit={ProcessTreeKillWorkerLimit}, pid={processId}).");
+            return false;
+        }
+
+        Task<Exception?> killTask;
+        try
+        {
+            killTask = Task.Factory.StartNew(
+                () =>
+                {
+                    try
+                    {
+                        _processTreeKiller(process);
+                        return (Exception?)null;
+                    }
+                    catch (Exception ex)
+                    {
+                        return ex;
+                    }
+                    finally
+                    {
+                        s_processTreeKillWorkers.Release();
+                    }
+                },
+                CancellationToken.None,
+                TaskCreationOptions.LongRunning,
+                TaskScheduler.Default);
+        }
+        catch (Exception ex)
+        {
+            s_processTreeKillWorkers.Release();
+            Trace.WriteLine($"MxcExecutor: process kill worker failed to start: {ex.Message}");
+            return false;
+        }
+
+        if (transferProcessOwnership is not null)
+        {
+            transferProcessOwnership();
+            ObserveFault(DisposeProcessAfterReleaseAsync(
+                process,
+                killTask,
+                processRelease ?? Task.CompletedTask));
+        }
+        var remainingTimeout = _cleanupTimeout - Stopwatch.GetElapsedTime(timeoutStarted);
+        try
+        {
+            if (!killTask.IsCompleted && remainingTimeout <= TimeSpan.Zero)
+                return false;
+
+            var error = killTask.IsCompleted
+                ? await killTask
+                : await killTask.WaitAsync(remainingTimeout);
+            if (error is null)
+                return true;
+
+            Trace.WriteLine($"MxcExecutor: process kill (cancellation path) failed: {error.Message}");
+            return false;
+        }
+        catch (TimeoutException)
+        {
+            return false;
+        }
+    }
+
+    private static async Task DisposeProcessAfterReleaseAsync(
+        Process process,
+        Task killTask,
+        Task processRelease)
+    {
+        try
+        {
+            await Task.WhenAll(killTask, processRelease).ConfigureAwait(false);
+        }
+        finally
+        {
+            process.Dispose();
+        }
+    }
+
+    private static void ObserveFault(Task task) =>
+        _ = task.ContinueWith(
+            static completed => { _ = completed.Exception; },
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
 
     internal static async Task<bool> WaitForCleanupAsync(
         Task processExited,
@@ -265,5 +410,346 @@ public sealed class MxcExecutor
     {
         if (text.Length <= maxLength) return text;
         return text[..maxLength] + $"\n\n... [TRUNCATED — showing first {maxLength} of {text.Length} chars]";
+    }
+
+    private sealed class RedirectedOutputCapture
+    {
+        private const uint ThreadTerminate = 0x0001;
+        private const int ErrorNotFound = 1168;
+        private readonly FileStream _stream;
+        private readonly Encoding _configuredEncoding;
+        private readonly int _maxChars;
+        private readonly object _lock = new();
+        private readonly object _readerThreadLock = new();
+        private readonly StringBuilder _output = new();
+        private readonly TaskCompletionSource _readerThreadStarted =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private nint _readerThread;
+        private int _closing;
+
+        internal RedirectedOutputCapture(
+            FileStream stream,
+            Encoding configuredEncoding,
+            int maxChars)
+        {
+            _stream = stream;
+            _configuredEncoding = configuredEncoding;
+            _maxChars = maxChars;
+            Completion = Task.Factory.StartNew(
+                Capture,
+                CancellationToken.None,
+                TaskCreationOptions.LongRunning,
+                TaskScheduler.Default);
+        }
+
+        internal Task Completion { get; }
+
+        internal string Output
+        {
+            get
+            {
+                lock (_lock)
+                    return _output.ToString();
+            }
+        }
+
+        internal async Task<string> StopAndSnapshotAsync(TimeSpan timeout)
+        {
+            var timeoutStarted = Stopwatch.GetTimestamp();
+            Interlocked.Exchange(ref _closing, 1);
+            try
+            {
+                await _readerThreadStarted.Task.WaitAsync(timeout);
+                while (!Completion.IsCompleted)
+                {
+                    CancelPendingRead();
+                    var remainingTimeout = timeout - Stopwatch.GetElapsedTime(timeoutStarted);
+                    if (remainingTimeout <= TimeSpan.Zero)
+                        break;
+
+                    var retryDelay = remainingTimeout < TimeSpan.FromMilliseconds(25)
+                        ? remainingTimeout
+                        : TimeSpan.FromMilliseconds(25);
+                    try
+                    {
+                        await Completion.WaitAsync(retryDelay).ConfigureAwait(false);
+                    }
+                    catch (TimeoutException)
+                    {
+                    }
+                }
+            }
+            catch (TimeoutException)
+            {
+                Trace.WriteLine("MxcExecutor: redirected output reader thread did not start in time.");
+                _stream.Dispose();
+            }
+
+            if (!Completion.IsCompleted)
+            {
+                Trace.WriteLine("MxcExecutor: redirected output reader did not stop in time.");
+                _stream.Dispose();
+            }
+
+            lock (_lock)
+            {
+                return _output.ToString();
+            }
+        }
+
+        private void CancelPendingRead()
+        {
+            lock (_readerThreadLock)
+            {
+                if (_readerThread == 0
+                    || Completion.IsCompleted
+                    || CancelSynchronousIo(_readerThread))
+                {
+                    return;
+                }
+
+                var error = Marshal.GetLastWin32Error();
+                if (error != ErrorNotFound && !Completion.IsCompleted)
+                {
+                    Trace.WriteLine(
+                        $"MxcExecutor: redirected output cancellation failed ({error}).");
+                }
+            }
+        }
+
+        private void Capture()
+        {
+            try
+            {
+                var readerThread = OpenThread(
+                    ThreadTerminate,
+                    bInheritHandle: false,
+                    GetCurrentThreadId());
+                if (readerThread == 0)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+
+                lock (_readerThreadLock)
+                {
+                    _readerThread = readerThread;
+                    _readerThreadStarted.TrySetResult();
+                }
+                CaptureCore();
+            }
+            catch (ObjectDisposedException) when (Volatile.Read(ref _closing) != 0)
+            {
+            }
+            catch (IOException) when (Volatile.Read(ref _closing) != 0)
+            {
+            }
+            catch (OperationCanceledException) when (Volatile.Read(ref _closing) != 0)
+            {
+            }
+            catch (Exception ex)
+            {
+                _readerThreadStarted.TrySetException(ex);
+                throw;
+            }
+            finally
+            {
+                _stream.Dispose();
+                lock (_readerThreadLock)
+                {
+                    if (_readerThread != 0)
+                    {
+                        _ = CloseHandle(_readerThread);
+                        _readerThread = 0;
+                    }
+                }
+            }
+        }
+
+        private void CaptureCore()
+        {
+            Decoder? decoder = null;
+            using var undecodedPrefix = new MemoryStream();
+            var byteBuffer = new byte[4_096];
+            var charBuffer = new char[GetMaxCharCount(byteBuffer.Length + 4)];
+            try
+            {
+                while (true)
+                {
+                    var byteCount = _stream.Read(byteBuffer, 0, byteBuffer.Length);
+                    if (byteCount == 0)
+                        break;
+
+                    if (decoder is null)
+                    {
+                        undecodedPrefix.Write(byteBuffer, 0, byteCount);
+                        var prefix = undecodedPrefix.GetBuffer()
+                            .AsSpan(0, checked((int)undecodedPrefix.Length));
+                        if (!TrySelectEncoding(prefix, final: false, out var encoding, out var preambleLength))
+                            continue;
+
+                        decoder = encoding.GetDecoder();
+                        AppendDecoded(
+                            decoder,
+                            prefix[preambleLength..],
+                            charBuffer,
+                            flush: false);
+                        undecodedPrefix.SetLength(0);
+                    }
+                    else
+                    {
+                        AppendDecoded(
+                            decoder,
+                            byteBuffer.AsSpan(0, byteCount),
+                            charBuffer,
+                            flush: false);
+                    }
+                }
+            }
+            catch (ObjectDisposedException) when (Volatile.Read(ref _closing) != 0)
+            {
+            }
+            catch (IOException) when (Volatile.Read(ref _closing) != 0)
+            {
+            }
+            catch (OperationCanceledException) when (Volatile.Read(ref _closing) != 0)
+            {
+            }
+
+            if (decoder is null)
+            {
+                var prefix = undecodedPrefix.GetBuffer()
+                    .AsSpan(0, checked((int)undecodedPrefix.Length));
+                _ = TrySelectEncoding(
+                    prefix,
+                    final: true,
+                    out var encoding,
+                    out var preambleLength);
+                decoder = encoding.GetDecoder();
+                AppendDecoded(
+                    decoder,
+                    prefix[preambleLength..],
+                    charBuffer,
+                    flush: true);
+            }
+            else
+            {
+                AppendDecoded(
+                    decoder,
+                    ReadOnlySpan<byte>.Empty,
+                    charBuffer,
+                    flush: true);
+            }
+        }
+
+        private int GetMaxCharCount(int byteCount) =>
+            new[]
+            {
+                _configuredEncoding.GetMaxCharCount(byteCount),
+                Encoding.UTF8.GetMaxCharCount(byteCount),
+                Encoding.Unicode.GetMaxCharCount(byteCount),
+                Encoding.BigEndianUnicode.GetMaxCharCount(byteCount),
+                Encoding.UTF32.GetMaxCharCount(byteCount),
+            }.Max();
+
+        private bool TrySelectEncoding(
+            ReadOnlySpan<byte> bytes,
+            bool final,
+            out Encoding encoding,
+            out int preambleLength)
+        {
+            if (bytes.StartsWith(new byte[] { 0xFF, 0xFE, 0x00, 0x00 }))
+            {
+                encoding = new UTF32Encoding(bigEndian: false, byteOrderMark: true);
+                preambleLength = 4;
+                return true;
+            }
+
+            if (bytes.StartsWith(new byte[] { 0x00, 0x00, 0xFE, 0xFF }))
+            {
+                encoding = new UTF32Encoding(bigEndian: true, byteOrderMark: true);
+                preambleLength = 4;
+                return true;
+            }
+
+            if (bytes.StartsWith(new byte[] { 0xEF, 0xBB, 0xBF }))
+            {
+                encoding = Encoding.UTF8;
+                preambleLength = 3;
+                return true;
+            }
+
+            if (bytes.StartsWith(new byte[] { 0xFF, 0xFE })
+                && (final || bytes.Length >= 4 || (bytes.Length >= 3 && bytes[2] != 0)))
+            {
+                encoding = Encoding.Unicode;
+                preambleLength = 2;
+                return true;
+            }
+
+            if (bytes.StartsWith(new byte[] { 0xFE, 0xFF }))
+            {
+                encoding = Encoding.BigEndianUnicode;
+                preambleLength = 2;
+                return true;
+            }
+
+            if (!final && IsPossiblePreamblePrefix(bytes))
+            {
+                encoding = null!;
+                preambleLength = 0;
+                return false;
+            }
+
+            encoding = _configuredEncoding;
+            preambleLength = 0;
+            return true;
+        }
+
+        private static bool IsPossiblePreamblePrefix(ReadOnlySpan<byte> bytes) =>
+            IsPrefix(bytes, new byte[] { 0xFF, 0xFE, 0x00, 0x00 })
+            || IsPrefix(bytes, new byte[] { 0x00, 0x00, 0xFE, 0xFF })
+            || IsPrefix(bytes, new byte[] { 0xEF, 0xBB, 0xBF })
+            || IsPrefix(bytes, new byte[] { 0xFE, 0xFF });
+
+        private static bool IsPrefix(ReadOnlySpan<byte> value, ReadOnlySpan<byte> candidate) =>
+            value.Length < candidate.Length && candidate[..value.Length].SequenceEqual(value);
+
+        private void AppendDecoded(
+            Decoder decoder,
+            ReadOnlySpan<byte> bytes,
+            char[] charBuffer,
+            bool flush)
+        {
+            var charCount = decoder.GetChars(bytes, charBuffer, flush);
+            Append(charBuffer, charCount);
+        }
+
+        private void Append(char[] buffer, int count)
+        {
+            if (count == 0)
+                return;
+
+            lock (_lock)
+            {
+                var remaining = _maxChars - _output.Length;
+                if (remaining > 0)
+                    _output.Append(buffer, 0, Math.Min(count, remaining));
+            }
+        }
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern nint OpenThread(
+            uint dwDesiredAccess,
+            [MarshalAs(UnmanagedType.Bool)] bool bInheritHandle,
+            uint dwThreadId);
+
+        [DllImport("kernel32.dll")]
+        private static extern uint GetCurrentThreadId();
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool CancelSynchronousIo(nint hThread);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool CloseHandle(nint hObject);
     }
 }

--- a/tests/OpenClaw.Shared.TestHost/Program.cs
+++ b/tests/OpenClaw.Shared.TestHost/Program.cs
@@ -1,6 +1,7 @@
 using OpenClaw.Shared;
 using System.Diagnostics;
 using System.Reflection;
+using System.Text;
 using System.Text.Json;
 
 if (args is ["--echo-args", .. var echoedArgs])
@@ -69,6 +70,32 @@ static async Task<int> RunProcessFixtureAsync(string[] args)
         return 0;
     }
 
+    if (args is ["bom-output"])
+    {
+        await WriteEncodedAsync(Console.OpenStandardOutput(), Encoding.Unicode, "wide-stdout");
+        await WriteEncodedAsync(Console.OpenStandardError(), Encoding.BigEndianUnicode, "wide-stderr");
+        return 0;
+    }
+
+    if (args is ["fragmented-bom-output"])
+    {
+        var stdout = Console.OpenStandardOutput();
+        await stdout.WriteAsync(new byte[] { 0xFF, 0xFE, 0x00 });
+        await stdout.FlushAsync();
+        await Task.Delay(25);
+        await stdout.WriteAsync(new byte[] { 0x00 });
+        await stdout.WriteAsync(new UTF32Encoding(false, false).GetBytes("utf32-stdout"));
+        await stdout.FlushAsync();
+
+        var stderr = Console.OpenStandardError();
+        await stderr.WriteAsync(new byte[] { 0x00, 0x00, 0xFE });
+        await stderr.FlushAsync();
+        await Task.Delay(25);
+        await stderr.WriteAsync(Encoding.ASCII.GetBytes(new string('x', 4_096)));
+        await stderr.FlushAsync();
+        return 0;
+    }
+
     if (args is ["hold", var holdText] && int.TryParse(holdText, out var holdMs))
     {
         Console.Out.Write("holding-stdout");
@@ -89,8 +116,46 @@ static async Task<int> RunProcessFixtureAsync(string[] args)
         return 0;
     }
 
+    if (args is ["inherit-handles-identity", var identityChildHoldText, var identityPidFile]
+        && int.TryParse(identityChildHoldText, out var identityChildHoldMs))
+    {
+        using var child = StartSelf("--process-fixture", "hold", identityChildHoldMs.ToString());
+        WriteProcessIdentity(identityPidFile, child);
+        Console.Out.Write("parent-stdout");
+        Console.Error.Write("parent-stderr");
+        return 0;
+    }
+
+    if (args is ["inherit-handles-sized", var sizedChildHoldText, var sizedPidFile, var outputLengthText]
+        && int.TryParse(sizedChildHoldText, out var sizedChildHoldMs)
+        && int.TryParse(outputLengthText, out var outputLength))
+    {
+        using var child = StartSelf("--process-fixture", "hold", sizedChildHoldMs.ToString());
+        WriteProcessIdentity(sizedPidFile, child);
+        Console.Out.Write(new string('o', outputLength));
+        Console.Error.Write(new string('e', outputLength));
+        Console.Out.Flush();
+        Console.Error.Flush();
+        return 0;
+    }
+
     Console.Error.WriteLine("Unknown process fixture.");
     return 64;
+}
+
+static async Task WriteEncodedAsync(Stream stream, Encoding encoding, string value)
+{
+    await stream.WriteAsync(encoding.GetPreamble());
+    await stream.WriteAsync(encoding.GetBytes(value));
+    await stream.FlushAsync();
+}
+
+static void WriteProcessIdentity(string path, Process process)
+{
+    var identity = $"{process.Id}|{process.StartTime.ToUniversalTime().Ticks}\n";
+    var temporaryPath = path + ".tmp";
+    File.WriteAllText(temporaryPath, identity);
+    File.Move(temporaryPath, path, overwrite: true);
 }
 
 static Process StartSelf(params string[] arguments)

--- a/tests/OpenClaw.Shared.TestHost/Program.cs
+++ b/tests/OpenClaw.Shared.TestHost/Program.cs
@@ -106,6 +106,13 @@ static async Task<int> RunProcessFixtureAsync(string[] args)
         return 0;
     }
 
+    if (args is ["hold-silent", var silentHoldText]
+        && int.TryParse(silentHoldText, out var silentHoldMs))
+    {
+        await Task.Delay(silentHoldMs);
+        return 0;
+    }
+
     if (args is ["inherit-handles", var childHoldText, var pidFile]
         && int.TryParse(childHoldText, out var childHoldMs))
     {
@@ -130,7 +137,7 @@ static async Task<int> RunProcessFixtureAsync(string[] args)
         && int.TryParse(sizedChildHoldText, out var sizedChildHoldMs)
         && int.TryParse(outputLengthText, out var outputLength))
     {
-        using var child = StartSelf("--process-fixture", "hold", sizedChildHoldMs.ToString());
+        using var child = StartSelf("--process-fixture", "hold-silent", sizedChildHoldMs.ToString());
         WriteProcessIdentity(sizedPidFile, child);
         Console.Out.Write(new string('o', outputLength));
         Console.Error.Write(new string('e', outputLength));

--- a/tests/OpenClaw.Shared.Tests/Mxc/MxcExecutorTests.cs
+++ b/tests/OpenClaw.Shared.Tests/Mxc/MxcExecutorTests.cs
@@ -1,6 +1,8 @@
 using System.Diagnostics;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using OpenClaw.Shared.Mxc;
+using OpenClaw.TestSupport;
 using Xunit;
 
 namespace OpenClaw.Shared.Tests.Mxc;
@@ -37,6 +39,58 @@ public class MxcExecutorTests
         Assert.Equal(0, result.ExitCode);
         Assert.Contains("stdout-line", result.Output);
         Assert.Contains("stderr-line", result.Error);
+    }
+
+    [Fact]
+    public async Task RunAsync_DetectsRedirectedOutputByteOrderMarks()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return;
+
+        var testHostPath = FindTestHost();
+        var executor = new MxcExecutor(
+            testHostPath,
+            stdoutCapBytes: null,
+            stderrCapBytes: null,
+            processFactory: _ => CreateFixtureProcess(testHostPath, "bom-output"),
+            processTreeKiller: process => process.Kill(entireProcessTree: true),
+            cleanupTimeout: TimeSpan.FromSeconds(1));
+
+        var result = await executor.RunAsync(new MxcConfig
+        {
+            ContainerId = "bom-output-test",
+            Process = new MxcProcess { CommandLine = "ignored-by-test-process" },
+        });
+
+        Assert.True(result.Success);
+        Assert.Equal("wide-stdout", result.Output);
+        Assert.Equal("wide-stderr", result.Error);
+    }
+
+    [Fact]
+    public async Task RunAsync_DecodesFragmentedPreamblesWithoutOverflow()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return;
+
+        var testHostPath = FindTestHost();
+        var executor = new MxcExecutor(
+            testHostPath,
+            stdoutCapBytes: null,
+            stderrCapBytes: null,
+            processFactory: _ => CreateFixtureProcess(testHostPath, "fragmented-bom-output"),
+            processTreeKiller: process => process.Kill(entireProcessTree: true),
+            cleanupTimeout: TimeSpan.FromSeconds(1));
+
+        var result = await executor.RunAsync(new MxcConfig
+        {
+            ContainerId = "fragmented-bom-output-test",
+            Process = new MxcProcess { CommandLine = "ignored-by-test-process" },
+        });
+
+        Assert.True(result.Success);
+        Assert.Equal("utf32-stdout", result.Output);
+        Assert.EndsWith(new string('x', 4_096), result.Error, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -83,7 +137,7 @@ public class MxcExecutorTests
             stopwatch.Stop();
 
             Assert.True(killAttempted);
-            Assert.True(result.TimedOut);
+            Assert.True(result.TimedOut, result.Error);
             Assert.Equal(-1, result.ExitCode);
             Assert.Contains("cancelled", result.Error, StringComparison.OrdinalIgnoreCase);
             Assert.True(
@@ -93,6 +147,322 @@ public class MxcExecutorTests
         finally
         {
             KillProcessTree(launcherPid);
+        }
+    }
+
+    [Fact]
+    public async Task RunAsync_CancellationCleanupIsBounded_WhenProcessTreeKillBlocks()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return;
+
+        var launcherPid = 0;
+        Process? launcher = null;
+        using var killRelease = new ManualResetEventSlim(false);
+        var killStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var killFinished = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var killProcessUseError = new TaskCompletionSource<Exception?>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        Action<Process> blockingKiller = _ =>
+        {
+            killStarted.TrySetResult();
+            killRelease.Wait();
+        };
+        var cmdPath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.System),
+            "cmd.exe");
+        var executor = new MxcExecutor(
+            cmdPath,
+            stdoutCapBytes: null,
+            stderrCapBytes: null,
+            processFactory: _ => launcher = CreateProcess(
+                cmdPath,
+                "echo launcher-started & ping -n 31 127.0.0.1 >nul"),
+            processTreeKiller: process =>
+            {
+                blockingKiller(process);
+                try
+                {
+                    _ = process.Id;
+                    killProcessUseError.TrySetResult(null);
+                }
+                catch (Exception ex)
+                {
+                    killProcessUseError.TrySetResult(ex);
+                }
+                killFinished.TrySetResult();
+            },
+            cleanupTimeout: TimeSpan.FromMilliseconds(100));
+        using var cancellation = new CancellationTokenSource();
+
+        try
+        {
+            var run = executor.RunAsync(
+                new MxcConfig
+                {
+                    ContainerId = "bounded-kill-test",
+                    Process = new MxcProcess { CommandLine = "ignored-by-test-process" },
+                },
+                cancellation.Token);
+            await WaitForProcessStartAsync(() => launcher, TimeSpan.FromSeconds(5));
+            launcherPid = launcher!.Id;
+            var stopwatch = Stopwatch.StartNew();
+            cancellation.Cancel();
+            await killStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            var result = await run.WaitAsync(TimeSpan.FromSeconds(5));
+            stopwatch.Stop();
+
+            Assert.True(result.TimedOut, result.Error);
+            Assert.Equal(-1, result.ExitCode);
+            Assert.Contains("cancelled", result.Error, StringComparison.OrdinalIgnoreCase);
+            Assert.True(
+                stopwatch.Elapsed < TimeSpan.FromSeconds(2),
+                $"Post-cancel cleanup took {stopwatch.ElapsedMilliseconds} ms.");
+        }
+        finally
+        {
+            killRelease.Set();
+            await killFinished.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.Null(await killProcessUseError.Task.WaitAsync(TimeSpan.FromSeconds(5)));
+            KillProcessTree(launcherPid);
+        }
+    }
+
+    [Fact]
+    public async Task KillProcessTreeWithTimeoutAsync_RepeatedBlockedKillsDoNotExceedProcessWideWorkerLimit()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return;
+
+        var killStartedCount = 0;
+        using var killRelease = new ManualResetEventSlim(false);
+        using var killStarted = new CountdownEvent(MxcExecutor.ProcessTreeKillWorkerLimit);
+        using var killFinished = new CountdownEvent(MxcExecutor.ProcessTreeKillWorkerLimit);
+        var cmdPath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.System),
+            "cmd.exe");
+        var attemptCount = MxcExecutor.ProcessTreeKillWorkerLimit + 2;
+        var workersFinished = false;
+        using var process = Process.GetCurrentProcess();
+
+        try
+        {
+            var killAttempts = Enumerable.Range(0, attemptCount).Select(_ =>
+            {
+                var executor = new MxcExecutor(
+                    cmdPath,
+                    stdoutCapBytes: null,
+                    stderrCapBytes: null,
+                    processFactory: _ => throw new InvalidOperationException("Not used by this test."),
+                    processTreeKiller: _ =>
+                    {
+                        Interlocked.Increment(ref killStartedCount);
+                        killStarted.Signal();
+                        try
+                        {
+                            killRelease.Wait();
+                        }
+                        finally
+                        {
+                            killFinished.Signal();
+                        }
+                    },
+                    cleanupTimeout: TimeSpan.FromMilliseconds(100));
+                return executor.KillProcessTreeWithTimeoutAsync(process);
+            }).ToArray();
+
+            var results = await Task.WhenAll(killAttempts).WaitAsync(TimeSpan.FromSeconds(5));
+            var workersStarted = killStarted.Wait(TimeSpan.FromSeconds(5));
+
+            Assert.All(results, Assert.False);
+            Assert.True(workersStarted, "Blocked kill workers did not all start within the test bound.");
+            Assert.Equal(
+                MxcExecutor.ProcessTreeKillWorkerLimit,
+                Volatile.Read(ref killStartedCount));
+        }
+        finally
+        {
+            killRelease.Set();
+            workersFinished = killFinished.Wait(TimeSpan.FromSeconds(5));
+        }
+
+        Assert.True(workersFinished, "Blocked kill workers did not exit after the test released them.");
+
+        var recoveredKillStarted = false;
+        var recoveredExecutor = new MxcExecutor(
+            cmdPath,
+            stdoutCapBytes: null,
+            stderrCapBytes: null,
+            processFactory: _ => throw new InvalidOperationException("Not used by this test."),
+            processTreeKiller: _ => recoveredKillStarted = true,
+            cleanupTimeout: TimeSpan.FromMilliseconds(100));
+        var recovered = false;
+        for (var attempt = 0; attempt < 50 && !recovered; attempt++)
+        {
+            recovered = await recoveredExecutor.KillProcessTreeWithTimeoutAsync(process);
+            if (!recovered)
+                await Task.Delay(10);
+        }
+
+        Assert.True(recovered, "Process-wide kill worker capacity did not recover.");
+        Assert.True(recoveredKillStarted);
+    }
+
+    [Fact]
+    public async Task KillProcessTreeWithTimeoutAsync_WaitsForTransientWorkerCapacityWithinCleanupBudget()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return;
+
+        using var process = Process.GetCurrentProcess();
+        using var killRelease = new SemaphoreSlim(0, MxcExecutor.ProcessTreeKillWorkerLimit);
+        using var killStarted = new CountdownEvent(MxcExecutor.ProcessTreeKillWorkerLimit);
+        var cmdPath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.System),
+            "cmd.exe");
+        var blockingAttempts = Array.Empty<Task<bool>>();
+
+        try
+        {
+            blockingAttempts = Enumerable.Range(0, MxcExecutor.ProcessTreeKillWorkerLimit)
+                .Select(_ =>
+                {
+                    var executor = new MxcExecutor(
+                        cmdPath,
+                        stdoutCapBytes: null,
+                        stderrCapBytes: null,
+                        processFactory: _ => throw new InvalidOperationException("Not used by this test."),
+                        processTreeKiller: _ =>
+                        {
+                            killStarted.Signal();
+                            killRelease.Wait();
+                        },
+                        cleanupTimeout: TimeSpan.FromSeconds(5));
+                    return executor.KillProcessTreeWithTimeoutAsync(process);
+                })
+                .ToArray();
+            Assert.True(
+                killStarted.Wait(TimeSpan.FromSeconds(5)),
+                "Initial kill workers did not occupy the process-wide limit.");
+
+            var queuedKillStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var queuedExecutor = new MxcExecutor(
+                cmdPath,
+                stdoutCapBytes: null,
+                stderrCapBytes: null,
+                processFactory: _ => throw new InvalidOperationException("Not used by this test."),
+                processTreeKiller: _ => queuedKillStarted.TrySetResult(),
+                cleanupTimeout: TimeSpan.FromSeconds(2));
+            var queuedAttempt = queuedExecutor.KillProcessTreeWithTimeoutAsync(process);
+
+            await Task.Delay(100);
+            Assert.False(queuedKillStarted.Task.IsCompleted);
+            killRelease.Release();
+
+            Assert.True(await queuedAttempt.WaitAsync(TimeSpan.FromSeconds(5)));
+            await queuedKillStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        finally
+        {
+            killRelease.Release(MxcExecutor.ProcessTreeKillWorkerLimit);
+            try { await Task.WhenAll(blockingAttempts).WaitAsync(TimeSpan.FromSeconds(5)); }
+            catch { }
+        }
+    }
+
+    [Fact]
+    public async Task RunAsync_OutputDrainIsBoundedAndPreservesFinalFragments_WhenDescendantRetainsHandles()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return;
+
+        using var temp = new TempDirectory("mxc-drain-test-");
+        var descendantPidPath = temp.Combine("descendant.pid");
+        var testHostPath = FindTestHost();
+        var executor = new MxcExecutor(
+            testHostPath,
+            stdoutCapBytes: null,
+            stderrCapBytes: null,
+            processFactory: _ => CreateFixtureProcess(
+                testHostPath,
+                "inherit-handles-identity",
+                "30000",
+                descendantPidPath),
+            processTreeKiller: process => process.Kill(entireProcessTree: true),
+            cleanupTimeout: TimeSpan.FromMilliseconds(100));
+        var run = executor.RunAsync(new MxcConfig
+        {
+            ContainerId = "bounded-output-drain-test",
+            Process = new MxcProcess { CommandLine = "ignored-by-test-process" },
+        });
+        ChildProcessIdentity? descendant = null;
+        try
+        {
+            descendant = await ReadChildIdentityAsync(descendantPidPath, TimeSpan.FromSeconds(5));
+            var stopwatch = Stopwatch.StartNew();
+            var result = await run.WaitAsync(TimeSpan.FromSeconds(2));
+            stopwatch.Stop();
+
+            Assert.True(result.Success, result.Error);
+            Assert.False(result.TimedOut);
+            Assert.Equal(0, result.ExitCode);
+            Assert.Contains("parent-stdout", result.Output);
+            Assert.Contains("parent-stderr", result.Error);
+            Assert.True(
+                stopwatch.Elapsed < TimeSpan.FromSeconds(1),
+                $"Post-exit output drain took {stopwatch.ElapsedMilliseconds} ms.");
+        }
+        finally
+        {
+            KillProcessTree(descendant);
+            try { await run.WaitAsync(TimeSpan.FromSeconds(5)); }
+            catch { }
+        }
+    }
+
+    [Fact]
+    public async Task RunAsync_OutputDrainPreservesExactPipeBufferFragments_WhenDescendantRetainsHandles()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return;
+
+        const int outputLength = 4_096;
+        using var temp = new TempDirectory("mxc-drain-buffer-test-");
+        var descendantPidPath = temp.Combine("descendant.pid");
+        var testHostPath = FindTestHost();
+        var executor = new MxcExecutor(
+            testHostPath,
+            stdoutCapBytes: outputLength + 1,
+            stderrCapBytes: outputLength + 1,
+            processFactory: _ => CreateFixtureProcess(
+                testHostPath,
+                "inherit-handles-sized",
+                "30000",
+                descendantPidPath,
+                outputLength.ToString()),
+            processTreeKiller: process => process.Kill(entireProcessTree: true),
+            cleanupTimeout: TimeSpan.FromMilliseconds(100));
+        var run = executor.RunAsync(new MxcConfig
+        {
+            ContainerId = "bounded-output-buffer-drain-test",
+            Process = new MxcProcess { CommandLine = "ignored-by-test-process" },
+        });
+        ChildProcessIdentity? descendant = null;
+
+        try
+        {
+            descendant = await ReadChildIdentityAsync(descendantPidPath, TimeSpan.FromSeconds(5));
+            var result = await run.WaitAsync(TimeSpan.FromSeconds(2));
+
+            Assert.True(result.Success, result.Error);
+            Assert.Equal(new string('o', outputLength), result.Output);
+            Assert.Equal(new string('e', outputLength), result.Error);
+        }
+        finally
+        {
+            KillProcessTree(descendant);
+            try { await run.WaitAsync(TimeSpan.FromSeconds(5)); }
+            catch { }
         }
     }
 
@@ -133,6 +503,36 @@ public class MxcExecutorTests
         throw new TimeoutException("Test launcher did not start within the expected time.");
     }
 
+    private static async Task<ChildProcessIdentity> ReadChildIdentityAsync(
+        string path,
+        TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            try
+            {
+                var text = await File.ReadAllTextAsync(path);
+                var parts = text.TrimEnd('\r', '\n').Split('|');
+                if (text.EndsWith('\n')
+                    && parts.Length == 2
+                    && int.TryParse(parts[0], out var processId)
+                    && long.TryParse(parts[1], out var startTimeUtcTicks))
+                {
+                    return new ChildProcessIdentity(processId, startTimeUtcTicks);
+                }
+            }
+            catch (IOException)
+            {
+                // The fixture may still be publishing the PID.
+            }
+
+            await Task.Delay(10);
+        }
+
+        throw new TimeoutException("Test descendant did not report its process ID within the expected time.");
+    }
+
     private static Process CreateProcess(string cmdPath, string command)
     {
         var startInfo = new ProcessStartInfo(cmdPath)
@@ -147,6 +547,50 @@ public class MxcExecutorTests
         startInfo.ArgumentList.Add("/c");
         startInfo.ArgumentList.Add(command);
         return new Process { StartInfo = startInfo };
+    }
+
+    private static Process CreateFixtureProcess(string testHostPath, params string[] arguments)
+    {
+        var startInfo = new ProcessStartInfo(testHostPath)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        startInfo.ArgumentList.Add("--process-fixture");
+        foreach (var argument in arguments)
+            startInfo.ArgumentList.Add(argument);
+        return new Process { StartInfo = startInfo };
+    }
+
+    private static string FindTestHost()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null
+            && !File.Exists(Path.Combine(current.FullName, "openclaw-windows-node.slnx")))
+        {
+            current = current.Parent;
+        }
+
+        Assert.NotNull(current);
+        var configuration = Assembly.GetExecutingAssembly()
+            .GetCustomAttribute<AssemblyConfigurationAttribute>()?
+            .Configuration;
+        Assert.False(string.IsNullOrWhiteSpace(configuration));
+        var executableName = OperatingSystem.IsWindows()
+            ? "OpenClaw.Shared.TestHost.exe"
+            : "OpenClaw.Shared.TestHost";
+        var hostPath = Path.Combine(
+            current.FullName,
+            "tests",
+            "OpenClaw.Shared.TestHost",
+            "bin",
+            configuration,
+            "net10.0",
+            executableName);
+        Assert.True(File.Exists(hostPath), $"Process test host was not built: {hostPath}");
+        return hostPath;
     }
 
     private static void KillProcessTree(int processId)
@@ -169,4 +613,30 @@ public class MxcExecutorTests
             // The process already exited.
         }
     }
+
+    private static void KillProcessTree(ChildProcessIdentity? identity)
+    {
+        if (identity is null)
+            return;
+
+        try
+        {
+            using var process = Process.GetProcessById(identity.Value.ProcessId);
+            if (process.StartTime.ToUniversalTime().Ticks != identity.Value.StartTimeUtcTicks)
+                return;
+
+            process.Kill(entireProcessTree: true);
+            process.WaitForExit(2_000);
+        }
+        catch (ArgumentException)
+        {
+        }
+        catch (InvalidOperationException)
+        {
+        }
+    }
+
+    private readonly record struct ChildProcessIdentity(
+        int ProcessId,
+        long StartTimeUtcTicks);
 }


### PR DESCRIPTION
Supersedes #1166 (fix(mxc): bound termination and output drain cleanup) with a current-main replacement based on `4064eb9c`. Current head: `fc54e2ee`.

This keeps MXC cleanup bounded without reusing SetupEngine ownership blindly. It caps blocked process-tree termination workers, preserves the original handle-backed `Process` until a kill worker releases it, bounds post-exit pipe drain, and captures raw redirected bytes so newline-free, exact-buffer, configured-encoding, and fragmented-BOM final output is retained. Dedicated reader threads use bounded repeated `CancelSynchronousIo` cancellation for the synchronous anonymous pipes created by `System.Diagnostics.Process`, closing the inherited-handle race without allowing the invocation to hang.

The exact-buffer regression uses a silent inherited-handle child, so the expected 4,096-byte parent output cannot be polluted by scheduler-dependent descendant writes.

## Required proof pools

- `windows-wsl-mxc`

## Validation

Current head `fc54e2ee`:

- `./build.ps1`: passed
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore`: 3,998 passed, 32 skipped, 0 failed
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore`: 2,865 passed, 0 skipped, 0 failed
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore --filter 'FullyQualifiedName~Mxc'`: 225 passed, 7 environment-gated skips, 0 failed
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore --filter 'FullyQualifiedName~MxcExecutorTests'`: 10 passed, 0 failed
- Focused exact-buffer output regression: passed individually and in the complete executor suite after the silent-child fixture fix
- Codex autoreview of the production change: clean, no accepted/actionable findings
- Rubber-duck review of the production change: clean, no actionable in-scope defects
- Codex autoreview of `fc54e2ee`: clean, no accepted/actionable findings
- Rubber-duck review of `fc54e2ee`: clean, no actionable findings

## Real behavior proof

**Not verified / blocked. Do not merge.**

`./scripts/validate-mxc-e2e.ps1` was run without `-AllowSkip`. Repository build succeeds, but fresh Ubuntu 24.04 WSL setup fails before any Gateway-to-Windows-node MXC behavior executes:

```text
Failed to attach disk '%LOCALAPPDATA%\Temp\<id>\swap.vhdx' to WSL2: Access is denied.
Error code: Wsl/InstallDistro/Service/RegisterDistro/CreateVm/MountDisk/E_ACCESSDENIED
```

No Crabbox validation was used. This PR must remain draft and blocked until the non-skipping `windows-wsl-mxc` proof passes on a capable host.