### PR TITLE
feat(local-ai): add verified legacy model cache migration

### DIFF
--- a/src/OpenClaw.Connection/LocalAi/LocalAiManifest.cs
+++ b/src/OpenClaw.Connection/LocalAi/LocalAiManifest.cs
@@ -14,9 +14,11 @@
 //   string contained = paths.ResolveContainedPath("models/model.gguf", "modelPath"); // traversal-safe
 // </summary>
 using System.Collections.Immutable;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using OpenClaw.Shared.Inference.Catalog;
+using OpenClaw.Shared.IO;
 
 namespace OpenClaw.Connection.LocalAi;
 
@@ -136,6 +138,7 @@ public sealed record LocalAiAssetReceipt
 public sealed record LocalAiInstallManifest
 {
     public const int CurrentSchemaVersion = 3;
+    public const int HubCacheReceiptSchemaVersion = 4;
     public const string SupportedEngine = "llama-server";
 
     public int SchemaVersion { get; init; } = CurrentSchemaVersion;
@@ -154,6 +157,20 @@ public sealed record LocalAiInstallManifest
     public required string ExecutablePath { get; init; }
     public required ImmutableArray<LocalAiAssetReceipt> RuntimeAssets { get; init; }
     public required string ModelPath { get; init; }
+    /// <summary>
+    /// Schema-4 migration receipt for the standard Hugging Face hub cache root.
+    /// The legacy <see cref="ModelPath"/> remains authoritative until the model
+    /// acquisition layer switches normal installs and reconciliation to the cache.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ModelCacheRoot { get; init; }
+    /// <summary>
+    /// Schema-4 migration receipt for the verified snapshot copy. Layer 3 may
+    /// promote this path to the active model path after its installer and rollback
+    /// behavior are cache-aware.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? CachedModelPath { get; init; }
     public required string ModelId { get; init; }
     public required string ModelAlias { get; init; }
     public required LocalAiAssetReceipt ModelAsset { get; init; }
@@ -186,6 +203,18 @@ public sealed record LocalAiResolvedInstall(
     string ExecutablePath,
     string ModelPath,
     Uri? Endpoint);
+
+public enum LocalAiModelMigrationPhase
+{
+    VerifyingLegacyModel,
+    CopyingToCache,
+    VerifyingCacheCopy,
+}
+
+public sealed record LocalAiModelMigrationProgress(
+    LocalAiModelMigrationPhase Phase,
+    long CompletedBytes,
+    long TotalBytes);
 
 /// <summary>Shared validation for setup, manifests, and runtime launch.</summary>
 public static class LocalAiPortPolicy
@@ -247,15 +276,97 @@ public sealed class LocalAiManifestStore
     }
 
     private readonly LocalAiPaths _paths;
+    private readonly Func<string> _cacheRootResolver;
+    private readonly Func<CancellationToken, Task> _beforeMigrationCommit;
+    private readonly Func<string, CancellationToken, Task> _beforeMigrationPromotion;
 
     public LocalAiManifestStore(LocalAiPaths paths) =>
-        _paths = paths ?? throw new ArgumentNullException(nameof(paths));
+        (_paths, _cacheRootResolver, _beforeMigrationCommit, _beforeMigrationPromotion) = (
+            paths ?? throw new ArgumentNullException(nameof(paths)),
+            HuggingFaceHubCache.ResolveCacheRoot,
+            static _ => Task.CompletedTask,
+            static (_, _) => Task.CompletedTask);
+
+    internal LocalAiManifestStore(
+        LocalAiPaths paths,
+        Func<string> cacheRootResolver,
+        Func<CancellationToken, Task>? beforeMigrationCommit = null,
+        Func<string, CancellationToken, Task>? beforeMigrationPromotion = null) =>
+        (_paths, _cacheRootResolver, _beforeMigrationCommit, _beforeMigrationPromotion) = (
+            paths ?? throw new ArgumentNullException(nameof(paths)),
+            cacheRootResolver ?? throw new ArgumentNullException(nameof(cacheRootResolver)),
+            beforeMigrationCommit ?? (static _ => Task.CompletedTask),
+            beforeMigrationPromotion ?? (static (_, _) => Task.CompletedTask));
 
     public async Task<LocalAiResolvedInstall?> LoadAsync(CancellationToken cancellationToken = default)
     {
         if (!File.Exists(_paths.ManifestPath))
             return null;
 
+        LocalAiInstallManifest manifest = await ReadManifestAsync(cancellationToken).ConfigureAwait(false);
+        return ResolveAndValidate(manifest);
+    }
+
+    /// <summary>
+    /// Copies a canonical schema-3 model into the standard Hugging Face cache and
+    /// records a transitional schema-4 receipt. The active legacy model path is
+    /// intentionally unchanged until the installer and reconciler become cache-aware.
+    /// </summary>
+    public async Task<LocalAiResolvedInstall?> MigrateLegacyModelToHubCacheAsync(
+        IProgress<LocalAiModelMigrationProgress>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (!File.Exists(_paths.ManifestPath))
+            return null;
+
+        byte[] originalManifest = await File
+            .ReadAllBytesAsync(_paths.ManifestPath, cancellationToken)
+            .ConfigureAwait(false);
+        LocalAiInstallManifest manifest = DeserializeManifest(originalManifest);
+        LocalAiResolvedInstall resolved = ResolveAndValidate(manifest);
+        if (manifest.SchemaVersion != LocalAiInstallManifest.CurrentSchemaVersion)
+            return resolved;
+
+        LocalAiInstallManifest migrated = await LocalAiManifestMigration
+            .MigrateAsync(
+                _paths,
+                resolved,
+                _cacheRootResolver(),
+                progress,
+                _beforeMigrationPromotion,
+                cancellationToken)
+            .ConfigureAwait(false);
+        if (ReferenceEquals(migrated, manifest))
+            return resolved;
+
+        await _beforeMigrationCommit(cancellationToken).ConfigureAwait(false);
+        await using FileStream writeLock = await AcquireManifestWriteLockAsync(cancellationToken)
+            .ConfigureAwait(false);
+        byte[] currentManifest;
+        try
+        {
+            currentManifest = await File
+                .ReadAllBytesAsync(_paths.ManifestPath, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (FileNotFoundException)
+        {
+            throw new InvalidDataException(
+                "The local AI installation manifest changed while its cache migration was in progress.");
+        }
+        if (!originalManifest.AsSpan().SequenceEqual(currentManifest))
+        {
+            throw new InvalidDataException(
+                "The local AI installation manifest changed while its cache migration was in progress.");
+        }
+
+        await SaveWithoutLockAsync(migrated, cancellationToken).ConfigureAwait(false);
+        return ResolveAndValidate(migrated);
+    }
+
+    private async Task<LocalAiInstallManifest> ReadManifestAsync(
+        CancellationToken cancellationToken)
+    {
         LocalAiInstallManifest? manifest;
         try
         {
@@ -277,14 +388,44 @@ public sealed class LocalAiManifestStore
             throw new InvalidDataException("The local AI installation manifest is invalid JSON or uses an unsupported format.", ex);
         }
 
-        return ResolveAndValidate(
-            manifest ?? throw new InvalidDataException("The local AI installation manifest is empty."));
+        if (manifest is null)
+            throw new InvalidDataException("The local AI installation manifest is empty.");
+        return manifest;
+    }
+
+    private static LocalAiInstallManifest DeserializeManifest(byte[] content)
+    {
+        try
+        {
+            ReadOnlySpan<byte> json = content;
+            ReadOnlySpan<byte> preamble = Encoding.UTF8.Preamble;
+            if (json.StartsWith(preamble))
+                json = json[preamble.Length..];
+
+            return JsonSerializer.Deserialize<LocalAiInstallManifest>(json, JsonOptions)
+                ?? throw new InvalidDataException("The local AI installation manifest is empty.");
+        }
+        catch (JsonException ex)
+        {
+            throw new InvalidDataException(
+                "The local AI installation manifest is invalid JSON or uses an unsupported format.",
+                ex);
+        }
     }
 
     public async Task SaveAsync(LocalAiInstallManifest manifest, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(manifest);
         _ = ResolveAndValidate(manifest);
+        await using FileStream writeLock = await AcquireManifestWriteLockAsync(cancellationToken)
+            .ConfigureAwait(false);
+        await SaveWithoutLockAsync(manifest, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task SaveWithoutLockAsync(
+        LocalAiInstallManifest manifest,
+        CancellationToken cancellationToken)
+    {
         Directory.CreateDirectory(_paths.RootDirectory);
         _ = _paths.ResolveContainedPath(Path.GetFileName(_paths.ManifestPath), nameof(_paths.ManifestPath));
 
@@ -323,18 +464,52 @@ public sealed class LocalAiManifestStore
         }
     }
 
-    public Task DeleteAsync(CancellationToken cancellationToken = default)
+    public async Task DeleteAsync(CancellationToken cancellationToken = default)
     {
-        cancellationToken.ThrowIfCancellationRequested();
+        await using FileStream writeLock = await AcquireManifestWriteLockAsync(cancellationToken)
+            .ConfigureAwait(false);
         File.Delete(_paths.ManifestPath);
-        return Task.CompletedTask;
     }
+
+    private async Task<FileStream> AcquireManifestWriteLockAsync(
+        CancellationToken cancellationToken)
+    {
+        Directory.CreateDirectory(_paths.RootDirectory);
+        string lockPath = _paths.ResolveContainedPath(
+            $".{Path.GetFileName(_paths.ManifestPath)}.lock",
+            "manifestLockPath");
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                return new FileStream(
+                    lockPath,
+                    FileMode.OpenOrCreate,
+                    FileAccess.ReadWrite,
+                    FileShare.None,
+                    bufferSize: 1,
+                    FileOptions.Asynchronous);
+            }
+            catch (IOException ex) when (IsSharingViolation(ex))
+            {
+                await Task.Delay(50, cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private static bool IsSharingViolation(IOException exception) =>
+        (exception.HResult & 0xFFFF) is 32 or 33;
 
     public LocalAiResolvedInstall ResolveAndValidate(LocalAiInstallManifest manifest)
     {
         ArgumentNullException.ThrowIfNull(manifest);
-        if (manifest.SchemaVersion != LocalAiInstallManifest.CurrentSchemaVersion)
+        if (manifest.SchemaVersion is not (
+                LocalAiInstallManifest.CurrentSchemaVersion or
+                LocalAiInstallManifest.HubCacheReceiptSchemaVersion))
+        {
             throw new InvalidDataException($"Unsupported local AI manifest schema version {manifest.SchemaVersion}.");
+        }
         if (!string.Equals(manifest.Engine, LocalAiInstallManifest.SupportedEngine, StringComparison.Ordinal))
             throw new InvalidDataException("The local AI manifest engine must be llama-server.");
         if (string.IsNullOrWhiteSpace(manifest.EngineVersion))
@@ -376,7 +551,7 @@ public sealed class LocalAiManifestStore
                 throw new InvalidDataException("The local AI manifest runtime asset filenames must be unique.");
         }
         ValidateAssetReceipt(manifest.ModelAsset, nameof(manifest.ModelAsset));
-        ValidateHuggingFaceModelProvenance(manifest);
+        HuggingFaceModelProvenance provenance = ValidateHuggingFaceModelProvenance(manifest);
 
         var executable = _paths.ResolveContainedPath(manifest.ExecutablePath, nameof(manifest.ExecutablePath));
         if (!string.Equals(Path.GetFileName(executable), "llama-server.exe", StringComparison.OrdinalIgnoreCase))
@@ -387,6 +562,8 @@ public sealed class LocalAiManifestStore
             throw new InvalidDataException("The managed local AI model must be a GGUF file.");
         if (!string.Equals(Path.GetFileName(model), manifest.ModelAsset.FileName, StringComparison.Ordinal))
             throw new InvalidDataException("The managed model path must match its asset receipt filename.");
+
+        ValidateHubCacheReceipt(manifest, provenance);
 
         LocalAiPortPolicy.Validate(manifest.RequestedPort);
         LocalAiGatewayModelPolicy.ValidateFallbackModel(manifest.GatewayFallbackModel);
@@ -451,7 +628,8 @@ public sealed class LocalAiManifestStore
             throw new InvalidDataException($"{fieldName}.Sha256 must be a lowercase SHA-256 digest.");
     }
 
-    private static void ValidateHuggingFaceModelProvenance(LocalAiInstallManifest manifest)
+    private static HuggingFaceModelProvenance ValidateHuggingFaceModelProvenance(
+        LocalAiInstallManifest manifest)
     {
         var revisionSeparator = manifest.ModelId.LastIndexOf('@');
         if (revisionSeparator <= 0 || revisionSeparator == manifest.ModelId.Length - 1)
@@ -478,15 +656,71 @@ public sealed class LocalAiManifestStore
         }
 
         var source = new Uri(manifest.ModelAsset.SourceUrl, UriKind.Absolute);
-        var expectedPath = $"/{repositoryId}/resolve/{revision}/{manifest.ModelAsset.FileName}";
+        var expectedPrefix = $"/{repositoryId}/resolve/{revision}/";
+        string sourcePath = Uri.UnescapeDataString(source.AbsolutePath);
         if (!string.Equals(source.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase) ||
             !string.Equals(source.Host, "huggingface.co", StringComparison.OrdinalIgnoreCase) ||
-            !string.Equals(Uri.UnescapeDataString(source.AbsolutePath), expectedPath, StringComparison.Ordinal) ||
+            !sourcePath.StartsWith(expectedPrefix, StringComparison.Ordinal) ||
             source.Query is not ("" or "?download=true"))
         {
             throw new InvalidDataException(
                 "The local AI manifest model source must match its immutable Hugging Face repository, revision, and filename.");
         }
+
+        string relativePath = sourcePath[expectedPrefix.Length..];
+        if (string.IsNullOrWhiteSpace(relativePath) ||
+            !string.Equals(
+                relativePath.Split('/').LastOrDefault(),
+                manifest.ModelAsset.FileName,
+                StringComparison.Ordinal))
+        {
+            throw new InvalidDataException(
+                "The local AI manifest model source must match its immutable Hugging Face repository, revision, and filename.");
+        }
+
+        return new HuggingFaceModelProvenance(repositoryId, revision, relativePath);
     }
 
+    private static void ValidateHubCacheReceipt(
+        LocalAiInstallManifest manifest,
+        HuggingFaceModelProvenance provenance)
+    {
+        if (manifest.SchemaVersion == LocalAiInstallManifest.CurrentSchemaVersion)
+        {
+            if (manifest.ModelCacheRoot is not null || manifest.CachedModelPath is not null)
+            {
+                throw new InvalidDataException(
+                    "Schema-3 local AI manifests cannot contain a Hugging Face cache migration receipt.");
+            }
+
+            return;
+        }
+
+        string error = "";
+        if (string.IsNullOrWhiteSpace(manifest.ModelCacheRoot) ||
+            string.IsNullOrWhiteSpace(manifest.CachedModelPath) ||
+            !HuggingFaceHubCache.TryGetSnapshotPaths(
+                manifest.ModelCacheRoot,
+                provenance.RepositoryId,
+                provenance.Revision,
+                provenance.RelativePath,
+                out string expectedCachedModelPath,
+                out _,
+                out error) ||
+            !string.Equals(
+                manifest.CachedModelPath,
+                expectedCachedModelPath,
+                StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidDataException(
+                string.IsNullOrWhiteSpace(error)
+                    ? "The local AI manifest Hugging Face cache migration receipt is invalid."
+                    : error);
+        }
+    }
+
+    internal sealed record HuggingFaceModelProvenance(
+        string RepositoryId,
+        string Revision,
+        string RelativePath);
 }

--- a/src/OpenClaw.Connection/LocalAi/LocalAiManifest.cs
+++ b/src/OpenClaw.Connection/LocalAi/LocalAiManifest.cs
@@ -668,9 +668,10 @@ public sealed class LocalAiManifestStore
         }
 
         string relativePath = sourcePath[expectedPrefix.Length..];
-        if (string.IsNullOrWhiteSpace(relativePath) ||
+        string[] relativeSegments = relativePath.Split('/');
+        if (relativeSegments.Any(segment => !WindowsPathSafety.IsSafeSegment(segment)) ||
             !string.Equals(
-                relativePath.Split('/').LastOrDefault(),
+                relativeSegments[^1],
                 manifest.ModelAsset.FileName,
                 StringComparison.Ordinal))
         {

--- a/src/OpenClaw.Connection/LocalAi/LocalAiManifestMigration.cs
+++ b/src/OpenClaw.Connection/LocalAi/LocalAiManifestMigration.cs
@@ -1,0 +1,614 @@
+using OpenClaw.Shared.Inference.Catalog;
+using OpenClaw.Shared.IO;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+
+namespace OpenClaw.Connection.LocalAi;
+
+/// <summary>
+/// Copies schema-3 model weights into a standard Hugging Face snapshot path and
+/// records the verified destination without changing the active legacy model path.
+/// </summary>
+internal static class LocalAiManifestMigration
+{
+    private const int CopyBufferSize = 1024 * 1024;
+
+    public static async Task<LocalAiInstallManifest> MigrateAsync(
+        LocalAiPaths paths,
+        LocalAiResolvedInstall legacyInstall,
+        string cacheRoot,
+        IProgress<LocalAiModelMigrationProgress>? progress,
+        Func<string, CancellationToken, Task> beforePromotion,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(paths);
+        ArgumentNullException.ThrowIfNull(legacyInstall);
+        if (legacyInstall.Manifest.SchemaVersion != LocalAiInstallManifest.CurrentSchemaVersion)
+            return legacyInstall.Manifest;
+
+        LocalAiInstallManifest manifest = legacyInstall.Manifest;
+        LocalAiManifestStore.HuggingFaceModelProvenance provenance =
+            GetProvenance(manifest);
+        if (!IsCanonicalLegacyModelPath(paths, legacyInstall.ModelPath, provenance))
+            return manifest;
+
+        var expectedSha256 = new Sha256Digest(manifest.ModelAsset.Sha256);
+        if (!HuggingFaceHubCache.TryGetSnapshotPaths(
+                cacheRoot,
+                provenance.RepositoryId,
+                provenance.Revision,
+                provenance.RelativePath,
+                out string cachedModelPath,
+                out _,
+                out string pathError))
+        {
+            throw new InvalidDataException(pathError);
+        }
+
+        if (Directory.Exists(cachedModelPath))
+        {
+            throw new InvalidDataException(
+                "The Hugging Face cache migration destination is an existing directory.");
+        }
+
+        if (PathEntryExists(cachedModelPath))
+        {
+            await RequireVerifiedCacheDestinationAsync(
+                    cacheRoot,
+                    cachedModelPath,
+                    manifest.ModelAsset,
+                    expectedSha256,
+                    progress,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            return CreateMigratedManifest(manifest, cacheRoot, cachedModelPath);
+        }
+
+        string destinationDirectory = Path.GetDirectoryName(cachedModelPath)
+            ?? throw new InvalidDataException("The Hugging Face cache migration destination has no parent directory.");
+        string temporaryPath = Path.Combine(
+            destinationDirectory,
+            $".openclaw-migration-{expectedSha256.Value}.partial");
+        bool ownsTemporary = false;
+        try
+        {
+            bool hasVerifiedTemporary = await IsVerifiedCacheFileAsync(
+                    cacheRoot,
+                    temporaryPath,
+                    manifest.ModelAsset,
+                    expectedSha256,
+                    progress,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            await using FileStream? source = hasVerifiedTemporary
+                ? null
+                : await OpenLegacySourceIfAvailableAsync(
+                        legacyInstall.ModelPath,
+                        manifest.ModelAsset,
+                        expectedSha256,
+                        progress,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+            if (!hasVerifiedTemporary && source is null)
+                return manifest;
+
+            EnsureSafeDestinationDirectory(cacheRoot, destinationDirectory);
+            if (!hasVerifiedTemporary)
+            {
+                RemoveUnverifiedTemporaryEntry(temporaryPath);
+                EnsureSufficientFreeSpace(
+                    destinationDirectory,
+                    manifest.ModelAsset.SizeBytes);
+                await using (FileStream destination = OpenOwnedTemporaryFile(
+                    temporaryPath,
+                    out ownsTemporary))
+                {
+                    await CopyVerifiedSourceAsync(
+                            source!,
+                            destination,
+                            manifest.ModelAsset.SizeBytes,
+                            progress,
+                            cancellationToken)
+                        .ConfigureAwait(false);
+                    await destination.FlushAsync(cancellationToken).ConfigureAwait(false);
+                    destination.Flush(flushToDisk: true);
+                }
+
+                await RequireVerifiedCacheDestinationAsync(
+                        cacheRoot,
+                        temporaryPath,
+                        manifest.ModelAsset,
+                        expectedSha256,
+                        progress,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            try
+            {
+                await beforePromotion(cachedModelPath, cancellationToken).ConfigureAwait(false);
+                File.Move(temporaryPath, cachedModelPath, overwrite: false);
+                ownsTemporary = false;
+            }
+            catch (IOException)
+            {
+                if (!PathEntryExists(cachedModelPath))
+                    throw;
+            }
+
+            await RequireVerifiedCacheDestinationAsync(
+                    cacheRoot,
+                    cachedModelPath,
+                    manifest.ModelAsset,
+                    expectedSha256,
+                    progress,
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            return CreateMigratedManifest(manifest, cacheRoot, cachedModelPath);
+        }
+        finally
+        {
+            if (ownsTemporary)
+                DeleteTemporaryCreatedThisRun(temporaryPath);
+        }
+    }
+
+    private static async Task<FileStream?> OpenLegacySourceIfAvailableAsync(
+        string legacyModelPath,
+        LocalAiAssetReceipt receipt,
+        Sha256Digest expectedSha256,
+        IProgress<LocalAiModelMigrationProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        if (Directory.Exists(legacyModelPath))
+            throw new InvalidDataException("The legacy Local AI model path is an existing directory.");
+        if (!PathEntryExists(legacyModelPath))
+            return null;
+
+        return await OpenVerifiedLegacySourceAsync(
+                legacyModelPath,
+                receipt,
+                expectedSha256,
+                progress,
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private static LocalAiManifestStore.HuggingFaceModelProvenance GetProvenance(
+        LocalAiInstallManifest manifest)
+    {
+        int separator = manifest.ModelId.LastIndexOf('@');
+        string repositoryId = manifest.ModelId[..separator];
+        string revision = manifest.ModelId[(separator + 1)..];
+        var source = new Uri(manifest.ModelAsset.SourceUrl, UriKind.Absolute);
+        string prefix = $"/{repositoryId}/resolve/{revision}/";
+        string relativePath = Uri.UnescapeDataString(source.AbsolutePath)[prefix.Length..];
+        return new(repositoryId, revision, relativePath);
+    }
+
+    private static bool IsCanonicalLegacyModelPath(
+        LocalAiPaths paths,
+        string modelPath,
+        LocalAiManifestStore.HuggingFaceModelProvenance provenance)
+    {
+        string[] repositorySegments = provenance.RepositoryId.Split('/');
+        string[] relativeSegments = provenance.RelativePath.Split('/');
+        try
+        {
+            string expected = WindowsPathSafety.NormalizePath(
+                Path.Combine(
+                    [
+                        paths.ModelsDirectory,
+                        repositorySegments[0],
+                        repositorySegments[1],
+                        provenance.Revision,
+                        .. relativeSegments,
+                    ]));
+            return WindowsPathSafety.PathEquals(modelPath, expected);
+        }
+        catch (Exception ex) when (
+            ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            return false;
+        }
+    }
+
+    private static LocalAiInstallManifest CreateMigratedManifest(
+        LocalAiInstallManifest manifest,
+        string cacheRoot,
+        string cachedModelPath) =>
+        manifest with
+        {
+            SchemaVersion = LocalAiInstallManifest.HubCacheReceiptSchemaVersion,
+            ModelCacheRoot = WindowsPathSafety.NormalizePath(cacheRoot),
+            CachedModelPath = WindowsPathSafety.NormalizePath(cachedModelPath),
+        };
+
+    private static async Task<FileStream> OpenVerifiedLegacySourceAsync(
+        string sourcePath,
+        LocalAiAssetReceipt receipt,
+        Sha256Digest expectedSha256,
+        IProgress<LocalAiModelMigrationProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        FileStream stream;
+        try
+        {
+            stream = new FileStream(
+                sourcePath,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.Read,
+                CopyBufferSize,
+                FileOptions.Asynchronous | FileOptions.SequentialScan);
+        }
+        catch (Exception ex) when (
+            ex is IOException or UnauthorizedAccessException or System.Security.SecurityException)
+        {
+            throw new InvalidDataException(
+                "The legacy Local AI model could not be opened safely for cache migration.",
+                ex);
+        }
+
+        bool verified = false;
+        try
+        {
+            if (stream.Length != receipt.SizeBytes)
+                throw new InvalidDataException("The legacy Local AI model size does not match its receipt.");
+
+            using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+            var buffer = new byte[CopyBufferSize];
+            long completed = 0;
+            Report(
+                progress,
+                LocalAiModelMigrationPhase.VerifyingLegacyModel,
+                completed,
+                receipt.SizeBytes);
+            while (true)
+            {
+                int read = await stream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+                if (read == 0)
+                    break;
+
+                hash.AppendData(buffer, 0, read);
+                completed += read;
+                Report(
+                    progress,
+                    LocalAiModelMigrationPhase.VerifyingLegacyModel,
+                    completed,
+                    receipt.SizeBytes);
+            }
+
+            if (completed != receipt.SizeBytes ||
+                !CryptographicOperations.FixedTimeEquals(
+                    hash.GetHashAndReset(),
+                    Convert.FromHexString(expectedSha256.Value)))
+            {
+                throw new InvalidDataException(
+                    "The legacy Local AI model SHA-256 digest does not match its receipt.");
+            }
+
+            stream.Position = 0;
+            verified = true;
+            return stream;
+        }
+        finally
+        {
+            if (!verified)
+                await stream.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    private static async Task RequireVerifiedCacheDestinationAsync(
+        string cacheRoot,
+        string candidatePath,
+        LocalAiAssetReceipt receipt,
+        Sha256Digest expectedSha256,
+        IProgress<LocalAiModelMigrationProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        await using FileStream? verified =
+            await HuggingFaceHubCache.TryOpenVerifiedCacheFileAsync(
+                    cacheRoot,
+                    candidatePath,
+                    receipt.SizeBytes,
+                    expectedSha256,
+                    new CacheVerificationProgress(progress, receipt.SizeBytes),
+                    cancellationToken)
+                .ConfigureAwait(false);
+        if (verified is null)
+        {
+            throw new InvalidDataException(
+                "The Hugging Face cache migration destination is unsafe or does not match its receipt.");
+        }
+    }
+
+    private static async Task<bool> IsVerifiedCacheFileAsync(
+        string cacheRoot,
+        string candidatePath,
+        LocalAiAssetReceipt receipt,
+        Sha256Digest expectedSha256,
+        IProgress<LocalAiModelMigrationProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        if (!PathEntryExists(candidatePath))
+            return false;
+
+        await using FileStream? verified =
+            await HuggingFaceHubCache.TryOpenVerifiedCacheFileAsync(
+                    cacheRoot,
+                    candidatePath,
+                    receipt.SizeBytes,
+                    expectedSha256,
+                    new CacheVerificationProgress(progress, receipt.SizeBytes),
+                    cancellationToken)
+                .ConfigureAwait(false);
+        return verified is not null;
+    }
+
+    private static async Task CopyVerifiedSourceAsync(
+        Stream source,
+        Stream destination,
+        long totalBytes,
+        IProgress<LocalAiModelMigrationProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        var buffer = new byte[CopyBufferSize];
+        long completed = 0;
+        Report(progress, LocalAiModelMigrationPhase.CopyingToCache, completed, totalBytes);
+        while (true)
+        {
+            int read = await source.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+            if (read == 0)
+                break;
+
+            await destination.WriteAsync(buffer.AsMemory(0, read), cancellationToken)
+                .ConfigureAwait(false);
+            completed += read;
+            Report(progress, LocalAiModelMigrationPhase.CopyingToCache, completed, totalBytes);
+        }
+
+        if (completed != totalBytes)
+            throw new InvalidDataException("The verified legacy Local AI model changed during cache migration.");
+    }
+
+    private static void EnsureSufficientFreeSpace(
+        string destinationDirectory,
+        long requiredBytes)
+    {
+        string capacityPath = FindExistingDirectory(destinationDirectory);
+        if (OperatingSystem.IsWindows())
+        {
+            if (!GetDiskFreeSpaceEx(
+                    capacityPath,
+                    out ulong availableBytes,
+                    out _,
+                    out _))
+            {
+                throw new InvalidDataException(
+                    "The Hugging Face cache volume capacity could not be inspected safely.",
+                    new Win32Exception(Marshal.GetLastWin32Error()));
+            }
+
+            if (availableBytes < (ulong)requiredBytes)
+            {
+                throw new InvalidDataException(
+                    "The Hugging Face cache volume does not have enough free space for the Local AI model migration.");
+            }
+            return;
+        }
+
+        try
+        {
+            string root = Path.GetPathRoot(capacityPath)
+                ?? throw new InvalidDataException(
+                    "The Hugging Face cache volume capacity could not be inspected safely.");
+            var drive = new DriveInfo(root);
+            if (!drive.IsReady)
+            {
+                throw new InvalidDataException(
+                    "The Hugging Face cache volume capacity could not be inspected safely.");
+            }
+            if (drive.AvailableFreeSpace < requiredBytes)
+            {
+                throw new InvalidDataException(
+                    "The Hugging Face cache volume does not have enough free space for the Local AI model migration.");
+            }
+        }
+        catch (Exception ex) when (
+            ex is IOException or
+                UnauthorizedAccessException or
+                System.Security.SecurityException)
+        {
+            throw new InvalidDataException(
+                "The Hugging Face cache volume capacity could not be inspected safely.",
+                ex);
+        }
+    }
+
+    private static string FindExistingDirectory(string path)
+    {
+        string? current = path;
+        while (current is not null && !Directory.Exists(current))
+            current = Path.GetDirectoryName(current);
+        return current
+            ?? throw new InvalidDataException(
+                "The Hugging Face cache volume capacity could not be inspected safely.");
+    }
+
+    private static void Report(
+        IProgress<LocalAiModelMigrationProgress>? progress,
+        LocalAiModelMigrationPhase phase,
+        long completedBytes,
+        long totalBytes) =>
+        progress?.Report(new LocalAiModelMigrationProgress(
+            phase,
+            completedBytes,
+            totalBytes));
+
+    private static FileStream OpenOwnedTemporaryFile(
+        string temporaryPath,
+        out bool ownsTemporary)
+    {
+        ownsTemporary = false;
+        try
+        {
+            if (Directory.Exists(temporaryPath))
+            {
+                throw new InvalidDataException(
+                    "The Hugging Face cache migration temporary path is an existing directory.");
+            }
+
+            var stream = new FileStream(
+                temporaryPath,
+                FileMode.CreateNew,
+                FileAccess.Write,
+                FileShare.None,
+                CopyBufferSize,
+                FileOptions.Asynchronous | FileOptions.SequentialScan | FileOptions.WriteThrough);
+            ownsTemporary = true;
+            return stream;
+        }
+        catch (Exception ex) when (
+            ex is IOException or
+                UnauthorizedAccessException or
+                System.Security.SecurityException or
+                NotSupportedException)
+        {
+            throw new InvalidDataException(
+                "The Hugging Face cache migration temporary file could not be claimed safely.",
+                ex);
+        }
+    }
+
+    private static void RemoveUnverifiedTemporaryEntry(string temporaryPath)
+    {
+        try
+        {
+            if (Directory.Exists(temporaryPath))
+            {
+                throw new InvalidDataException(
+                    "The Hugging Face cache migration temporary path is an existing directory.");
+            }
+
+            File.Delete(temporaryPath);
+        }
+        catch (Exception ex) when (
+            ex is IOException or
+                UnauthorizedAccessException or
+                System.Security.SecurityException or
+                NotSupportedException)
+        {
+            throw new InvalidDataException(
+                "The Hugging Face cache migration temporary file could not be replaced safely.",
+                ex);
+        }
+    }
+
+    private static void EnsureSafeDestinationDirectory(
+        string cacheRoot,
+        string destinationDirectory)
+    {
+        string normalizedRoot = WindowsPathSafety.NormalizePath(cacheRoot);
+        string normalizedDestination = WindowsPathSafety.NormalizePath(destinationDirectory);
+        if (!WindowsPathSafety.IsStrictDescendant(normalizedDestination, normalizedRoot))
+            throw new InvalidDataException("The Hugging Face cache migration destination escaped its cache root.");
+
+        EnsureDirectory(normalizedRoot, rejectReparsePoint: false);
+        string current = normalizedRoot;
+        foreach (string segment in Path.GetRelativePath(normalizedRoot, normalizedDestination).Split(
+                     [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
+                     StringSplitOptions.RemoveEmptyEntries))
+        {
+            current = Path.Combine(current, segment);
+            EnsureDirectory(current, rejectReparsePoint: true);
+        }
+    }
+
+    private static void EnsureDirectory(string path, bool rejectReparsePoint)
+    {
+        try
+        {
+            if (File.Exists(path))
+                throw new InvalidDataException($"The Hugging Face cache path '{path}' is an existing file.");
+
+            Directory.CreateDirectory(path);
+            if (rejectReparsePoint &&
+                (File.GetAttributes(path) & FileAttributes.ReparsePoint) != 0)
+                throw new InvalidDataException($"The Hugging Face cache path '{path}' is a reparse point.");
+        }
+        catch (Exception ex) when (
+            ex is IOException or
+                UnauthorizedAccessException or
+                System.Security.SecurityException or
+                NotSupportedException)
+        {
+            throw new InvalidDataException(
+                $"The Hugging Face cache path '{path}' could not be created safely.",
+                ex);
+        }
+    }
+
+    [DllImport("kernel32.dll", EntryPoint = "GetDiskFreeSpaceExW", CharSet = CharSet.Unicode, SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetDiskFreeSpaceEx(
+        string directoryName,
+        out ulong freeBytesAvailable,
+        out ulong totalNumberOfBytes,
+        out ulong totalNumberOfFreeBytes);
+
+    private static bool PathEntryExists(string path)
+    {
+        try
+        {
+            _ = File.GetAttributes(path);
+            return true;
+        }
+        catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
+        {
+            return false;
+        }
+        catch (Exception ex) when (
+            ex is IOException or
+                UnauthorizedAccessException or
+                System.Security.SecurityException)
+        {
+            throw new InvalidDataException(
+                $"The Hugging Face cache migration destination '{path}' could not be inspected safely.",
+                ex);
+        }
+    }
+
+    private static void DeleteTemporaryCreatedThisRun(string temporaryPath)
+    {
+        try
+        {
+            if (!File.Exists(temporaryPath))
+                return;
+            if ((File.GetAttributes(temporaryPath) & FileAttributes.ReparsePoint) != 0)
+                return;
+            File.Delete(temporaryPath);
+        }
+        catch (Exception ex) when (
+            ex is IOException or
+                UnauthorizedAccessException or
+                System.Security.SecurityException)
+        {
+            // A failed cleanup must not replace the migration result.
+        }
+    }
+
+    private sealed class CacheVerificationProgress(
+        IProgress<LocalAiModelMigrationProgress>? progress,
+        long totalBytes) : IProgress<long>
+    {
+        public void Report(long value) =>
+            LocalAiManifestMigration.Report(
+                progress,
+                LocalAiModelMigrationPhase.VerifyingCacheCopy,
+                value,
+                totalBytes);
+    }
+}

--- a/src/OpenClaw.Connection/LocalAi/LocalAiManifestMigration.cs
+++ b/src/OpenClaw.Connection/LocalAi/LocalAiManifestMigration.cs
@@ -3,6 +3,8 @@ using OpenClaw.Shared.IO;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Win32.SafeHandles;
 
 namespace OpenClaw.Connection.LocalAi;
 
@@ -67,92 +69,154 @@ internal static class LocalAiManifestMigration
 
         string destinationDirectory = Path.GetDirectoryName(cachedModelPath)
             ?? throw new InvalidDataException("The Hugging Face cache migration destination has no parent directory.");
-        string temporaryPath = Path.Combine(
-            destinationDirectory,
-            $".openclaw-migration-{expectedSha256.Value}.partial");
-        bool ownsTemporary = false;
+        string temporaryFileName = $".openclaw-migration-{expectedSha256.Value}.partial";
+        string destinationFileName = Path.GetFileName(cachedModelPath);
+        SafeCacheDirectory? directory = null;
+        CacheMigrationFile? temporary = null;
+        FileStream? source = null;
         try
         {
-            bool hasVerifiedTemporary = await IsVerifiedCacheFileAsync(
-                    cacheRoot,
-                    temporaryPath,
-                    manifest.ModelAsset,
-                    expectedSha256,
-                    progress,
-                    cancellationToken)
-                .ConfigureAwait(false);
-            await using FileStream? source = hasVerifiedTemporary
-                ? null
-                : await OpenLegacySourceIfAvailableAsync(
+            if (Directory.Exists(destinationDirectory))
+            {
+                directory = SafeCacheDirectory.OpenOrCreate(cacheRoot, destinationDirectory);
+                temporary = await TryOpenVerifiedTemporaryAsync(
+                        directory,
+                        temporaryFileName,
+                        manifest.ModelAsset,
+                        expectedSha256,
+                        progress,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            if (temporary is null)
+            {
+                source = await OpenLegacySourceIfAvailableAsync(
                         legacyInstall.ModelPath,
                         manifest.ModelAsset,
                         expectedSha256,
                         progress,
                         cancellationToken)
                     .ConfigureAwait(false);
-            if (!hasVerifiedTemporary && source is null)
-                return manifest;
+                if (source is null)
+                    return manifest;
 
-            EnsureSafeDestinationDirectory(cacheRoot, destinationDirectory);
-            if (!hasVerifiedTemporary)
-            {
-                RemoveUnverifiedTemporaryEntry(temporaryPath);
-                EnsureSufficientFreeSpace(
-                    destinationDirectory,
-                    manifest.ModelAsset.SizeBytes);
-                await using (FileStream destination = OpenOwnedTemporaryFile(
-                    temporaryPath,
-                    out ownsTemporary))
+                EnsureSufficientFreeSpace(destinationDirectory, manifest.ModelAsset.SizeBytes);
+                if (directory is null)
                 {
-                    await CopyVerifiedSourceAsync(
-                            source!,
-                            destination,
-                            manifest.ModelAsset.SizeBytes,
+                    directory = SafeCacheDirectory.OpenOrCreate(cacheRoot, destinationDirectory);
+                    temporary = await TryOpenVerifiedTemporaryAsync(
+                            directory,
+                            temporaryFileName,
+                            manifest.ModelAsset,
+                            expectedSha256,
                             progress,
                             cancellationToken)
                         .ConfigureAwait(false);
-                    await destination.FlushAsync(cancellationToken).ConfigureAwait(false);
-                    destination.Flush(flushToDisk: true);
                 }
+            }
 
-                await RequireVerifiedCacheDestinationAsync(
-                        cacheRoot,
-                        temporaryPath,
+            if (temporary is null)
+            {
+                temporary = directory!.CreateNew(temporaryFileName);
+                await CopyVerifiedSourceAsync(
+                        source!,
+                        temporary.Stream,
+                        manifest.ModelAsset.SizeBytes,
+                        progress,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+                await temporary.Stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+                temporary.Stream.Flush(flushToDisk: true);
+                if (!await IsVerifiedOpenCacheFileAsync(
+                        temporary.Stream,
                         manifest.ModelAsset,
                         expectedSha256,
                         progress,
                         cancellationToken)
-                    .ConfigureAwait(false);
+                    .ConfigureAwait(false))
+                {
+                    throw new InvalidDataException(
+                        "The copied Hugging Face cache model does not match its receipt.");
+                }
             }
 
             try
             {
                 await beforePromotion(cachedModelPath, cancellationToken).ConfigureAwait(false);
-                File.Move(temporaryPath, cachedModelPath, overwrite: false);
-                ownsTemporary = false;
+                temporary.Promote(destinationFileName);
             }
-            catch (IOException)
+            catch (IOException ex)
             {
+                temporary.Dispose();
+                temporary = null;
                 if (!PathEntryExists(cachedModelPath))
-                    throw;
+                {
+                    throw new InvalidDataException(
+                        "The Hugging Face cache migration temporary file could not be promoted safely.",
+                        ex);
+                }
+
+                await RequireVerifiedCacheDestinationAsync(
+                        cacheRoot,
+                        cachedModelPath,
+                        manifest.ModelAsset,
+                        expectedSha256,
+                        progress,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+                return CreateMigratedManifest(manifest, cacheRoot, cachedModelPath);
             }
 
-            await RequireVerifiedCacheDestinationAsync(
-                    cacheRoot,
-                    cachedModelPath,
+            if (!await IsVerifiedOpenCacheFileAsync(
+                    temporary.Stream,
                     manifest.ModelAsset,
                     expectedSha256,
                     progress,
                     cancellationToken)
-                .ConfigureAwait(false);
+                .ConfigureAwait(false))
+            {
+                throw new InvalidDataException(
+                    "The promoted Hugging Face cache model does not match its receipt.");
+            }
 
+            directory!.RequirePromotedFile(temporary.Stream.SafeFileHandle, destinationFileName);
+            temporary.Commit();
             return CreateMigratedManifest(manifest, cacheRoot, cachedModelPath);
         }
         finally
         {
-            if (ownsTemporary)
-                DeleteTemporaryCreatedThisRun(temporaryPath);
+            temporary?.Dispose();
+            directory?.Dispose();
+            if (source is not null)
+                await source.DisposeAsync().ConfigureAwait(false);
         }
+    }
+
+    private static async Task<CacheMigrationFile?> TryOpenVerifiedTemporaryAsync(
+        SafeCacheDirectory directory,
+        string temporaryFileName,
+        LocalAiAssetReceipt receipt,
+        Sha256Digest expectedSha256,
+        IProgress<LocalAiModelMigrationProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        CacheMigrationFile? temporary = directory.TryOpenExisting(temporaryFileName);
+        if (temporary is null)
+            return null;
+        if (await IsVerifiedOpenCacheFileAsync(
+                temporary.Stream,
+                receipt,
+                expectedSha256,
+                progress,
+                cancellationToken)
+            .ConfigureAwait(false))
+        {
+            return temporary;
+        }
+
+        temporary.Dispose();
+        return null;
     }
 
     private static async Task<FileStream?> OpenLegacySourceIfAvailableAsync(
@@ -325,27 +389,46 @@ internal static class LocalAiManifestMigration
         }
     }
 
-    private static async Task<bool> IsVerifiedCacheFileAsync(
-        string cacheRoot,
-        string candidatePath,
+    private static async Task<bool> IsVerifiedOpenCacheFileAsync(
+        FileStream stream,
         LocalAiAssetReceipt receipt,
         Sha256Digest expectedSha256,
         IProgress<LocalAiModelMigrationProgress>? progress,
         CancellationToken cancellationToken)
     {
-        if (!PathEntryExists(candidatePath))
+        if (stream.Length != receipt.SizeBytes)
             return false;
 
-        await using FileStream? verified =
-            await HuggingFaceHubCache.TryOpenVerifiedCacheFileAsync(
-                    cacheRoot,
-                    candidatePath,
-                    receipt.SizeBytes,
-                    expectedSha256,
-                    new CacheVerificationProgress(progress, receipt.SizeBytes),
-                    cancellationToken)
-                .ConfigureAwait(false);
-        return verified is not null;
+        stream.Position = 0;
+        using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        var buffer = new byte[CopyBufferSize];
+        long completed = 0;
+        Report(
+            progress,
+            LocalAiModelMigrationPhase.VerifyingCacheCopy,
+            completed,
+            receipt.SizeBytes);
+        while (true)
+        {
+            int read = await stream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+            if (read == 0)
+                break;
+
+            hash.AppendData(buffer, 0, read);
+            completed += read;
+            Report(
+                progress,
+                LocalAiModelMigrationPhase.VerifyingCacheCopy,
+                completed,
+                receipt.SizeBytes);
+        }
+
+        bool verified = completed == receipt.SizeBytes &&
+            CryptographicOperations.FixedTimeEquals(
+                hash.GetHashAndReset(),
+                Convert.FromHexString(expectedSha256.Value));
+        stream.Position = 0;
+        return verified;
     }
 
     private static async Task CopyVerifiedSourceAsync(
@@ -448,109 +531,6 @@ internal static class LocalAiManifestMigration
             completedBytes,
             totalBytes));
 
-    private static FileStream OpenOwnedTemporaryFile(
-        string temporaryPath,
-        out bool ownsTemporary)
-    {
-        ownsTemporary = false;
-        try
-        {
-            if (Directory.Exists(temporaryPath))
-            {
-                throw new InvalidDataException(
-                    "The Hugging Face cache migration temporary path is an existing directory.");
-            }
-
-            var stream = new FileStream(
-                temporaryPath,
-                FileMode.CreateNew,
-                FileAccess.Write,
-                FileShare.None,
-                CopyBufferSize,
-                FileOptions.Asynchronous | FileOptions.SequentialScan | FileOptions.WriteThrough);
-            ownsTemporary = true;
-            return stream;
-        }
-        catch (Exception ex) when (
-            ex is IOException or
-                UnauthorizedAccessException or
-                System.Security.SecurityException or
-                NotSupportedException)
-        {
-            throw new InvalidDataException(
-                "The Hugging Face cache migration temporary file could not be claimed safely.",
-                ex);
-        }
-    }
-
-    private static void RemoveUnverifiedTemporaryEntry(string temporaryPath)
-    {
-        try
-        {
-            if (Directory.Exists(temporaryPath))
-            {
-                throw new InvalidDataException(
-                    "The Hugging Face cache migration temporary path is an existing directory.");
-            }
-
-            File.Delete(temporaryPath);
-        }
-        catch (Exception ex) when (
-            ex is IOException or
-                UnauthorizedAccessException or
-                System.Security.SecurityException or
-                NotSupportedException)
-        {
-            throw new InvalidDataException(
-                "The Hugging Face cache migration temporary file could not be replaced safely.",
-                ex);
-        }
-    }
-
-    private static void EnsureSafeDestinationDirectory(
-        string cacheRoot,
-        string destinationDirectory)
-    {
-        string normalizedRoot = WindowsPathSafety.NormalizePath(cacheRoot);
-        string normalizedDestination = WindowsPathSafety.NormalizePath(destinationDirectory);
-        if (!WindowsPathSafety.IsStrictDescendant(normalizedDestination, normalizedRoot))
-            throw new InvalidDataException("The Hugging Face cache migration destination escaped its cache root.");
-
-        EnsureDirectory(normalizedRoot, rejectReparsePoint: false);
-        string current = normalizedRoot;
-        foreach (string segment in Path.GetRelativePath(normalizedRoot, normalizedDestination).Split(
-                     [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
-                     StringSplitOptions.RemoveEmptyEntries))
-        {
-            current = Path.Combine(current, segment);
-            EnsureDirectory(current, rejectReparsePoint: true);
-        }
-    }
-
-    private static void EnsureDirectory(string path, bool rejectReparsePoint)
-    {
-        try
-        {
-            if (File.Exists(path))
-                throw new InvalidDataException($"The Hugging Face cache path '{path}' is an existing file.");
-
-            Directory.CreateDirectory(path);
-            if (rejectReparsePoint &&
-                (File.GetAttributes(path) & FileAttributes.ReparsePoint) != 0)
-                throw new InvalidDataException($"The Hugging Face cache path '{path}' is a reparse point.");
-        }
-        catch (Exception ex) when (
-            ex is IOException or
-                UnauthorizedAccessException or
-                System.Security.SecurityException or
-                NotSupportedException)
-        {
-            throw new InvalidDataException(
-                $"The Hugging Face cache path '{path}' could not be created safely.",
-                ex);
-        }
-    }
-
     [DllImport("kernel32.dll", EntryPoint = "GetDiskFreeSpaceExW", CharSet = CharSet.Unicode, SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     private static extern bool GetDiskFreeSpaceEx(
@@ -581,25 +561,6 @@ internal static class LocalAiManifestMigration
         }
     }
 
-    private static void DeleteTemporaryCreatedThisRun(string temporaryPath)
-    {
-        try
-        {
-            if (!File.Exists(temporaryPath))
-                return;
-            if ((File.GetAttributes(temporaryPath) & FileAttributes.ReparsePoint) != 0)
-                return;
-            File.Delete(temporaryPath);
-        }
-        catch (Exception ex) when (
-            ex is IOException or
-                UnauthorizedAccessException or
-                System.Security.SecurityException)
-        {
-            // A failed cleanup must not replace the migration result.
-        }
-    }
-
     private sealed class CacheVerificationProgress(
         IProgress<LocalAiModelMigrationProgress>? progress,
         long totalBytes) : IProgress<long>
@@ -611,4 +572,600 @@ internal static class LocalAiManifestMigration
                 value,
                 totalBytes);
     }
+
+    /// <summary>
+    /// Roots every cache mutation in directory handles whose identities are checked
+    /// against the configured cache root, so path swaps cannot redirect file writes.
+    /// </summary>
+    private sealed class SafeCacheDirectory : IDisposable
+    {
+        private readonly SafeFileHandle _cacheRootHandle;
+        private readonly SafeFileHandle _directoryHandle;
+        private readonly string _destinationPath;
+
+        private SafeCacheDirectory(
+            SafeFileHandle cacheRootHandle,
+            SafeFileHandle directoryHandle,
+            string destinationPath)
+        {
+            _cacheRootHandle = cacheRootHandle;
+            _directoryHandle = directoryHandle;
+            _destinationPath = destinationPath;
+        }
+
+        public static SafeCacheDirectory OpenOrCreate(
+            string cacheRoot,
+            string destinationDirectory)
+        {
+            if (!OperatingSystem.IsWindows())
+            {
+                throw new PlatformNotSupportedException(
+                    "Local AI Hugging Face cache migration requires Windows handle-relative file operations.");
+            }
+
+            string normalizedRoot = WindowsPathSafety.NormalizePath(cacheRoot);
+            string normalizedDestination = WindowsPathSafety.NormalizePath(destinationDirectory);
+            if (!WindowsPathSafety.IsStrictDescendant(normalizedDestination, normalizedRoot))
+            {
+                throw new InvalidDataException(
+                    "The Hugging Face cache migration destination escaped its cache root.");
+            }
+            if (File.Exists(normalizedRoot))
+            {
+                throw new InvalidDataException(
+                    "The Hugging Face cache root is an existing file.");
+            }
+
+            Directory.CreateDirectory(normalizedRoot);
+            SafeFileHandle? rootHandle = null;
+            SafeFileHandle? directoryHandle = null;
+            try
+            {
+                rootHandle = OpenDirectory(normalizedRoot, openReparsePoint: false);
+                directoryHandle = rootHandle;
+                string[] segments = Path.GetRelativePath(normalizedRoot, normalizedDestination).Split(
+                    [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
+                    StringSplitOptions.RemoveEmptyEntries);
+                foreach (string segment in segments)
+                {
+                    SafeFileHandle next = OpenOrCreateRelativeDirectory(directoryHandle, segment);
+                    if (!ReferenceEquals(directoryHandle, rootHandle))
+                        directoryHandle.Dispose();
+                    directoryHandle = next;
+                }
+
+                var result = new SafeCacheDirectory(
+                    rootHandle,
+                    directoryHandle,
+                    normalizedDestination);
+                result.RequireDirectoryInsideCacheRoot();
+                rootHandle = null;
+                directoryHandle = null;
+                return result;
+            }
+            finally
+            {
+                rootHandle?.Dispose();
+                directoryHandle?.Dispose();
+            }
+        }
+
+        public CacheMigrationFile? TryOpenExisting(string fileName)
+        {
+            ValidateFileName(fileName);
+            int status = OpenRelativeFile(
+                _directoryHandle,
+                fileName,
+                GenericRead | DeleteAccess | SynchronizeAccess,
+                FileOpen,
+                out SafeFileHandle? handle);
+            if (status != 0)
+            {
+                int error = checked((int)RtlNtStatusToDosError(status));
+                if (error is ErrorFileNotFound or ErrorPathNotFound)
+                    return null;
+                throw CreateNativeIOException(
+                    "The Hugging Face cache migration temporary file could not be opened safely.",
+                    error);
+            }
+
+            var file = new CacheMigrationFile(handle!, FileAccess.Read, this);
+            BY_HANDLE_FILE_INFORMATION info = GetHandleInformation(handle!);
+            if ((info.FileAttributes & (uint)FileAttributes.ReparsePoint) != 0 ||
+                info.NumberOfLinks != 1)
+            {
+                file.Delete();
+                file.Dispose();
+                return null;
+            }
+
+            RequireContainedFile(handle!, fileName);
+            return file;
+        }
+
+        public CacheMigrationFile CreateNew(string fileName)
+        {
+            ValidateFileName(fileName);
+            int status = OpenRelativeFile(
+                _directoryHandle,
+                fileName,
+                GenericRead | GenericWrite | DeleteAccess | SynchronizeAccess,
+                FileCreate,
+                out SafeFileHandle? handle);
+            if (status != 0)
+            {
+                throw CreateNativeIOException(
+                    "The Hugging Face cache migration temporary file could not be claimed safely.",
+                    checked((int)RtlNtStatusToDosError(status)));
+            }
+
+            var file = new CacheMigrationFile(handle!, FileAccess.ReadWrite, this);
+            try
+            {
+                RequireContainedFile(handle!, fileName);
+                return file;
+            }
+            catch
+            {
+                file.Dispose();
+                throw;
+            }
+        }
+
+        public void RequirePromotedFile(SafeFileHandle handle, string fileName)
+        {
+            RequireContainedFile(handle, fileName);
+            using SafeFileHandle namedDirectory = OpenDirectory(
+                _destinationPath,
+                openReparsePoint: true);
+            BY_HANDLE_FILE_INFORMATION held = GetHandleInformation(_directoryHandle);
+            BY_HANDLE_FILE_INFORMATION named = GetHandleInformation(namedDirectory);
+            if ((named.FileAttributes & (uint)FileAttributes.ReparsePoint) != 0 ||
+                held.VolumeSerialNumber != named.VolumeSerialNumber ||
+                held.FileIndexHigh != named.FileIndexHigh ||
+                held.FileIndexLow != named.FileIndexLow)
+            {
+                throw new InvalidDataException(
+                    "The Hugging Face cache migration destination directory changed during promotion.");
+            }
+        }
+
+        public void Rename(SafeFileHandle handle, string fileName)
+        {
+            ValidateFileName(fileName);
+            int rootOffset = IntPtr.Size == 8 ? 8 : 4;
+            int lengthOffset = rootOffset + IntPtr.Size;
+            int nameOffset = lengthOffset + sizeof(int);
+            byte[] nameBytes = Encoding.Unicode.GetBytes(fileName);
+            IntPtr buffer = Marshal.AllocHGlobal(nameOffset + nameBytes.Length);
+            try
+            {
+                for (int index = 0; index < nameOffset; index++)
+                    Marshal.WriteByte(buffer, index, 0);
+                Marshal.WriteIntPtr(buffer, rootOffset, _directoryHandle.DangerousGetHandle());
+                Marshal.WriteInt32(buffer, lengthOffset, nameBytes.Length);
+                Marshal.Copy(nameBytes, 0, buffer + nameOffset, nameBytes.Length);
+                int status = NtSetInformationFile(
+                    handle,
+                    out _,
+                    buffer,
+                    (uint)(nameOffset + nameBytes.Length),
+                    FileRenameInformation);
+                if (status != 0)
+                {
+                    throw CreateNativeIOException(
+                        "The Hugging Face cache migration temporary file could not be promoted safely.",
+                        checked((int)RtlNtStatusToDosError(status)));
+                }
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(buffer);
+            }
+        }
+
+        public void Dispose()
+        {
+            _directoryHandle.Dispose();
+            _cacheRootHandle.Dispose();
+        }
+
+        private void RequireContainedFile(SafeFileHandle handle, string fileName)
+        {
+            RequireDirectoryInsideCacheRoot();
+            string finalDirectory = GetFinalPathFromHandle(_directoryHandle);
+            string finalFile = GetFinalPathFromHandle(handle);
+            string expected = WindowsPathSafety.NormalizePath(Path.Combine(finalDirectory, fileName));
+            if (!WindowsPathSafety.PathEquals(finalFile, expected))
+            {
+                throw new InvalidDataException(
+                    "The Hugging Face cache migration file resolved outside its validated destination directory.");
+            }
+        }
+
+        private void RequireDirectoryInsideCacheRoot()
+        {
+            string finalRoot = GetFinalPathFromHandle(_cacheRootHandle);
+            string finalDirectory = GetFinalPathFromHandle(_directoryHandle);
+            if (!WindowsPathSafety.IsStrictDescendant(finalDirectory, finalRoot))
+            {
+                throw new InvalidDataException(
+                    "The Hugging Face cache migration destination directory resolved outside its cache root.");
+            }
+        }
+
+        private static SafeFileHandle OpenDirectory(string path, bool openReparsePoint)
+        {
+            uint flags = FileFlagBackupSemantics;
+            if (openReparsePoint)
+                flags |= FileFlagOpenReparsePoint;
+            SafeFileHandle handle = CreateFileW(
+                path,
+                GenericRead,
+                FileShare.ReadWrite | FileShare.Delete,
+                IntPtr.Zero,
+                OpenExisting,
+                flags,
+                IntPtr.Zero);
+            if (handle.IsInvalid)
+            {
+                handle.Dispose();
+                throw CreateNativeIOException(
+                    $"The Hugging Face cache directory '{path}' could not be opened safely.",
+                    Marshal.GetLastWin32Error());
+            }
+
+            return handle;
+        }
+
+        private static SafeFileHandle OpenOrCreateRelativeDirectory(
+            SafeFileHandle parent,
+            string segment)
+        {
+            ValidateFileName(segment);
+            int status = OpenRelative(
+                parent,
+                segment,
+                DirectoryAccess | SynchronizeAccess,
+                FileShare.ReadWrite | FileShare.Delete,
+                FileOpenIf,
+                FileDirectoryFile | FileSynchronousIoNonAlert | FileOpenReparsePoint,
+                out SafeFileHandle? handle);
+            if (status != 0)
+            {
+                throw CreateNativeIOException(
+                    "The Hugging Face cache migration directory could not be opened or created safely.",
+                    checked((int)RtlNtStatusToDosError(status)));
+            }
+
+            BY_HANDLE_FILE_INFORMATION info = GetHandleInformation(handle!);
+            if ((info.FileAttributes & (uint)FileAttributes.ReparsePoint) != 0)
+            {
+                handle!.Dispose();
+                throw new InvalidDataException(
+                    "The Hugging Face cache migration destination contains a reparse point.");
+            }
+            return handle!;
+        }
+
+        private static void ValidateFileName(string fileName)
+        {
+            if (!WindowsPathSafety.IsSafeSegment(fileName))
+                throw new InvalidDataException("The Hugging Face cache migration file name is unsafe.");
+        }
+    }
+
+    private sealed class CacheMigrationFile : IAsyncDisposable, IDisposable
+    {
+        private readonly SafeCacheDirectory _directory;
+        private bool _deleteOnDispose = true;
+        private bool _disposed;
+
+        public CacheMigrationFile(
+            SafeFileHandle handle,
+            FileAccess access,
+            SafeCacheDirectory directory)
+        {
+            _directory = directory;
+            Stream = new FileStream(handle, access, CopyBufferSize, isAsync: false);
+        }
+
+        public FileStream Stream { get; }
+
+        public void Promote(string destinationFileName) =>
+            _directory.Rename(Stream.SafeFileHandle, destinationFileName);
+
+        public void Commit() => _deleteOnDispose = false;
+
+        public void Delete()
+        {
+            if (_disposed || !_deleteOnDispose)
+                return;
+
+            SetDeleteDisposition(Stream.SafeFileHandle);
+            _deleteOnDispose = false;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+            try
+            {
+                if (_deleteOnDispose)
+                    SetDeleteDisposition(Stream.SafeFileHandle);
+            }
+            finally
+            {
+                _deleteOnDispose = false;
+                _disposed = true;
+                Stream.Dispose();
+            }
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            Dispose();
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private static int OpenRelativeFile(
+        SafeFileHandle directoryHandle,
+        string fileName,
+        uint desiredAccess,
+        uint createDisposition,
+        out SafeFileHandle? handle) =>
+        OpenRelative(
+            directoryHandle,
+            fileName,
+            desiredAccess,
+            shareAccess: 0,
+            createDisposition,
+            FileNonDirectoryFile | FileSynchronousIoNonAlert | FileOpenReparsePoint,
+            out handle);
+
+    // NtCreateFile is used with RootDirectory so creation/opening remains bound to
+    // the validated directory object even if its pathname is concurrently replaced.
+    private static int OpenRelative(
+        SafeFileHandle directoryHandle,
+        string fileName,
+        uint desiredAccess,
+        FileShare shareAccess,
+        uint createDisposition,
+        uint createOptions,
+        out SafeFileHandle? handle)
+    {
+        IntPtr nameBuffer = Marshal.StringToHGlobalUni(fileName);
+        IntPtr unicodeStringBuffer = Marshal.AllocHGlobal(Marshal.SizeOf<UNICODE_STRING>());
+        try
+        {
+            var unicodeString = new UNICODE_STRING
+            {
+                Length = checked((ushort)(fileName.Length * sizeof(char))),
+                MaximumLength = checked((ushort)((fileName.Length + 1) * sizeof(char))),
+                Buffer = nameBuffer,
+            };
+            Marshal.StructureToPtr(unicodeString, unicodeStringBuffer, fDeleteOld: false);
+            var objectAttributes = new OBJECT_ATTRIBUTES
+            {
+                Length = Marshal.SizeOf<OBJECT_ATTRIBUTES>(),
+                RootDirectory = directoryHandle.DangerousGetHandle(),
+                ObjectName = unicodeStringBuffer,
+                Attributes = ObjectCaseInsensitive,
+            };
+            int status = NtCreateFile(
+                out IntPtr rawHandle,
+                desiredAccess,
+                ref objectAttributes,
+                out _,
+                IntPtr.Zero,
+                (uint)FileAttributes.Normal,
+                (uint)shareAccess,
+                createDisposition,
+                createOptions,
+                IntPtr.Zero,
+                0);
+            handle = status == 0
+                ? new SafeFileHandle(rawHandle, ownsHandle: true)
+                : null;
+            return status;
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(unicodeStringBuffer);
+            Marshal.FreeHGlobal(nameBuffer);
+        }
+    }
+
+    private static void SetDeleteDisposition(SafeFileHandle handle)
+    {
+        IntPtr buffer = Marshal.AllocHGlobal(1);
+        try
+        {
+            Marshal.WriteByte(buffer, 1);
+            if (!SetFileInformationByHandle(
+                    handle,
+                    FileDispositionInfo,
+                    buffer,
+                    1))
+            {
+                throw CreateNativeIOException(
+                    "The Hugging Face cache migration temporary file could not be removed safely.",
+                    Marshal.GetLastWin32Error());
+            }
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(buffer);
+        }
+    }
+
+    private static BY_HANDLE_FILE_INFORMATION GetHandleInformation(SafeFileHandle handle)
+    {
+        if (!GetFileInformationByHandle(handle, out BY_HANDLE_FILE_INFORMATION info))
+        {
+            throw CreateNativeIOException(
+                "The Hugging Face cache migration handle could not be inspected safely.",
+                Marshal.GetLastWin32Error());
+        }
+        return info;
+    }
+
+    private static string GetFinalPathFromHandle(SafeFileHandle handle)
+    {
+        int capacity = 512;
+        while (capacity <= 32_768)
+        {
+            var builder = new StringBuilder(capacity);
+            uint length = GetFinalPathNameByHandleW(
+                handle,
+                builder,
+                (uint)builder.Capacity,
+                0);
+            if (length == 0)
+            {
+                throw CreateNativeIOException(
+                    "The Hugging Face cache migration handle path could not be resolved safely.",
+                    Marshal.GetLastWin32Error());
+            }
+            if (length < builder.Capacity)
+                return WindowsPathSafety.NormalizePath(NormalizeFinalPath(builder.ToString()));
+            capacity = checked((int)length + 1);
+        }
+
+        throw new IOException("A resolved Hugging Face cache migration path exceeded the supported length.");
+    }
+
+    private static string NormalizeFinalPath(string path)
+    {
+        const string extendedPrefix = @"\\?\";
+        const string extendedUncPrefix = @"\\?\UNC\";
+        if (path.StartsWith(extendedUncPrefix, StringComparison.OrdinalIgnoreCase))
+            return @"\\" + path[extendedUncPrefix.Length..];
+        return path.StartsWith(extendedPrefix, StringComparison.OrdinalIgnoreCase)
+            ? path[extendedPrefix.Length..]
+            : path;
+    }
+
+    private static IOException CreateNativeIOException(string message, int error) =>
+        new($"{message} {new Win32Exception(error).Message} (Win32 error {error}).");
+
+    private const uint GenericRead = 0x80000000;
+    private const uint GenericWrite = 0x40000000;
+    private const uint DeleteAccess = 0x00010000;
+    private const uint SynchronizeAccess = 0x00100000;
+    private const uint OpenExisting = 3;
+    private const uint FileOpen = 1;
+    private const uint FileCreate = 2;
+    private const uint FileOpenIf = 3;
+    private const uint FileDirectoryFile = 0x00000001;
+    private const uint FileNonDirectoryFile = 0x00000040;
+    private const uint FileSynchronousIoNonAlert = 0x00000020;
+    private const uint FileOpenReparsePoint = 0x00200000;
+    private const uint FileFlagBackupSemantics = 0x02000000;
+    private const uint FileFlagOpenReparsePoint = 0x00200000;
+    private const uint ObjectCaseInsensitive = 0x00000040;
+    private const uint DirectoryAccess = 0x00000087;
+    private const int FileDispositionInfo = 4;
+    private const int FileRenameInformation = 10;
+    private const int ErrorFileNotFound = 2;
+    private const int ErrorPathNotFound = 3;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct UNICODE_STRING
+    {
+        public ushort Length;
+        public ushort MaximumLength;
+        public IntPtr Buffer;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct OBJECT_ATTRIBUTES
+    {
+        public int Length;
+        public IntPtr RootDirectory;
+        public IntPtr ObjectName;
+        public uint Attributes;
+        public IntPtr SecurityDescriptor;
+        public IntPtr SecurityQualityOfService;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct IO_STATUS_BLOCK
+    {
+        public IntPtr Status;
+        public IntPtr Information;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct BY_HANDLE_FILE_INFORMATION
+    {
+        public uint FileAttributes;
+        public System.Runtime.InteropServices.ComTypes.FILETIME CreationTime;
+        public System.Runtime.InteropServices.ComTypes.FILETIME LastAccessTime;
+        public System.Runtime.InteropServices.ComTypes.FILETIME LastWriteTime;
+        public uint VolumeSerialNumber;
+        public uint FileSizeHigh;
+        public uint FileSizeLow;
+        public uint NumberOfLinks;
+        public uint FileIndexHigh;
+        public uint FileIndexLow;
+    }
+
+    [DllImport("ntdll.dll")]
+    private static extern int NtCreateFile(
+        out IntPtr fileHandle,
+        uint desiredAccess,
+        ref OBJECT_ATTRIBUTES objectAttributes,
+        out IO_STATUS_BLOCK ioStatusBlock,
+        IntPtr allocationSize,
+        uint fileAttributes,
+        uint shareAccess,
+        uint createDisposition,
+        uint createOptions,
+        IntPtr eaBuffer,
+        uint eaLength);
+
+    [DllImport("ntdll.dll")]
+    private static extern uint RtlNtStatusToDosError(int status);
+
+    [DllImport("ntdll.dll")]
+    private static extern int NtSetInformationFile(
+        SafeFileHandle fileHandle,
+        out IO_STATUS_BLOCK ioStatusBlock,
+        IntPtr fileInformation,
+        uint length,
+        int fileInformationClass);
+
+    [DllImport("kernel32.dll", EntryPoint = "CreateFileW", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern SafeFileHandle CreateFileW(
+        string fileName,
+        uint desiredAccess,
+        FileShare shareMode,
+        IntPtr securityAttributes,
+        uint creationDisposition,
+        uint flagsAndAttributes,
+        IntPtr templateFile);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool SetFileInformationByHandle(
+        SafeFileHandle file,
+        int fileInformationClass,
+        IntPtr fileInformation,
+        uint bufferSize);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetFileInformationByHandle(
+        SafeFileHandle file,
+        out BY_HANDLE_FILE_INFORMATION fileInformation);
+
+    [DllImport("kernel32.dll", EntryPoint = "GetFinalPathNameByHandleW", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern uint GetFinalPathNameByHandleW(
+        SafeFileHandle file,
+        StringBuilder filePath,
+        uint filePathLength,
+        uint flags);
 }

--- a/src/OpenClaw.Connection/LocalAi/LocalAiManifestMigration.cs
+++ b/src/OpenClaw.Connection/LocalAi/LocalAiManifestMigration.cs
@@ -32,7 +32,11 @@ internal static class LocalAiManifestMigration
         LocalAiInstallManifest manifest = legacyInstall.Manifest;
         LocalAiManifestStore.HuggingFaceModelProvenance provenance =
             GetProvenance(manifest);
-        if (!IsCanonicalLegacyModelPath(paths, legacyInstall.ModelPath, provenance))
+        if (!IsCanonicalLegacyModelPath(
+                paths,
+                legacyInstall.ModelPath,
+                provenance,
+                manifest.ModelAsset.FileName))
             return manifest;
 
         var expectedSha256 = new Sha256Digest(manifest.ModelAsset.Sha256);
@@ -252,10 +256,10 @@ internal static class LocalAiManifestMigration
     private static bool IsCanonicalLegacyModelPath(
         LocalAiPaths paths,
         string modelPath,
-        LocalAiManifestStore.HuggingFaceModelProvenance provenance)
+        LocalAiManifestStore.HuggingFaceModelProvenance provenance,
+        string fileName)
     {
         string[] repositorySegments = provenance.RepositoryId.Split('/');
-        string[] relativeSegments = provenance.RelativePath.Split('/');
         try
         {
             string expected = WindowsPathSafety.NormalizePath(
@@ -265,7 +269,7 @@ internal static class LocalAiManifestMigration
                         repositorySegments[0],
                         repositorySegments[1],
                         provenance.Revision,
-                        .. relativeSegments,
+                        fileName,
                     ]));
             return WindowsPathSafety.PathEquals(modelPath, expected);
         }
@@ -439,7 +443,8 @@ internal static class LocalAiManifestMigration
         string destinationDirectory,
         long requiredBytes)
     {
-        string capacityPath = FindExistingDirectory(destinationDirectory);
+        string capacityPath = NormalizeCapacityPath(
+            FindExistingDirectory(destinationDirectory));
         if (OperatingSystem.IsWindows())
         {
             if (!GetDiskFreeSpaceEx(
@@ -497,6 +502,17 @@ internal static class LocalAiManifestMigration
         return current
             ?? throw new InvalidDataException(
                 "The Hugging Face cache volume capacity could not be inspected safely.");
+    }
+
+    private static string NormalizeCapacityPath(string path)
+    {
+        string? root = Path.GetPathRoot(path);
+        return root is not null &&
+            WindowsPathSafety.PathEquals(
+                WindowsPathSafety.NormalizePath(path),
+                WindowsPathSafety.NormalizePath(root))
+            ? WindowsPathSafety.EnsureTrailingDirectorySeparator(root)
+            : path;
     }
 
     private static void Report(
@@ -560,15 +576,18 @@ internal static class LocalAiManifestMigration
         private readonly SafeFileHandle _cacheRootHandle;
         private readonly SafeFileHandle _directoryHandle;
         private readonly string _destinationPath;
+        private readonly bool _isNetworkCache;
 
         private SafeCacheDirectory(
             SafeFileHandle cacheRootHandle,
             SafeFileHandle directoryHandle,
-            string destinationPath)
+            string destinationPath,
+            bool isNetworkCache)
         {
             _cacheRootHandle = cacheRootHandle;
             _directoryHandle = directoryHandle;
             _destinationPath = destinationPath;
+            _isNetworkCache = isNetworkCache;
         }
 
         public static SafeCacheDirectory OpenOrCreate(
@@ -599,6 +618,8 @@ internal static class LocalAiManifestMigration
             try
             {
                 rootHandle = OpenAbsoluteDirectory(normalizedRoot, create: true);
+                if (rootHandle is null)
+                    throw new InvalidDataException("The Hugging Face cache root could not be created.");
                 directoryHandle = rootHandle;
                 string[] segments = Path.GetRelativePath(normalizedRoot, normalizedDestination).Split(
                     [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
@@ -614,7 +635,8 @@ internal static class LocalAiManifestMigration
                 var result = new SafeCacheDirectory(
                     rootHandle,
                     directoryHandle,
-                    normalizedDestination);
+                    normalizedDestination,
+                    normalizedRoot.StartsWith(@"\\", StringComparison.Ordinal));
                 result.RequireDirectoryInsideCacheRoot();
                 rootHandle = null;
                 directoryHandle = null;
@@ -727,7 +749,10 @@ internal static class LocalAiManifestMigration
             {
                 for (int index = 0; index < nameOffset; index++)
                     Marshal.WriteByte(buffer, index, 0);
-                Marshal.WriteIntPtr(buffer, rootOffset, _directoryHandle.DangerousGetHandle());
+                Marshal.WriteIntPtr(
+                    buffer,
+                    rootOffset,
+                    _isNetworkCache ? IntPtr.Zero : _directoryHandle.DangerousGetHandle());
                 Marshal.WriteInt32(buffer, lengthOffset, nameBytes.Length);
                 Marshal.Copy(nameBytes, 0, buffer + nameOffset, nameBytes.Length);
                 int status = NtSetInformationFile(
@@ -811,6 +836,14 @@ internal static class LocalAiManifestMigration
         internal static SafeFileHandle OpenRelativeDirectory(
             SafeFileHandle parent,
             string segment,
+            bool create) =>
+            TryOpenRelativeDirectory(parent, segment, create)
+            ?? throw new DirectoryNotFoundException(
+                "The Hugging Face cache migration directory does not exist.");
+
+        internal static SafeFileHandle? TryOpenRelativeDirectory(
+            SafeFileHandle parent,
+            string segment,
             bool create)
         {
             ValidateFileName(segment);
@@ -824,9 +857,12 @@ internal static class LocalAiManifestMigration
                 out SafeFileHandle? handle);
             if (status != 0)
             {
+                int error = checked((int)RtlNtStatusToDosError(status));
+                if (!create && error is ErrorFileNotFound or ErrorPathNotFound)
+                    return null;
                 throw CreateNativeIOException(
                     "The Hugging Face cache migration directory could not be opened or created safely.",
-                    checked((int)RtlNtStatusToDosError(status)));
+                    error);
             }
 
             BY_HANDLE_FILE_INFORMATION info = GetHandleInformation(handle!);
@@ -839,12 +875,15 @@ internal static class LocalAiManifestMigration
             return handle!;
         }
 
-        internal static SafeFileHandle OpenAbsoluteDirectory(string path, bool create)
+        internal static SafeFileHandle? OpenAbsoluteDirectory(string path, bool create)
         {
             string normalizedPath = WindowsPathSafety.NormalizePath(path);
             string pathRoot = Path.GetPathRoot(normalizedPath)
                 ?? throw new InvalidDataException("The Windows path has no volume root.");
             SafeFileHandle root = OpenDirectory(pathRoot, openReparsePoint: true);
+            if (WindowsPathSafety.PathEquals(normalizedPath, pathRoot))
+                return root;
+
             SafeFileHandle current = root;
             try
             {
@@ -852,7 +891,14 @@ internal static class LocalAiManifestMigration
                              [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
                              StringSplitOptions.RemoveEmptyEntries))
                 {
-                    SafeFileHandle next = OpenRelativeDirectory(current, segment, create);
+                    SafeFileHandle? next = TryOpenRelativeDirectory(current, segment, create);
+                    if (next is null)
+                    {
+                        if (!ReferenceEquals(current, root))
+                            current.Dispose();
+                        root.Dispose();
+                        return null;
+                    }
                     if (!ReferenceEquals(current, root))
                         current.Dispose();
                     current = next;
@@ -894,9 +940,11 @@ internal static class LocalAiManifestMigration
         if (!WindowsPathSafety.IsStrictDescendant(normalizedCandidate, normalizedRoot))
             throw new InvalidDataException("The legacy Local AI model escaped its managed model root.");
 
-        using SafeFileHandle root = SafeCacheDirectory.OpenAbsoluteDirectory(
+        using SafeFileHandle? root = SafeCacheDirectory.OpenAbsoluteDirectory(
             normalizedRoot,
             create: false);
+        if (root is null)
+            return null;
         string relativePath = Path.GetRelativePath(normalizedRoot, normalizedCandidate);
         string[] segments = relativePath.Split(
             [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
@@ -906,20 +954,24 @@ internal static class LocalAiManifestMigration
         {
             for (int index = 0; index < segments.Length - 1; index++)
             {
-                SafeFileHandle next = SafeCacheDirectory.OpenRelativeDirectory(
+                SafeFileHandle? next = SafeCacheDirectory.TryOpenRelativeDirectory(
                     directory,
                     segments[index],
                     create: false);
+                if (next is null)
+                    return null;
                 if (!ReferenceEquals(directory, root))
                     directory.Dispose();
                 directory = next;
             }
 
-            int status = OpenRelativeFile(
+            int status = OpenRelative(
                 directory,
                 segments[^1],
                 GenericRead | SynchronizeAccess,
+                FileShare.Read,
                 FileOpen,
+                FileNonDirectoryFile | FileSynchronousIoNonAlert | FileOpenReparsePoint,
                 out SafeFileHandle? handle);
             if (status != 0)
             {

--- a/src/OpenClaw.Connection/LocalAi/LocalAiManifestMigration.cs
+++ b/src/OpenClaw.Connection/LocalAi/LocalAiManifestMigration.cs
@@ -92,6 +92,7 @@ internal static class LocalAiManifestMigration
             if (temporary is null)
             {
                 source = await OpenLegacySourceIfAvailableAsync(
+                        paths.ModelsDirectory,
                         legacyInstall.ModelPath,
                         manifest.ModelAsset,
                         expectedSha256,
@@ -168,18 +169,6 @@ internal static class LocalAiManifestMigration
                 return CreateMigratedManifest(manifest, cacheRoot, cachedModelPath);
             }
 
-            if (!await IsVerifiedOpenCacheFileAsync(
-                    temporary.Stream,
-                    manifest.ModelAsset,
-                    expectedSha256,
-                    progress,
-                    cancellationToken)
-                .ConfigureAwait(false))
-            {
-                throw new InvalidDataException(
-                    "The promoted Hugging Face cache model does not match its receipt.");
-            }
-
             directory!.RequirePromotedFile(temporary.Stream.SafeFileHandle, destinationFileName);
             temporary.Commit();
             return CreateMigratedManifest(manifest, cacheRoot, cachedModelPath);
@@ -204,15 +193,23 @@ internal static class LocalAiManifestMigration
         CacheMigrationFile? temporary = directory.TryOpenExisting(temporaryFileName);
         if (temporary is null)
             return null;
-        if (await IsVerifiedOpenCacheFileAsync(
-                temporary.Stream,
-                receipt,
-                expectedSha256,
-                progress,
-                cancellationToken)
-            .ConfigureAwait(false))
+        try
         {
-            return temporary;
+            if (await IsVerifiedOpenCacheFileAsync(
+                    temporary.Stream,
+                    receipt,
+                    expectedSha256,
+                    progress,
+                    cancellationToken)
+                .ConfigureAwait(false))
+            {
+                return temporary;
+            }
+        }
+        catch
+        {
+            temporary.Dispose();
+            throw;
         }
 
         temporary.Dispose();
@@ -220,19 +217,19 @@ internal static class LocalAiManifestMigration
     }
 
     private static async Task<FileStream?> OpenLegacySourceIfAvailableAsync(
+        string modelsDirectory,
         string legacyModelPath,
         LocalAiAssetReceipt receipt,
         Sha256Digest expectedSha256,
         IProgress<LocalAiModelMigrationProgress>? progress,
         CancellationToken cancellationToken)
     {
-        if (Directory.Exists(legacyModelPath))
-            throw new InvalidDataException("The legacy Local AI model path is an existing directory.");
-        if (!PathEntryExists(legacyModelPath))
+        FileStream? source = OpenContainedReadFile(modelsDirectory, legacyModelPath);
+        if (source is null)
             return null;
 
         return await OpenVerifiedLegacySourceAsync(
-                legacyModelPath,
+                source,
                 receipt,
                 expectedSha256,
                 progress,
@@ -291,31 +288,12 @@ internal static class LocalAiManifestMigration
         };
 
     private static async Task<FileStream> OpenVerifiedLegacySourceAsync(
-        string sourcePath,
+        FileStream stream,
         LocalAiAssetReceipt receipt,
         Sha256Digest expectedSha256,
         IProgress<LocalAiModelMigrationProgress>? progress,
         CancellationToken cancellationToken)
     {
-        FileStream stream;
-        try
-        {
-            stream = new FileStream(
-                sourcePath,
-                FileMode.Open,
-                FileAccess.Read,
-                FileShare.Read,
-                CopyBufferSize,
-                FileOptions.Asynchronous | FileOptions.SequentialScan);
-        }
-        catch (Exception ex) when (
-            ex is IOException or UnauthorizedAccessException or System.Security.SecurityException)
-        {
-            throw new InvalidDataException(
-                "The legacy Local AI model could not be opened safely for cache migration.",
-                ex);
-        }
-
         bool verified = false;
         try
         {
@@ -616,12 +594,11 @@ internal static class LocalAiManifestMigration
                     "The Hugging Face cache root is an existing file.");
             }
 
-            Directory.CreateDirectory(normalizedRoot);
             SafeFileHandle? rootHandle = null;
             SafeFileHandle? directoryHandle = null;
             try
             {
-                rootHandle = OpenDirectory(normalizedRoot, openReparsePoint: false);
+                rootHandle = OpenAbsoluteDirectory(normalizedRoot, create: true);
                 directoryHandle = rootHandle;
                 string[] segments = Path.GetRelativePath(normalizedRoot, normalizedDestination).Split(
                     [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
@@ -670,17 +647,25 @@ internal static class LocalAiManifestMigration
             }
 
             var file = new CacheMigrationFile(handle!, FileAccess.Read, this);
-            BY_HANDLE_FILE_INFORMATION info = GetHandleInformation(handle!);
-            if ((info.FileAttributes & (uint)FileAttributes.ReparsePoint) != 0 ||
-                info.NumberOfLinks != 1)
+            try
             {
-                file.Delete();
-                file.Dispose();
-                return null;
-            }
+                BY_HANDLE_FILE_INFORMATION info = GetHandleInformation(handle!);
+                if ((info.FileAttributes & (uint)FileAttributes.ReparsePoint) != 0 ||
+                    info.NumberOfLinks != 1)
+                {
+                    file.Delete();
+                    file.Dispose();
+                    return null;
+                }
 
-            RequireContainedFile(handle!, fileName);
-            return file;
+                RequireContainedFile(handle!, fileName);
+                return file;
+            }
+            catch
+            {
+                file.Dispose();
+                throw;
+            }
         }
 
         public CacheMigrationFile CreateNew(string fileName)
@@ -820,7 +805,13 @@ internal static class LocalAiManifestMigration
 
         private static SafeFileHandle OpenOrCreateRelativeDirectory(
             SafeFileHandle parent,
-            string segment)
+            string segment) =>
+            OpenRelativeDirectory(parent, segment, create: true);
+
+        internal static SafeFileHandle OpenRelativeDirectory(
+            SafeFileHandle parent,
+            string segment,
+            bool create)
         {
             ValidateFileName(segment);
             int status = OpenRelative(
@@ -828,7 +819,7 @@ internal static class LocalAiManifestMigration
                 segment,
                 DirectoryAccess | SynchronizeAccess,
                 FileShare.ReadWrite | FileShare.Delete,
-                FileOpenIf,
+                create ? FileOpenIf : FileOpen,
                 FileDirectoryFile | FileSynchronousIoNonAlert | FileOpenReparsePoint,
                 out SafeFileHandle? handle);
             if (status != 0)
@@ -848,10 +839,127 @@ internal static class LocalAiManifestMigration
             return handle!;
         }
 
+        internal static SafeFileHandle OpenAbsoluteDirectory(string path, bool create)
+        {
+            string normalizedPath = WindowsPathSafety.NormalizePath(path);
+            string pathRoot = Path.GetPathRoot(normalizedPath)
+                ?? throw new InvalidDataException("The Windows path has no volume root.");
+            SafeFileHandle root = OpenDirectory(pathRoot, openReparsePoint: true);
+            SafeFileHandle current = root;
+            try
+            {
+                foreach (string segment in Path.GetRelativePath(pathRoot, normalizedPath).Split(
+                             [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
+                             StringSplitOptions.RemoveEmptyEntries))
+                {
+                    SafeFileHandle next = OpenRelativeDirectory(current, segment, create);
+                    if (!ReferenceEquals(current, root))
+                        current.Dispose();
+                    current = next;
+                }
+
+                if (ReferenceEquals(current, root))
+                    return root;
+                root.Dispose();
+                return current;
+            }
+            catch
+            {
+                if (!ReferenceEquals(current, root))
+                    current.Dispose();
+                root.Dispose();
+                throw;
+            }
+        }
+
         private static void ValidateFileName(string fileName)
         {
             if (!WindowsPathSafety.IsSafeSegment(fileName))
                 throw new InvalidDataException("The Hugging Face cache migration file name is unsafe.");
+        }
+    }
+
+    private static FileStream? OpenContainedReadFile(
+        string containedRoot,
+        string candidatePath)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            throw new PlatformNotSupportedException(
+                "Local AI Hugging Face cache migration requires Windows handle-relative file operations.");
+        }
+
+        string normalizedRoot = WindowsPathSafety.NormalizePath(containedRoot);
+        string normalizedCandidate = WindowsPathSafety.NormalizePath(candidatePath);
+        if (!WindowsPathSafety.IsStrictDescendant(normalizedCandidate, normalizedRoot))
+            throw new InvalidDataException("The legacy Local AI model escaped its managed model root.");
+
+        using SafeFileHandle root = SafeCacheDirectory.OpenAbsoluteDirectory(
+            normalizedRoot,
+            create: false);
+        string relativePath = Path.GetRelativePath(normalizedRoot, normalizedCandidate);
+        string[] segments = relativePath.Split(
+            [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
+            StringSplitOptions.RemoveEmptyEntries);
+        SafeFileHandle directory = root;
+        try
+        {
+            for (int index = 0; index < segments.Length - 1; index++)
+            {
+                SafeFileHandle next = SafeCacheDirectory.OpenRelativeDirectory(
+                    directory,
+                    segments[index],
+                    create: false);
+                if (!ReferenceEquals(directory, root))
+                    directory.Dispose();
+                directory = next;
+            }
+
+            int status = OpenRelativeFile(
+                directory,
+                segments[^1],
+                GenericRead | SynchronizeAccess,
+                FileOpen,
+                out SafeFileHandle? handle);
+            if (status != 0)
+            {
+                int error = checked((int)RtlNtStatusToDosError(status));
+                if (error is ErrorFileNotFound or ErrorPathNotFound)
+                    return null;
+                throw CreateNativeIOException(
+                    "The legacy Local AI model could not be opened safely for cache migration.",
+                    error);
+            }
+
+            try
+            {
+                BY_HANDLE_FILE_INFORMATION info = GetHandleInformation(handle!);
+                if ((info.FileAttributes & (uint)FileAttributes.ReparsePoint) != 0 ||
+                    info.NumberOfLinks != 1 ||
+                    !WindowsPathSafety.PathEquals(
+                        GetFinalPathFromHandle(handle!),
+                        normalizedCandidate))
+                {
+                    throw new InvalidDataException(
+                        "The legacy Local AI model path is not a safely owned regular file.");
+                }
+
+                return new FileStream(
+                    handle!,
+                    FileAccess.Read,
+                    CopyBufferSize,
+                    isAsync: false);
+            }
+            catch
+            {
+                handle!.Dispose();
+                throw;
+            }
+        }
+        finally
+        {
+            if (!ReferenceEquals(directory, root))
+                directory.Dispose();
         }
     }
 
@@ -1066,7 +1174,7 @@ internal static class LocalAiManifestMigration
     private const uint FileFlagBackupSemantics = 0x02000000;
     private const uint FileFlagOpenReparsePoint = 0x00200000;
     private const uint ObjectCaseInsensitive = 0x00000040;
-    private const uint DirectoryAccess = 0x00000087;
+    private const uint DirectoryAccess = 0x00000081;
     private const int FileDispositionInfo = 4;
     private const int FileRenameInformation = 10;
     private const int ErrorFileNotFound = 2;

--- a/tests/OpenClaw.Connection.Tests/LocalAiManifestMigrationTests.cs
+++ b/tests/OpenClaw.Connection.Tests/LocalAiManifestMigrationTests.cs
@@ -50,6 +50,23 @@ public sealed class LocalAiManifestMigrationTests
     }
 
     [Fact]
+    public async Task Migration_AllowsExistingReadHandleOnActiveLegacyModel()
+    {
+        using var temp = new TempDirectory("local-ai-cache-migration-");
+        MigrationFixture fixture = await CreateFixtureAsync(temp);
+        await using var activeModel = new FileStream(
+            fixture.LegacyModelPath,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read);
+
+        LocalAiResolvedInstall migrated = (await fixture.Store.MigrateLegacyModelToHubCacheAsync())!;
+
+        Assert.Equal(LocalAiInstallManifest.HubCacheReceiptSchemaVersion, migrated.Manifest.SchemaVersion);
+        Assert.Equal(fixture.Content, await File.ReadAllBytesAsync(fixture.CachedModelPath));
+    }
+
+    [Fact]
     public async Task Load_IsIdempotentAndDoesNotRewriteVerifiedCacheContent()
     {
         using var temp = new TempDirectory("local-ai-cache-migration-");
@@ -230,6 +247,19 @@ public sealed class LocalAiManifestMigrationTests
         using var temp = new TempDirectory("local-ai-cache-migration-");
         MigrationFixture fixture = await CreateFixtureAsync(temp);
         File.Delete(fixture.LegacyModelPath);
+
+        LocalAiResolvedInstall unchanged = (await fixture.Store.MigrateLegacyModelToHubCacheAsync())!;
+
+        Assert.Equal(LocalAiInstallManifest.CurrentSchemaVersion, unchanged.Manifest.SchemaVersion);
+        Assert.False(Directory.Exists(fixture.CacheRoot));
+    }
+
+    [Fact]
+    public async Task Migration_MissingLegacyDirectoryTreeDoesNotCreateCacheDirectories()
+    {
+        using var temp = new TempDirectory("local-ai-cache-migration-");
+        MigrationFixture fixture = await CreateFixtureAsync(temp);
+        Directory.Delete(Path.GetDirectoryName(fixture.LegacyModelPath)!, recursive: true);
 
         LocalAiResolvedInstall unchanged = (await fixture.Store.MigrateLegacyModelToHubCacheAsync())!;
 
@@ -502,6 +532,35 @@ public sealed class LocalAiManifestMigrationTests
     }
 
     [Fact]
+    public async Task Migration_MapsFlatLegacyFileIntoNestedHuggingFaceSnapshotPath()
+    {
+        using var temp = new TempDirectory("local-ai-cache-migration-");
+        MigrationFixture fixture = await CreateFixtureAsync(temp);
+        LocalAiInstallManifest nestedManifest = fixture.Manifest with
+        {
+            ModelAsset = fixture.Manifest.ModelAsset with
+            {
+                SourceUrl =
+                    $"https://huggingface.co/{RepositoryId}/resolve/{Revision}/weights/model.gguf?download=true",
+            },
+        };
+        await fixture.Store.SaveAsync(nestedManifest);
+        Assert.True(HuggingFaceHubCache.TryGetSnapshotPaths(
+            fixture.CacheRoot,
+            RepositoryId,
+            Revision,
+            "weights/model.gguf",
+            out string nestedCachedModelPath,
+            out _,
+            out string error), error);
+
+        LocalAiResolvedInstall migrated = (await fixture.Store.MigrateLegacyModelToHubCacheAsync())!;
+
+        Assert.Equal(nestedCachedModelPath, migrated.Manifest.CachedModelPath);
+        Assert.Equal(fixture.Content, await File.ReadAllBytesAsync(nestedCachedModelPath));
+    }
+
+    [Fact]
     public async Task Migration_RejectsReparsePointCacheRootWithoutWritingItsTarget()
     {
         using var temp = new TempDirectory("local-ai-cache-migration-");
@@ -522,12 +581,10 @@ public sealed class LocalAiManifestMigrationTests
             await ReadPersistedSchemaVersionAsync(fixture.Paths.ManifestPath));
     }
 
-    [Fact]
+    [CrossVolumeFact]
     public async Task Migration_CopiesAcrossConfiguredDistinctVolume()
     {
-        string? configuredRoot = Environment.GetEnvironmentVariable("OPENCLAW_TEST_HF_CACHE_ROOT");
-        if (string.IsNullOrWhiteSpace(configuredRoot))
-            return;
+        string configuredRoot = Environment.GetEnvironmentVariable("OPENCLAW_TEST_HF_CACHE_ROOT")!;
 
         using var temp = new TempDirectory("local-ai-cache-migration-");
         string cacheRoot = Path.Combine(
@@ -700,6 +757,18 @@ internal sealed class ConnectionSymbolicLinkFactAttribute : FactAttribute
             {
                 // A failed capability probe must not fail the test host.
             }
+        }
+    }
+}
+
+internal sealed class CrossVolumeFactAttribute : FactAttribute
+{
+    public CrossVolumeFactAttribute()
+    {
+        if (string.IsNullOrWhiteSpace(
+                Environment.GetEnvironmentVariable("OPENCLAW_TEST_HF_CACHE_ROOT")))
+        {
+            Skip = "Set OPENCLAW_TEST_HF_CACHE_ROOT to a directory on a distinct volume.";
         }
     }
 }

--- a/tests/OpenClaw.Connection.Tests/LocalAiManifestMigrationTests.cs
+++ b/tests/OpenClaw.Connection.Tests/LocalAiManifestMigrationTests.cs
@@ -207,6 +207,23 @@ public sealed class LocalAiManifestMigrationTests
             await ReadPersistedSchemaVersionAsync(fixture.Paths.ManifestPath));
     }
 
+    [ConnectionSymbolicLinkFact]
+    public async Task Migration_RejectsLegacyModelSymlinkOutsideManagedModelRoot()
+    {
+        using var temp = new TempDirectory("local-ai-cache-migration-");
+        MigrationFixture fixture = await CreateFixtureAsync(temp);
+        string outsideModel = temp.Combine("outside-model.gguf");
+        await File.WriteAllBytesAsync(outsideModel, fixture.Content);
+        File.Delete(fixture.LegacyModelPath);
+        File.CreateSymbolicLink(fixture.LegacyModelPath, outsideModel);
+
+        await Assert.ThrowsAsync<InvalidDataException>(
+            () => fixture.Store.MigrateLegacyModelToHubCacheAsync());
+
+        Assert.Equal(fixture.Content, await File.ReadAllBytesAsync(outsideModel));
+        Assert.False(File.Exists(fixture.CachedModelPath));
+    }
+
     [Fact]
     public async Task Migration_MissingLegacySourceDoesNotCreateCacheDirectories()
     {
@@ -409,6 +426,32 @@ public sealed class LocalAiManifestMigrationTests
     }
 
     [Fact]
+    public async Task Migration_CancellationWhileVerifyingRecoveredPartialReleasesItForRetry()
+    {
+        using var temp = new TempDirectory("local-ai-cache-migration-");
+        MigrationFixture fixture = await CreateFixtureAsync(temp);
+        string partial = Path.Combine(
+            Path.GetDirectoryName(fixture.CachedModelPath)!,
+            $".openclaw-migration-{fixture.Manifest.ModelAsset.Sha256}.partial");
+        Directory.CreateDirectory(Path.GetDirectoryName(partial)!);
+        await File.WriteAllBytesAsync(partial, fixture.Content);
+        using var cancellation = new CancellationTokenSource();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => fixture.Store.MigrateLegacyModelToHubCacheAsync(
+                new InlineProgress<LocalAiModelMigrationProgress>(value =>
+                {
+                    if (value.Phase == LocalAiModelMigrationPhase.VerifyingCacheCopy)
+                        cancellation.Cancel();
+                }),
+                cancellation.Token));
+
+        LocalAiResolvedInstall migrated = (await fixture.Store.MigrateLegacyModelToHubCacheAsync())!;
+        Assert.Equal(LocalAiInstallManifest.HubCacheReceiptSchemaVersion, migrated.Manifest.SchemaVersion);
+        Assert.Equal(fixture.Content, await File.ReadAllBytesAsync(fixture.CachedModelPath));
+    }
+
+    [Fact]
     public async Task Load_RejectsTamperedSchemaFourCacheReceipt()
     {
         using var temp = new TempDirectory("local-ai-cache-migration-");
@@ -438,6 +481,45 @@ public sealed class LocalAiManifestMigrationTests
         LocalAiResolvedInstall migrated = (await fixture.Store.MigrateLegacyModelToHubCacheAsync())!;
 
         Assert.Equal(LocalAiInstallManifest.HubCacheReceiptSchemaVersion, migrated.Manifest.SchemaVersion);
+    }
+
+    [Fact]
+    public async Task Save_RejectsEncodedTraversalInHuggingFaceRelativePath()
+    {
+        using var temp = new TempDirectory("local-ai-cache-migration-");
+        MigrationFixture fixture = await CreateFixtureAsync(temp);
+        LocalAiInstallManifest unsafeManifest = fixture.Manifest with
+        {
+            ModelAsset = fixture.Manifest.ModelAsset with
+            {
+                SourceUrl =
+                    $"https://huggingface.co/{RepositoryId}/resolve/{Revision}/%2e%2e/model.gguf?download=true",
+            },
+        };
+
+        await Assert.ThrowsAsync<InvalidDataException>(
+            () => fixture.Store.SaveAsync(unsafeManifest));
+    }
+
+    [Fact]
+    public async Task Migration_RejectsReparsePointCacheRootWithoutWritingItsTarget()
+    {
+        using var temp = new TempDirectory("local-ai-cache-migration-");
+        string outsideCache = temp.Combine("outside-cache-root");
+        string cacheRoot = temp.Combine("hf-cache-link");
+        Directory.CreateDirectory(outsideCache);
+        Assert.True(TryCreateJunction(cacheRoot, outsideCache));
+        MigrationFixture fixture = await CreateFixtureAsync(
+            temp,
+            cacheRootOverride: cacheRoot);
+
+        await Assert.ThrowsAsync<InvalidDataException>(
+            () => fixture.Store.MigrateLegacyModelToHubCacheAsync());
+
+        Assert.Empty(Directory.EnumerateFileSystemEntries(outsideCache));
+        Assert.Equal(
+            LocalAiInstallManifest.CurrentSchemaVersion,
+            await ReadPersistedSchemaVersionAsync(fixture.Paths.ManifestPath));
     }
 
     [Fact]

--- a/tests/OpenClaw.Connection.Tests/LocalAiManifestMigrationTests.cs
+++ b/tests/OpenClaw.Connection.Tests/LocalAiManifestMigrationTests.cs
@@ -305,7 +305,7 @@ public sealed class LocalAiManifestMigrationTests
     }
 
     [Fact]
-    public async Task Migration_RejectsTemporaryContentChangedBeforePromotion()
+    public async Task Migration_RejectsAttemptedTemporaryChangeAndRemovesOwnedPartial()
     {
         using var temp = new TempDirectory("local-ai-cache-migration-");
         MigrationFixture fixture = await CreateFixtureAsync(
@@ -327,9 +327,39 @@ public sealed class LocalAiManifestMigrationTests
         Assert.Equal(
             LocalAiInstallManifest.CurrentSchemaVersion,
             await ReadPersistedSchemaVersionAsync(fixture.Paths.ManifestPath));
+        Assert.False(File.Exists(fixture.CachedModelPath));
+        Assert.DoesNotContain(
+            Directory.EnumerateFiles(Path.GetDirectoryName(fixture.CachedModelPath)!),
+            path => Path.GetFileName(path).StartsWith(".openclaw-migration-", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Migration_RejectsDestinationDirectorySwapWithoutWritingOutsideCache()
+    {
+        using var temp = new TempDirectory("local-ai-cache-migration-");
+        string? preservedDirectory = null;
+        string outsideDirectory = temp.Combine("outside-cache");
+        Directory.CreateDirectory(outsideDirectory);
+        MigrationFixture fixture = await CreateFixtureAsync(
+            temp,
+            beforeMigrationPromotion: (destinationPath, _) =>
+            {
+                string destinationDirectory = Path.GetDirectoryName(destinationPath)!;
+                preservedDirectory = destinationDirectory + "-preserved";
+                Directory.Move(destinationDirectory, preservedDirectory);
+                Assert.True(TryCreateJunction(destinationDirectory, outsideDirectory));
+                return Task.CompletedTask;
+            });
+
+        InvalidDataException error = await Assert.ThrowsAsync<InvalidDataException>(
+            () => fixture.Store.MigrateLegacyModelToHubCacheAsync());
+
+        Assert.Contains("promoted safely", error.Message, StringComparison.Ordinal);
+        Assert.Empty(Directory.EnumerateFiles(outsideDirectory));
+        Assert.NotNull(preservedDirectory);
         Assert.Equal(
-            Enumerable.Repeat((byte)0x7f, FixtureContent.Length).ToArray(),
-            await File.ReadAllBytesAsync(fixture.CachedModelPath));
+            LocalAiInstallManifest.CurrentSchemaVersion,
+            await ReadPersistedSchemaVersionAsync(fixture.Paths.ManifestPath));
     }
 
     [Fact]
@@ -507,11 +537,17 @@ public sealed class LocalAiManifestMigrationTests
     }
 
     private static bool TryCreateHardLink(string linkPath, string existingPath)
+        => RunMklink($"/H \"{linkPath}\" \"{existingPath}\"");
+
+    private static bool TryCreateJunction(string linkPath, string targetPath)
+        => RunMklink($"/J \"{linkPath}\" \"{targetPath}\"");
+
+    private static bool RunMklink(string arguments)
     {
         using var process = Process.Start(new ProcessStartInfo
         {
             FileName = Environment.GetEnvironmentVariable("COMSPEC") ?? "cmd.exe",
-            Arguments = $"/d /c mklink /H \"{linkPath}\" \"{existingPath}\"",
+            Arguments = $"/d /c mklink {arguments}",
             CreateNoWindow = true,
             UseShellExecute = false,
             RedirectStandardOutput = true,

--- a/tests/OpenClaw.Connection.Tests/LocalAiManifestMigrationTests.cs
+++ b/tests/OpenClaw.Connection.Tests/LocalAiManifestMigrationTests.cs
@@ -1,0 +1,587 @@
+using OpenClaw.Connection.LocalAi;
+using OpenClaw.Shared.Inference.Catalog;
+using OpenClaw.TestSupport;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json.Nodes;
+
+namespace OpenClaw.Connection.Tests;
+
+public sealed class LocalAiManifestMigrationTests
+{
+    private const string RepositoryId = "owner/repository";
+    private const string RelativeModelPath = "model.gguf";
+    private static readonly string Revision = new('a', 40);
+
+    [Fact]
+    public async Task Load_DoesNotTriggerCacheMigration()
+    {
+        using var temp = new TempDirectory("local-ai-cache-migration-");
+        MigrationFixture fixture = await CreateFixtureAsync(temp);
+
+        LocalAiResolvedInstall loaded = (await fixture.Store.LoadAsync())!;
+
+        Assert.Equal(LocalAiInstallManifest.CurrentSchemaVersion, loaded.Manifest.SchemaVersion);
+        Assert.False(File.Exists(fixture.CachedModelPath));
+        Assert.Equal(fixture.Content, await File.ReadAllBytesAsync(fixture.LegacyModelPath));
+    }
+
+    [Fact]
+    public async Task Load_CopiesVerifiedLegacyWeightsAndRecordsTransitionalReceipt()
+    {
+        using var temp = new TempDirectory("local-ai-cache-migration-");
+        MigrationFixture fixture = await CreateFixtureAsync(temp);
+        var progress = new List<LocalAiModelMigrationProgress>();
+
+        LocalAiResolvedInstall migrated = (await fixture.Store.MigrateLegacyModelToHubCacheAsync(
+            new InlineProgress<LocalAiModelMigrationProgress>(progress.Add)))!;
+
+        Assert.Equal(LocalAiInstallManifest.HubCacheReceiptSchemaVersion, migrated.Manifest.SchemaVersion);
+        Assert.Equal(fixture.LegacyModelPath, migrated.ModelPath);
+        Assert.Equal(fixture.CacheRoot, migrated.Manifest.ModelCacheRoot);
+        Assert.Equal(fixture.CachedModelPath, migrated.Manifest.CachedModelPath);
+        Assert.Equal(fixture.Content, await File.ReadAllBytesAsync(fixture.CachedModelPath));
+        Assert.Equal(fixture.Content, await File.ReadAllBytesAsync(fixture.LegacyModelPath));
+        Assert.Contains(progress, value => value.Phase == LocalAiModelMigrationPhase.VerifyingLegacyModel);
+        Assert.Contains(progress, value => value.Phase == LocalAiModelMigrationPhase.CopyingToCache);
+        Assert.Contains(progress, value => value.Phase == LocalAiModelMigrationPhase.VerifyingCacheCopy);
+    }
+
+    [Fact]
+    public async Task Load_IsIdempotentAndDoesNotRewriteVerifiedCacheContent()
+    {
+        using var temp = new TempDirectory("local-ai-cache-migration-");
+        MigrationFixture fixture = await CreateFixtureAsync(temp);
+        _ = await fixture.Store.MigrateLegacyModelToHubCacheAsync();
+        DateTime firstWrite = File.GetLastWriteTimeUtc(fixture.CachedModelPath);
+        string firstManifest = await File.ReadAllTextAsync(fixture.Paths.ManifestPath);
+
+        _ = await fixture.Store.MigrateLegacyModelToHubCacheAsync();
+
+        Assert.Equal(firstWrite, File.GetLastWriteTimeUtc(fixture.CachedModelPath));
+        Assert.Equal(firstManifest, await File.ReadAllTextAsync(fixture.Paths.ManifestPath));
+        Assert.Equal(fixture.Content, await File.ReadAllBytesAsync(fixture.LegacyModelPath));
+    }
+
+    [Fact]
+    public async Task Load_RecoversWhenVerifiedDestinationExistsBeforeReceiptCommit()
+    {
+        using var temp = new TempDirectory("local-ai-cache-migration-");
+        MigrationFixture fixture = await CreateFixtureAsync(temp);
+        Directory.CreateDirectory(Path.GetDirectoryName(fixture.CachedModelPath)!);
+        await File.WriteAllBytesAsync(fixture.CachedModelPath, fixture.Content);
+        DateTime existingWrite = File.GetLastWriteTimeUtc(fixture.CachedModelPath);
+
+        LocalAiResolvedInstall migrated = (await fixture.Store.MigrateLegacyModelToHubCacheAsync())!;
+
+        Assert.Equal(existingWrite, File.GetLastWriteTimeUtc(fixture.CachedModelPath));
+        Assert.Equal(LocalAiInstallManifest.HubCacheReceiptSchemaVersion, migrated.Manifest.SchemaVersion);
+        Assert.True(File.Exists(fixture.LegacyModelPath));
+    }
+
+    [ConnectionSymbolicLinkFact]
+    public async Task Load_ReusesVerifiedStandardSnapshotSymlink()
+    {
+        using var temp = new TempDirectory("local-ai-cache-migration-");
+        MigrationFixture fixture = await CreateFixtureAsync(temp);
+        var digest = new Sha256Digest(fixture.Manifest.ModelAsset.Sha256);
+        Assert.True(HuggingFaceHubCache.TryGetBlobPath(
+            fixture.CacheRoot,
+            RepositoryId,
+            digest,
+            out string blobPath,
+            out string error), error);
+        Directory.CreateDirectory(Path.GetDirectoryName(blobPath)!);
+        Directory.CreateDirectory(Path.GetDirectoryName(fixture.CachedModelPath)!);
+        await File.WriteAllBytesAsync(blobPath, fixture.Content);
+        File.CreateSymbolicLink(
+            fixture.CachedModelPath,
+            Path.GetRelativePath(Path.GetDirectoryName(fixture.CachedModelPath)!, blobPath));
+
+        LocalAiResolvedInstall migrated = (await fixture.Store.MigrateLegacyModelToHubCacheAsync())!;
+
+        Assert.Equal(fixture.CachedModelPath, migrated.Manifest.CachedModelPath);
+        Assert.NotNull(new FileInfo(fixture.CachedModelPath).LinkTarget);
+        Assert.True(File.Exists(fixture.LegacyModelPath));
+    }
+
+    [Fact]
+    public async Task Load_RejectsMismatchedPreExistingDestinationWithoutChangingEitherCopy()
+    {
+        using var temp = new TempDirectory("local-ai-cache-migration-");
+        MigrationFixture fixture = await CreateFixtureAsync(temp);
+        byte[] mismatched = Enumerable.Repeat((byte)0x5a, fixture.Content.Length).ToArray();
+        Directory.CreateDirectory(Path.GetDirectoryName(fixture.CachedModelPath)!);
+        await File.WriteAllBytesAsync(fixture.CachedModelPath, mismatched);
+
+        InvalidDataException error = await Assert.ThrowsAsync<InvalidDataException>(
+            () => fixture.Store.MigrateLegacyModelToHubCacheAsync());
+
+        Assert.Contains("unsafe or does not match", error.Message, StringComparison.Ordinal);
+        Assert.Equal(mismatched, await File.ReadAllBytesAsync(fixture.CachedModelPath));
+        Assert.Equal(fixture.Content, await File.ReadAllBytesAsync(fixture.LegacyModelPath));
+        Assert.Equal(
+            LocalAiInstallManifest.CurrentSchemaVersion,
+            await ReadPersistedSchemaVersionAsync(fixture.Paths.ManifestPath));
+    }
+
+    [ConnectionSymbolicLinkFact]
+    public async Task Load_RejectsSnapshotSymlinkOutsideCacheAndPreservesLegacyReceipt()
+    {
+        using var temp = new TempDirectory("local-ai-cache-migration-");
+        using var outside = new TempDirectory("local-ai-cache-outside-");
+        MigrationFixture fixture = await CreateFixtureAsync(temp);
+        string outsideModel = outside.Combine("model.gguf");
+        await File.WriteAllBytesAsync(outsideModel, fixture.Content);
+        Directory.CreateDirectory(Path.GetDirectoryName(fixture.CachedModelPath)!);
+        File.CreateSymbolicLink(fixture.CachedModelPath, outsideModel);
+
+        await Assert.ThrowsAsync<InvalidDataException>(
+            () => fixture.Store.MigrateLegacyModelToHubCacheAsync());
+
+        Assert.Equal(fixture.Content, await File.ReadAllBytesAsync(outsideModel));
+        Assert.Equal(fixture.Content, await File.ReadAllBytesAsync(fixture.LegacyModelPath));
+        Assert.Equal(
+            LocalAiInstallManifest.CurrentSchemaVersion,
+            await ReadPersistedSchemaVersionAsync(fixture.Paths.ManifestPath));
+    }
+
+    [Fact]
+    public async Task Migration_RecoversFromInterruptedPartialCopy()
+    {
+        using var temp = new TempDirectory("local-ai-cache-migration-");
+        MigrationFixture fixture = await CreateFixtureAsync(temp);
+        string destinationDirectory = Path.GetDirectoryName(fixture.CachedModelPath)!;
+        Directory.CreateDirectory(destinationDirectory);
+        string partial = Path.Combine(
+            destinationDirectory,
+            $".openclaw-migration-{fixture.Manifest.ModelAsset.Sha256}.partial");
+        await File.WriteAllBytesAsync(partial, "interrupted copy"u8.ToArray());
+
+        LocalAiResolvedInstall migrated = (await fixture.Store.MigrateLegacyModelToHubCacheAsync())!;
+
+        Assert.Equal(LocalAiInstallManifest.HubCacheReceiptSchemaVersion, migrated.Manifest.SchemaVersion);
+        Assert.False(File.Exists(partial));
+        Assert.Equal(fixture.Content, await File.ReadAllBytesAsync(fixture.CachedModelPath));
+    }
+
+    [Fact]
+    public async Task Migration_ReplacesHardLinkedPartialWithoutChangingItsOtherLink()
+    {
+        using var temp = new TempDirectory("local-ai-cache-migration-");
+        MigrationFixture fixture = await CreateFixtureAsync(temp);
+        string destinationDirectory = Path.GetDirectoryName(fixture.CachedModelPath)!;
+        Directory.CreateDirectory(destinationDirectory);
+        string partial = Path.Combine(
+            destinationDirectory,
+            $".openclaw-migration-{fixture.Manifest.ModelAsset.Sha256}.partial");
+        string outside = temp.Combine("outside-partial.bin");
+        byte[] outsideContent = "must remain unchanged"u8.ToArray();
+        await File.WriteAllBytesAsync(outside, outsideContent);
+        Assert.True(TryCreateHardLink(partial, outside));
+
+        LocalAiResolvedInstall migrated = (await fixture.Store.MigrateLegacyModelToHubCacheAsync())!;
+
+        Assert.Equal(LocalAiInstallManifest.HubCacheReceiptSchemaVersion, migrated.Manifest.SchemaVersion);
+        Assert.Equal(outsideContent, await File.ReadAllBytesAsync(outside));
+        Assert.Equal(fixture.Content, await File.ReadAllBytesAsync(fixture.CachedModelPath));
+    }
+
+    [Fact]
+    public async Task Load_RejectsMismatchedLegacySourceWithoutWritingCacheOrReceipt()
+    {
+        using var temp = new TempDirectory("local-ai-cache-migration-");
+        MigrationFixture fixture = await CreateFixtureAsync(temp);
+        await File.WriteAllBytesAsync(
+            fixture.LegacyModelPath,
+            Enumerable.Repeat((byte)0x41, fixture.Content.Length).ToArray());
+
+        await Assert.ThrowsAsync<InvalidDataException>(
+            () => fixture.Store.MigrateLegacyModelToHubCacheAsync());
+
+        Assert.False(File.Exists(fixture.CachedModelPath));
+        Assert.Equal(
+            LocalAiInstallManifest.CurrentSchemaVersion,
+            await ReadPersistedSchemaVersionAsync(fixture.Paths.ManifestPath));
+    }
+
+    [Fact]
+    public async Task Migration_MissingLegacySourceDoesNotCreateCacheDirectories()
+    {
+        using var temp = new TempDirectory("local-ai-cache-migration-");
+        MigrationFixture fixture = await CreateFixtureAsync(temp);
+        File.Delete(fixture.LegacyModelPath);
+
+        LocalAiResolvedInstall unchanged = (await fixture.Store.MigrateLegacyModelToHubCacheAsync())!;
+
+        Assert.Equal(LocalAiInstallManifest.CurrentSchemaVersion, unchanged.Manifest.SchemaVersion);
+        Assert.False(Directory.Exists(fixture.CacheRoot));
+    }
+
+    [Fact]
+    public async Task ManifestDeletion_DoesNotDeleteMigratedSharedCacheContent()
+    {
+        using var temp = new TempDirectory("local-ai-cache-migration-");
+        MigrationFixture fixture = await CreateFixtureAsync(temp);
+        _ = await fixture.Store.MigrateLegacyModelToHubCacheAsync();
+
+        await fixture.Store.DeleteAsync();
+
+        Assert.False(File.Exists(fixture.Paths.ManifestPath));
+        Assert.Equal(fixture.Content, await File.ReadAllBytesAsync(fixture.CachedModelPath));
+        Assert.Equal(fixture.Content, await File.ReadAllBytesAsync(fixture.LegacyModelPath));
+    }
+
+    [Fact]
+    public async Task Migration_RejectsConcurrentManifestUpdateWithoutLosingIt()
+    {
+        using var temp = new TempDirectory("local-ai-cache-migration-");
+        MigrationFixture fixture = await CreateFixtureAsync(
+            temp,
+            async cancellationToken =>
+            {
+                JsonObject current =
+                    (JsonNode.Parse(await File.ReadAllTextAsync(
+                        Path.Combine(temp.Path, "app-data", "LocalAI", "state.json"),
+                        cancellationToken)) as JsonObject)!;
+                current["endpoint"] = "http://127.0.0.1:28888/v1";
+                await File.WriteAllTextAsync(
+                    Path.Combine(temp.Path, "app-data", "LocalAI", "state.json"),
+                    current.ToJsonString(),
+                    cancellationToken);
+            });
+
+        InvalidDataException error = await Assert.ThrowsAsync<InvalidDataException>(
+            () => fixture.Store.MigrateLegacyModelToHubCacheAsync());
+
+        Assert.Contains("changed while", error.Message, StringComparison.Ordinal);
+        JsonObject persisted =
+            (JsonNode.Parse(await File.ReadAllTextAsync(fixture.Paths.ManifestPath)) as JsonObject)!;
+        Assert.Equal("http://127.0.0.1:28888/v1", persisted["endpoint"]!.GetValue<string>());
+        Assert.Equal(
+            LocalAiInstallManifest.CurrentSchemaVersion,
+            persisted["schemaVersion"]!.GetValue<int>());
+        Assert.Equal(fixture.Content, await File.ReadAllBytesAsync(fixture.CachedModelPath));
+    }
+
+    [Fact]
+    public async Task Migration_RejectsConcurrentManifestDeletionWithoutResurrectingIt()
+    {
+        using var temp = new TempDirectory("local-ai-cache-migration-");
+        LocalAiManifestStore? concurrentStore = null;
+        MigrationFixture fixture = await CreateFixtureAsync(
+            temp,
+            cancellationToken => concurrentStore!.DeleteAsync(cancellationToken));
+        concurrentStore = new LocalAiManifestStore(fixture.Paths);
+
+        InvalidDataException error = await Assert.ThrowsAsync<InvalidDataException>(
+            () => fixture.Store.MigrateLegacyModelToHubCacheAsync());
+
+        Assert.Contains("changed while", error.Message, StringComparison.Ordinal);
+        Assert.False(File.Exists(fixture.Paths.ManifestPath));
+        Assert.Equal(fixture.Content, await File.ReadAllBytesAsync(fixture.CachedModelPath));
+    }
+
+    [Fact]
+    public async Task Migration_UsesVerifiedDestinationThatWinsPromotionRace()
+    {
+        using var temp = new TempDirectory("local-ai-cache-migration-");
+        MigrationFixture fixture = await CreateFixtureAsync(
+            temp,
+            beforeMigrationPromotion: async (destinationPath, cancellationToken) =>
+            {
+                await File.WriteAllBytesAsync(destinationPath, FixtureContent, cancellationToken);
+            });
+
+        LocalAiResolvedInstall migrated = (await fixture.Store.MigrateLegacyModelToHubCacheAsync())!;
+
+        Assert.Equal(LocalAiInstallManifest.HubCacheReceiptSchemaVersion, migrated.Manifest.SchemaVersion);
+        Assert.Equal(fixture.Content, await File.ReadAllBytesAsync(fixture.CachedModelPath));
+        Assert.DoesNotContain(
+            Directory.EnumerateFiles(Path.GetDirectoryName(fixture.CachedModelPath)!),
+            path => Path.GetFileName(path).StartsWith(".openclaw-migration-", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Migration_RejectsTemporaryContentChangedBeforePromotion()
+    {
+        using var temp = new TempDirectory("local-ai-cache-migration-");
+        MigrationFixture fixture = await CreateFixtureAsync(
+            temp,
+            beforeMigrationPromotion: async (destinationPath, cancellationToken) =>
+            {
+                string partial = Path.Combine(
+                    Path.GetDirectoryName(destinationPath)!,
+                    $".openclaw-migration-{Convert.ToHexString(SHA256.HashData(FixtureContent)).ToLowerInvariant()}.partial");
+                await File.WriteAllBytesAsync(
+                    partial,
+                    Enumerable.Repeat((byte)0x7f, FixtureContent.Length).ToArray(),
+                    cancellationToken);
+            });
+
+        await Assert.ThrowsAsync<InvalidDataException>(
+            () => fixture.Store.MigrateLegacyModelToHubCacheAsync());
+
+        Assert.Equal(
+            LocalAiInstallManifest.CurrentSchemaVersion,
+            await ReadPersistedSchemaVersionAsync(fixture.Paths.ManifestPath));
+        Assert.Equal(
+            Enumerable.Repeat((byte)0x7f, FixtureContent.Length).ToArray(),
+            await File.ReadAllBytesAsync(fixture.CachedModelPath));
+    }
+
+    [Fact]
+    public async Task Migration_HonorsCancellationBeforeMutation()
+    {
+        using var temp = new TempDirectory("local-ai-cache-migration-");
+        MigrationFixture fixture = await CreateFixtureAsync(temp);
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => fixture.Store.MigrateLegacyModelToHubCacheAsync(
+                null,
+                cancellation.Token));
+
+        Assert.False(File.Exists(fixture.CachedModelPath));
+        Assert.Equal(
+            LocalAiInstallManifest.CurrentSchemaVersion,
+            await ReadPersistedSchemaVersionAsync(fixture.Paths.ManifestPath));
+    }
+
+    [Fact]
+    public async Task Migration_CancellationDuringCopyRemovesOwnedPartialAndPreservesLegacyState()
+    {
+        using var temp = new TempDirectory("local-ai-cache-migration-");
+        MigrationFixture fixture = await CreateFixtureAsync(temp);
+        using var cancellation = new CancellationTokenSource();
+        var progress = new InlineProgress<LocalAiModelMigrationProgress>(value =>
+        {
+            if (value.Phase == LocalAiModelMigrationPhase.CopyingToCache)
+                cancellation.Cancel();
+        });
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => fixture.Store.MigrateLegacyModelToHubCacheAsync(
+                progress,
+                cancellation.Token));
+
+        Assert.False(File.Exists(fixture.CachedModelPath));
+        Assert.DoesNotContain(
+            Directory.EnumerateFiles(Path.GetDirectoryName(fixture.CachedModelPath)!),
+            path => Path.GetFileName(path).StartsWith(".openclaw-migration-", StringComparison.Ordinal));
+        Assert.Equal(fixture.Content, await File.ReadAllBytesAsync(fixture.LegacyModelPath));
+        Assert.Equal(
+            LocalAiInstallManifest.CurrentSchemaVersion,
+            await ReadPersistedSchemaVersionAsync(fixture.Paths.ManifestPath));
+    }
+
+    [Fact]
+    public async Task Load_RejectsTamperedSchemaFourCacheReceipt()
+    {
+        using var temp = new TempDirectory("local-ai-cache-migration-");
+        MigrationFixture fixture = await CreateFixtureAsync(temp);
+        _ = await fixture.Store.MigrateLegacyModelToHubCacheAsync();
+        JsonObject persisted =
+            (JsonNode.Parse(await File.ReadAllTextAsync(fixture.Paths.ManifestPath)) as JsonObject)!;
+        persisted["cachedModelPath"] = Path.Combine(fixture.CacheRoot, "other", "model.gguf");
+        await File.WriteAllTextAsync(fixture.Paths.ManifestPath, persisted.ToJsonString());
+
+        InvalidDataException error = await Assert.ThrowsAsync<InvalidDataException>(
+            () => fixture.Store.LoadAsync());
+
+        Assert.Contains("cache migration receipt", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Migration_AcceptsUtf8BomManifest()
+    {
+        using var temp = new TempDirectory("local-ai-cache-migration-");
+        MigrationFixture fixture = await CreateFixtureAsync(temp);
+        byte[] json = await File.ReadAllBytesAsync(fixture.Paths.ManifestPath);
+        await File.WriteAllBytesAsync(
+            fixture.Paths.ManifestPath,
+            [.. Encoding.UTF8.Preamble, .. json]);
+
+        LocalAiResolvedInstall migrated = (await fixture.Store.MigrateLegacyModelToHubCacheAsync())!;
+
+        Assert.Equal(LocalAiInstallManifest.HubCacheReceiptSchemaVersion, migrated.Manifest.SchemaVersion);
+    }
+
+    [Fact]
+    public async Task Migration_CopiesAcrossConfiguredDistinctVolume()
+    {
+        string? configuredRoot = Environment.GetEnvironmentVariable("OPENCLAW_TEST_HF_CACHE_ROOT");
+        if (string.IsNullOrWhiteSpace(configuredRoot))
+            return;
+
+        using var temp = new TempDirectory("local-ai-cache-migration-");
+        string cacheRoot = Path.Combine(
+            Path.GetFullPath(configuredRoot),
+            $"openclaw-cross-volume-{Guid.NewGuid():N}");
+        Assert.False(string.Equals(
+            Path.GetPathRoot(temp.Path),
+            Path.GetPathRoot(cacheRoot),
+            StringComparison.OrdinalIgnoreCase));
+        try
+        {
+            MigrationFixture fixture = await CreateFixtureAsync(temp, cacheRootOverride: cacheRoot);
+
+            LocalAiResolvedInstall migrated = (await fixture.Store.MigrateLegacyModelToHubCacheAsync())!;
+
+            Assert.Equal(LocalAiInstallManifest.HubCacheReceiptSchemaVersion, migrated.Manifest.SchemaVersion);
+            Assert.Equal(fixture.Content, await File.ReadAllBytesAsync(fixture.CachedModelPath));
+            Assert.Equal(fixture.Content, await File.ReadAllBytesAsync(fixture.LegacyModelPath));
+        }
+        finally
+        {
+            if (Directory.Exists(cacheRoot))
+                Directory.Delete(cacheRoot, recursive: true);
+        }
+    }
+
+    private static async Task<MigrationFixture> CreateFixtureAsync(
+        TempDirectory temp,
+        Func<CancellationToken, Task>? beforeMigrationCommit = null,
+        Func<string, CancellationToken, Task>? beforeMigrationPromotion = null,
+        string? cacheRootOverride = null)
+    {
+        byte[] content = FixtureContent;
+        string digest = Convert.ToHexString(SHA256.HashData(content)).ToLowerInvariant();
+        string cacheRoot = cacheRootOverride ?? temp.Combine("hf-cache");
+        var paths = new LocalAiPaths(temp.Combine("app-data"));
+        string legacyRelativePath = Path.Combine(
+            "models",
+            "owner",
+            "repository",
+            Revision,
+            "model.gguf");
+        string legacyModelPath = paths.ResolveContainedPath(legacyRelativePath, "modelPath");
+        Directory.CreateDirectory(Path.GetDirectoryName(legacyModelPath)!);
+        await File.WriteAllBytesAsync(legacyModelPath, content);
+
+        var manifest = new LocalAiInstallManifest
+        {
+            EngineVersion = "b1",
+            Architecture = "x64",
+            RuntimeId = "llama-server-test",
+            ModelCatalogId = "test-model",
+            SelectedGpuId = "GPU-TEST",
+            ExecutablePath = Path.Combine("engines", "llama-server.exe"),
+            RuntimeAssets = ImmutableArray.Create(new LocalAiAssetReceipt
+            {
+                FileName = "runtime.zip",
+                SourceUrl = "https://example.invalid/runtime.zip",
+                SizeBytes = 1,
+                Sha256 = new string('a', 64),
+            }),
+            ModelPath = legacyRelativePath,
+            ModelId = $"{RepositoryId}@{Revision}",
+            ModelAlias = "test-model",
+            ModelAsset = new LocalAiAssetReceipt
+            {
+                FileName = "model.gguf",
+                SourceUrl = $"https://huggingface.co/{RepositoryId}/resolve/{Revision}/{RelativeModelPath}?download=true",
+                SizeBytes = content.Length,
+                Sha256 = digest,
+            },
+            ContextLength = 4096,
+        };
+        var store = new LocalAiManifestStore(
+            paths,
+            () => cacheRoot,
+            beforeMigrationCommit,
+            beforeMigrationPromotion);
+        await store.SaveAsync(manifest);
+        Assert.True(HuggingFaceHubCache.TryGetSnapshotPaths(
+            cacheRoot,
+            RepositoryId,
+            Revision,
+            RelativeModelPath,
+            out string cachedModelPath,
+            out _,
+            out string error), error);
+        return new(paths, store, manifest, cacheRoot, legacyModelPath, cachedModelPath, content);
+    }
+
+    private static bool TryCreateHardLink(string linkPath, string existingPath)
+    {
+        using var process = Process.Start(new ProcessStartInfo
+        {
+            FileName = Environment.GetEnvironmentVariable("COMSPEC") ?? "cmd.exe",
+            Arguments = $"/d /c mklink /H \"{linkPath}\" \"{existingPath}\"",
+            CreateNoWindow = true,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        });
+        process!.WaitForExit();
+        return process.ExitCode == 0;
+    }
+
+    private static async Task<int> ReadPersistedSchemaVersionAsync(string manifestPath)
+    {
+        JsonObject manifest = (JsonNode.Parse(await File.ReadAllTextAsync(manifestPath)) as JsonObject)!;
+        return manifest["schemaVersion"]!.GetValue<int>();
+    }
+
+    private sealed record MigrationFixture(
+        LocalAiPaths Paths,
+        LocalAiManifestStore Store,
+        LocalAiInstallManifest Manifest,
+        string CacheRoot,
+        string LegacyModelPath,
+        string CachedModelPath,
+        byte[] Content);
+
+    private sealed class InlineProgress<T>(Action<T> report) : IProgress<T>
+    {
+        public void Report(T value) => report(value);
+    }
+
+    private static readonly byte[] FixtureContent = "verified legacy model weights"u8.ToArray();
+}
+
+internal sealed class ConnectionSymbolicLinkFactAttribute : FactAttribute
+{
+    private static readonly Lazy<bool> s_isAvailable = new(Probe, isThreadSafe: true);
+
+    public ConnectionSymbolicLinkFactAttribute()
+    {
+        if (!s_isAvailable.Value)
+            Skip = "Creating symbolic links requires Windows Developer Mode or elevation.";
+    }
+
+    private static bool Probe()
+    {
+        string directory = Path.Combine(
+            Path.GetTempPath(),
+            $"openclaw-connection-symlink-probe-{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(directory);
+            string target = Path.Combine(directory, "target");
+            File.WriteAllText(target, "probe");
+            File.CreateSymbolicLink(Path.Combine(directory, "link"), target);
+            return true;
+        }
+        catch (Exception ex) when (
+            ex is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+        {
+            return false;
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                // A failed capability probe must not fail the test host.
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Layer 2 of the current-main replacement train for #1288 (feat(local-ai): store downloaded models in the standard HF hub cache), stacked after #1385 (feat(shared): add safe Hugging Face cache primitives).

- adds an explicit, cancellable `LocalAiManifestStore.MigrateLegacyModelToHubCacheAsync` transaction
- copies canonical legacy model weights into the standard Hugging Face snapshot layout from the same SHA-256-verified source handle, including across volumes
- validates or reuses pre-existing destinations only through `HuggingFaceHubCache.TryOpenVerifiedCacheFileAsync`
- roots cache and legacy path walks at Windows volume handles, rejects reparse segments and hard-linked partials, and performs cache mutation/promotion/rollback through exact handles
- records a transitional schema-4 cache receipt without changing the active legacy `ModelPath`
- keeps `LoadAsync`, runtime refresh, status, uninstall, normal downloads, active model selection, installer, reconciler, and setup wiring unchanged

The parent train item remains open. Layer 3 owns normal Hub-cache downloads and switching active selection.

## Layer 3 contract

- `LocalAiInstallManifest.CurrentSchemaVersion` remains `3` for normal setup writes.
- Schema `4` means a verified cache-copy receipt exists.
- `ModelPath` remains the active legacy path in this layer.
- `ModelCacheRoot` is the normalized cache root used for verification.
- `CachedModelPath` is the verified standard snapshot path.
- Invoke `MigrateLegacyModelToHubCacheAsync` explicitly. Do not trigger migration from `LoadAsync` or another status/runtime/uninstall read path.
- A concurrent manifest change aborts receipt persistence without deleting either model copy. Retry reuses the verified destination.
- Layer 3 must continue verifying receipts through `HuggingFaceHubCache` before selecting cached content, wire `HuggingFaceModelInstaller` / `LocalAiArtifactInstaller` / reconciler / setup behavior, and decide rollout or downgrade gating before enabling migration automatically.

## Required proof pools

- `none`: this is a non-UI manifest and filesystem migration API. Deterministic Windows tests and an explicit two-volume local proof cover the changed behavior without a custom host class.

## Validation

- `./build.ps1` - passed
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` - 3,991 passed, 32 skipped
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` - 2,888 passed
- `dotnet test ./tests/OpenClaw.Connection.Tests/OpenClaw.Connection.Tests.csproj --no-restore` - 746 passed, 1 cross-volume proof skipped unless explicitly configured
- `dotnet test ./tests/OpenClaw.SetupEngine.Tests/OpenClaw.SetupEngine.Tests.csproj --no-restore` - 1,134 passed
- focused migration suite with `OPENCLAW_TEST_HF_CACHE_ROOT=E:\OpenClawHfMigrationProof` - 29 passed, 0 skipped
- autoreview: `python .agents\skills\autoreview\scripts\autoreview --mode branch --base origin/main ...` - clean, no accepted/actionable findings
- final rubber-duck review - no blocking findings

## Real behavior proof

Current-head cross-volume proof:

```text
Legacy fixture volume: C:\
HF cache proof volume: E:\
Passed OpenClaw.Connection.Tests.LocalAiManifestMigrationTests.Migration_CopiesAcrossConfiguredDistinctVolume
Total tests: 1
Passed: 1
```

The proof asserts the destination bytes equal the pinned content, the legacy source remains unchanged, and the schema-4 receipt records the standard snapshot path. Focused deterministic coverage also proves interruption recovery, cancellation cleanup, hard-link preservation, destination collision handling, directory-swap rejection, source/cache-root reparse rejection, concurrent manifest update/deletion handling, nested Hub paths, and rollback preserving shared-cache content.