### PR TITLE
fix(local-ai): keep routing safe across endpoint restarts

### DIFF
--- a/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
@@ -935,12 +935,6 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         }
     }
 
-    /// <summary>
-    /// Terminates a startup attempt. When <paramref name="routeToWithdraw"/> is
-    /// set, the gateway is still pointing at a route this attempt left standing
-    /// and no listener will answer it after the child stops, so the route is
-    /// withdrawn before the child is disposed.
-    /// </summary>
     private async Task<LocalAiRuntimeSnapshot> FailStartupAsync(
         LocalAiRuntimeState state,
         string detail,
@@ -996,10 +990,6 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         Publish(LocalAiRuntimeState.Stopped, LocalAiOwnership.None, "Local AI startup was canceled.");
     }
 
-    /// <summary>
-    /// Restores terminal gateway routing when no restart or publish will follow.
-    /// Failures are logged and never mask the original startup outcome.
-    /// </summary>
     private async Task<bool> WithdrawRouteAsync(LocalAiResolvedInstall install, string context)
         => await RetryQuiesceAsync(
                 install,
@@ -1192,10 +1182,6 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                 if (exited is not null)
                     await exited.DisposeAsync().ConfigureAwait(false);
 
-                // The quiesce reason depends on what follows: a pending restart
-                // is an endpoint cycle and keeps the managed primary selected,
-                // while exhausted retries are terminal and restore the prior
-                // gateway routing instead of leaving the provider absent.
                 bool willRestart = !_explicitStopRequested &&
                     _restartAttempts < _options.MaxRestartAttempts;
                 restartInstall = _install;

--- a/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
@@ -541,6 +541,10 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                         .PublishAsync(install, cancellationToken)
                         .ConfigureAwait(false);
                 }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
                 catch (Exception ex)
                 {
                     await FailStartupAsync(

--- a/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
@@ -148,7 +148,8 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                     LocalAiQuiesceReason.Teardown,
                     cancellationToken)
                 .ConfigureAwait(false);
-            _explicitStopRequested = stopped.State == LocalAiRuntimeState.Failed;
+            _explicitStopRequested = stopped.State == LocalAiRuntimeState.Failed &&
+                (_gatewayRouteRequiresResolution || _managedProcess is { HasExited: false });
             return stopped;
         }
         finally
@@ -351,7 +352,8 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                     return await FailStartupAsync(
                             LocalAiRuntimeState.Conflict,
                             "TCP listener ownership could not be determined.",
-                            install)
+                            install,
+                            stopUnsafeListener: true)
                         .ConfigureAwait(false);
                 }
                 if (ownership.ConflictDetail is not null)
@@ -888,6 +890,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
 
         if (_managedProcess is null)
         {
+            ++_generation;
             return Publish(
                 LocalAiRuntimeState.Stopped,
                 LocalAiOwnership.None,

--- a/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
@@ -211,6 +211,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
             publishedRoute.Port == plannedPort
                 ? publishedRoute
                 : null;
+        bool terminalTeardownRequired = retainedRoute is not null;
         if (retainedRoute is null)
         {
             LocalAiEndpointLifecycleResult quiesced = await _options.EndpointLifecycle
@@ -223,6 +224,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                     LocalAiOwnership.None,
                     quiesced.Detail ?? "The Local AI gateway provider could not be safely disabled.");
             }
+            terminalTeardownRequired = true;
         }
 
         LlamaServerRouterLaunchPlan launchPlan;
@@ -236,13 +238,18 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                 plannedPort);
             await WritePresetAtomicallyAsync(launchPlan, cancellationToken).ConfigureAwait(false);
         }
+        catch (OperationCanceledException)
+        {
+            await CancelStartupAsync(install, terminalTeardownRequired).ConfigureAwait(false);
+            throw;
+        }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidDataException)
         {
             _logger.Error("Could not prepare the managed llama-server router.", ex);
             return await FailStartupAsync(
                     LocalAiRuntimeState.Failed,
                     Sanitize(ex.Message),
-                    retainedRoute is null ? null : install)
+                    terminalTeardownRequired ? install : null)
                 .ConfigureAwait(false);
         }
 
@@ -280,7 +287,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                     return await FailStartupAsync(
                             LocalAiRuntimeState.Conflict,
                             "TCP listener ownership could not be determined.",
-                            retainedRoute is null ? null : install)
+                            terminalTeardownRequired ? install : null)
                         .ConfigureAwait(false);
                 }
                 if (ownership.ConflictDetail is not null)
@@ -288,7 +295,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                     return await FailStartupAsync(
                             LocalAiRuntimeState.Conflict,
                             ownership.ConflictDetail,
-                            retainedRoute is null ? null : install)
+                            terminalTeardownRequired ? install : null)
                         .ConfigureAwait(false);
                 }
                 if (ownership.Endpoint is not null)
@@ -354,26 +361,19 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
             return await FailStartupAsync(
                     LocalAiRuntimeState.Failed,
                     "The local AI router did not become healthy before the startup timeout.",
-                    retainedRoute is null ? null : install)
+                    terminalTeardownRequired ? install : null)
                 .ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {
-            ++_generation;
-            // Cancellation is terminal for this startup attempt: if a route was
-            // retained, withdraw it before the child's listener disappears, or
-            // the gateway would keep routing to a port nothing serves.
-            await WithdrawRetainedRouteAsync(install).ConfigureAwait(false);
-            await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
-            Publish(LocalAiRuntimeState.Stopped, LocalAiOwnership.None, "Local AI startup was canceled.");
+            await CancelStartupAsync(install, terminalTeardownRequired).ConfigureAwait(false);
             throw;
         }
         catch (Exception ex)
         {
             ++_generation;
-            // A launch failure or immediate child exit is terminal: withdraw any
-            // retained route before the child's listener disappears.
-            await WithdrawRetainedRouteAsync(install).ConfigureAwait(false);
+            if (terminalTeardownRequired)
+                await WithdrawRouteAsync(install, "after a terminal startup failure").ConfigureAwait(false);
             await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
             _logger.Error("Managed llama-server startup failed.", ex);
             return Publish(LocalAiRuntimeState.Failed, LocalAiOwnership.None, Sanitize(ex.Message));
@@ -691,18 +691,21 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         return Publish(state, LocalAiOwnership.None, detail);
     }
 
-    /// <summary>
-    /// Withdraws the gateway route that a terminal startup outcome left
-    /// standing, as teardown semantics: no restart will follow on this path.
-    /// Failures are logged and never mask the original outcome.
-    /// </summary>
-    private async Task WithdrawRetainedRouteAsync(LocalAiResolvedInstall install)
+    private async Task CancelStartupAsync(
+        LocalAiResolvedInstall install,
+        bool terminalTeardownRequired)
     {
-        if (install.Endpoint is null)
-            return;
-        await WithdrawRouteAsync(install, "after a terminal startup failure").ConfigureAwait(false);
+        ++_generation;
+        if (terminalTeardownRequired)
+            await WithdrawRouteAsync(install, "after startup cancellation").ConfigureAwait(false);
+        await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
+        Publish(LocalAiRuntimeState.Stopped, LocalAiOwnership.None, "Local AI startup was canceled.");
     }
 
+    /// <summary>
+    /// Restores terminal gateway routing when no restart or publish will follow.
+    /// Failures are logged and never mask the original startup outcome.
+    /// </summary>
     private async Task WithdrawRouteAsync(LocalAiResolvedInstall install, string context)
     {
         try

--- a/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
@@ -174,8 +174,9 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                 if (restarted.State is LocalAiRuntimeState.Failed or LocalAiRuntimeState.NotInstalled &&
                     restartInstall is not null)
                 {
+                    LocalAiResolvedInstall cleanupInstall = _install ?? restartInstall;
                     bool withdrawn = await WithdrawRouteAsync(
-                        restartInstall,
+                        cleanupInstall,
                         "after restart startup did not complete").ConfigureAwait(false);
                     if (!withdrawn)
                     {
@@ -184,6 +185,12 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                                 "Local AI restart did not complete and gateway routing could not be safely disabled; the managed listener remains running.")
                             : PublishTerminalCleanupFailure(
                                 "Local AI restart did not complete and gateway routing could not be safely disabled.");
+                    }
+                    if (_managedProcess is { HasExited: false })
+                    {
+                        ++_generation;
+                        await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
+                        return PublishTerminalCleanupFailure("Local AI restart did not complete.");
                     }
                 }
                 return restarted;
@@ -198,11 +205,8 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
             catch (OperationCanceledException)
             {
                 LocalAiResolvedInstall? canceledInstall = restartInstall ?? _install;
-                if (canceledInstall is not null &&
-                    (_managedProcess is not null || Snapshot.State != LocalAiRuntimeState.Stopped))
-                {
+                if (canceledInstall is not null)
                     await CompleteInterruptedRestartAsync(canceledInstall, "canceled").ConfigureAwait(false);
-                }
                 throw;
             }
         }
@@ -701,17 +705,9 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         if (_install is null && !await TryLoadInstallAsync(cancellationToken).ConfigureAwait(false))
             return Snapshot;
 
-        LocalAiEndpointLifecycleResult quiesced;
-        try
-        {
-            quiesced = await _options.EndpointLifecycle
-                .QuiesceAsync(_install!, reason, cancellationToken)
-                .ConfigureAwait(false);
-        }
-        catch
-        {
-            throw;
-        }
+        LocalAiEndpointLifecycleResult quiesced = await _options.EndpointLifecycle
+            .QuiesceAsync(_install!, reason, cancellationToken)
+            .ConfigureAwait(false);
         if (!quiesced.Success)
         {
             if (reason == LocalAiQuiesceReason.EndpointCycle)
@@ -966,26 +962,42 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                         }
                         catch (Exception ex)
                         {
-                            await WithdrawRouteAsync(
+                            bool withdrawn = await WithdrawRouteAsync(
                                     _install,
                                     "after automatic-restart withdrawal was interrupted")
                                 .ConfigureAwait(false);
-                            Publish(
-                                LocalAiRuntimeState.Failed,
-                                LocalAiOwnership.None,
-                                $"The Local AI gateway provider withdrawal failed after the router exited: {Sanitize(ex.Message)}");
+                            if (withdrawn)
+                            {
+                                Publish(
+                                    LocalAiRuntimeState.Failed,
+                                    LocalAiOwnership.None,
+                                    $"The Local AI gateway provider withdrawal failed after the router exited: {Sanitize(ex.Message)}");
+                            }
+                            else
+                            {
+                                PublishTerminalCleanupFailure(
+                                    $"The Local AI gateway provider withdrawal failed after the router exited: {Sanitize(ex.Message)} Terminal gateway routing could not be restored.");
+                            }
                             return;
                         }
                         if (!quiesced.Success)
                         {
-                            await WithdrawRouteAsync(
+                            bool withdrawn = await WithdrawRouteAsync(
                                     _install,
                                     "after automatic-restart withdrawal failed")
                                 .ConfigureAwait(false);
-                            Publish(
-                                LocalAiRuntimeState.Failed,
-                                LocalAiOwnership.None,
-                                quiesced.Detail ?? "The Local AI gateway provider could not be safely disabled after the router exited.");
+                            if (withdrawn)
+                            {
+                                Publish(
+                                    LocalAiRuntimeState.Failed,
+                                    LocalAiOwnership.None,
+                                    quiesced.Detail ?? "The Local AI gateway provider could not be safely disabled after the router exited.");
+                            }
+                            else
+                            {
+                                PublishTerminalCleanupFailure(
+                                    $"{quiesced.Detail ?? "The Local AI gateway provider could not be safely disabled after the router exited."} Terminal gateway routing could not be restored.");
+                            }
                             return;
                         }
                     }

--- a/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
@@ -214,15 +214,33 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         bool terminalTeardownRequired = retainedRoute is not null;
         if (retainedRoute is null)
         {
-            LocalAiEndpointLifecycleResult quiesced = await _options.EndpointLifecycle
-                .QuiesceAsync(install, LocalAiQuiesceReason.EndpointCycle, cancellationToken)
-                .ConfigureAwait(false);
+            LocalAiEndpointLifecycleResult quiesced;
+            try
+            {
+                quiesced = await _options.EndpointLifecycle
+                    .QuiesceAsync(install, LocalAiQuiesceReason.EndpointCycle, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                await CancelStartupAsync(install, terminalTeardownRequired: true).ConfigureAwait(false);
+                throw;
+            }
+            catch
+            {
+                await WithdrawRouteAsync(
+                        install,
+                        "after endpoint-cycle withdrawal was interrupted")
+                    .ConfigureAwait(false);
+                throw;
+            }
             if (!quiesced.Success)
             {
-                return Publish(
-                    LocalAiRuntimeState.Failed,
-                    LocalAiOwnership.None,
-                    quiesced.Detail ?? "The Local AI gateway provider could not be safely disabled.");
+                return await FailStartupAsync(
+                        LocalAiRuntimeState.Failed,
+                        quiesced.Detail ?? "The Local AI gateway provider could not be safely disabled.",
+                        install)
+                    .ConfigureAwait(false);
             }
             terminalTeardownRequired = true;
         }
@@ -306,11 +324,6 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                             install.ModelPath,
                             cancellationToken)
                         .ConfigureAwait(false);
-                    if (!probe.IsReadyForManagedModel(install.ModelPath))
-                    {
-                        // A failed probe means the retained route is about to lose
-                        // its listener; the eventual timeout path must withdraw it.
-                    }
                     if (probe.IsReadyForManagedModel(install.ModelPath))
                     {
                         if (retainedRoute is not null && retainedRoute != ownership.Endpoint)

--- a/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
@@ -579,14 +579,15 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                 {
                     try
                     {
+                        using var recoveryTimeout = new CancellationTokenSource(_options.ShutdownTimeout);
                         install = await BindVerifiedEndpointAsync(
                                 install,
                                 ownership.Endpoint,
-                                CancellationToken.None)
+                                recoveryTimeout.Token)
                             .ConfigureAwait(false);
                         LocalAiEndpointLifecycleResult recovered = await PublishRouteAsync(
                                 install,
-                                CancellationToken.None)
+                                recoveryTimeout.Token)
                             .ConfigureAwait(false);
                         if (recovered.Success)
                         {
@@ -688,7 +689,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                 Publish(
                     LocalAiRuntimeState.Failed,
                     LocalAiOwnership.None,
-                    "The Local AI gateway provider withdrawal did not complete.");
+                    "The Local AI endpoint cycle was interrupted; terminal gateway routing was restored.");
             }
             else if (stopUnsafeProcessOnFailure)
             {
@@ -1118,7 +1119,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         {
             await process.StopAsync(_options.ShutdownTimeout, cancellationToken).ConfigureAwait(false);
         }
-        catch
+        catch (Exception ex)
         {
             if (preserveForRetry)
             {
@@ -1126,6 +1127,13 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                 {
                     _managedProcess = process;
                     preserved = true;
+                    PublishManagedFailure(
+                        $"The managed listener remains running because it could not be stopped: {Sanitize(ex.Message)}");
+                }
+                else
+                {
+                    PublishTerminalCleanupFailure(
+                        $"The managed Local AI listener shutdown failed after the process exited: {Sanitize(ex.Message)}");
                 }
                 throw;
             }
@@ -1136,10 +1144,10 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                     await process.StopAsync(_options.ShutdownTimeout, CancellationToken.None)
                         .ConfigureAwait(false);
                 }
-                catch (Exception ex)
+                catch (Exception stopException)
                 {
                     _logger.Warn(
-                        $"The managed Local AI process could not be stopped during final disposal: {Sanitize(ex.Message)}");
+                        $"The managed Local AI process could not be stopped during final disposal: {Sanitize(stopException.Message)}");
                 }
             }
         }

--- a/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
@@ -455,11 +455,14 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         if (!ownership.IsComplete)
         {
             // Incomplete enumeration cannot prove that the child owns only the
-            // intended endpoint. Withdraw routing first, then stop it.
+            // intended endpoint. Remove the provider while retaining the local
+            // primary, then stop the child so this trust failure cannot route
+            // requests to a cloud fallback.
             LocalAiRuntimeSnapshot? failure = await QuiesceOrStopAsync(
                     install,
-                    LocalAiQuiesceReason.Teardown,
+                    LocalAiQuiesceReason.EndpointCycle,
                     stopAfterQuiesce: true,
+                    preserveManagedPrimaryOnFailure: true,
                     cancellationToken)
                 .ConfigureAwait(false);
             return failure ?? Publish(
@@ -471,8 +474,9 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         {
             LocalAiRuntimeSnapshot? failure = await QuiesceOrStopAsync(
                     install,
-                    LocalAiQuiesceReason.Teardown,
+                    LocalAiQuiesceReason.EndpointCycle,
                     stopAfterQuiesce: true,
+                    preserveManagedPrimaryOnFailure: true,
                     cancellationToken)
                 .ConfigureAwait(false);
             return failure ?? Publish(
@@ -486,6 +490,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                     install,
                     LocalAiQuiesceReason.EndpointCycle,
                     stopAfterQuiesce: false,
+                    preserveManagedPrimaryOnFailure: false,
                     cancellationToken)
                 .ConfigureAwait(false);
             return failure ?? Publish(
@@ -513,28 +518,41 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                             install,
                             LocalAiQuiesceReason.EndpointCycle,
                             stopAfterQuiesce: false,
+                            preserveManagedPrimaryOnFailure: false,
                             cancellationToken)
                         .ConfigureAwait(false);
                     if (failure is not null)
                         return failure;
                 }
 
-                install = await BindVerifiedEndpointAsync(
-                        install,
-                        ownership.Endpoint,
-                        cancellationToken)
-                    .ConfigureAwait(false);
-                LocalAiEndpointLifecycleResult published = await _options.EndpointLifecycle
-                    .PublishAsync(install, cancellationToken)
-                    .ConfigureAwait(false);
+                LocalAiEndpointLifecycleResult published;
+                try
+                {
+                    install = await BindVerifiedEndpointAsync(
+                            install,
+                            ownership.Endpoint,
+                            cancellationToken)
+                        .ConfigureAwait(false);
+                    published = await _options.EndpointLifecycle
+                        .PublishAsync(install, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    await FailStartupAsync(
+                            LocalAiRuntimeState.Failed,
+                            $"The verified Local AI endpoint could not be republished: {Sanitize(ex.Message)}",
+                            _install ?? install)
+                        .ConfigureAwait(false);
+                    throw;
+                }
                 if (!published.Success)
                 {
-                    return Publish(
-                        LocalAiRuntimeState.Failed,
-                        LocalAiOwnership.CompanionManaged,
-                        published.Detail ?? "The verified Local AI endpoint could not be republished.",
-                        _managedProcess.ProcessId,
-                        _managedProcess.StartedAtUtc);
+                    return await FailStartupAsync(
+                            LocalAiRuntimeState.Failed,
+                            published.Detail ?? "The verified Local AI endpoint could not be republished.",
+                            _install ?? install)
+                        .ConfigureAwait(false);
                 }
             }
 
@@ -545,6 +563,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                 install,
                 LocalAiQuiesceReason.EndpointCycle,
                 stopAfterQuiesce: false,
+                preserveManagedPrimaryOnFailure: false,
                 cancellationToken)
             .ConfigureAwait(false);
         if (quiesceFailure is not null)
@@ -562,6 +581,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         LocalAiResolvedInstall install,
         LocalAiQuiesceReason reason,
         bool stopAfterQuiesce,
+        bool preserveManagedPrimaryOnFailure,
         CancellationToken cancellationToken)
     {
         LocalAiEndpointLifecycleResult quiesced;
@@ -573,8 +593,12 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         }
         catch
         {
-            bool withdrawn = await WithdrawRouteAsync(
+            LocalAiQuiesceReason recoveryReason = preserveManagedPrimaryOnFailure
+                ? LocalAiQuiesceReason.EndpointCycle
+                : LocalAiQuiesceReason.Teardown;
+            bool withdrawn = await RetryQuiesceAsync(
                         install,
+                        recoveryReason,
                         "after refresh withdrawal was interrupted")
                     .ConfigureAwait(false);
             if (withdrawn)
@@ -601,6 +625,22 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
             ++_generation;
             await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
             return null;
+        }
+
+        if (preserveManagedPrimaryOnFailure)
+        {
+            bool retried = await RetryQuiesceAsync(
+                    install,
+                    LocalAiQuiesceReason.EndpointCycle,
+                    "after refresh endpoint-cycle withdrawal failed")
+                .ConfigureAwait(false);
+            if (retried)
+            {
+                ++_generation;
+                await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
+                return null;
+            }
+            return await PublishRefreshCleanupFailureAsync(quiesced.Detail).ConfigureAwait(false);
         }
 
         bool teardownSucceeded = reason != LocalAiQuiesceReason.Teardown &&
@@ -709,9 +749,42 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         if (_install is null && !await TryLoadInstallAsync(cancellationToken).ConfigureAwait(false))
             return Snapshot;
 
-        LocalAiEndpointLifecycleResult quiesced = await _options.EndpointLifecycle
-            .QuiesceAsync(_install!, reason, cancellationToken)
-            .ConfigureAwait(false);
+        LocalAiEndpointLifecycleResult quiesced;
+        try
+        {
+            quiesced = await _options.EndpointLifecycle
+                .QuiesceAsync(_install!, reason, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch
+        {
+            if (reason == LocalAiQuiesceReason.Teardown)
+            {
+                bool withdrawn = await WithdrawRouteAsync(
+                        _install!,
+                        "after explicit stop withdrawal was interrupted")
+                    .ConfigureAwait(false);
+                if (withdrawn)
+                {
+                    ++_generation;
+                    await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
+                    PublishTerminalCleanupFailure("Local AI stop was interrupted.");
+                }
+                else if (_managedProcess is { HasExited: false })
+                {
+                    PublishManagedFailure(
+                        "Local AI stop was interrupted, but gateway routing could not be safely disabled; the managed listener remains running.");
+                }
+                else
+                {
+                    ++_generation;
+                    await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
+                    PublishTerminalCleanupFailure(
+                        "Local AI stop was interrupted, but gateway routing could not be safely disabled.");
+                }
+            }
+            throw;
+        }
         if (!quiesced.Success)
         {
             if (reason == LocalAiQuiesceReason.EndpointCycle)
@@ -823,11 +896,21 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
     /// Failures are logged and never mask the original startup outcome.
     /// </summary>
     private async Task<bool> WithdrawRouteAsync(LocalAiResolvedInstall install, string context)
+        => await RetryQuiesceAsync(
+                install,
+                LocalAiQuiesceReason.Teardown,
+                context)
+            .ConfigureAwait(false);
+
+    private async Task<bool> RetryQuiesceAsync(
+        LocalAiResolvedInstall install,
+        LocalAiQuiesceReason reason,
+        string context)
     {
         try
         {
             LocalAiEndpointLifecycleResult withdrawn = await _options.EndpointLifecycle
-                .QuiesceAsync(install, LocalAiQuiesceReason.Teardown, CancellationToken.None)
+                .QuiesceAsync(install, reason, CancellationToken.None)
                 .ConfigureAwait(false);
             if (!withdrawn.Success)
             {

--- a/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
@@ -396,7 +396,10 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         }
         catch (OperationCanceledException)
         {
-            await CancelStartupAsync(install, terminalTeardownRequired: true).ConfigureAwait(false);
+            await CancelStartupAsync(
+                    _install ?? install,
+                    terminalTeardownRequired: true)
+                .ConfigureAwait(false);
             throw;
         }
         catch (Exception ex)
@@ -405,7 +408,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
             return await FailStartupAsync(
                     LocalAiRuntimeState.Failed,
                     Sanitize(ex.Message),
-                    install)
+                    _install ?? install)
                 .ConfigureAwait(false);
         }
     }
@@ -451,6 +454,8 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         EndpointOwnershipObservation ownership = DiscoverOwnedEndpoint(install, _managedProcess);
         if (!ownership.IsComplete)
         {
+            // Incomplete enumeration cannot prove that the child owns only the
+            // intended endpoint. Withdraw routing first, then stop it.
             LocalAiRuntimeSnapshot? failure = await QuiesceOrStopAsync(
                     install,
                     LocalAiQuiesceReason.Teardown,
@@ -568,8 +573,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         }
         catch
         {
-            bool withdrawn = reason != LocalAiQuiesceReason.Teardown &&
-                await WithdrawRouteAsync(
+            bool withdrawn = await WithdrawRouteAsync(
                         install,
                         "after refresh withdrawal was interrupted")
                     .ConfigureAwait(false);

--- a/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
@@ -495,10 +495,6 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         EndpointOwnershipObservation ownership = DiscoverOwnedEndpoint(install, _managedProcess);
         if (!ownership.IsComplete)
         {
-            // Incomplete enumeration cannot prove that the child owns only the
-            // intended endpoint. Remove the provider while retaining the local
-            // primary, then stop the child so this trust failure cannot route
-            // requests to a cloud fallback.
             LocalAiRuntimeSnapshot? failure = await QuiesceOrStopAsync(
                     install,
                     LocalAiQuiesceReason.EndpointCycle,

--- a/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
@@ -686,10 +686,13 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
             {
                 ++_generation;
                 await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
+                string detail = recoveryReason == LocalAiQuiesceReason.Teardown
+                    ? "The Local AI endpoint cycle was interrupted; terminal gateway routing was restored."
+                    : "The Local AI provider was withdrawn after an interrupted endpoint cycle; the managed primary remains selected until Local AI is started or stopped.";
                 Publish(
                     LocalAiRuntimeState.Failed,
                     LocalAiOwnership.None,
-                    "The Local AI endpoint cycle was interrupted; terminal gateway routing was restored.");
+                    detail);
             }
             else if (stopUnsafeProcessOnFailure)
             {

--- a/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
@@ -177,41 +177,73 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         if (_managedProcess is not null)
             await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
 
-        LocalAiEndpointLifecycleResult quiesced = await _options.EndpointLifecycle
-            .QuiesceAsync(install, cancellationToken)
-            .ConfigureAwait(false);
-        if (!quiesced.Success)
+        // Decide the port before touching gateway routing. Rebinding the last
+        // verified port keeps the already-published route valid for the whole
+        // startup, so the gateway is never left without a Local AI provider.
+        WindowsTcpListenerSnapshotResult beforeStart = _platform.CaptureListeners();
+        if (!beforeStart.Ipv4Complete)
         {
-            return Publish(
-                LocalAiRuntimeState.Failed,
-                LocalAiOwnership.None,
-                quiesced.Detail ?? "The Local AI gateway provider could not be safely disabled.");
+            return await FailStartupAsync(
+                    LocalAiRuntimeState.Conflict,
+                    "TCP listener ownership could not be determined.",
+                    install)
+                .ConfigureAwait(false);
+        }
+
+        // A foreign process owns the port the published route points at, so that
+        // route must be withdrawn before returning rather than left aimed at it.
+        int plannedPort = ResolvePlannedPort(install, beforeStart);
+        if (plannedPort != LocalAiPortPolicy.Automatic &&
+            FindEndpointListeners(beforeStart, plannedPort).Count > 0)
+        {
+            return await FailStartupAsync(
+                    LocalAiRuntimeState.Conflict,
+                    "The configured llama-server port is already in use.",
+                    install)
+                .ConfigureAwait(false);
+        }
+
+        // The published route already names the port we are about to bind, so
+        // withdrawing it would only open a window in which the gateway falls
+        // back to its built-in default provider. PublishAsync re-verifies below.
+        Uri? retainedRoute = plannedPort != LocalAiPortPolicy.Automatic &&
+            install.Endpoint is { } publishedRoute &&
+            publishedRoute.Port == plannedPort
+                ? publishedRoute
+                : null;
+        if (retainedRoute is null)
+        {
+            LocalAiEndpointLifecycleResult quiesced = await _options.EndpointLifecycle
+                .QuiesceAsync(install, LocalAiQuiesceReason.EndpointCycle, cancellationToken)
+                .ConfigureAwait(false);
+            if (!quiesced.Success)
+            {
+                return Publish(
+                    LocalAiRuntimeState.Failed,
+                    LocalAiOwnership.None,
+                    quiesced.Detail ?? "The Local AI gateway provider could not be safely disabled.");
+            }
         }
 
         LlamaServerRouterLaunchPlan launchPlan;
         try
         {
             ValidateInstalledFiles(install);
-            LocalAiPortPolicy.Validate(install.Manifest.RequestedPort);
+            LocalAiPortPolicy.Validate(plannedPort);
             launchPlan = LlamaServerRouterConfiguration.Build(
                 _options.Paths,
                 install,
-                install.Manifest.RequestedPort);
+                plannedPort);
             await WritePresetAtomicallyAsync(launchPlan, cancellationToken).ConfigureAwait(false);
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidDataException)
         {
             _logger.Error("Could not prepare the managed llama-server router.", ex);
-            return Publish(LocalAiRuntimeState.Failed, LocalAiOwnership.None, Sanitize(ex.Message));
-        }
-
-        WindowsTcpListenerSnapshotResult beforeStart = _platform.CaptureListeners();
-        if (!beforeStart.Ipv4Complete)
-            return Publish(LocalAiRuntimeState.Conflict, LocalAiOwnership.None, "TCP listener ownership could not be determined.");
-        if (install.Manifest.RequestedPort != LocalAiPortPolicy.Automatic &&
-            FindEndpointListeners(beforeStart, install.Manifest.RequestedPort).Count > 0)
-        {
-            return Publish(LocalAiRuntimeState.Conflict, LocalAiOwnership.None, "The configured llama-server port is already in use.");
+            return await FailStartupAsync(
+                    LocalAiRuntimeState.Failed,
+                    Sanitize(ex.Message),
+                    retainedRoute is null ? null : install)
+                .ConfigureAwait(false);
         }
 
         long generation = ++_generation;
@@ -244,10 +276,19 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
 
                 EndpointOwnershipObservation ownership = DiscoverOwnedEndpoint(install, _managedProcess);
                 if (!ownership.IsComplete)
-                    return await FailStartupAsync(LocalAiRuntimeState.Conflict, "TCP listener ownership could not be determined.").ConfigureAwait(false);
+                {
+                    return await FailStartupAsync(
+                            LocalAiRuntimeState.Conflict,
+                            "TCP listener ownership could not be determined.",
+                            retainedRoute is null ? null : install)
+                        .ConfigureAwait(false);
+                }
                 if (ownership.ConflictDetail is not null)
                 {
-                    return await FailStartupAsync(LocalAiRuntimeState.Conflict, ownership.ConflictDetail)
+                    return await FailStartupAsync(
+                            LocalAiRuntimeState.Conflict,
+                            ownership.ConflictDetail,
+                            retainedRoute is null ? null : install)
                         .ConfigureAwait(false);
                 }
                 if (ownership.Endpoint is not null)
@@ -260,6 +301,24 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                         .ConfigureAwait(false);
                     if (probe.IsReadyForManagedModel(install.ModelPath))
                     {
+                        // The router bound a different port than the retained route
+                        // advertises, so that route is now stale and must be withdrawn
+                        // before the new one is published.
+                        if (retainedRoute is not null && retainedRoute != ownership.Endpoint)
+                        {
+                            LocalAiEndpointLifecycleResult withdrawn = await _options.EndpointLifecycle
+                                .QuiesceAsync(install, LocalAiQuiesceReason.EndpointCycle, cancellationToken)
+                                .ConfigureAwait(false);
+                            if (!withdrawn.Success)
+                            {
+                                return await FailStartupAsync(
+                                        LocalAiRuntimeState.Failed,
+                                        withdrawn.Detail ?? "The stale Local AI route could not be withdrawn.",
+                                        install)
+                                    .ConfigureAwait(false);
+                            }
+                        }
+
                         LocalAiInstallManifest verifiedManifest = install.Manifest with
                         {
                             Endpoint = ownership.Endpoint.AbsoluteUri,
@@ -274,7 +333,8 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                         {
                             return await FailStartupAsync(
                                     LocalAiRuntimeState.Failed,
-                                    published.Detail ?? "The Local AI gateway provider could not be safely published.")
+                                    published.Detail ?? "The Local AI gateway provider could not be safely published.",
+                                    _install)
                                 .ConfigureAwait(false);
                         }
 
@@ -287,7 +347,8 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
 
             return await FailStartupAsync(
                     LocalAiRuntimeState.Failed,
-                    "The local AI router did not become healthy before the startup timeout.")
+                    "The local AI router did not become healthy before the startup timeout.",
+                    retainedRoute is null ? null : install)
                 .ConfigureAwait(false);
         }
         catch (OperationCanceledException)
@@ -447,7 +508,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         try
         {
             quiesced = await _options.EndpointLifecycle
-                .QuiesceAsync(install, cancellationToken)
+                .QuiesceAsync(install, LocalAiQuiesceReason.EndpointCycle, cancellationToken)
                 .ConfigureAwait(false);
         }
         finally
@@ -560,7 +621,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
             return Snapshot;
 
         LocalAiEndpointLifecycleResult quiesced = await _options.EndpointLifecycle
-            .QuiesceAsync(_install!, cancellationToken)
+            .QuiesceAsync(_install!, LocalAiQuiesceReason.Teardown, cancellationToken)
             .ConfigureAwait(false);
         if (!quiesced.Success)
         {
@@ -599,11 +660,59 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         }
     }
 
-    private async Task<LocalAiRuntimeSnapshot> FailStartupAsync(LocalAiRuntimeState state, string detail)
+    /// <summary>
+    /// Fails a startup attempt. When <paramref name="routeToWithdraw"/> is set, the
+    /// gateway is still pointing at a route this attempt left standing (or just
+    /// published) and no listener will answer it, so it must be withdrawn here.
+    /// </summary>
+    private async Task<LocalAiRuntimeSnapshot> FailStartupAsync(
+        LocalAiRuntimeState state,
+        string detail,
+        LocalAiResolvedInstall? routeToWithdraw = null)
     {
         ++_generation;
         await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
+        if (routeToWithdraw is not null)
+        {
+            try
+            {
+                LocalAiEndpointLifecycleResult withdrawn = await _options.EndpointLifecycle
+                    .QuiesceAsync(routeToWithdraw, LocalAiQuiesceReason.Teardown, CancellationToken.None)
+                    .ConfigureAwait(false);
+                if (!withdrawn.Success)
+                    _logger.Warn(withdrawn.Detail ?? "The Local AI route could not be withdrawn after a failed start.");
+            }
+            catch (Exception ex)
+            {
+                _logger.Warn($"The Local AI route could not be withdrawn after a failed start: {Sanitize(ex.Message)}");
+            }
+        }
         return Publish(state, LocalAiOwnership.None, detail);
+    }
+
+    /// <summary>
+    /// Picks the port the router should bind. An explicit port always wins. Otherwise
+    /// the last verified port is reused when it is free, so the published gateway
+    /// route survives a restart instead of having to be withdrawn and rewritten.
+    /// </summary>
+    private static int ResolvePlannedPort(
+        LocalAiResolvedInstall install,
+        WindowsTcpListenerSnapshotResult listeners)
+    {
+        int requestedPort = install.Manifest.RequestedPort;
+        if (requestedPort != LocalAiPortPolicy.Automatic)
+            return requestedPort;
+
+        if (install.Endpoint is not { } lastVerified ||
+            !LocalAiPortPolicy.TryValidate(lastVerified.Port, out _) ||
+            lastVerified.Port == LocalAiPortPolicy.Automatic)
+        {
+            return LocalAiPortPolicy.Automatic;
+        }
+
+        return FindEndpointListeners(listeners, lastVerified.Port).Count == 0
+            ? lastVerified.Port
+            : LocalAiPortPolicy.Automatic;
     }
 
     private async Task DisposeManagedProcessAsync(CancellationToken cancellationToken)
@@ -652,7 +761,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                 if (_install is not null)
                 {
                     LocalAiEndpointLifecycleResult quiesced = await _options.EndpointLifecycle
-                        .QuiesceAsync(_install, CancellationToken.None)
+                        .QuiesceAsync(_install, LocalAiQuiesceReason.EndpointCycle, CancellationToken.None)
                         .ConfigureAwait(false);
                     if (!quiesced.Success)
                     {
@@ -880,7 +989,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                     try
                     {
                         LocalAiEndpointLifecycleResult quiesced = await _options.EndpointLifecycle
-                            .QuiesceAsync(_install, CancellationToken.None)
+                            .QuiesceAsync(_install, LocalAiQuiesceReason.Teardown, CancellationToken.None)
                             .ConfigureAwait(false);
                         if (!quiesced.Success)
                             _logger.Warn(quiesced.Detail ?? "The Local AI gateway provider could not be disabled during shutdown.");

--- a/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
@@ -69,6 +69,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
     private int _restartAttempts;
     private bool _stopping;
     private bool _explicitStopRequested;
+    private bool _gatewayRouteRequiresResolution;
     private bool _disposed;
     private bool _acceptExitTasks = true;
     private int _disposeStarted;
@@ -143,10 +144,12 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         {
             ThrowIfDisposed();
             _explicitStopRequested = true;
-            return await StopCoreAsync(
+            LocalAiRuntimeSnapshot stopped = await StopCoreAsync(
                     LocalAiQuiesceReason.Teardown,
                     cancellationToken)
                 .ConfigureAwait(false);
+            _explicitStopRequested = stopped.State == LocalAiRuntimeState.Failed;
+            return stopped;
         }
         finally
         {
@@ -255,8 +258,10 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         LocalAiEndpointLifecycleResult quiesced;
         try
         {
-            quiesced = await _options.EndpointLifecycle
-                .QuiesceAsync(install, LocalAiQuiesceReason.EndpointCycle, cancellationToken)
+            quiesced = await QuiesceRouteAsync(
+                    install,
+                    LocalAiQuiesceReason.EndpointCycle,
+                    cancellationToken)
                 .ConfigureAwait(false);
         }
         catch (OperationCanceledException)
@@ -373,8 +378,9 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                         await _manifestStore.SaveAsync(verifiedManifest, cancellationToken).ConfigureAwait(false);
                         _install = _manifestStore.ResolveAndValidate(verifiedManifest);
 
-                        LocalAiEndpointLifecycleResult published = await _options.EndpointLifecycle
-                            .PublishAsync(_install, cancellationToken)
+                        LocalAiEndpointLifecycleResult published = await PublishRouteAsync(
+                                _install,
+                                cancellationToken)
                             .ConfigureAwait(false);
                         if (!published.Success)
                         {
@@ -421,6 +427,11 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
     {
         if (_explicitStopRequested)
             return Snapshot;
+        if (_gatewayRouteRequiresResolution &&
+            (_managedProcess is null || _managedProcess.HasExited))
+        {
+            return Snapshot;
+        }
 
         if (!await TryLoadInstallAsync(cancellationToken).ConfigureAwait(false))
             return Snapshot;
@@ -540,8 +551,9 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                             ownership.Endpoint,
                             cancellationToken)
                         .ConfigureAwait(false);
-                    published = await _options.EndpointLifecycle
-                        .PublishAsync(install, cancellationToken)
+                    published = await PublishRouteAsync(
+                            install,
+                            cancellationToken)
                         .ConfigureAwait(false);
                 }
                 catch (OperationCanceledException)
@@ -553,8 +565,9 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                                 ownership.Endpoint,
                                 CancellationToken.None)
                             .ConfigureAwait(false);
-                        LocalAiEndpointLifecycleResult recovered = await _options.EndpointLifecycle
-                            .PublishAsync(install, CancellationToken.None)
+                        LocalAiEndpointLifecycleResult recovered = await PublishRouteAsync(
+                                install,
+                                CancellationToken.None)
                             .ConfigureAwait(false);
                         if (recovered.Success)
                         {
@@ -636,8 +649,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         LocalAiEndpointLifecycleResult quiesced;
         try
         {
-            quiesced = await _options.EndpointLifecycle
-                .QuiesceAsync(install, reason, cancellationToken)
+            quiesced = await QuiesceRouteAsync(install, reason, cancellationToken)
                 .ConfigureAwait(false);
         }
         catch
@@ -804,8 +816,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         LocalAiEndpointLifecycleResult quiesced;
         try
         {
-            quiesced = await _options.EndpointLifecycle
-                .QuiesceAsync(_install!, reason, cancellationToken)
+            quiesced = await QuiesceRouteAsync(_install!, reason, cancellationToken)
                 .ConfigureAwait(false);
         }
         catch
@@ -961,8 +972,10 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
     {
         try
         {
-            LocalAiEndpointLifecycleResult withdrawn = await _options.EndpointLifecycle
-                .QuiesceAsync(install, reason, CancellationToken.None)
+            LocalAiEndpointLifecycleResult withdrawn = await QuiesceRouteAsync(
+                    install,
+                    reason,
+                    CancellationToken.None)
                 .ConfigureAwait(false);
             if (!withdrawn.Success)
             {
@@ -976,6 +989,33 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
             _logger.Warn($"The Local AI route could not be withdrawn {context}: {Sanitize(ex.Message)}");
             return false;
         }
+    }
+
+    private async Task<LocalAiEndpointLifecycleResult> QuiesceRouteAsync(
+        LocalAiResolvedInstall install,
+        LocalAiQuiesceReason reason,
+        CancellationToken cancellationToken)
+    {
+        _gatewayRouteRequiresResolution = true;
+
+        LocalAiEndpointLifecycleResult result = await _options.EndpointLifecycle
+            .QuiesceAsync(install, reason, cancellationToken)
+            .ConfigureAwait(false);
+        if (reason == LocalAiQuiesceReason.Teardown && result.Success)
+            _gatewayRouteRequiresResolution = false;
+        return result;
+    }
+
+    private async Task<LocalAiEndpointLifecycleResult> PublishRouteAsync(
+        LocalAiResolvedInstall install,
+        CancellationToken cancellationToken)
+    {
+        LocalAiEndpointLifecycleResult result = await _options.EndpointLifecycle
+            .PublishAsync(install, cancellationToken)
+            .ConfigureAwait(false);
+        if (result.Success)
+            _gatewayRouteRequiresResolution = false;
+        return result;
     }
 
     private LocalAiRuntimeSnapshot PublishManagedFailure(string detail) =>
@@ -1095,8 +1135,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                         LocalAiEndpointLifecycleResult quiesced;
                         try
                         {
-                            quiesced = await _options.EndpointLifecycle
-                                .QuiesceAsync(
+                            quiesced = await QuiesceRouteAsync(
                                     _install,
                                     LocalAiQuiesceReason.EndpointCycle,
                                     CancellationToken.None)
@@ -1174,8 +1213,18 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
             {
                 if (!_disposed && !_stopping && !_explicitStopRequested && generation == _generation)
                 {
-                    LocalAiRuntimeSnapshot restarted = await EnsureStartedCoreAsync(CancellationToken.None)
-                        .ConfigureAwait(false);
+                    LocalAiRuntimeSnapshot restarted;
+                    try
+                    {
+                        restarted = await EnsureStartedCoreAsync(CancellationToken.None)
+                            .ConfigureAwait(false);
+                    }
+                    catch
+                    {
+                        if (restartInstall is not null)
+                            await CompleteAutomaticRestartFailureAsync(restartInstall).ConfigureAwait(false);
+                        throw;
+                    }
                     if (restarted.State is LocalAiRuntimeState.Failed or LocalAiRuntimeState.NotInstalled &&
                         restartInstall is not null)
                     {

--- a/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
@@ -419,6 +419,9 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
 
     private async Task<LocalAiRuntimeSnapshot> RefreshCoreAsync(CancellationToken cancellationToken)
     {
+        if (_explicitStopRequested)
+            return Snapshot;
+
         if (!await TryLoadInstallAsync(cancellationToken).ConfigureAwait(false))
             return Snapshot;
 

--- a/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
@@ -299,13 +299,18 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                             install.ModelPath,
                             cancellationToken)
                         .ConfigureAwait(false);
+                    if (!probe.IsReadyForManagedModel(install.ModelPath))
+                    {
+                        // A failed probe means the retained route is about to lose
+                        // its listener; the eventual timeout path must withdraw it.
+                    }
                     if (probe.IsReadyForManagedModel(install.ModelPath))
                     {
-                        // The router bound a different port than the retained route
-                        // advertises, so that route is now stale and must be withdrawn
-                        // before the new one is published.
                         if (retainedRoute is not null && retainedRoute != ownership.Endpoint)
                         {
+                            // The router bound a different port than the retained route
+                            // advertises, so that route is now stale and must be withdrawn
+                            // before the new one is published.
                             LocalAiEndpointLifecycleResult withdrawn = await _options.EndpointLifecycle
                                 .QuiesceAsync(install, LocalAiQuiesceReason.EndpointCycle, cancellationToken)
                                 .ConfigureAwait(false);
@@ -317,6 +322,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                                         install)
                                     .ConfigureAwait(false);
                             }
+                            retainedRoute = null;
                         }
 
                         LocalAiInstallManifest verifiedManifest = install.Manifest with
@@ -354,6 +360,10 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         catch (OperationCanceledException)
         {
             ++_generation;
+            // Cancellation is terminal for this startup attempt: if a route was
+            // retained, withdraw it before the child's listener disappears, or
+            // the gateway would keep routing to a port nothing serves.
+            await WithdrawRetainedRouteAsync(install).ConfigureAwait(false);
             await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
             Publish(LocalAiRuntimeState.Stopped, LocalAiOwnership.None, "Local AI startup was canceled.");
             throw;
@@ -361,6 +371,9 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         catch (Exception ex)
         {
             ++_generation;
+            // A launch failure or immediate child exit is terminal: withdraw any
+            // retained route before the child's listener disappears.
+            await WithdrawRetainedRouteAsync(install).ConfigureAwait(false);
             await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
             _logger.Error("Managed llama-server startup failed.", ex);
             return Publish(LocalAiRuntimeState.Failed, LocalAiOwnership.None, Sanitize(ex.Message));
@@ -661,9 +674,10 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
     }
 
     /// <summary>
-    /// Fails a startup attempt. When <paramref name="routeToWithdraw"/> is set, the
-    /// gateway is still pointing at a route this attempt left standing (or just
-    /// published) and no listener will answer it, so it must be withdrawn here.
+    /// Terminates a startup attempt. When <paramref name="routeToWithdraw"/> is
+    /// set, the gateway is still pointing at a route this attempt left standing
+    /// and no listener will answer it after the child stops, so the route is
+    /// withdrawn before the child is disposed.
     /// </summary>
     private async Task<LocalAiRuntimeSnapshot> FailStartupAsync(
         LocalAiRuntimeState state,
@@ -671,23 +685,38 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         LocalAiResolvedInstall? routeToWithdraw = null)
     {
         ++_generation;
-        await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
         if (routeToWithdraw is not null)
-        {
-            try
-            {
-                LocalAiEndpointLifecycleResult withdrawn = await _options.EndpointLifecycle
-                    .QuiesceAsync(routeToWithdraw, LocalAiQuiesceReason.Teardown, CancellationToken.None)
-                    .ConfigureAwait(false);
-                if (!withdrawn.Success)
-                    _logger.Warn(withdrawn.Detail ?? "The Local AI route could not be withdrawn after a failed start.");
-            }
-            catch (Exception ex)
-            {
-                _logger.Warn($"The Local AI route could not be withdrawn after a failed start: {Sanitize(ex.Message)}");
-            }
-        }
+            await WithdrawRouteAsync(routeToWithdraw, "after a failed start").ConfigureAwait(false);
+        await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
         return Publish(state, LocalAiOwnership.None, detail);
+    }
+
+    /// <summary>
+    /// Withdraws the gateway route that a terminal startup outcome left
+    /// standing, as teardown semantics: no restart will follow on this path.
+    /// Failures are logged and never mask the original outcome.
+    /// </summary>
+    private async Task WithdrawRetainedRouteAsync(LocalAiResolvedInstall install)
+    {
+        if (install.Endpoint is null)
+            return;
+        await WithdrawRouteAsync(install, "after a terminal startup failure").ConfigureAwait(false);
+    }
+
+    private async Task WithdrawRouteAsync(LocalAiResolvedInstall install, string context)
+    {
+        try
+        {
+            LocalAiEndpointLifecycleResult withdrawn = await _options.EndpointLifecycle
+                .QuiesceAsync(install, LocalAiQuiesceReason.Teardown, CancellationToken.None)
+                .ConfigureAwait(false);
+            if (!withdrawn.Success)
+                _logger.Warn($"{withdrawn.Detail ?? "The Local AI route could not be withdrawn"} {context}.");
+        }
+        catch (Exception ex)
+        {
+            _logger.Warn($"The Local AI route could not be withdrawn {context}: {Sanitize(ex.Message)}");
+        }
     }
 
     /// <summary>
@@ -758,10 +787,18 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                 if (exited is not null)
                     await exited.DisposeAsync().ConfigureAwait(false);
 
+                // The quiesce reason depends on what follows: a pending restart
+                // is an endpoint cycle and keeps the managed primary selected,
+                // while exhausted retries are terminal and restore the prior
+                // gateway routing instead of leaving the provider absent.
+                bool willRestart = _restartAttempts < _options.MaxRestartAttempts;
                 if (_install is not null)
                 {
                     LocalAiEndpointLifecycleResult quiesced = await _options.EndpointLifecycle
-                        .QuiesceAsync(_install, LocalAiQuiesceReason.EndpointCycle, CancellationToken.None)
+                        .QuiesceAsync(
+                            _install,
+                            willRestart ? LocalAiQuiesceReason.EndpointCycle : LocalAiQuiesceReason.Teardown,
+                            CancellationToken.None)
                         .ConfigureAwait(false);
                     if (!quiesced.Success)
                     {
@@ -776,7 +813,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                     LocalAiRuntimeState.Failed,
                     LocalAiOwnership.None,
                     $"Managed llama-server exited unexpectedly{(exit.ExitCode.HasValue ? $" with code {exit.ExitCode.Value}" : string.Empty)}.");
-                if (_restartAttempts >= _options.MaxRestartAttempts)
+                if (!willRestart)
                     return;
                 _restartAttempts++;
             }

--- a/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
@@ -140,7 +140,10 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         try
         {
             ThrowIfDisposed();
-            return await StopCoreAsync(cancellationToken).ConfigureAwait(false);
+            return await StopCoreAsync(
+                    LocalAiQuiesceReason.Teardown,
+                    cancellationToken)
+                .ConfigureAwait(false);
         }
         finally
         {
@@ -154,11 +157,37 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         try
         {
             ThrowIfDisposed();
-            LocalAiRuntimeSnapshot stopped = await StopCoreAsync(cancellationToken).ConfigureAwait(false);
+            LocalAiRuntimeSnapshot stopped = await StopCoreAsync(
+                    LocalAiQuiesceReason.EndpointCycle,
+                    cancellationToken)
+                .ConfigureAwait(false);
             if (_managedProcess is not null || stopped.State == LocalAiRuntimeState.Failed)
                 return stopped;
             _restartAttempts = 0;
-            return await EnsureStartedCoreAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                LocalAiRuntimeSnapshot restarted = await EnsureStartedCoreAsync(cancellationToken)
+                    .ConfigureAwait(false);
+                if (restarted.State == LocalAiRuntimeState.Failed && _managedProcess is null && _install is not null)
+                {
+                    await WithdrawRouteAsync(
+                            _install,
+                            "after restart startup failed")
+                        .ConfigureAwait(false);
+                }
+                return restarted;
+            }
+            catch
+            {
+                if (_install is not null)
+                {
+                    await WithdrawRouteAsync(
+                            _install,
+                            "after restart startup was interrupted")
+                        .ConfigureAwait(false);
+                }
+                throw;
+            }
         }
         finally
         {
@@ -177,9 +206,6 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         if (_managedProcess is not null)
             await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
 
-        // Decide the port before touching gateway routing. Rebinding the last
-        // verified port keeps the already-published route valid for the whole
-        // startup, so the gateway is never left without a Local AI provider.
         WindowsTcpListenerSnapshotResult beforeStart = _platform.CaptureListeners();
         if (!beforeStart.Ipv4Complete)
         {
@@ -190,11 +216,9 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                 .ConfigureAwait(false);
         }
 
-        // A foreign process owns the port the published route points at, so that
-        // route must be withdrawn before returning rather than left aimed at it.
-        int plannedPort = ResolvePlannedPort(install, beforeStart);
-        if (plannedPort != LocalAiPortPolicy.Automatic &&
-            FindEndpointListeners(beforeStart, plannedPort).Count > 0)
+        int requestedPort = install.Manifest.RequestedPort;
+        if (requestedPort != LocalAiPortPolicy.Automatic &&
+            FindEndpointListeners(beforeStart, requestedPort).Count > 0)
         {
             return await FailStartupAsync(
                     LocalAiRuntimeState.Conflict,
@@ -203,62 +227,49 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                 .ConfigureAwait(false);
         }
 
-        // The published route already names the port we are about to bind, so
-        // withdrawing it would only open a window in which the gateway falls
-        // back to its built-in default provider. PublishAsync re-verifies below.
-        Uri? retainedRoute = plannedPort != LocalAiPortPolicy.Automatic &&
-            install.Endpoint is { } publishedRoute &&
-            publishedRoute.Port == plannedPort
-                ? publishedRoute
-                : null;
-        bool terminalTeardownRequired = retainedRoute is not null;
-        if (retainedRoute is null)
+        LocalAiEndpointLifecycleResult quiesced;
+        try
         {
-            LocalAiEndpointLifecycleResult quiesced;
-            try
-            {
-                quiesced = await _options.EndpointLifecycle
-                    .QuiesceAsync(install, LocalAiQuiesceReason.EndpointCycle, cancellationToken)
-                    .ConfigureAwait(false);
-            }
-            catch (OperationCanceledException)
-            {
-                await CancelStartupAsync(install, terminalTeardownRequired: true).ConfigureAwait(false);
-                throw;
-            }
-            catch
-            {
-                await WithdrawRouteAsync(
-                        install,
-                        "after endpoint-cycle withdrawal was interrupted")
-                    .ConfigureAwait(false);
-                throw;
-            }
-            if (!quiesced.Success)
-            {
-                return await FailStartupAsync(
-                        LocalAiRuntimeState.Failed,
-                        quiesced.Detail ?? "The Local AI gateway provider could not be safely disabled.",
-                        install)
-                    .ConfigureAwait(false);
-            }
-            terminalTeardownRequired = true;
+            quiesced = await _options.EndpointLifecycle
+                .QuiesceAsync(install, LocalAiQuiesceReason.EndpointCycle, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            await CancelStartupAsync(install, terminalTeardownRequired: true).ConfigureAwait(false);
+            throw;
+        }
+        catch
+        {
+            await WithdrawRouteAsync(
+                    install,
+                    "after endpoint-cycle withdrawal was interrupted")
+                .ConfigureAwait(false);
+            throw;
+        }
+        if (!quiesced.Success)
+        {
+            return await FailStartupAsync(
+                    LocalAiRuntimeState.Failed,
+                    quiesced.Detail ?? "The Local AI gateway provider could not be safely disabled.",
+                    install)
+                .ConfigureAwait(false);
         }
 
         LlamaServerRouterLaunchPlan launchPlan;
         try
         {
             ValidateInstalledFiles(install);
-            LocalAiPortPolicy.Validate(plannedPort);
+            LocalAiPortPolicy.Validate(requestedPort);
             launchPlan = LlamaServerRouterConfiguration.Build(
                 _options.Paths,
                 install,
-                plannedPort);
+                requestedPort);
             await WritePresetAtomicallyAsync(launchPlan, cancellationToken).ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {
-            await CancelStartupAsync(install, terminalTeardownRequired).ConfigureAwait(false);
+            await CancelStartupAsync(install, terminalTeardownRequired: true).ConfigureAwait(false);
             throw;
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidDataException)
@@ -267,7 +278,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
             return await FailStartupAsync(
                     LocalAiRuntimeState.Failed,
                     Sanitize(ex.Message),
-                    terminalTeardownRequired ? install : null)
+                    install)
                 .ConfigureAwait(false);
         }
 
@@ -305,7 +316,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                     return await FailStartupAsync(
                             LocalAiRuntimeState.Conflict,
                             "TCP listener ownership could not be determined.",
-                            terminalTeardownRequired ? install : null)
+                            install)
                         .ConfigureAwait(false);
                 }
                 if (ownership.ConflictDetail is not null)
@@ -313,7 +324,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                     return await FailStartupAsync(
                             LocalAiRuntimeState.Conflict,
                             ownership.ConflictDetail,
-                            terminalTeardownRequired ? install : null)
+                            install)
                         .ConfigureAwait(false);
                 }
                 if (ownership.Endpoint is not null)
@@ -326,25 +337,6 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                         .ConfigureAwait(false);
                     if (probe.IsReadyForManagedModel(install.ModelPath))
                     {
-                        if (retainedRoute is not null && retainedRoute != ownership.Endpoint)
-                        {
-                            // The router bound a different port than the retained route
-                            // advertises, so that route is now stale and must be withdrawn
-                            // before the new one is published.
-                            LocalAiEndpointLifecycleResult withdrawn = await _options.EndpointLifecycle
-                                .QuiesceAsync(install, LocalAiQuiesceReason.EndpointCycle, cancellationToken)
-                                .ConfigureAwait(false);
-                            if (!withdrawn.Success)
-                            {
-                                return await FailStartupAsync(
-                                        LocalAiRuntimeState.Failed,
-                                        withdrawn.Detail ?? "The stale Local AI route could not be withdrawn.",
-                                        install)
-                                    .ConfigureAwait(false);
-                            }
-                            retainedRoute = null;
-                        }
-
                         LocalAiInstallManifest verifiedManifest = install.Manifest with
                         {
                             Endpoint = ownership.Endpoint.AbsoluteUri,
@@ -374,22 +366,22 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
             return await FailStartupAsync(
                     LocalAiRuntimeState.Failed,
                     "The local AI router did not become healthy before the startup timeout.",
-                    terminalTeardownRequired ? install : null)
+                    install)
                 .ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {
-            await CancelStartupAsync(install, terminalTeardownRequired).ConfigureAwait(false);
+            await CancelStartupAsync(install, terminalTeardownRequired: true).ConfigureAwait(false);
             throw;
         }
         catch (Exception ex)
         {
-            ++_generation;
-            if (terminalTeardownRequired)
-                await WithdrawRouteAsync(install, "after a terminal startup failure").ConfigureAwait(false);
-            await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
             _logger.Error("Managed llama-server startup failed.", ex);
-            return Publish(LocalAiRuntimeState.Failed, LocalAiOwnership.None, Sanitize(ex.Message));
+            return await FailStartupAsync(
+                    LocalAiRuntimeState.Failed,
+                    Sanitize(ex.Message),
+                    install)
+                .ConfigureAwait(false);
         }
     }
 
@@ -530,16 +522,20 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         LocalAiResolvedInstall install,
         CancellationToken cancellationToken)
     {
-        LocalAiEndpointLifecycleResult? quiesced = null;
+        LocalAiEndpointLifecycleResult quiesced;
         try
         {
             quiesced = await _options.EndpointLifecycle
                 .QuiesceAsync(install, LocalAiQuiesceReason.EndpointCycle, cancellationToken)
                 .ConfigureAwait(false);
         }
-        finally
+        catch
         {
-            if (quiesced is null)
+            bool withdrawn = await WithdrawRouteAsync(
+                    install,
+                    "after refresh withdrawal was interrupted")
+                .ConfigureAwait(false);
+            if (withdrawn)
             {
                 ++_generation;
                 await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
@@ -548,9 +544,26 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                     LocalAiOwnership.None,
                     "The Local AI gateway provider withdrawal did not complete.");
             }
+            else
+            {
+                PublishManagedFailure(
+                    "The Local AI gateway provider withdrawal did not complete; the managed listener remains running.");
+            }
+            throw;
         }
         if (quiesced.Success)
             return null;
+
+        bool teardownSucceeded = await WithdrawRouteAsync(
+                install,
+                "after refresh withdrawal failed")
+            .ConfigureAwait(false);
+        if (!teardownSucceeded)
+        {
+            return PublishManagedFailure(
+                quiesced.Detail ??
+                "The Local AI gateway provider could not be safely disabled; the managed listener remains running.");
+        }
 
         ++_generation;
         await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
@@ -641,16 +654,63 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         }
     }
 
-    private async Task<LocalAiRuntimeSnapshot> StopCoreAsync(CancellationToken cancellationToken)
+    private async Task<LocalAiRuntimeSnapshot> StopCoreAsync(
+        LocalAiQuiesceReason reason,
+        CancellationToken cancellationToken)
     {
         if (_install is null && !await TryLoadInstallAsync(cancellationToken).ConfigureAwait(false))
             return Snapshot;
 
-        LocalAiEndpointLifecycleResult quiesced = await _options.EndpointLifecycle
-            .QuiesceAsync(_install!, LocalAiQuiesceReason.Teardown, cancellationToken)
-            .ConfigureAwait(false);
+        LocalAiEndpointLifecycleResult quiesced;
+        try
+        {
+            quiesced = await _options.EndpointLifecycle
+                .QuiesceAsync(_install!, reason, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch
+        {
+            if (reason == LocalAiQuiesceReason.EndpointCycle)
+            {
+                bool withdrawn = await WithdrawRouteAsync(
+                        _install!,
+                        "after restart withdrawal was interrupted")
+                    .ConfigureAwait(false);
+                if (withdrawn)
+                {
+                    ++_generation;
+                    await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
+                    Publish(
+                        LocalAiRuntimeState.Failed,
+                        LocalAiOwnership.None,
+                        "The Local AI gateway provider withdrawal did not complete.");
+                }
+                else
+                {
+                    PublishManagedFailure(
+                        "The Local AI gateway provider withdrawal did not complete; the managed listener remains running.");
+                }
+            }
+            throw;
+        }
         if (!quiesced.Success)
         {
+            if (reason == LocalAiQuiesceReason.EndpointCycle)
+            {
+                bool withdrawn = await WithdrawRouteAsync(
+                        _install!,
+                        "after restart withdrawal failed")
+                    .ConfigureAwait(false);
+                if (withdrawn)
+                {
+                    ++_generation;
+                    await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
+                    return Publish(
+                        LocalAiRuntimeState.Failed,
+                        LocalAiOwnership.None,
+                        quiesced.Detail ?? "The Local AI gateway provider could not be safely disabled.");
+                }
+            }
             return Publish(
                 LocalAiRuntimeState.Failed,
                 _managedProcess is null ? LocalAiOwnership.None : LocalAiOwnership.CompanionManaged,
@@ -698,8 +758,13 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         LocalAiResolvedInstall? routeToWithdraw = null)
     {
         ++_generation;
-        if (routeToWithdraw is not null)
-            await WithdrawRouteAsync(routeToWithdraw, "after a failed start").ConfigureAwait(false);
+        if (routeToWithdraw is not null &&
+            !await WithdrawRouteAsync(routeToWithdraw, "after a failed start").ConfigureAwait(false) &&
+            _managedProcess is { HasExited: false })
+        {
+            return PublishManagedFailure(
+                $"{detail} The Local AI route could not be safely disabled; the managed listener remains running.");
+        }
         await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
         return Publish(state, LocalAiOwnership.None, detail);
     }
@@ -709,8 +774,14 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         bool terminalTeardownRequired)
     {
         ++_generation;
-        if (terminalTeardownRequired)
-            await WithdrawRouteAsync(install, "after startup cancellation").ConfigureAwait(false);
+        if (terminalTeardownRequired &&
+            !await WithdrawRouteAsync(install, "after startup cancellation").ConfigureAwait(false) &&
+            _managedProcess is { HasExited: false })
+        {
+            PublishManagedFailure(
+                "Local AI startup was canceled, but gateway routing could not be safely disabled; the managed listener remains running.");
+            return;
+        }
         await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
         Publish(LocalAiRuntimeState.Stopped, LocalAiOwnership.None, "Local AI startup was canceled.");
     }
@@ -719,7 +790,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
     /// Restores terminal gateway routing when no restart or publish will follow.
     /// Failures are logged and never mask the original startup outcome.
     /// </summary>
-    private async Task WithdrawRouteAsync(LocalAiResolvedInstall install, string context)
+    private async Task<bool> WithdrawRouteAsync(LocalAiResolvedInstall install, string context)
     {
         try
         {
@@ -727,38 +798,26 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                 .QuiesceAsync(install, LocalAiQuiesceReason.Teardown, CancellationToken.None)
                 .ConfigureAwait(false);
             if (!withdrawn.Success)
+            {
                 _logger.Warn($"{withdrawn.Detail ?? "The Local AI route could not be withdrawn"} {context}.");
+                return false;
+            }
+            return true;
         }
         catch (Exception ex)
         {
             _logger.Warn($"The Local AI route could not be withdrawn {context}: {Sanitize(ex.Message)}");
+            return false;
         }
     }
 
-    /// <summary>
-    /// Picks the port the router should bind. An explicit port always wins. Otherwise
-    /// the last verified port is reused when it is free, so the published gateway
-    /// route survives a restart instead of having to be withdrawn and rewritten.
-    /// </summary>
-    private static int ResolvePlannedPort(
-        LocalAiResolvedInstall install,
-        WindowsTcpListenerSnapshotResult listeners)
-    {
-        int requestedPort = install.Manifest.RequestedPort;
-        if (requestedPort != LocalAiPortPolicy.Automatic)
-            return requestedPort;
-
-        if (install.Endpoint is not { } lastVerified ||
-            !LocalAiPortPolicy.TryValidate(lastVerified.Port, out _) ||
-            lastVerified.Port == LocalAiPortPolicy.Automatic)
-        {
-            return LocalAiPortPolicy.Automatic;
-        }
-
-        return FindEndpointListeners(listeners, lastVerified.Port).Count == 0
-            ? lastVerified.Port
-            : LocalAiPortPolicy.Automatic;
-    }
+    private LocalAiRuntimeSnapshot PublishManagedFailure(string detail) =>
+        Publish(
+            LocalAiRuntimeState.Failed,
+            LocalAiOwnership.CompanionManaged,
+            detail,
+            _managedProcess?.ProcessId,
+            _managedProcess?.StartedAtUtc);
 
     private async Task DisposeManagedProcessAsync(CancellationToken cancellationToken)
     {
@@ -810,18 +869,52 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                 bool willRestart = _restartAttempts < _options.MaxRestartAttempts;
                 if (_install is not null)
                 {
-                    LocalAiEndpointLifecycleResult quiesced = await _options.EndpointLifecycle
-                        .QuiesceAsync(
+                    if (willRestart)
+                    {
+                        LocalAiEndpointLifecycleResult quiesced;
+                        try
+                        {
+                            quiesced = await _options.EndpointLifecycle
+                                .QuiesceAsync(
+                                    _install,
+                                    LocalAiQuiesceReason.EndpointCycle,
+                                    CancellationToken.None)
+                                .ConfigureAwait(false);
+                        }
+                        catch (Exception ex)
+                        {
+                            await WithdrawRouteAsync(
+                                    _install,
+                                    "after automatic-restart withdrawal was interrupted")
+                                .ConfigureAwait(false);
+                            Publish(
+                                LocalAiRuntimeState.Failed,
+                                LocalAiOwnership.None,
+                                $"The Local AI gateway provider withdrawal failed after the router exited: {Sanitize(ex.Message)}");
+                            return;
+                        }
+                        if (!quiesced.Success)
+                        {
+                            await WithdrawRouteAsync(
+                                    _install,
+                                    "after automatic-restart withdrawal failed")
+                                .ConfigureAwait(false);
+                            Publish(
+                                LocalAiRuntimeState.Failed,
+                                LocalAiOwnership.None,
+                                quiesced.Detail ?? "The Local AI gateway provider could not be safely disabled after the router exited.");
+                            return;
+                        }
+                    }
+                    else if (!await WithdrawRouteAsync(
                             _install,
-                            willRestart ? LocalAiQuiesceReason.EndpointCycle : LocalAiQuiesceReason.Teardown,
-                            CancellationToken.None)
-                        .ConfigureAwait(false);
-                    if (!quiesced.Success)
+                            "after automatic restart attempts were exhausted")
+                        .ConfigureAwait(false))
                     {
                         Publish(
                             LocalAiRuntimeState.Failed,
                             LocalAiOwnership.None,
-                            quiesced.Detail ?? "The Local AI gateway provider could not be safely disabled after the router exited.");
+                            "The Local AI gateway provider could not be safely disabled after restart attempts were exhausted.");
                         return;
                     }
                 }

--- a/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
@@ -157,34 +157,51 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         try
         {
             ThrowIfDisposed();
-            LocalAiRuntimeSnapshot stopped = await StopCoreAsync(
-                    LocalAiQuiesceReason.EndpointCycle,
-                    cancellationToken)
-                .ConfigureAwait(false);
-            if (_managedProcess is not null || stopped.State == LocalAiRuntimeState.Failed)
-                return stopped;
-            _restartAttempts = 0;
+            LocalAiResolvedInstall? restartInstall = _install;
             try
             {
+                LocalAiRuntimeSnapshot stopped = await StopCoreAsync(
+                        LocalAiQuiesceReason.EndpointCycle,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+                restartInstall ??= _install;
+                if (_managedProcess is not null || stopped.State == LocalAiRuntimeState.Failed)
+                    return stopped;
+
+                _restartAttempts = 0;
                 LocalAiRuntimeSnapshot restarted = await EnsureStartedCoreAsync(cancellationToken)
                     .ConfigureAwait(false);
-                if (restarted.State == LocalAiRuntimeState.Failed && _managedProcess is null && _install is not null)
+                if (restarted.State is LocalAiRuntimeState.Failed or LocalAiRuntimeState.NotInstalled &&
+                    restartInstall is not null)
                 {
-                    await WithdrawRouteAsync(
-                            _install,
-                            "after restart startup failed")
-                        .ConfigureAwait(false);
+                    bool withdrawn = await WithdrawRouteAsync(
+                        restartInstall,
+                        "after restart startup did not complete").ConfigureAwait(false);
+                    if (!withdrawn)
+                    {
+                        return _managedProcess is { HasExited: false }
+                            ? PublishManagedFailure(
+                                "Local AI restart did not complete and gateway routing could not be safely disabled; the managed listener remains running.")
+                            : PublishTerminalCleanupFailure(
+                                "Local AI restart did not complete and gateway routing could not be safely disabled.");
+                    }
                 }
                 return restarted;
             }
-            catch
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
-                if (_install is not null)
+                LocalAiResolvedInstall? interruptedInstall = restartInstall ?? _install;
+                if (interruptedInstall is not null)
+                    await CompleteInterruptedRestartAsync(interruptedInstall, "interrupted").ConfigureAwait(false);
+                throw;
+            }
+            catch (OperationCanceledException)
+            {
+                LocalAiResolvedInstall? canceledInstall = restartInstall ?? _install;
+                if (canceledInstall is not null &&
+                    (_managedProcess is not null || Snapshot.State != LocalAiRuntimeState.Stopped))
                 {
-                    await WithdrawRouteAsync(
-                            _install,
-                            "after restart startup was interrupted")
-                        .ConfigureAwait(false);
+                    await CompleteInterruptedRestartAsync(canceledInstall, "canceled").ConfigureAwait(false);
                 }
                 throw;
             }
@@ -239,13 +256,17 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
             await CancelStartupAsync(install, terminalTeardownRequired: true).ConfigureAwait(false);
             throw;
         }
-        catch
+        catch (Exception ex)
         {
-            await WithdrawRouteAsync(
+            _logger.Error("The Local AI gateway provider withdrawal failed before startup.", ex);
+            bool withdrawn = await WithdrawRouteAsync(
                     install,
                     "after endpoint-cycle withdrawal was interrupted")
                 .ConfigureAwait(false);
-            throw;
+            return withdrawn
+                ? Publish(LocalAiRuntimeState.Failed, LocalAiOwnership.None, Sanitize(ex.Message))
+                : PublishTerminalCleanupFailure(
+                    $"Local AI startup failed: {Sanitize(ex.Message)} Gateway routing could not be safely disabled.");
         }
         if (!quiesced.Success)
         {
@@ -428,6 +449,8 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         {
             LocalAiRuntimeSnapshot? failure = await QuiesceOrStopAsync(
                     install,
+                    LocalAiQuiesceReason.Teardown,
+                    stopAfterQuiesce: true,
                     cancellationToken)
                 .ConfigureAwait(false);
             return failure ?? Publish(
@@ -439,6 +462,8 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         {
             LocalAiRuntimeSnapshot? failure = await QuiesceOrStopAsync(
                     install,
+                    LocalAiQuiesceReason.Teardown,
+                    stopAfterQuiesce: true,
                     cancellationToken)
                 .ConfigureAwait(false);
             return failure ?? Publish(
@@ -450,6 +475,8 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         {
             LocalAiRuntimeSnapshot? failure = await QuiesceOrStopAsync(
                     install,
+                    LocalAiQuiesceReason.EndpointCycle,
+                    stopAfterQuiesce: false,
                     cancellationToken)
                 .ConfigureAwait(false);
             return failure ?? Publish(
@@ -475,6 +502,8 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                 {
                     LocalAiRuntimeSnapshot? failure = await QuiesceOrStopAsync(
                             install,
+                            LocalAiQuiesceReason.EndpointCycle,
+                            stopAfterQuiesce: false,
                             cancellationToken)
                         .ConfigureAwait(false);
                     if (failure is not null)
@@ -505,6 +534,8 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
 
         LocalAiRuntimeSnapshot? quiesceFailure = await QuiesceOrStopAsync(
                 install,
+                LocalAiQuiesceReason.EndpointCycle,
+                stopAfterQuiesce: false,
                 cancellationToken)
             .ConfigureAwait(false);
         if (quiesceFailure is not null)
@@ -520,21 +551,24 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
 
     private async Task<LocalAiRuntimeSnapshot?> QuiesceOrStopAsync(
         LocalAiResolvedInstall install,
+        LocalAiQuiesceReason reason,
+        bool stopAfterQuiesce,
         CancellationToken cancellationToken)
     {
         LocalAiEndpointLifecycleResult quiesced;
         try
         {
             quiesced = await _options.EndpointLifecycle
-                .QuiesceAsync(install, LocalAiQuiesceReason.EndpointCycle, cancellationToken)
+                .QuiesceAsync(install, reason, cancellationToken)
                 .ConfigureAwait(false);
         }
         catch
         {
-            bool withdrawn = await WithdrawRouteAsync(
-                    install,
-                    "after refresh withdrawal was interrupted")
-                .ConfigureAwait(false);
+            bool withdrawn = reason != LocalAiQuiesceReason.Teardown &&
+                await WithdrawRouteAsync(
+                        install,
+                        "after refresh withdrawal was interrupted")
+                    .ConfigureAwait(false);
             if (withdrawn)
             {
                 ++_generation;
@@ -546,23 +580,29 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
             }
             else
             {
-                PublishManagedFailure(
-                    "The Local AI gateway provider withdrawal did not complete; the managed listener remains running.");
+                await PublishRefreshCleanupFailureAsync(
+                        "The Local AI gateway provider withdrawal did not complete.")
+                    .ConfigureAwait(false);
             }
             throw;
         }
-        if (quiesced.Success)
+        if (quiesced.Success && !stopAfterQuiesce)
             return null;
+        if (quiesced.Success)
+        {
+            ++_generation;
+            await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
+            return null;
+        }
 
-        bool teardownSucceeded = await WithdrawRouteAsync(
-                install,
-                "after refresh withdrawal failed")
-            .ConfigureAwait(false);
+        bool teardownSucceeded = reason != LocalAiQuiesceReason.Teardown &&
+            await WithdrawRouteAsync(
+                    install,
+                    "after refresh withdrawal failed")
+                .ConfigureAwait(false);
         if (!teardownSucceeded)
         {
-            return PublishManagedFailure(
-                quiesced.Detail ??
-                "The Local AI gateway provider could not be safely disabled; the managed listener remains running.");
+            return await PublishRefreshCleanupFailureAsync(quiesced.Detail).ConfigureAwait(false);
         }
 
         ++_generation;
@@ -670,27 +710,6 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         }
         catch
         {
-            if (reason == LocalAiQuiesceReason.EndpointCycle)
-            {
-                bool withdrawn = await WithdrawRouteAsync(
-                        _install!,
-                        "after restart withdrawal was interrupted")
-                    .ConfigureAwait(false);
-                if (withdrawn)
-                {
-                    ++_generation;
-                    await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
-                    Publish(
-                        LocalAiRuntimeState.Failed,
-                        LocalAiOwnership.None,
-                        "The Local AI gateway provider withdrawal did not complete.");
-                }
-                else
-                {
-                    PublishManagedFailure(
-                        "The Local AI gateway provider withdrawal did not complete; the managed listener remains running.");
-                }
-            }
             throw;
         }
         if (!quiesced.Success)
@@ -757,15 +776,21 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         string detail,
         LocalAiResolvedInstall? routeToWithdraw = null)
     {
-        ++_generation;
-        if (routeToWithdraw is not null &&
-            !await WithdrawRouteAsync(routeToWithdraw, "after a failed start").ConfigureAwait(false) &&
-            _managedProcess is { HasExited: false })
+        bool withdrawalFailed = routeToWithdraw is not null &&
+            !await WithdrawRouteAsync(routeToWithdraw, "after a failed start").ConfigureAwait(false);
+        if (withdrawalFailed && _managedProcess is { HasExited: false })
         {
             return PublishManagedFailure(
                 $"{detail} The Local AI route could not be safely disabled; the managed listener remains running.");
         }
+
+        ++_generation;
         await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
+        if (withdrawalFailed)
+        {
+            return PublishTerminalCleanupFailure(
+                $"{detail} The Local AI route could not be safely disabled.");
+        }
         return Publish(state, LocalAiOwnership.None, detail);
     }
 
@@ -773,16 +798,23 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         LocalAiResolvedInstall install,
         bool terminalTeardownRequired)
     {
-        ++_generation;
-        if (terminalTeardownRequired &&
-            !await WithdrawRouteAsync(install, "after startup cancellation").ConfigureAwait(false) &&
-            _managedProcess is { HasExited: false })
+        bool withdrawalFailed = terminalTeardownRequired &&
+            !await WithdrawRouteAsync(install, "after startup cancellation").ConfigureAwait(false);
+        if (withdrawalFailed && _managedProcess is { HasExited: false })
         {
             PublishManagedFailure(
                 "Local AI startup was canceled, but gateway routing could not be safely disabled; the managed listener remains running.");
             return;
         }
+
+        ++_generation;
         await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
+        if (withdrawalFailed)
+        {
+            PublishTerminalCleanupFailure(
+                "Local AI startup was canceled, but gateway routing could not be safely disabled.");
+            return;
+        }
         Publish(LocalAiRuntimeState.Stopped, LocalAiOwnership.None, "Local AI startup was canceled.");
     }
 
@@ -818,6 +850,57 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
             detail,
             _managedProcess?.ProcessId,
             _managedProcess?.StartedAtUtc);
+
+    private LocalAiRuntimeSnapshot PublishTerminalCleanupFailure(string detail) =>
+        Publish(
+            LocalAiRuntimeState.Failed,
+            LocalAiOwnership.None,
+            detail);
+
+    private async Task<LocalAiRuntimeSnapshot> PublishRefreshCleanupFailureAsync(string? detail)
+    {
+        const string fallbackDetail =
+            "The Local AI gateway provider could not be safely disabled during endpoint refresh.";
+        if (_managedProcess is { HasExited: false })
+        {
+            return PublishManagedFailure(
+                $"{detail ?? fallbackDetail} The managed listener remains running.");
+        }
+
+        ++_generation;
+        if (_managedProcess is not null)
+            await _managedProcess.DisposeAsync().ConfigureAwait(false);
+        _managedProcess = null;
+        return PublishTerminalCleanupFailure(detail ?? fallbackDetail);
+    }
+
+    private async Task CompleteInterruptedRestartAsync(LocalAiResolvedInstall install, string outcome)
+    {
+        bool withdrawn = await WithdrawRouteAsync(
+                install,
+                $"after restart was {outcome}")
+            .ConfigureAwait(false);
+        if (!withdrawn)
+        {
+            if (_managedProcess is { HasExited: false })
+            {
+                PublishManagedFailure(
+                    $"Local AI restart was {outcome}, but gateway routing could not be safely disabled; the managed listener remains running.");
+            }
+            else
+            {
+                ++_generation;
+                await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
+                PublishTerminalCleanupFailure(
+                    $"Local AI restart was {outcome}, but gateway routing could not be safely disabled.");
+            }
+            return;
+        }
+
+        ++_generation;
+        await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
+        PublishTerminalCleanupFailure($"Local AI restart was {outcome}.");
+    }
 
     private async Task DisposeManagedProcessAsync(CancellationToken cancellationToken)
     {

--- a/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
@@ -543,6 +543,37 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                 }
                 catch (OperationCanceledException)
                 {
+                    try
+                    {
+                        install = await BindVerifiedEndpointAsync(
+                                install,
+                                ownership.Endpoint,
+                                CancellationToken.None)
+                            .ConfigureAwait(false);
+                        LocalAiEndpointLifecycleResult recovered = await _options.EndpointLifecycle
+                            .PublishAsync(install, CancellationToken.None)
+                            .ConfigureAwait(false);
+                        if (recovered.Success)
+                        {
+                            PublishHealthy(probe);
+                        }
+                        else
+                        {
+                            await FailStartupAsync(
+                                    LocalAiRuntimeState.Failed,
+                                    recovered.Detail ?? "The canceled Local AI endpoint refresh could not restore gateway routing.",
+                                    install)
+                                .ConfigureAwait(false);
+                        }
+                    }
+                    catch (Exception recoveryException)
+                    {
+                        await FailStartupAsync(
+                                LocalAiRuntimeState.Failed,
+                                $"The canceled Local AI endpoint refresh could not restore gateway routing: {Sanitize(recoveryException.Message)}",
+                                _install ?? install)
+                            .ConfigureAwait(false);
+                    }
                     throw;
                 }
                 catch (Exception ex)
@@ -1034,6 +1065,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
 
     private async Task HandleManagedProcessExitedAsync(long generation, LocalAiManagedProcessExit exit)
     {
+        LocalAiResolvedInstall? restartInstall = null;
         try
         {
             await _operationGate.WaitAsync().ConfigureAwait(false);
@@ -1052,6 +1084,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                 // gateway routing instead of leaving the provider absent.
                 bool willRestart = !_explicitStopRequested &&
                     _restartAttempts < _options.MaxRestartAttempts;
+                restartInstall = _install;
                 if (_install is not null)
                 {
                     if (willRestart)
@@ -1137,7 +1170,15 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
             try
             {
                 if (!_disposed && !_stopping && !_explicitStopRequested && generation == _generation)
-                    await EnsureStartedCoreAsync(CancellationToken.None).ConfigureAwait(false);
+                {
+                    LocalAiRuntimeSnapshot restarted = await EnsureStartedCoreAsync(CancellationToken.None)
+                        .ConfigureAwait(false);
+                    if (restarted.State is LocalAiRuntimeState.Failed or LocalAiRuntimeState.NotInstalled &&
+                        restartInstall is not null)
+                    {
+                        await CompleteAutomaticRestartFailureAsync(restartInstall).ConfigureAwait(false);
+                    }
+                }
             }
             finally
             {
@@ -1147,6 +1188,36 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         catch (Exception ex)
         {
             _logger.Error("Managed llama-server automatic restart failed.", ex);
+        }
+    }
+
+    private async Task CompleteAutomaticRestartFailureAsync(LocalAiResolvedInstall restartInstall)
+    {
+        LocalAiResolvedInstall cleanupInstall = _install ?? restartInstall;
+        bool withdrawn = await WithdrawRouteAsync(
+                cleanupInstall,
+                "after automatic restart startup did not complete")
+            .ConfigureAwait(false);
+        if (!withdrawn)
+        {
+            if (_managedProcess is { HasExited: false })
+            {
+                PublishManagedFailure(
+                    "Automatic Local AI restart did not complete and gateway routing could not be safely disabled; the managed listener remains running.");
+            }
+            else
+            {
+                PublishTerminalCleanupFailure(
+                    "Automatic Local AI restart did not complete and gateway routing could not be safely disabled.");
+            }
+            return;
+        }
+
+        if (_managedProcess is { HasExited: false })
+        {
+            ++_generation;
+            await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
+            PublishTerminalCleanupFailure("Automatic Local AI restart did not complete.");
         }
     }
 

--- a/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
@@ -68,6 +68,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
     private long _generation;
     private int _restartAttempts;
     private bool _stopping;
+    private bool _explicitStopRequested;
     private bool _disposed;
     private bool _acceptExitTasks = true;
     private int _disposeStarted;
@@ -111,6 +112,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         try
         {
             ThrowIfDisposed();
+            _explicitStopRequested = false;
             _restartAttempts = 0;
             return await EnsureStartedCoreAsync(cancellationToken).ConfigureAwait(false);
         }
@@ -140,6 +142,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         try
         {
             ThrowIfDisposed();
+            _explicitStopRequested = true;
             return await StopCoreAsync(
                     LocalAiQuiesceReason.Teardown,
                     cancellationToken)
@@ -157,6 +160,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         try
         {
             ThrowIfDisposed();
+            _explicitStopRequested = false;
             LocalAiResolvedInstall? restartInstall = _install;
             try
             {
@@ -584,6 +588,13 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         bool preserveManagedPrimaryOnFailure,
         CancellationToken cancellationToken)
     {
+        if (preserveManagedPrimaryOnFailure && !stopAfterQuiesce)
+        {
+            throw new ArgumentException(
+                "Managed-primary preservation is only valid when the untrusted endpoint will be stopped.",
+                nameof(preserveManagedPrimaryOnFailure));
+        }
+
         LocalAiEndpointLifecycleResult quiesced;
         try
         {
@@ -636,8 +647,11 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                 .ConfigureAwait(false);
             if (retried)
             {
-                ++_generation;
-                await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
+                if (stopAfterQuiesce)
+                {
+                    ++_generation;
+                    await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
+                }
                 return null;
             }
             return await PublishRefreshCleanupFailureAsync(quiesced.Detail).ConfigureAwait(false);
@@ -1032,7 +1046,8 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                 // is an endpoint cycle and keeps the managed primary selected,
                 // while exhausted retries are terminal and restore the prior
                 // gateway routing instead of leaving the provider absent.
-                bool willRestart = _restartAttempts < _options.MaxRestartAttempts;
+                bool willRestart = !_explicitStopRequested &&
+                    _restartAttempts < _options.MaxRestartAttempts;
                 if (_install is not null)
                 {
                     if (willRestart)
@@ -1117,7 +1132,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
             await _operationGate.WaitAsync().ConfigureAwait(false);
             try
             {
-                if (!_disposed && !_stopping && generation == _generation)
+                if (!_disposed && !_stopping && !_explicitStopRequested && generation == _generation)
                     await EnsureStartedCoreAsync(CancellationToken.None).ConfigureAwait(false);
             }
             finally

--- a/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
@@ -240,7 +240,8 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
             return await FailStartupAsync(
                     LocalAiRuntimeState.Conflict,
                     "TCP listener ownership could not be determined.",
-                    install)
+                    install,
+                    stopUnsafeListener: true)
                 .ConfigureAwait(false);
         }
 
@@ -358,7 +359,8 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                     return await FailStartupAsync(
                             LocalAiRuntimeState.Conflict,
                             ownership.ConflictDetail,
-                            install)
+                            install,
+                            stopUnsafeListener: true)
                         .ConfigureAwait(false);
                 }
                 if (ownership.Endpoint is not null)
@@ -480,7 +482,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                     install,
                     LocalAiQuiesceReason.EndpointCycle,
                     stopAfterQuiesce: true,
-                    preserveManagedPrimaryOnFailure: true,
+                    stopUnsafeProcessOnFailure: true,
                     cancellationToken)
                 .ConfigureAwait(false);
             return failure ?? Publish(
@@ -494,7 +496,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                     install,
                     LocalAiQuiesceReason.EndpointCycle,
                     stopAfterQuiesce: true,
-                    preserveManagedPrimaryOnFailure: true,
+                    stopUnsafeProcessOnFailure: true,
                     cancellationToken)
                 .ConfigureAwait(false);
             return failure ?? Publish(
@@ -508,7 +510,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                     install,
                     LocalAiQuiesceReason.EndpointCycle,
                     stopAfterQuiesce: false,
-                    preserveManagedPrimaryOnFailure: false,
+                    stopUnsafeProcessOnFailure: false,
                     cancellationToken)
                 .ConfigureAwait(false);
             return failure ?? Publish(
@@ -536,7 +538,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                             install,
                             LocalAiQuiesceReason.EndpointCycle,
                             stopAfterQuiesce: false,
-                            preserveManagedPrimaryOnFailure: false,
+                            stopUnsafeProcessOnFailure: false,
                             cancellationToken)
                         .ConfigureAwait(false);
                     if (failure is not null)
@@ -618,7 +620,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                 install,
                 LocalAiQuiesceReason.EndpointCycle,
                 stopAfterQuiesce: false,
-                preserveManagedPrimaryOnFailure: false,
+                stopUnsafeProcessOnFailure: false,
                 cancellationToken)
             .ConfigureAwait(false);
         if (quiesceFailure is not null)
@@ -636,14 +638,14 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         LocalAiResolvedInstall install,
         LocalAiQuiesceReason reason,
         bool stopAfterQuiesce,
-        bool preserveManagedPrimaryOnFailure,
+        bool stopUnsafeProcessOnFailure,
         CancellationToken cancellationToken)
     {
-        if (preserveManagedPrimaryOnFailure && !stopAfterQuiesce)
+        if (stopUnsafeProcessOnFailure && !stopAfterQuiesce)
         {
             throw new ArgumentException(
-                "Managed-primary preservation is only valid when the untrusted endpoint will be stopped.",
-                nameof(preserveManagedPrimaryOnFailure));
+                "Unsafe-process cleanup is only valid when the endpoint will be stopped.",
+                nameof(stopUnsafeProcessOnFailure));
         }
 
         LocalAiEndpointLifecycleResult quiesced;
@@ -654,7 +656,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         }
         catch
         {
-            LocalAiQuiesceReason recoveryReason = preserveManagedPrimaryOnFailure
+            LocalAiQuiesceReason recoveryReason = stopUnsafeProcessOnFailure
                 ? LocalAiQuiesceReason.EndpointCycle
                 : LocalAiQuiesceReason.Teardown;
             bool withdrawn = await RetryQuiesceAsync(
@@ -670,6 +672,13 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                     LocalAiRuntimeState.Failed,
                     LocalAiOwnership.None,
                     "The Local AI gateway provider withdrawal did not complete.");
+            }
+            else if (stopUnsafeProcessOnFailure)
+            {
+                ++_generation;
+                await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
+                PublishTerminalCleanupFailure(
+                    "The Local AI gateway provider withdrawal did not complete; the untrusted managed listener was stopped.");
             }
             else
             {
@@ -688,7 +697,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
             return null;
         }
 
-        if (preserveManagedPrimaryOnFailure)
+        if (stopUnsafeProcessOnFailure)
         {
             bool retried = await RetryQuiesceAsync(
                     install,
@@ -704,7 +713,10 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                 }
                 return null;
             }
-            return await PublishRefreshCleanupFailureAsync(quiesced.Detail).ConfigureAwait(false);
+            ++_generation;
+            await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
+            return PublishTerminalCleanupFailure(
+                $"{quiesced.Detail ?? "The Local AI gateway provider could not be safely disabled."} The untrusted managed listener was stopped.");
         }
 
         bool teardownSucceeded = reason != LocalAiQuiesceReason.Teardown &&
@@ -910,12 +922,20 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
     private async Task<LocalAiRuntimeSnapshot> FailStartupAsync(
         LocalAiRuntimeState state,
         string detail,
-        LocalAiResolvedInstall? routeToWithdraw = null)
+        LocalAiResolvedInstall? routeToWithdraw = null,
+        bool stopUnsafeListener = false)
     {
         bool withdrawalFailed = routeToWithdraw is not null &&
             !await WithdrawRouteAsync(routeToWithdraw, "after a failed start").ConfigureAwait(false);
         if (withdrawalFailed && _managedProcess is { HasExited: false })
         {
+            if (stopUnsafeListener)
+            {
+                ++_generation;
+                await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
+                return PublishTerminalCleanupFailure(
+                    $"{detail} The Local AI route could not be safely disabled; the untrusted managed listener was stopped.");
+            }
             return PublishManagedFailure(
                 $"{detail} The Local AI route could not be safely disabled; the managed listener remains running.");
         }

--- a/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
@@ -152,6 +152,25 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                 (_gatewayRouteRequiresResolution || _managedProcess is { HasExited: false });
             return stopped;
         }
+        catch (Exception ex)
+        {
+            bool processStillRunning = _managedProcess is { HasExited: false };
+            _explicitStopRequested = _gatewayRouteRequiresResolution || processStillRunning;
+            if (Snapshot.State == LocalAiRuntimeState.Stopping)
+            {
+                string outcome = ex is OperationCanceledException ? "canceled" : "interrupted";
+                if (processStillRunning)
+                {
+                    PublishManagedFailure(
+                        $"Local AI stop was {outcome}; the managed listener remains running.");
+                }
+                else
+                {
+                    PublishTerminalCleanupFailure($"Local AI stop was {outcome}.");
+                }
+            }
+            throw;
+        }
         finally
         {
             _operationGate.Release();
@@ -1106,13 +1125,24 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         _managedProcess = null;
         if (process is null)
             return;
+        bool preserveForRetry = false;
         try
         {
             await process.StopAsync(_options.ShutdownTimeout, cancellationToken).ConfigureAwait(false);
         }
+        catch
+        {
+            if (!process.HasExited)
+            {
+                _managedProcess = process;
+                preserveForRetry = true;
+            }
+            throw;
+        }
         finally
         {
-            await process.DisposeAsync().ConfigureAwait(false);
+            if (!preserveForRetry)
+                await process.DisposeAsync().ConfigureAwait(false);
         }
     }
 

--- a/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
@@ -1119,29 +1119,47 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         PublishTerminalCleanupFailure($"Local AI restart was {outcome}.");
     }
 
-    private async Task DisposeManagedProcessAsync(CancellationToken cancellationToken)
+    private async Task DisposeManagedProcessAsync(
+        CancellationToken cancellationToken,
+        bool preserveForRetry = true)
     {
         ILocalAiManagedProcess? process = _managedProcess;
         _managedProcess = null;
         if (process is null)
             return;
-        bool preserveForRetry = false;
+        bool preserved = false;
         try
         {
             await process.StopAsync(_options.ShutdownTimeout, cancellationToken).ConfigureAwait(false);
         }
         catch
         {
+            if (preserveForRetry)
+            {
+                if (!process.HasExited)
+                {
+                    _managedProcess = process;
+                    preserved = true;
+                }
+                throw;
+            }
             if (!process.HasExited)
             {
-                _managedProcess = process;
-                preserveForRetry = true;
+                try
+                {
+                    await process.StopAsync(_options.ShutdownTimeout, CancellationToken.None)
+                        .ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger.Warn(
+                        $"The managed Local AI process could not be stopped during final disposal: {Sanitize(ex.Message)}");
+                }
             }
-            throw;
         }
         finally
         {
-            if (!preserveForRetry)
+            if (!preserved)
                 await process.DisposeAsync().ConfigureAwait(false);
         }
     }
@@ -1522,7 +1540,10 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                         _logger.Warn($"The Local AI gateway provider could not be disabled during shutdown: {Sanitize(ex.Message)}");
                     }
                 }
-                await DisposeManagedProcessAsync(CancellationToken.None).ConfigureAwait(false);
+                await DisposeManagedProcessAsync(
+                        CancellationToken.None,
+                        preserveForRetry: false)
+                    .ConfigureAwait(false);
                 _disposed = true;
                 _client.Dispose();
             }

--- a/src/OpenClaw.Connection/LocalAi/LocalAiEndpointLifecycle.cs
+++ b/src/OpenClaw.Connection/LocalAi/LocalAiEndpointLifecycle.cs
@@ -21,6 +21,26 @@ public sealed record LocalAiEndpointLifecycleResult(bool Success, string? Detail
 }
 
 /// <summary>
+/// Why managed routing is being withdrawn. The distinction matters because an
+/// endpoint cycle is followed by a republish, while a teardown is not.
+/// </summary>
+public enum LocalAiQuiesceReason
+{
+    /// <summary>
+    /// The managed endpoint is about to move or restart and will be republished.
+    /// The managed primary model is retained so the gateway cannot resolve its
+    /// built-in default provider while the endpoint is briefly absent.
+    /// </summary>
+    EndpointCycle,
+
+    /// <summary>
+    /// Local AI is being stopped for good (stop, shutdown, failed publish).
+    /// The gateway primary model is restored to whatever preceded Local AI.
+    /// </summary>
+    Teardown,
+}
+
+/// <summary>
 /// Coordinates consumers of the app-owned endpoint with native process changes.
 /// Implementations must remove managed routing before a listener can disappear,
 /// and publish routing only after the replacement endpoint is proven healthy.
@@ -29,6 +49,7 @@ public interface ILocalAiEndpointLifecycle
 {
     Task<LocalAiEndpointLifecycleResult> QuiesceAsync(
         LocalAiResolvedInstall install,
+        LocalAiQuiesceReason reason = LocalAiQuiesceReason.Teardown,
         CancellationToken cancellationToken = default);
 
     Task<LocalAiEndpointLifecycleResult> PublishAsync(
@@ -42,6 +63,7 @@ internal sealed class NullLocalAiEndpointLifecycle : ILocalAiEndpointLifecycle
 
     public Task<LocalAiEndpointLifecycleResult> QuiesceAsync(
         LocalAiResolvedInstall install,
+        LocalAiQuiesceReason reason = LocalAiQuiesceReason.Teardown,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();

--- a/src/OpenClaw.Connection/LocalAi/LocalAiEndpointLifecycle.cs
+++ b/src/OpenClaw.Connection/LocalAi/LocalAiEndpointLifecycle.cs
@@ -1,17 +1,3 @@
-// <summary>
-// Contract for coordinating consumers of the app-owned local AI endpoint with native process
-// changes: QuiesceAsync removes managed routing before a listener can disappear, and
-// PublishAsync publishes routing only after the replacement endpoint is proven healthy.
-// The runtime options use a no-op lifecycle by default.
-// Usage:
-//   var options = new LlamaServerRuntimeOptions
-//   {
-//       Paths = paths,
-//       EndpointLifecycle = gatewayProviderCoordinator,
-//   };
-//   // LlamaServerRuntimeService owns QuiesceAsync/PublishAsync and treats an unsuccessful
-//   // LocalAiEndpointLifecycleResult as a failed runtime transition.
-// </summary>
 namespace OpenClaw.Connection.LocalAi;
 
 public sealed record LocalAiEndpointLifecycleResult(bool Success, string? Detail = null)
@@ -20,23 +6,9 @@ public sealed record LocalAiEndpointLifecycleResult(bool Success, string? Detail
     public static LocalAiEndpointLifecycleResult Failed(string detail) => new(false, detail);
 }
 
-/// <summary>
-/// Why managed routing is being withdrawn. The distinction matters because an
-/// endpoint cycle is followed by a republish, while a teardown is not.
-/// </summary>
 public enum LocalAiQuiesceReason
 {
-    /// <summary>
-    /// The managed endpoint is about to move or restart and will be republished.
-    /// The managed primary model is retained so the gateway cannot resolve its
-    /// built-in default provider while the endpoint is briefly absent.
-    /// </summary>
     EndpointCycle,
-
-    /// <summary>
-    /// Local AI is being stopped for good (stop, shutdown, failed publish).
-    /// The gateway primary model is restored to whatever preceded Local AI.
-    /// </summary>
     Teardown,
 }
 

--- a/src/OpenClaw.SetupEngine/LocalAiGatewayConfiguration.cs
+++ b/src/OpenClaw.SetupEngine/LocalAiGatewayConfiguration.cs
@@ -78,7 +78,6 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
         try
         {
             prior = ParseSnapshot(snapshotResult.Stdout);
-            ctx.LocalAiGatewayPriorState = prior;
         }
         catch (Exception ex) when (ex is FormatException or JsonException or InvalidDataException)
         {
@@ -124,6 +123,16 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
         {
             fallbackModel = null;
         }
+
+        ctx.LocalAiGatewayPriorState = retainedManagedPrimary
+            ? prior with
+            {
+                PrimaryModelExisted = fallbackModel is not null,
+                PrimaryModelJson = fallbackModel is null
+                    ? null
+                    : JsonSerializer.Serialize(fallbackModel),
+            }
+            : prior;
 
         if (!string.Equals(
                 install.Manifest.GatewayFallbackModel,

--- a/src/OpenClaw.SetupEngine/LocalAiGatewayConfiguration.cs
+++ b/src/OpenClaw.SetupEngine/LocalAiGatewayConfiguration.cs
@@ -105,8 +105,6 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
         }
         else if (retainedManagedPrimary)
         {
-            // A crash during an endpoint cycle can leave this companion's
-            // primary selected after its provider was intentionally removed.
             fallbackModel = install.Manifest.GatewayFallbackModel;
         }
         else if (prior.PrimaryModelExisted)

--- a/src/OpenClaw.SetupEngine/LocalAiGatewayConfiguration.cs
+++ b/src/OpenClaw.SetupEngine/LocalAiGatewayConfiguration.cs
@@ -88,6 +88,9 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
         LocalAiResolvedInstall install = ctx.LocalAiResolvedInstall;
         string expectedPrimary = JsonSerializer.Serialize(
             LocalAiGatewayProviderDefinition.BuildPrimaryModel(install));
+        bool retainedManagedPrimary = !prior.ProviderExisted &&
+            prior.PrimaryModelExisted &&
+            JsonEquals(prior.PrimaryModelJson!, expectedPrimary);
         string? fallbackModel;
         if (prior.ProviderExisted)
         {
@@ -99,6 +102,12 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
                 return StepResult.Fail(
                     "The existing llamacpp gateway route is not the exact companion-managed configuration; preserving it.");
             }
+            fallbackModel = install.Manifest.GatewayFallbackModel;
+        }
+        else if (retainedManagedPrimary)
+        {
+            // A crash during an endpoint cycle can leave this companion's
+            // primary selected after its provider was intentionally removed.
             fallbackModel = install.Manifest.GatewayFallbackModel;
         }
         else if (prior.PrimaryModelExisted)

--- a/src/OpenClaw.Tray.WinUI/Presentation/LocalAiPageViewModel.cs
+++ b/src/OpenClaw.Tray.WinUI/Presentation/LocalAiPageViewModel.cs
@@ -134,7 +134,7 @@ internal sealed class LocalAiPageViewModel : INavigationAware, IDisposable, INot
     public bool CanStart => !IsBusy && HasManagedInstall &&
         _runtimeSnapshot.State is LocalAiRuntimeState.Stopped or LocalAiRuntimeState.Failed;
     public bool CanStop => !IsBusy && HasManagedInstall &&
-        (_runtimeSnapshot.State == LocalAiRuntimeState.Conflict ||
+        (_runtimeSnapshot.State is LocalAiRuntimeState.Conflict or LocalAiRuntimeState.Failed ||
             (_runtimeSnapshot.Ownership == LocalAiOwnership.CompanionManaged &&
                 _runtimeSnapshot.State is LocalAiRuntimeState.Starting or LocalAiRuntimeState.Healthy));
     public bool CanRestart => !IsBusy && _runtimeSnapshot.Ownership == LocalAiOwnership.CompanionManaged &&

--- a/src/OpenClaw.Tray.WinUI/Presentation/LocalAiPageViewModel.cs
+++ b/src/OpenClaw.Tray.WinUI/Presentation/LocalAiPageViewModel.cs
@@ -135,9 +135,10 @@ internal sealed class LocalAiPageViewModel : INavigationAware, IDisposable, INot
         (_runtimeSnapshot.State == LocalAiRuntimeState.Stopped ||
             (_runtimeSnapshot.State == LocalAiRuntimeState.Failed &&
                 _runtimeSnapshot.Ownership != LocalAiOwnership.CompanionManaged));
-    public bool CanStop => !IsBusy && HasManagedInstall &&
+    public bool CanStop => !IsBusy &&
         (_runtimeSnapshot.State is LocalAiRuntimeState.Conflict or LocalAiRuntimeState.Failed ||
-            (_runtimeSnapshot.Ownership == LocalAiOwnership.CompanionManaged &&
+            (HasManagedInstall &&
+                _runtimeSnapshot.Ownership == LocalAiOwnership.CompanionManaged &&
                 _runtimeSnapshot.State is LocalAiRuntimeState.Starting or LocalAiRuntimeState.Healthy));
     public bool CanRestart => !IsBusy && _runtimeSnapshot.Ownership == LocalAiOwnership.CompanionManaged &&
         _runtimeSnapshot.State == LocalAiRuntimeState.Healthy;

--- a/src/OpenClaw.Tray.WinUI/Presentation/LocalAiPageViewModel.cs
+++ b/src/OpenClaw.Tray.WinUI/Presentation/LocalAiPageViewModel.cs
@@ -133,8 +133,10 @@ internal sealed class LocalAiPageViewModel : INavigationAware, IDisposable, INot
     public LocalInferenceUnavailableReason? LocalAiUnavailableReason => _localAiUnavailableReason;
     public bool CanStart => !IsBusy && HasManagedInstall &&
         _runtimeSnapshot.State is LocalAiRuntimeState.Stopped or LocalAiRuntimeState.Failed;
-    public bool CanStop => !IsBusy && _runtimeSnapshot.Ownership == LocalAiOwnership.CompanionManaged &&
-        _runtimeSnapshot.State is LocalAiRuntimeState.Starting or LocalAiRuntimeState.Healthy;
+    public bool CanStop => !IsBusy && HasManagedInstall &&
+        (_runtimeSnapshot.State == LocalAiRuntimeState.Conflict ||
+            (_runtimeSnapshot.Ownership == LocalAiOwnership.CompanionManaged &&
+                _runtimeSnapshot.State is LocalAiRuntimeState.Starting or LocalAiRuntimeState.Healthy));
     public bool CanRestart => !IsBusy && _runtimeSnapshot.Ownership == LocalAiOwnership.CompanionManaged &&
         _runtimeSnapshot.State == LocalAiRuntimeState.Healthy;
     public bool CanOpenLogs => !IsBusy && HasManagedInstall;

--- a/src/OpenClaw.Tray.WinUI/Presentation/LocalAiPageViewModel.cs
+++ b/src/OpenClaw.Tray.WinUI/Presentation/LocalAiPageViewModel.cs
@@ -132,7 +132,9 @@ internal sealed class LocalAiPageViewModel : INavigationAware, IDisposable, INot
     public bool CanRecheckAvailability => _hasAvailabilityProbeError && _availabilityCancellation is null && !IsBusy;
     public LocalInferenceUnavailableReason? LocalAiUnavailableReason => _localAiUnavailableReason;
     public bool CanStart => !IsBusy && HasManagedInstall &&
-        _runtimeSnapshot.State is LocalAiRuntimeState.Stopped or LocalAiRuntimeState.Failed;
+        (_runtimeSnapshot.State == LocalAiRuntimeState.Stopped ||
+            (_runtimeSnapshot.State == LocalAiRuntimeState.Failed &&
+                _runtimeSnapshot.Ownership != LocalAiOwnership.CompanionManaged));
     public bool CanStop => !IsBusy && HasManagedInstall &&
         (_runtimeSnapshot.State is LocalAiRuntimeState.Conflict or LocalAiRuntimeState.Failed ||
             (_runtimeSnapshot.Ownership == LocalAiOwnership.CompanionManaged &&

--- a/src/OpenClaw.Tray.WinUI/Services/LocalAiGatewayProviderCoordinator.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/LocalAiGatewayProviderCoordinator.cs
@@ -31,6 +31,7 @@ internal sealed class LocalAiGatewayProviderCoordinator : ILocalAiEndpointLifecy
 
     public async Task<LocalAiEndpointLifecycleResult> QuiesceAsync(
         LocalAiResolvedInstall install,
+        LocalAiQuiesceReason reason = LocalAiQuiesceReason.Teardown,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(install);
@@ -69,8 +70,15 @@ internal sealed class LocalAiGatewayProviderCoordinator : ILocalAiEndpointLifecy
             return Failed("The llamacpp primary model was changed outside the companion; preserving it and refusing to cycle the managed endpoint.");
         }
 
+        // Unsetting the primary model does not make the gateway idle; it makes the
+        // gateway resolve its built-in default (an OpenAI model), so a request that
+        // lands mid-cycle fails with an unrelated provider-auth error instead of a
+        // Local AI one. Retain the managed primary unless there is a real prior
+        // model to restore, or Local AI is going away for good.
         string? expectedPrimary = current.PrimaryModel;
-        if (primaryIsManaged)
+        bool retainManagedPrimary = reason == LocalAiQuiesceReason.EndpointCycle &&
+            install.Manifest.GatewayFallbackModel is null;
+        if (primaryIsManaged && !retainManagedPrimary)
         {
             expectedPrimary = install.Manifest.GatewayFallbackModel;
             LocalAiEndpointLifecycleResult primaryResult = expectedPrimary is null
@@ -130,10 +138,17 @@ internal sealed class LocalAiGatewayProviderCoordinator : ILocalAiEndpointLifecy
                 : Failed("The Local AI gateway route changed outside the companion; preserving it instead of publishing the managed endpoint.");
         }
 
+        // An endpoint cycle leaves the managed primary in place (there is no prior
+        // model to fall back to), so seeing it here is this companion's own state,
+        // not an outside edit.
         string? fallbackModel = install.Manifest.GatewayFallbackModel;
-        if (current.PrimaryExists != (fallbackModel is not null) ||
-            (fallbackModel is not null &&
-                !string.Equals(current.PrimaryModel, fallbackModel, StringComparison.Ordinal)))
+        bool retainedManagedPrimary = fallbackModel is null &&
+            current.PrimaryExists &&
+            string.Equals(current.PrimaryModel, managedPrimary, StringComparison.Ordinal);
+        if (!retainedManagedPrimary &&
+            (current.PrimaryExists != (fallbackModel is not null) ||
+                (fallbackModel is not null &&
+                    !string.Equals(current.PrimaryModel, fallbackModel, StringComparison.Ordinal))))
         {
             return Failed("The gateway primary model changed while Local AI was stopped; preserving it instead of overwriting it.");
         }
@@ -143,7 +158,7 @@ internal sealed class LocalAiGatewayProviderCoordinator : ILocalAiEndpointLifecy
             return Failed(applied.Detail!);
         if (!applied.Result!.Success)
         {
-            LocalAiEndpointLifecycleResult cleanup = await QuiesceAsync(install, cancellationToken)
+            LocalAiEndpointLifecycleResult cleanup = await QuiesceAsync(install, LocalAiQuiesceReason.Teardown, cancellationToken)
                 .ConfigureAwait(false);
             return PublicationFailed(
                 "The verified Local AI route could not be published to the app-owned gateway.",
@@ -156,7 +171,7 @@ internal sealed class LocalAiGatewayProviderCoordinator : ILocalAiEndpointLifecy
             !verified.PrimaryExists ||
             !string.Equals(verified.PrimaryModel, managedPrimary, StringComparison.Ordinal))
         {
-            LocalAiEndpointLifecycleResult cleanup = await QuiesceAsync(install, cancellationToken)
+            LocalAiEndpointLifecycleResult cleanup = await QuiesceAsync(install, LocalAiQuiesceReason.Teardown, cancellationToken)
                 .ConfigureAwait(false);
             return PublicationFailed(
                 "The app-owned gateway did not retain the verified Local AI route.",

--- a/src/OpenClaw.Tray.WinUI/Services/LocalAiGatewayProviderCoordinator.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/LocalAiGatewayProviderCoordinator.cs
@@ -70,8 +70,6 @@ internal sealed class LocalAiGatewayProviderCoordinator : ILocalAiEndpointLifecy
             return Failed("The llamacpp primary model was changed outside the companion; preserving it and refusing to cycle the managed endpoint.");
         }
 
-        // Endpoint cycles retain the managed primary so the gateway cannot fall
-        // through to its built-in OpenAI default while the provider is absent.
         string? expectedPrimary = current.PrimaryModel;
         bool retainManagedPrimary = reason == LocalAiQuiesceReason.EndpointCycle;
         if (primaryIsManaged && !retainManagedPrimary)

--- a/src/OpenClaw.Tray.WinUI/Services/LocalAiGatewayProviderCoordinator.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/LocalAiGatewayProviderCoordinator.cs
@@ -70,12 +70,8 @@ internal sealed class LocalAiGatewayProviderCoordinator : ILocalAiEndpointLifecy
             return Failed("The llamacpp primary model was changed outside the companion; preserving it and refusing to cycle the managed endpoint.");
         }
 
-        // Unsetting the primary model does not make the gateway idle; it makes the
-        // gateway resolve its built-in default (an OpenAI model), so a request that
-        // lands mid-cycle fails with an unrelated provider-auth error instead of a
-        // Local AI one. Retain the managed primary for every endpoint cycle,
-        // including installs with a cloud fallback. The fallback is restored
-        // only when Local AI is going away for good.
+        // Endpoint cycles retain the managed primary so the gateway cannot fall
+        // through to its built-in OpenAI default while the provider is absent.
         string? expectedPrimary = current.PrimaryModel;
         bool retainManagedPrimary = reason == LocalAiQuiesceReason.EndpointCycle;
         if (primaryIsManaged && !retainManagedPrimary)
@@ -138,8 +134,6 @@ internal sealed class LocalAiGatewayProviderCoordinator : ILocalAiEndpointLifecy
                 : Failed("The Local AI gateway route changed outside the companion; preserving it instead of publishing the managed endpoint.");
         }
 
-        // An endpoint cycle leaves the managed primary in place, so seeing it
-        // here is this companion's own state, not an outside edit.
         string? fallbackModel = install.Manifest.GatewayFallbackModel;
         bool retainedManagedPrimary = current.PrimaryExists &&
             string.Equals(current.PrimaryModel, managedPrimary, StringComparison.Ordinal);

--- a/src/OpenClaw.Tray.WinUI/Services/LocalAiGatewayProviderCoordinator.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/LocalAiGatewayProviderCoordinator.cs
@@ -73,11 +73,11 @@ internal sealed class LocalAiGatewayProviderCoordinator : ILocalAiEndpointLifecy
         // Unsetting the primary model does not make the gateway idle; it makes the
         // gateway resolve its built-in default (an OpenAI model), so a request that
         // lands mid-cycle fails with an unrelated provider-auth error instead of a
-        // Local AI one. Retain the managed primary unless there is a real prior
-        // model to restore, or Local AI is going away for good.
+        // Local AI one. Retain the managed primary for every endpoint cycle,
+        // including installs with a cloud fallback. The fallback is restored
+        // only when Local AI is going away for good.
         string? expectedPrimary = current.PrimaryModel;
-        bool retainManagedPrimary = reason == LocalAiQuiesceReason.EndpointCycle &&
-            install.Manifest.GatewayFallbackModel is null;
+        bool retainManagedPrimary = reason == LocalAiQuiesceReason.EndpointCycle;
         if (primaryIsManaged && !retainManagedPrimary)
         {
             expectedPrimary = install.Manifest.GatewayFallbackModel;
@@ -138,12 +138,10 @@ internal sealed class LocalAiGatewayProviderCoordinator : ILocalAiEndpointLifecy
                 : Failed("The Local AI gateway route changed outside the companion; preserving it instead of publishing the managed endpoint.");
         }
 
-        // An endpoint cycle leaves the managed primary in place (there is no prior
-        // model to fall back to), so seeing it here is this companion's own state,
-        // not an outside edit.
+        // An endpoint cycle leaves the managed primary in place, so seeing it
+        // here is this companion's own state, not an outside edit.
         string? fallbackModel = install.Manifest.GatewayFallbackModel;
-        bool retainedManagedPrimary = fallbackModel is null &&
-            current.PrimaryExists &&
+        bool retainedManagedPrimary = current.PrimaryExists &&
             string.Equals(current.PrimaryModel, managedPrimary, StringComparison.Ordinal);
         if (!retainedManagedPrimary &&
             (current.PrimaryExists != (fallbackModel is not null) ||

--- a/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
+++ b/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
@@ -157,11 +157,95 @@ public sealed class LocalAiPortLifecycleTests
         Assert.Equal(LocalAiRuntimeState.Healthy, snapshot.State);
         Assert.Equal(28_765, snapshot.Endpoint.Port);
         Assert.Equal("0", ArgumentAfter(host.LastSpec!.Arguments, "--port"));
-        Assert.Equal(["quiesce", "start", "probe:28765", "publish:28765"], events);
+        Assert.Equal(["quiesce:EndpointCycle", "start", "probe:28765", "publish:28765"], events);
         Assert.Equal([28_765], client.ProbedPorts);
         LocalAiResolvedInstall? saved = await new LocalAiManifestStore(paths).LoadAsync();
         Assert.Equal(0, saved!.Manifest.RequestedPort);
         Assert.Equal(28_765, saved.Endpoint!.Port);
+    }
+
+    [Fact]
+    public async Task Restart_ReusesLastVerifiedPortAndNeverWithdrawsThePublishedRoute()
+    {
+        // The published route stays valid for the whole startup, so the gateway is
+        // never left without a Local AI provider to fall back from.
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var store = new LocalAiManifestStore(paths);
+        LocalAiResolvedInstall install = (await store.LoadAsync())!;
+        await store.SaveAsync(install.Manifest with { Endpoint = "http://127.0.0.1:28765/v1" });
+
+        var events = new List<string>();
+        var platform = new FakePlatform();
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_765);
+        var client = new FakeClient(events);
+        await using var runtime = CreateRuntime(paths, host, platform, client, new FakeLifecycle(events));
+
+        LocalAiRuntimeSnapshot snapshot = await runtime.EnsureStartedAsync();
+
+        Assert.Equal(LocalAiRuntimeState.Healthy, snapshot.State);
+        Assert.Equal("28765", ArgumentAfter(host.LastSpec!.Arguments, "--port"));
+        Assert.Equal(["start", "probe:28765", "publish:28765"], events);
+        Assert.DoesNotContain(events, e => e.StartsWith("quiesce", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Restart_WithdrawsStaleRouteWhenTheLastVerifiedPortIsTaken()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var store = new LocalAiManifestStore(paths);
+        LocalAiResolvedInstall install = (await store.LoadAsync())!;
+        await store.SaveAsync(install.Manifest with { Endpoint = "http://127.0.0.1:28765/v1" });
+
+        var events = new List<string>();
+        var platform = new FakePlatform();
+        platform.Listeners.Add(new WindowsTcpListenerInfo(
+            IPAddress.Loopback,
+            28_765,
+            9001,
+            "other-process",
+            @"C:\other\server.exe",
+            platform.UtcNow.UtcDateTime));
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_771);
+        var client = new FakeClient(events);
+        await using var runtime = CreateRuntime(paths, host, platform, client, new FakeLifecycle(events));
+
+        LocalAiRuntimeSnapshot snapshot = await runtime.EnsureStartedAsync();
+
+        Assert.Equal(LocalAiRuntimeState.Healthy, snapshot.State);
+        Assert.Equal("0", ArgumentAfter(host.LastSpec!.Arguments, "--port"));
+        Assert.Equal(
+            ["quiesce:EndpointCycle", "start", "probe:28771", "publish:28771"],
+            events);
+    }
+
+    [Fact]
+    public async Task Restart_WithdrawsRetainedRouteWhenStartupNeverBecomesHealthy()
+    {
+        // Nothing will answer the retained route, so it must not be left published.
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var store = new LocalAiManifestStore(paths);
+        LocalAiResolvedInstall install = (await store.LoadAsync())!;
+        await store.SaveAsync(install.Manifest with { Endpoint = "http://127.0.0.1:28765/v1" });
+
+        var events = new List<string>();
+        var platform = new FakePlatform();
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_765) { SuppressListener = true };
+        var client = new FakeClient(events);
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            client,
+            new FakeLifecycle(events),
+            startupTimeout: TimeSpan.FromMilliseconds(5));
+
+        LocalAiRuntimeSnapshot snapshot = await runtime.EnsureStartedAsync();
+
+        Assert.Equal(LocalAiRuntimeState.Failed, snapshot.State);
+        Assert.Equal(["start", "stop", "quiesce:Teardown"], events);
     }
 
     [Theory]
@@ -232,7 +316,7 @@ public sealed class LocalAiPortLifecycleTests
 
         Assert.Equal(LocalAiRuntimeState.Starting, refreshed.State);
         Assert.Equal(LocalAiModelAvailabilityState.Unknown, refreshed.ModelEvidence.State);
-        Assert.Equal(["probe:28773", "quiesce"], events);
+        Assert.Equal(["probe:28773", "quiesce:EndpointCycle"], events);
         events.Clear();
 
         LocalAiRuntimeSnapshot recovered = await runtime.RefreshAsync();
@@ -282,7 +366,7 @@ public sealed class LocalAiPortLifecycleTests
         LocalAiRuntimeSnapshot refreshed = await runtime.RefreshAsync();
 
         Assert.Equal(expectedState, refreshed.State);
-        Assert.Equal(["quiesce"], events);
+        Assert.Equal(["quiesce:EndpointCycle"], events);
         Assert.False(host.Process!.HasExited);
     }
 
@@ -314,7 +398,7 @@ public sealed class LocalAiPortLifecycleTests
         Assert.Equal(LocalAiOwnership.None, refreshed.Ownership);
         Assert.Null(refreshed.ProcessId);
         Assert.True(host.Process!.HasExited);
-        Assert.Equal(["probe:28776", "quiesce", "stop"], events);
+        Assert.Equal(["probe:28776", "quiesce:EndpointCycle", "stop"], events);
     }
 
     [Fact]
@@ -345,7 +429,7 @@ public sealed class LocalAiPortLifecycleTests
         Assert.Equal(LocalAiOwnership.None, runtime.Snapshot.Ownership);
         Assert.Null(runtime.Snapshot.ProcessId);
         Assert.True(host.Process!.HasExited);
-        Assert.Equal(["quiesce", "stop"], events);
+        Assert.Equal(["quiesce:EndpointCycle", "stop"], events);
     }
 
     [Fact]
@@ -477,7 +561,7 @@ public sealed class LocalAiPortLifecycleTests
         LocalAiRuntimeSnapshot snapshot = await runtime.EnsureStartedAsync();
 
         Assert.Equal(LocalAiRuntimeState.Conflict, snapshot.State);
-        Assert.Equal(["quiesce"], events);
+        Assert.Equal(["quiesce:Teardown"], events);
         Assert.Null(host.LastSpec);
     }
 
@@ -501,7 +585,7 @@ public sealed class LocalAiPortLifecycleTests
         LocalAiRuntimeSnapshot snapshot = await runtime.EnsureStartedAsync();
 
         Assert.Equal(LocalAiRuntimeState.Failed, snapshot.State);
-        Assert.Equal(["quiesce"], events);
+        Assert.Equal(["quiesce:EndpointCycle"], events);
         Assert.Null(host.LastSpec);
     }
 
@@ -529,7 +613,7 @@ public sealed class LocalAiPortLifecycleTests
 
         Assert.Equal(LocalAiRuntimeState.Conflict, snapshot.State);
         Assert.Empty(client.ProbedPorts);
-        Assert.Equal(["quiesce", "start", "stop"], events);
+        Assert.Equal(["quiesce:EndpointCycle", "start", "stop"], events);
         LocalAiResolvedInstall? saved = await new LocalAiManifestStore(paths).LoadAsync();
         Assert.Null(saved!.Endpoint);
     }
@@ -554,7 +638,7 @@ public sealed class LocalAiPortLifecycleTests
         LocalAiRuntimeSnapshot stopped = await runtime.StopAsync();
 
         Assert.Equal(LocalAiRuntimeState.Stopped, stopped.State);
-        Assert.Equal(["quiesce", "stop"], events);
+        Assert.Equal(["quiesce:Teardown", "stop"], events);
     }
 
     [Fact]
@@ -572,7 +656,7 @@ public sealed class LocalAiPortLifecycleTests
 
         Assert.Equal(LocalAiRuntimeState.Failed, snapshot.State);
         Assert.Equal(1, host.Process!.StopCount);
-        Assert.Equal(["quiesce", "start", "probe:28767", "publish:28767", "stop"], events);
+        Assert.Equal(["quiesce:EndpointCycle", "start", "probe:28767", "publish:28767", "stop", "quiesce:Teardown"], events);
 
         // The endpoint receipt is already durable but the provider is still absent.
         // A later tray start must safely allocate again and complete publication.
@@ -818,6 +902,9 @@ public sealed class LocalAiPortLifecycleTests
         public LocalAiProcessStartSpec? LastSpec { get; private set; }
         public FakeProcess? Process { get; private set; }
 
+        /// <summary>Starts the child without ever opening a listener, so startup times out.</summary>
+        public bool SuppressListener { get; init; }
+
         public Task<ILocalAiManagedProcess> StartProcessAsync(
             LocalAiProcessStartSpec spec,
             Action<LocalAiManagedProcessExit> exited,
@@ -827,6 +914,8 @@ public sealed class LocalAiPortLifecycleTests
             events.Add("start");
             LastSpec = spec;
             Process = new FakeProcess(4201, platform.UtcNow, platform, events);
+            if (SuppressListener)
+                return Task.FromResult<ILocalAiManagedProcess>(Process);
             platform.Listeners.Add(new WindowsTcpListenerInfo(
                 listenerAddress ?? IPAddress.Loopback,
                 selectedPort,
@@ -898,9 +987,10 @@ public sealed class LocalAiPortLifecycleTests
 
         public Task<LocalAiEndpointLifecycleResult> QuiesceAsync(
             LocalAiResolvedInstall install,
+            LocalAiQuiesceReason reason = LocalAiQuiesceReason.Teardown,
             CancellationToken cancellationToken = default)
         {
-            events.Add("quiesce");
+            events.Add($"quiesce:{reason}");
             if (QuiesceException is not null)
                 return Task.FromException<LocalAiEndpointLifecycleResult>(QuiesceException);
             return Task.FromResult(FailQuiesce

--- a/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
+++ b/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
@@ -245,7 +245,157 @@ public sealed class LocalAiPortLifecycleTests
         LocalAiRuntimeSnapshot snapshot = await runtime.EnsureStartedAsync();
 
         Assert.Equal(LocalAiRuntimeState.Failed, snapshot.State);
-        Assert.Equal(["start", "stop", "quiesce:Teardown"], events);
+        Assert.Equal(["start", "quiesce:Teardown", "stop"], events);
+    }
+
+    [Fact]
+    public async Task Restart_LaunchExceptionWithdrawsRetainedRouteAsTeardown()
+    {
+        // A launch exception is terminal: the retained route must be withdrawn
+        // before the gateway is left pointing at a port nothing will serve.
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var store = new LocalAiManifestStore(paths);
+        LocalAiResolvedInstall install = (await store.LoadAsync())!;
+        await store.SaveAsync(install.Manifest with { Endpoint = "http://127.0.0.1:28765/v1" });
+
+        var events = new List<string>();
+        var platform = new FakePlatform();
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_765) { ThrowOnStart = true };
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            new FakeLifecycle(events));
+
+        LocalAiRuntimeSnapshot snapshot = await runtime.EnsureStartedAsync();
+
+        Assert.Equal(LocalAiRuntimeState.Failed, snapshot.State);
+        Assert.Equal(["quiesce:Teardown"], events);
+        Assert.Null(host.LastSpec);
+        LocalAiResolvedInstall? saved = await new LocalAiManifestStore(paths).LoadAsync();
+        Assert.Equal(28_765, saved!.Endpoint!.Port);
+    }
+
+    [Fact]
+    public async Task Restart_ExhaustedAutomaticRestoresEndInTeardownNotEndpointCycle()
+    {
+        // The first unexpected exit schedules a restart and is an endpoint
+        // cycle. Once the retry budget is spent, the next exit is terminal and
+        // must restore gateway routing (teardown) rather than retain a managed
+        // primary whose provider is gone.
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var store = new LocalAiManifestStore(paths);
+        LocalAiResolvedInstall install = (await store.LoadAsync())!;
+        await store.SaveAsync(install.Manifest with { Endpoint = "http://127.0.0.1:28765/v1" });
+
+        var events = new List<string>();
+        var platform = new FakePlatform();
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_765);
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            new FakeLifecycle(events),
+            startupTimeout: TimeSpan.FromSeconds(5),
+            maxRestartAttempts: 1);
+
+        LocalAiRuntimeSnapshot started = await runtime.EnsureStartedAsync();
+        Assert.Equal(LocalAiRuntimeState.Healthy, started.State);
+        int settled = events.Count;
+
+        host.Process!.MarkExited();
+        host.LastExitCallback!(new LocalAiManagedProcessExit(
+            host.Process.ProcessId,
+            host.Process.StartedAtUtc,
+            1));
+        await WaitForRestartSettledAsync(events, settled);
+
+        host.Process!.MarkExited();
+        host.LastExitCallback!(new LocalAiManagedProcessExit(
+            host.Process.ProcessId,
+            host.Process.StartedAtUtc,
+            1));
+        await WaitForEventAsync(events, "quiesce:Teardown", settled);
+
+        Assert.Equal(LocalAiRuntimeState.Failed, runtime.Snapshot.State);
+        Assert.Equal(
+            [
+                "quiesce:EndpointCycle",
+                "quiesce:EndpointCycle",
+                "start",
+                "probe:28765",
+                "publish:28765",
+                "quiesce:Teardown",
+            ],
+            events.Skip(settled).ToArray());
+    }
+
+    /// <summary>
+    /// Waits until the automatic restart scheduled by an unexpected exit has
+    /// either published a fresh endpoint or failed, so the next trigger is not
+    /// racing the previous restart chain.
+    /// </summary>
+    private static async Task WaitForRestartSettledAsync(List<string> events, int settledCount)
+    {
+        DateTimeOffset deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(10);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            string[] current = [.. events.Skip(settledCount)];
+            if (current.Contains("publish:28765") && current.LastOrDefault() == "publish:28765")
+                return;
+            await Task.Delay(10);
+        }
+        Assert.Fail(
+            "Timed out waiting for the restart to settle; saw " +
+            $"[{string.Join(", ", events.Skip(settledCount))}].");
+    }
+
+    private static async Task WaitForEventAsync(List<string> events, string expected, int settledCount)
+    {
+        DateTimeOffset deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(10);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (events.Skip(settledCount).Contains(expected))
+                return;
+            await Task.Delay(10);
+        }
+        Assert.Fail(
+            $"Timed out waiting for {expected}; saw " +
+            $"[{string.Join(", ", events.Skip(settledCount))}].");
+    }
+
+    [Fact]
+    public async Task Restart_CancellationWithdrawsRetainedRouteBeforeDisposingChild()
+    {
+        // A canceled startup is terminal for the attempt: the retained route is
+        // withdrawn before the child's listener disappears.
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var store = new LocalAiManifestStore(paths);
+        LocalAiResolvedInstall install = (await store.LoadAsync())!;
+        await store.SaveAsync(install.Manifest with { Endpoint = "http://127.0.0.1:28765/v1" });
+
+        var events = new List<string>();
+        var platform = new FakePlatform { YieldOnDelay = true };
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_765) { SuppressListener = true };
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            new FakeLifecycle(events),
+            startupTimeout: TimeSpan.FromSeconds(30));
+
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromMilliseconds(20));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => runtime.EnsureStartedAsync(cancellation.Token));
+
+        Assert.Equal(LocalAiRuntimeState.Stopped, runtime.Snapshot.State);
+        Assert.Equal(["start", "quiesce:Teardown", "stop"], events);
     }
 
     [Theory]
@@ -551,12 +701,8 @@ public sealed class LocalAiPortLifecycleTests
             @"C:\other\server.exe",
             platform.UtcNow.UtcDateTime));
         var host = new FakeProcessHost(platform, events, selectedPort: fixedPort);
-        await using var runtime = CreateRuntime(
-            paths,
-            host,
-            platform,
-            new FakeClient(events),
-            new FakeLifecycle(events));
+        var lifecycle = new FakeLifecycle(events);
+        await using var runtime = CreateRuntime(paths, host, platform, new FakeClient(events), lifecycle);
 
         LocalAiRuntimeSnapshot snapshot = await runtime.EnsureStartedAsync();
 
@@ -656,7 +802,7 @@ public sealed class LocalAiPortLifecycleTests
 
         Assert.Equal(LocalAiRuntimeState.Failed, snapshot.State);
         Assert.Equal(1, host.Process!.StopCount);
-        Assert.Equal(["quiesce:EndpointCycle", "start", "probe:28767", "publish:28767", "stop", "quiesce:Teardown"], events);
+        Assert.Equal(["quiesce:EndpointCycle", "start", "probe:28767", "publish:28767", "quiesce:Teardown", "stop"], events);
 
         // The endpoint receipt is already durable but the provider is still absent.
         // A later tray start must safely allocate again and complete publication.
@@ -681,7 +827,8 @@ public sealed class LocalAiPortLifecycleTests
         FakePlatform platform,
         FakeClient client,
         ILocalAiEndpointLifecycle lifecycle,
-        TimeSpan? startupTimeout = null) => new(
+        TimeSpan? startupTimeout = null,
+        int maxRestartAttempts = 2) => new(
             new LlamaServerRuntimeOptions
             {
                 Paths = paths,
@@ -689,6 +836,7 @@ public sealed class LocalAiPortLifecycleTests
                 HealthPollInterval = TimeSpan.FromMilliseconds(1),
                 StartupTimeout = startupTimeout ?? TimeSpan.FromSeconds(1),
                 RestartDelay = TimeSpan.Zero,
+                MaxRestartAttempts = maxRestartAttempts,
             },
             NullLogger.Instance,
             host,
@@ -884,11 +1032,14 @@ public sealed class LocalAiPortLifecycleTests
         public WindowsTcpListenerSnapshotResult CaptureListeners() =>
             new([.. Listeners], Ipv4Complete, Ipv6Complete: true);
 
-        public Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken)
+        public bool YieldOnDelay { get; init; }
+
+        public async Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            if (YieldOnDelay)
+                await Task.Yield();
             UtcNow += delay;
-            return Task.CompletedTask;
         }
     }
 
@@ -901,9 +1052,16 @@ public sealed class LocalAiPortLifecycleTests
     {
         public LocalAiProcessStartSpec? LastSpec { get; private set; }
         public FakeProcess? Process { get; private set; }
+        public Action<LocalAiManagedProcessExit>? LastExitCallback { get; private set; }
 
         /// <summary>Starts the child without ever opening a listener, so startup times out.</summary>
         public bool SuppressListener { get; init; }
+
+        /// <summary>Throws from StartProcessAsync, simulating a process-launch failure.</summary>
+        public bool ThrowOnStart { get; init; }
+
+        /// <summary>Fires the exit callback during StartProcessAsync, simulating an immediate child exit.</summary>
+        public bool ImmediateExit { get; init; }
 
         public Task<ILocalAiManagedProcess> StartProcessAsync(
             LocalAiProcessStartSpec spec,
@@ -911,9 +1069,18 @@ public sealed class LocalAiPortLifecycleTests
             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            if (ThrowOnStart)
+                throw new IOException("The managed llama-server process could not be launched.");
             events.Add("start");
             LastSpec = spec;
+            LastExitCallback = exited;
             Process = new FakeProcess(4201, platform.UtcNow, platform, events);
+            if (ImmediateExit)
+            {
+                Process.MarkExited();
+                exited(new LocalAiManagedProcessExit(Process.ProcessId, Process.StartedAtUtc, 1));
+                return Task.FromResult<ILocalAiManagedProcess>(Process);
+            }
             if (SuppressListener)
                 return Task.FromResult<ILocalAiManagedProcess>(Process);
             platform.Listeners.Add(new WindowsTcpListenerInfo(
@@ -937,6 +1104,9 @@ public sealed class LocalAiPortLifecycleTests
         public DateTimeOffset StartedAtUtc { get; } = startedAtUtc;
         public bool HasExited { get; private set; }
         public int StopCount { get; private set; }
+
+        /// <summary>Marks the child as exited without going through StopAsync.</summary>
+        public void MarkExited() => HasExited = true;
 
         public Task StopAsync(TimeSpan timeout, CancellationToken cancellationToken)
         {

--- a/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
+++ b/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
@@ -221,6 +221,41 @@ public sealed class LocalAiPortLifecycleTests
     }
 
     [Fact]
+    public async Task Restart_PortRelocationFailureRestoresTerminalRouting()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var store = new LocalAiManifestStore(paths);
+        LocalAiResolvedInstall install = (await store.LoadAsync())!;
+        await store.SaveAsync(install.Manifest with { Endpoint = "http://127.0.0.1:28765/v1" });
+
+        var events = new List<string>();
+        var platform = new FakePlatform();
+        platform.Listeners.Add(new WindowsTcpListenerInfo(
+            IPAddress.Loopback,
+            28_765,
+            9001,
+            "other-process",
+            @"C:\other\server.exe",
+            platform.UtcNow.UtcDateTime));
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_771) { SuppressListener = true };
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            new FakeLifecycle(events),
+            startupTimeout: TimeSpan.FromMilliseconds(5));
+
+        LocalAiRuntimeSnapshot snapshot = await runtime.EnsureStartedAsync();
+
+        Assert.Equal(LocalAiRuntimeState.Failed, snapshot.State);
+        Assert.Equal(
+            ["quiesce:EndpointCycle", "start", "quiesce:Teardown", "stop"],
+            events);
+    }
+
+    [Fact]
     public async Task Restart_WithdrawsRetainedRouteWhenStartupNeverBecomesHealthy()
     {
         // Nothing will answer the retained route, so it must not be left published.
@@ -380,7 +415,12 @@ public sealed class LocalAiPortLifecycleTests
         await store.SaveAsync(install.Manifest with { Endpoint = "http://127.0.0.1:28765/v1" });
 
         var events = new List<string>();
-        var platform = new FakePlatform { YieldOnDelay = true };
+        using var cancellation = new CancellationTokenSource();
+        var platform = new FakePlatform
+        {
+            YieldOnDelay = true,
+            AfterDelay = cancellation.Cancel,
+        };
         var host = new FakeProcessHost(platform, events, selectedPort: 28_765) { SuppressListener = true };
         await using var runtime = CreateRuntime(
             paths,
@@ -390,12 +430,43 @@ public sealed class LocalAiPortLifecycleTests
             new FakeLifecycle(events),
             startupTimeout: TimeSpan.FromSeconds(30));
 
-        using var cancellation = new CancellationTokenSource(TimeSpan.FromMilliseconds(20));
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
             () => runtime.EnsureStartedAsync(cancellation.Token));
 
         Assert.Equal(LocalAiRuntimeState.Stopped, runtime.Snapshot.State);
         Assert.Equal(["start", "quiesce:Teardown", "stop"], events);
+    }
+
+    [Fact]
+    public async Task Restart_CancellationDuringPresetPreparationRestoresTerminalRouting()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var store = new LocalAiManifestStore(paths);
+        LocalAiResolvedInstall install = (await store.LoadAsync())!;
+        await store.SaveAsync(install.Manifest with { Endpoint = "http://127.0.0.1:28765/v1" });
+
+        var events = new List<string>();
+        using var cancellation = new CancellationTokenSource();
+        var platform = new FakePlatform
+        {
+            AfterCapture = cancellation.Cancel,
+        };
+        var lifecycle = new FakeLifecycle(events);
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_765);
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            lifecycle);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => runtime.EnsureStartedAsync(cancellation.Token));
+
+        Assert.Equal(LocalAiRuntimeState.Stopped, runtime.Snapshot.State);
+        Assert.Equal(["quiesce:Teardown"], events);
+        Assert.Null(host.LastSpec);
     }
 
     [Theory]
@@ -731,7 +802,7 @@ public sealed class LocalAiPortLifecycleTests
         LocalAiRuntimeSnapshot snapshot = await runtime.EnsureStartedAsync();
 
         Assert.Equal(LocalAiRuntimeState.Failed, snapshot.State);
-        Assert.Equal(["quiesce:EndpointCycle"], events);
+        Assert.Equal(["quiesce:EndpointCycle", "quiesce:Teardown"], events);
         Assert.Null(host.LastSpec);
     }
 
@@ -759,7 +830,7 @@ public sealed class LocalAiPortLifecycleTests
 
         Assert.Equal(LocalAiRuntimeState.Conflict, snapshot.State);
         Assert.Empty(client.ProbedPorts);
-        Assert.Equal(["quiesce:EndpointCycle", "start", "stop"], events);
+        Assert.Equal(["quiesce:EndpointCycle", "start", "quiesce:Teardown", "stop"], events);
         LocalAiResolvedInstall? saved = await new LocalAiManifestStore(paths).LoadAsync();
         Assert.Null(saved!.Endpoint);
     }
@@ -1028,9 +1099,16 @@ public sealed class LocalAiPortLifecycleTests
         public DateTimeOffset UtcNow { get; private set; } = DateTimeOffset.Parse("2026-08-18T12:00:00Z");
         public List<WindowsTcpListenerInfo> Listeners { get; } = [];
         public bool Ipv4Complete { get; set; } = true;
+        public Action? AfterCapture { get; init; }
+        public Action? AfterDelay { get; init; }
 
-        public WindowsTcpListenerSnapshotResult CaptureListeners() =>
-            new([.. Listeners], Ipv4Complete, Ipv6Complete: true);
+        public WindowsTcpListenerSnapshotResult CaptureListeners()
+        {
+            WindowsTcpListenerSnapshotResult result =
+                new([.. Listeners], Ipv4Complete, Ipv6Complete: true);
+            AfterCapture?.Invoke();
+            return result;
+        }
 
         public bool YieldOnDelay { get; init; }
 
@@ -1039,6 +1117,8 @@ public sealed class LocalAiPortLifecycleTests
             cancellationToken.ThrowIfCancellationRequested();
             if (YieldOnDelay)
                 await Task.Yield();
+            AfterDelay?.Invoke();
+            cancellationToken.ThrowIfCancellationRequested();
             UtcNow += delay;
         }
     }

--- a/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
+++ b/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
@@ -258,6 +258,51 @@ public sealed class LocalAiPortLifecycleTests
     }
 
     [Fact]
+    public async Task Refresh_EndpointChangePublishCancellationPreservesManagedProcess()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        using var cancellation = new CancellationTokenSource();
+        var events = new SynchronizedEventLog();
+        var platform = new FakePlatform();
+        var lifecycle = new FakeLifecycle(events)
+        {
+            PublishHandler = (_, _) =>
+            {
+                cancellation.Cancel();
+                return Task.FromCanceled<LocalAiEndpointLifecycleResult>(cancellation.Token);
+            },
+        };
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_789);
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            lifecycle);
+        lifecycle.PublishHandler = null;
+        LocalAiRuntimeSnapshot started = await runtime.EnsureStartedAsync();
+        Assert.Equal(LocalAiRuntimeState.Healthy, started.State);
+        events.Clear();
+        platform.Listeners[0] = platform.Listeners[0] with { Port = 28_790 };
+        lifecycle.PublishHandler = (_, _) =>
+        {
+            cancellation.Cancel();
+            return Task.FromCanceled<LocalAiEndpointLifecycleResult>(cancellation.Token);
+        };
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => runtime.RefreshAsync(cancellation.Token));
+
+        Assert.False(host.Process!.HasExited);
+        Assert.Equal(LocalAiRuntimeState.Healthy, runtime.Snapshot.State);
+        Assert.Equal(
+            ["probe:28790", "quiesce:EndpointCycle", "publish:28790"],
+            events);
+        Assert.DoesNotContain("quiesce:Teardown", events);
+    }
+
+    [Fact]
     public async Task Refresh_QuiesceExceptionStopsManagedProcessAfterFallbackTeardown()
     {
         using var temp = new TempDirectory("local-ai-port-");
@@ -2155,6 +2200,8 @@ public sealed class LocalAiPortLifecycleTests
         public bool FailQuiesce { get; set; }
         public Exception? PublishException { get; set; }
         public Exception? QuiesceException { get; set; }
+        public Func<LocalAiResolvedInstall, CancellationToken, Task<LocalAiEndpointLifecycleResult>>?
+            PublishHandler { get; set; }
         public List<Uri?> QuiescedEndpoints { get; } = [];
         public Func<int, LocalAiQuiesceReason, CancellationToken, Task<LocalAiEndpointLifecycleResult>>?
             QuiesceHandler { get; set; }
@@ -2182,6 +2229,8 @@ public sealed class LocalAiPortLifecycleTests
             CancellationToken cancellationToken = default)
         {
             events.Add($"publish:{install.Endpoint!.Port}");
+            if (PublishHandler is not null)
+                return PublishHandler(install, cancellationToken);
             if (PublishException is not null)
                 return Task.FromException<LocalAiEndpointLifecycleResult>(PublishException);
             return Task.FromResult(FailPublish

--- a/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
+++ b/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
@@ -685,6 +685,59 @@ public sealed class LocalAiPortLifecycleTests
     }
 
     [Fact]
+    public async Task Restart_AutomaticStartupExceptionCompletesTerminalTeardown()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var teardown = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var events = new SynchronizedEventLog();
+        bool failListenerCapture = false;
+        var platform = new FakePlatform
+        {
+            AfterCapture = () =>
+            {
+                if (failListenerCapture)
+                    throw new InvalidOperationException("listener capture failed");
+            },
+        };
+        var lifecycle = new FakeLifecycle(events)
+        {
+            QuiesceHandler = (_, reason, _) =>
+            {
+                if (reason == LocalAiQuiesceReason.Teardown)
+                    teardown.TrySetResult();
+                return Task.FromResult(LocalAiEndpointLifecycleResult.Ok());
+            },
+        };
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_765);
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            lifecycle,
+            maxRestartAttempts: 1);
+        LocalAiRuntimeSnapshot started = await runtime.EnsureStartedAsync();
+        Assert.Equal(LocalAiRuntimeState.Healthy, started.State);
+        int settled = events.Count;
+        failListenerCapture = true;
+
+        FakeProcess process = host.Process!;
+        process.MarkExited();
+        host.LastExitCallback!(new LocalAiManagedProcessExit(
+            process.ProcessId,
+            process.StartedAtUtc,
+            1));
+        await teardown.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.Equal(LocalAiRuntimeState.Failed, runtime.Snapshot.State);
+        Assert.Equal(
+            ["quiesce:EndpointCycle", "quiesce:Teardown"],
+            events.Skip(settled).ToArray());
+        Assert.DoesNotContain("start", events.Skip(settled));
+    }
+
+    [Fact]
     public async Task Restart_AutomaticEndpointCycleFailureCompletesTeardown()
     {
         using var temp = new TempDirectory("local-ai-port-");
@@ -983,6 +1036,15 @@ public sealed class LocalAiPortLifecycleTests
                 : [$"quiesce:{expectedReason}"],
             events);
         Assert.Equal(expectedExited, host.Process!.HasExited);
+        if (expectedExited)
+        {
+            events.Clear();
+
+            LocalAiRuntimeSnapshot retained = await runtime.RefreshAsync();
+
+            Assert.Equal(expectedState, retained.State);
+            Assert.Empty(events);
+        }
     }
 
     [Fact]
@@ -1475,6 +1537,11 @@ public sealed class LocalAiPortLifecycleTests
 
         Assert.Equal(LocalAiRuntimeState.Stopped, stopped.State);
         Assert.Equal(["quiesce:Teardown", "stop"], events);
+
+        File.Delete(paths.ManifestPath);
+        LocalAiRuntimeSnapshot refreshed = await runtime.RefreshAsync();
+
+        Assert.Equal(LocalAiRuntimeState.NotInstalled, refreshed.State);
     }
 
     [Fact]

--- a/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
+++ b/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
@@ -265,14 +265,7 @@ public sealed class LocalAiPortLifecycleTests
         using var cancellation = new CancellationTokenSource();
         var events = new SynchronizedEventLog();
         var platform = new FakePlatform();
-        var lifecycle = new FakeLifecycle(events)
-        {
-            PublishHandler = (_, _) =>
-            {
-                cancellation.Cancel();
-                return Task.FromCanceled<LocalAiEndpointLifecycleResult>(cancellation.Token);
-            },
-        };
+        var lifecycle = new FakeLifecycle(events);
         var host = new FakeProcessHost(platform, events, selectedPort: 28_789);
         await using var runtime = CreateRuntime(
             paths,
@@ -280,15 +273,18 @@ public sealed class LocalAiPortLifecycleTests
             platform,
             new FakeClient(events),
             lifecycle);
-        lifecycle.PublishHandler = null;
         LocalAiRuntimeSnapshot started = await runtime.EnsureStartedAsync();
         Assert.Equal(LocalAiRuntimeState.Healthy, started.State);
         events.Clear();
         platform.Listeners[0] = platform.Listeners[0] with { Port = 28_790 };
-        lifecycle.PublishHandler = (_, _) =>
+        lifecycle.PublishHandler = (_, token) =>
         {
-            cancellation.Cancel();
-            return Task.FromCanceled<LocalAiEndpointLifecycleResult>(cancellation.Token);
+            if (token.CanBeCanceled)
+            {
+                cancellation.Cancel();
+                return Task.FromCanceled<LocalAiEndpointLifecycleResult>(cancellation.Token);
+            }
+            return Task.FromResult(LocalAiEndpointLifecycleResult.Ok());
         };
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
@@ -297,7 +293,7 @@ public sealed class LocalAiPortLifecycleTests
         Assert.False(host.Process!.HasExited);
         Assert.Equal(LocalAiRuntimeState.Healthy, runtime.Snapshot.State);
         Assert.Equal(
-            ["probe:28790", "quiesce:EndpointCycle", "publish:28790"],
+            ["probe:28790", "quiesce:EndpointCycle", "publish:28790", "publish:28790"],
             events);
         Assert.DoesNotContain("quiesce:Teardown", events);
     }
@@ -639,6 +635,53 @@ public sealed class LocalAiPortLifecycleTests
         Assert.Equal(
             ["quiesce:EndpointCycle", "quiesce:Teardown"],
             events.Skip(settled).ToArray());
+    }
+
+    [Fact]
+    public async Task Restart_AutomaticNotInstalledOutcomeCompletesTerminalTeardown()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var teardown = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var events = new SynchronizedEventLog();
+        var platform = new FakePlatform
+        {
+            AfterDelay = () => File.Delete(paths.ManifestPath),
+        };
+        var lifecycle = new FakeLifecycle(events)
+        {
+            QuiesceHandler = (call, _, _) =>
+            {
+                if (call == 3)
+                    teardown.TrySetResult();
+                return Task.FromResult(LocalAiEndpointLifecycleResult.Ok());
+            },
+        };
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_765);
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            lifecycle,
+            maxRestartAttempts: 1);
+        LocalAiRuntimeSnapshot started = await runtime.EnsureStartedAsync();
+        Assert.Equal(LocalAiRuntimeState.Healthy, started.State);
+        int settled = events.Count;
+
+        FakeProcess process = host.Process!;
+        process.MarkExited();
+        host.LastExitCallback!(new LocalAiManagedProcessExit(
+            process.ProcessId,
+            process.StartedAtUtc,
+            1));
+        await teardown.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.Equal(LocalAiRuntimeState.NotInstalled, runtime.Snapshot.State);
+        Assert.Equal(
+            ["quiesce:EndpointCycle", "quiesce:Teardown"],
+            events.Skip(settled).ToArray());
+        Assert.DoesNotContain("start", events.Skip(settled));
     }
 
     [Fact]

--- a/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
+++ b/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
@@ -277,10 +277,12 @@ public sealed class LocalAiPortLifecycleTests
         Assert.Equal(LocalAiRuntimeState.Healthy, started.State);
         events.Clear();
         platform.Listeners[0] = platform.Listeners[0] with { Port = 28_790 };
+        bool canceled = false;
         lifecycle.PublishHandler = (_, token) =>
         {
-            if (token.CanBeCanceled)
+            if (!canceled)
             {
+                canceled = true;
                 cancellation.Cancel();
                 return Task.FromCanceled<LocalAiEndpointLifecycleResult>(cancellation.Token);
             }
@@ -296,6 +298,47 @@ public sealed class LocalAiPortLifecycleTests
             ["probe:28790", "quiesce:EndpointCycle", "publish:28790", "publish:28790"],
             events);
         Assert.DoesNotContain("quiesce:Teardown", events);
+    }
+
+    [Fact]
+    public async Task Refresh_CanceledManifestRebindTimesOutAndCompletesTeardown()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var events = new SynchronizedEventLog();
+        var platform = new FakePlatform();
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_791);
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            new FakeLifecycle(events),
+            shutdownTimeout: TimeSpan.FromMilliseconds(20));
+        Assert.Equal(LocalAiRuntimeState.Healthy, (await runtime.EnsureStartedAsync()).State);
+        platform.Listeners[0] = platform.Listeners[0] with { Port = 28_792 };
+        events.Clear();
+
+        string lockPath = Path.Combine(
+            paths.RootDirectory,
+            $".{Path.GetFileName(paths.ManifestPath)}.lock");
+        await using var writeLock = new FileStream(
+            lockPath,
+            FileMode.OpenOrCreate,
+            FileAccess.ReadWrite,
+            FileShare.None);
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromMilliseconds(20));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => runtime.RefreshAsync(cancellation.Token).WaitAsync(TimeSpan.FromSeconds(2)));
+
+        Assert.True(host.Process!.HasExited);
+        Assert.Equal(LocalAiRuntimeState.Failed, runtime.Snapshot.State);
+        Assert.Equal(LocalAiOwnership.None, runtime.Snapshot.Ownership);
+        Assert.Contains("could not restore gateway routing", runtime.Snapshot.Detail, StringComparison.Ordinal);
+        Assert.Equal(
+            ["probe:28792", "quiesce:EndpointCycle", "quiesce:Teardown", "stop"],
+            events);
     }
 
     [Fact]
@@ -547,8 +590,10 @@ public sealed class LocalAiPortLifecycleTests
         Assert.Equal(28_765, saved!.Endpoint!.Port);
     }
 
-    [Fact]
-    public async Task Restart_ExhaustedAutomaticRestoresEndInTeardownNotEndpointCycle()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Restart_ExhaustedAutomaticRestoresTerminalRouting(bool teardownFails)
     {
         using var temp = new TempDirectory("local-ai-port-");
         LocalAiPaths paths = await PrepareInstallAsync(temp);
@@ -559,12 +604,19 @@ public sealed class LocalAiPortLifecycleTests
         var events = new SynchronizedEventLog();
         var platform = new FakePlatform();
         var host = new FakeProcessHost(platform, events, selectedPort: 28_765);
+        var lifecycle = new FakeLifecycle(events)
+        {
+            QuiesceHandler = (call, _, _) => Task.FromResult(
+                teardownFails && call == 4
+                    ? LocalAiEndpointLifecycleResult.Failed("exhausted teardown failed")
+                    : LocalAiEndpointLifecycleResult.Ok()),
+        };
         await using var runtime = CreateRuntime(
             paths,
             host,
             platform,
             new FakeClient(events),
-            new FakeLifecycle(events),
+            lifecycle,
             startupTimeout: TimeSpan.FromSeconds(5),
             maxRestartAttempts: 1);
 
@@ -580,9 +632,12 @@ public sealed class LocalAiPortLifecycleTests
             runtime,
             host,
             snapshot => snapshot.State == LocalAiRuntimeState.Failed &&
-                snapshot.Detail?.Contains("exited unexpectedly", StringComparison.Ordinal) == true);
+                snapshot.Detail?.Contains(
+                    teardownFails ? "safely disabled" : "exited unexpectedly",
+                    StringComparison.Ordinal) == true);
 
         Assert.Equal(LocalAiRuntimeState.Failed, exhausted.State);
+        Assert.Equal(LocalAiOwnership.None, exhausted.Ownership);
         Assert.Equal(
             [
                 "quiesce:EndpointCycle",
@@ -1694,6 +1749,42 @@ public sealed class LocalAiPortLifecycleTests
     }
 
     [Fact]
+    public async Task Startup_ProcessShutdownExceptionPublishesRetryableFailure()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var events = new SynchronizedEventLog();
+        FakeProcessHost? host = null;
+        var platform = new FakePlatform
+        {
+            AfterDelay = () => host!.Process!.StopException =
+                new IOException("process shutdown failed"),
+        };
+        host = new FakeProcessHost(platform, events, selectedPort: 28_793)
+        {
+            SuppressListener = true,
+        };
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            new FakeLifecycle(events),
+            startupTimeout: TimeSpan.FromMilliseconds(2));
+
+        IOException error = await Assert.ThrowsAsync<IOException>(() => runtime.EnsureStartedAsync());
+
+        Assert.Equal("process shutdown failed", error.Message);
+        Assert.Equal(LocalAiRuntimeState.Failed, runtime.Snapshot.State);
+        Assert.Equal(LocalAiOwnership.CompanionManaged, runtime.Snapshot.Ownership);
+        Assert.False(host.Process!.HasExited);
+        Assert.Contains("remains running", runtime.Snapshot.Detail, StringComparison.Ordinal);
+
+        host.Process.StopException = null;
+        Assert.Equal(LocalAiRuntimeState.Stopped, (await runtime.StopAsync()).State);
+    }
+
+    [Fact]
     public async Task Dispose_ProcessShutdownFailureRetriesAndReleasesProcess()
     {
         using var temp = new TempDirectory("local-ai-port-");
@@ -2149,13 +2240,15 @@ public sealed class LocalAiPortLifecycleTests
         FakeClient client,
         ILocalAiEndpointLifecycle lifecycle,
         TimeSpan? startupTimeout = null,
-        int maxRestartAttempts = 2) => new(
+        int maxRestartAttempts = 2,
+        TimeSpan? shutdownTimeout = null) => new(
             new LlamaServerRuntimeOptions
             {
                 Paths = paths,
                 EndpointLifecycle = lifecycle,
                 HealthPollInterval = TimeSpan.FromMilliseconds(1),
                 StartupTimeout = startupTimeout ?? TimeSpan.FromSeconds(1),
+                ShutdownTimeout = shutdownTimeout ?? TimeSpan.FromSeconds(10),
                 RestartDelay = TimeSpan.Zero,
                 MaxRestartAttempts = maxRestartAttempts,
             },

--- a/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
+++ b/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
@@ -190,6 +190,41 @@ public sealed class LocalAiPortLifecycleTests
     }
 
     [Fact]
+    public async Task Refresh_TeardownExceptionRetriesBeforeStoppingManagedProcess()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var events = new SynchronizedEventLog();
+        var platform = new FakePlatform();
+        var lifecycle = new FakeLifecycle(events)
+        {
+            QuiesceHandler = (call, _, _) => call == 2
+                ? Task.FromException<LocalAiEndpointLifecycleResult>(
+                    new IOException("terminal withdrawal interrupted"))
+                : Task.FromResult(LocalAiEndpointLifecycleResult.Ok()),
+        };
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_786);
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            lifecycle);
+        LocalAiRuntimeSnapshot started = await runtime.EnsureStartedAsync();
+        Assert.Equal(LocalAiRuntimeState.Healthy, started.State);
+        events.Clear();
+        platform.Ipv4Complete = false;
+
+        IOException error = await Assert.ThrowsAsync<IOException>(() => runtime.RefreshAsync());
+
+        Assert.Equal("terminal withdrawal interrupted", error.Message);
+        Assert.Equal(LocalAiRuntimeState.Failed, runtime.Snapshot.State);
+        Assert.Equal(LocalAiOwnership.None, runtime.Snapshot.Ownership);
+        Assert.True(host.Process!.HasExited);
+        Assert.Equal(["quiesce:Teardown", "quiesce:Teardown", "stop"], events);
+    }
+
+    [Fact]
     public async Task Refresh_QuiesceExceptionStopsManagedProcessAfterFallbackTeardown()
     {
         using var temp = new TempDirectory("local-ai-port-");
@@ -937,6 +972,35 @@ public sealed class LocalAiPortLifecycleTests
         Assert.Equal(LocalAiOwnership.None, failed.Ownership);
         Assert.Equal("endpoint-cycle withdrawal failed", failed.Detail);
         Assert.Equal(["quiesce:EndpointCycle", "quiesce:Teardown"], events);
+    }
+
+    [Fact]
+    public async Task Startup_PublishExceptionWithdrawsUsingVerifiedEndpoint()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var events = new SynchronizedEventLog();
+        var platform = new FakePlatform();
+        var lifecycle = new FakeLifecycle(events)
+        {
+            PublishException = new IOException("publish wrote then failed"),
+        };
+        await using var runtime = CreateRuntime(
+            paths,
+            new FakeProcessHost(platform, events, selectedPort: 28_785),
+            platform,
+            new FakeClient(events),
+            lifecycle);
+
+        LocalAiRuntimeSnapshot failed = await runtime.EnsureStartedAsync();
+
+        Assert.Equal(LocalAiRuntimeState.Failed, failed.State);
+        Assert.Equal(
+            [null, new Uri("http://127.0.0.1:28785/v1")],
+            lifecycle.QuiescedEndpoints);
+        Assert.Equal(
+            ["quiesce:EndpointCycle", "start", "probe:28785", "publish:28785", "quiesce:Teardown", "stop"],
+            events);
     }
 
     [Fact]
@@ -1948,7 +2012,9 @@ public sealed class LocalAiPortLifecycleTests
     {
         public bool FailPublish { get; set; }
         public bool FailQuiesce { get; set; }
+        public Exception? PublishException { get; set; }
         public Exception? QuiesceException { get; set; }
+        public List<Uri?> QuiescedEndpoints { get; } = [];
         public Func<int, LocalAiQuiesceReason, CancellationToken, Task<LocalAiEndpointLifecycleResult>>?
             QuiesceHandler { get; set; }
         private int _quiesceCount;
@@ -1959,6 +2025,7 @@ public sealed class LocalAiPortLifecycleTests
             CancellationToken cancellationToken = default)
         {
             events.Add($"quiesce:{reason}");
+            QuiescedEndpoints.Add(install.Endpoint);
             int call = ++_quiesceCount;
             if (QuiesceHandler is not null)
                 return QuiesceHandler(call, reason, cancellationToken);
@@ -1974,6 +2041,8 @@ public sealed class LocalAiPortLifecycleTests
             CancellationToken cancellationToken = default)
         {
             events.Add($"publish:{install.Endpoint!.Port}");
+            if (PublishException is not null)
+                return Task.FromException<LocalAiEndpointLifecycleResult>(PublishException);
             return Task.FromResult(FailPublish
                 ? LocalAiEndpointLifecycleResult.Failed("publish failed")
                 : LocalAiEndpointLifecycleResult.Ok());

--- a/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
+++ b/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
@@ -671,6 +671,7 @@ public sealed class LocalAiPortLifecycleTests
 
         FakeProcess process = host.Process!;
         process.MarkExited();
+        platform.Listeners.Clear();
         host.LastExitCallback!(new LocalAiManagedProcessExit(
             process.ProcessId,
             process.StartedAtUtc,
@@ -1224,6 +1225,43 @@ public sealed class LocalAiPortLifecycleTests
     }
 
     [Fact]
+    public async Task Startup_UnverifiableListenerStopsWhenTeardownFails()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var events = new SynchronizedEventLog();
+        FakePlatform? platform = null;
+        platform = new FakePlatform
+        {
+            AfterCapture = () => platform!.Ipv4Complete = false,
+        };
+        var lifecycle = new FakeLifecycle(events)
+        {
+            QuiesceHandler = (call, _, _) => Task.FromResult(
+                call == 2
+                    ? LocalAiEndpointLifecycleResult.Failed("terminal teardown failed")
+                    : LocalAiEndpointLifecycleResult.Ok()),
+        };
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_785);
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            lifecycle);
+
+        LocalAiRuntimeSnapshot failed = await runtime.EnsureStartedAsync();
+
+        Assert.Equal(LocalAiRuntimeState.Failed, failed.State);
+        Assert.Equal(LocalAiOwnership.None, failed.Ownership);
+        Assert.True(host.Process!.HasExited);
+        Assert.Contains("untrusted managed listener was stopped", failed.Detail, StringComparison.Ordinal);
+        Assert.Equal(
+            ["quiesce:EndpointCycle", "start", "quiesce:Teardown", "stop"],
+            events);
+    }
+
+    [Fact]
     public async Task Startup_PreservedListenerRemainsSupervisedAfterTeardownFailure()
     {
         using var temp = new TempDirectory("local-ai-port-");
@@ -1698,6 +1736,72 @@ public sealed class LocalAiPortLifecycleTests
         Assert.Equal(LocalAiRuntimeState.Failed, exited.State);
         Assert.Equal(["quiesce:Teardown"], events.Skip(settled).ToArray());
         Assert.DoesNotContain(events.Skip(settled), value => value is "start" || value.StartsWith("publish:", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Stop_DuringAutomaticRestartDelayInvalidatesPendingRestart()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var delayEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseDelay = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var stopTeardownEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseStopTeardown = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var events = new SynchronizedEventLog();
+        var platform = new FakePlatform
+        {
+            AfterDelay = () =>
+            {
+                delayEntered.TrySetResult();
+                releaseDelay.Task.GetAwaiter().GetResult();
+            },
+        };
+        var lifecycle = new FakeLifecycle(events)
+        {
+            QuiesceHandler = async (call, reason, _) =>
+            {
+                if (call == 3 && reason == LocalAiQuiesceReason.Teardown)
+                {
+                    stopTeardownEntered.TrySetResult();
+                    await releaseStopTeardown.Task.ConfigureAwait(false);
+                }
+                return LocalAiEndpointLifecycleResult.Ok();
+            },
+        };
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_769);
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            lifecycle,
+            maxRestartAttempts: 1);
+        LocalAiRuntimeSnapshot started = await runtime.EnsureStartedAsync();
+        Assert.Equal(LocalAiRuntimeState.Healthy, started.State);
+        int settled = events.Count;
+
+        FakeProcess process = host.Process!;
+        process.MarkExited();
+        platform.Listeners.Clear();
+        host.LastExitCallback!(new LocalAiManagedProcessExit(
+            process.ProcessId,
+            process.StartedAtUtc,
+            1));
+        await delayEntered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        Task<LocalAiRuntimeSnapshot> stopTask = runtime.StopAsync();
+        await stopTeardownEntered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        releaseDelay.TrySetResult();
+        releaseStopTeardown.TrySetResult();
+        LocalAiRuntimeSnapshot stopped = await stopTask;
+        LocalAiRuntimeSnapshot refreshed = await runtime.RefreshAsync();
+
+        Assert.Equal(LocalAiRuntimeState.Stopped, stopped.State);
+        Assert.Equal(LocalAiRuntimeState.Stopped, refreshed.State);
+        Assert.DoesNotContain("start", events.Skip(settled));
+        Assert.Equal(
+            ["quiesce:EndpointCycle", "quiesce:Teardown"],
+            events.Skip(settled).ToArray());
     }
 
     [Fact]

--- a/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
+++ b/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
@@ -1187,6 +1187,43 @@ public sealed class LocalAiPortLifecycleTests
     }
 
     [Fact]
+    public async Task Startup_UnsafeListenerStopsWhenTeardownFails()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var events = new SynchronizedEventLog();
+        var platform = new FakePlatform();
+        var lifecycle = new FakeLifecycle(events)
+        {
+            QuiesceHandler = (call, _, _) => Task.FromResult(
+                call == 2
+                    ? LocalAiEndpointLifecycleResult.Failed("terminal teardown failed")
+                    : LocalAiEndpointLifecycleResult.Ok()),
+        };
+        var host = new FakeProcessHost(
+            platform,
+            events,
+            selectedPort: 28_785,
+            listenerAddress: IPAddress.Any);
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            lifecycle);
+
+        LocalAiRuntimeSnapshot failed = await runtime.EnsureStartedAsync();
+
+        Assert.Equal(LocalAiRuntimeState.Failed, failed.State);
+        Assert.Equal(LocalAiOwnership.None, failed.Ownership);
+        Assert.True(host.Process!.HasExited);
+        Assert.Contains("untrusted managed listener was stopped", failed.Detail, StringComparison.Ordinal);
+        Assert.Equal(
+            ["quiesce:EndpointCycle", "start", "quiesce:Teardown", "stop"],
+            events);
+    }
+
+    [Fact]
     public async Task Startup_PreservedListenerRemainsSupervisedAfterTeardownFailure()
     {
         using var temp = new TempDirectory("local-ai-port-");
@@ -1329,6 +1366,43 @@ public sealed class LocalAiPortLifecycleTests
         Assert.False(host.Process.HasExited);
         Assert.Equal(
             ["quiesce:EndpointCycle", "quiesce:Teardown"],
+            events);
+    }
+
+    [Fact]
+    public async Task Refresh_UnsafeListenerStopsWhenEndpointCycleCleanupFails()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var events = new SynchronizedEventLog();
+        var platform = new FakePlatform();
+        var lifecycle = new FakeLifecycle(events)
+        {
+            QuiesceHandler = (call, _, _) => Task.FromResult(
+                call is 2 or 3
+                    ? LocalAiEndpointLifecycleResult.Failed("endpoint-cycle cleanup failed")
+                    : LocalAiEndpointLifecycleResult.Ok()),
+        };
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_779);
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            lifecycle);
+        LocalAiRuntimeSnapshot started = await runtime.EnsureStartedAsync();
+        Assert.Equal(LocalAiRuntimeState.Healthy, started.State);
+        platform.Ipv4Complete = false;
+        events.Clear();
+
+        LocalAiRuntimeSnapshot failed = await runtime.RefreshAsync();
+
+        Assert.Equal(LocalAiRuntimeState.Failed, failed.State);
+        Assert.Equal(LocalAiOwnership.None, failed.Ownership);
+        Assert.True(host.Process!.HasExited);
+        Assert.Contains("untrusted managed listener was stopped", failed.Detail, StringComparison.Ordinal);
+        Assert.Equal(
+            ["quiesce:EndpointCycle", "quiesce:EndpointCycle", "stop"],
             events);
     }
 

--- a/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
+++ b/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
@@ -190,7 +190,7 @@ public sealed class LocalAiPortLifecycleTests
     }
 
     [Fact]
-    public async Task Refresh_TeardownExceptionRetriesBeforeStoppingManagedProcess()
+    public async Task Refresh_TrustConflictExceptionRetriesEndpointCycleBeforeStopping()
     {
         using var temp = new TempDirectory("local-ai-port-");
         LocalAiPaths paths = await PrepareInstallAsync(temp);
@@ -221,7 +221,40 @@ public sealed class LocalAiPortLifecycleTests
         Assert.Equal(LocalAiRuntimeState.Failed, runtime.Snapshot.State);
         Assert.Equal(LocalAiOwnership.None, runtime.Snapshot.Ownership);
         Assert.True(host.Process!.HasExited);
-        Assert.Equal(["quiesce:Teardown", "quiesce:Teardown", "stop"], events);
+        Assert.Equal(["quiesce:EndpointCycle", "quiesce:EndpointCycle", "stop"], events);
+    }
+
+    [Fact]
+    public async Task Refresh_EndpointChangePublishExceptionFailsAndWithdrawsNewEndpoint()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var events = new SynchronizedEventLog();
+        var platform = new FakePlatform();
+        var lifecycle = new FakeLifecycle(events);
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_787);
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            lifecycle);
+        LocalAiRuntimeSnapshot started = await runtime.EnsureStartedAsync();
+        Assert.Equal(LocalAiRuntimeState.Healthy, started.State);
+        events.Clear();
+        platform.Listeners[0] = platform.Listeners[0] with { Port = 28_788 };
+        lifecycle.PublishException = new IOException("republish wrote then failed");
+
+        IOException error = await Assert.ThrowsAsync<IOException>(() => runtime.RefreshAsync());
+
+        Assert.Equal("republish wrote then failed", error.Message);
+        Assert.Equal(LocalAiRuntimeState.Failed, runtime.Snapshot.State);
+        Assert.Equal(LocalAiOwnership.None, runtime.Snapshot.Ownership);
+        Assert.True(host.Process!.HasExited);
+        Assert.Equal(new Uri("http://127.0.0.1:28788/v1"), lifecycle.QuiescedEndpoints[^1]);
+        Assert.Equal(
+            ["probe:28788", "quiesce:EndpointCycle", "publish:28788", "quiesce:Teardown", "stop"],
+            events);
     }
 
     [Fact]
@@ -814,8 +847,8 @@ public sealed class LocalAiPortLifecycleTests
     }
 
     [Theory]
-    [InlineData(RefreshOwnershipLoss.Incomplete, LocalAiRuntimeState.Conflict, LocalAiQuiesceReason.Teardown, true)]
-    [InlineData(RefreshOwnershipLoss.Conflict, LocalAiRuntimeState.Conflict, LocalAiQuiesceReason.Teardown, true)]
+    [InlineData(RefreshOwnershipLoss.Incomplete, LocalAiRuntimeState.Conflict, LocalAiQuiesceReason.EndpointCycle, true)]
+    [InlineData(RefreshOwnershipLoss.Conflict, LocalAiRuntimeState.Conflict, LocalAiQuiesceReason.EndpointCycle, true)]
     [InlineData(RefreshOwnershipLoss.MissingEndpoint, LocalAiRuntimeState.Starting, LocalAiQuiesceReason.EndpointCycle, false)]
     public async Task Refresh_QuiescesPublishedRouteWhenEndpointOwnershipIsLost(
         RefreshOwnershipLoss ownershipLoss,
@@ -1352,6 +1385,40 @@ public sealed class LocalAiPortLifecycleTests
 
         Assert.Equal(LocalAiRuntimeState.Stopped, stopped.State);
         Assert.Equal(["quiesce:Teardown", "stop"], events);
+    }
+
+    [Fact]
+    public async Task Stop_QuiesceExceptionRetriesTeardownBeforeStopping()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var events = new SynchronizedEventLog();
+        var platform = new FakePlatform();
+        var lifecycle = new FakeLifecycle(events)
+        {
+            QuiesceHandler = (call, _, _) => call == 2
+                ? Task.FromException<LocalAiEndpointLifecycleResult>(
+                    new IOException("stop withdrawal interrupted"))
+                : Task.FromResult(LocalAiEndpointLifecycleResult.Ok()),
+        };
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_769);
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            lifecycle);
+        LocalAiRuntimeSnapshot started = await runtime.EnsureStartedAsync();
+        Assert.Equal(LocalAiRuntimeState.Healthy, started.State);
+        events.Clear();
+
+        IOException error = await Assert.ThrowsAsync<IOException>(() => runtime.StopAsync());
+
+        Assert.Equal("stop withdrawal interrupted", error.Message);
+        Assert.Equal(LocalAiRuntimeState.Failed, runtime.Snapshot.State);
+        Assert.Equal(LocalAiOwnership.None, runtime.Snapshot.Ownership);
+        Assert.True(host.Process!.HasExited);
+        Assert.Equal(["quiesce:Teardown", "quiesce:Teardown", "stop"], events);
     }
 
     [Fact]

--- a/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
+++ b/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
@@ -550,10 +550,6 @@ public sealed class LocalAiPortLifecycleTests
     [Fact]
     public async Task Restart_ExhaustedAutomaticRestoresEndInTeardownNotEndpointCycle()
     {
-        // The first unexpected exit schedules a restart and is an endpoint
-        // cycle. Once the retry budget is spent, the next exit is terminal and
-        // must restore gateway routing (teardown) rather than retain a managed
-        // primary whose provider is gone.
         using var temp = new TempDirectory("local-ai-port-");
         LocalAiPaths paths = await PrepareInstallAsync(temp);
         var store = new LocalAiManifestStore(paths);
@@ -809,8 +805,6 @@ public sealed class LocalAiPortLifecycleTests
     [Fact]
     public async Task Restart_CancellationWithdrawsRetainedRouteBeforeDisposingChild()
     {
-        // A canceled startup is terminal for the attempt: the retained route is
-        // withdrawn before the child's listener disappears.
         using var temp = new TempDirectory("local-ai-port-");
         LocalAiPaths paths = await PrepareInstallAsync(temp);
         var store = new LocalAiManifestStore(paths);
@@ -2399,13 +2393,10 @@ public sealed class LocalAiPortLifecycleTests
         public FakeProcess? Process { get; private set; }
         public Action<LocalAiManagedProcessExit>? LastExitCallback { get; private set; }
 
-        /// <summary>Starts the child without ever opening a listener, so startup times out.</summary>
         public bool SuppressListener { get; init; }
 
-        /// <summary>Throws from StartProcessAsync, simulating a process-launch failure.</summary>
         public bool ThrowOnStart { get; init; }
 
-        /// <summary>Fires the exit callback during StartProcessAsync, simulating an immediate child exit.</summary>
         public bool ImmediateExit { get; init; }
 
         public Task<ILocalAiManagedProcess> StartProcessAsync(
@@ -2452,7 +2443,6 @@ public sealed class LocalAiPortLifecycleTests
         public Action? AfterStop { get; set; }
         public Exception? StopException { get; set; }
 
-        /// <summary>Marks the child as exited without going through StopAsync.</summary>
         public void MarkExited() => HasExited = true;
 
         public Task StopAsync(TimeSpan timeout, CancellationToken cancellationToken)

--- a/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
+++ b/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
@@ -1187,13 +1187,22 @@ public sealed class LocalAiPortLifecycleTests
             events);
     }
 
-    [Fact]
-    public async Task Startup_UnsafeListenerStopsWhenTeardownFails()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Startup_UnsafeOrUnverifiableListenerStopsWhenTeardownFails(
+        bool incompleteListenerSnapshot)
     {
         using var temp = new TempDirectory("local-ai-port-");
         LocalAiPaths paths = await PrepareInstallAsync(temp);
         var events = new SynchronizedEventLog();
-        var platform = new FakePlatform();
+        FakePlatform? platform = null;
+        platform = new FakePlatform
+        {
+            AfterCapture = incompleteListenerSnapshot
+                ? () => platform!.Ipv4Complete = false
+                : null,
+        };
         var lifecycle = new FakeLifecycle(events)
         {
             QuiesceHandler = (call, _, _) => Task.FromResult(
@@ -1205,44 +1214,7 @@ public sealed class LocalAiPortLifecycleTests
             platform,
             events,
             selectedPort: 28_785,
-            listenerAddress: IPAddress.Any);
-        await using var runtime = CreateRuntime(
-            paths,
-            host,
-            platform,
-            new FakeClient(events),
-            lifecycle);
-
-        LocalAiRuntimeSnapshot failed = await runtime.EnsureStartedAsync();
-
-        Assert.Equal(LocalAiRuntimeState.Failed, failed.State);
-        Assert.Equal(LocalAiOwnership.None, failed.Ownership);
-        Assert.True(host.Process!.HasExited);
-        Assert.Contains("untrusted managed listener was stopped", failed.Detail, StringComparison.Ordinal);
-        Assert.Equal(
-            ["quiesce:EndpointCycle", "start", "quiesce:Teardown", "stop"],
-            events);
-    }
-
-    [Fact]
-    public async Task Startup_UnverifiableListenerStopsWhenTeardownFails()
-    {
-        using var temp = new TempDirectory("local-ai-port-");
-        LocalAiPaths paths = await PrepareInstallAsync(temp);
-        var events = new SynchronizedEventLog();
-        FakePlatform? platform = null;
-        platform = new FakePlatform
-        {
-            AfterCapture = () => platform!.Ipv4Complete = false,
-        };
-        var lifecycle = new FakeLifecycle(events)
-        {
-            QuiesceHandler = (call, _, _) => Task.FromResult(
-                call == 2
-                    ? LocalAiEndpointLifecycleResult.Failed("terminal teardown failed")
-                    : LocalAiEndpointLifecycleResult.Ok()),
-        };
-        var host = new FakeProcessHost(platform, events, selectedPort: 28_785);
+            listenerAddress: incompleteListenerSnapshot ? null : IPAddress.Any);
         await using var runtime = CreateRuntime(
             paths,
             host,

--- a/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
+++ b/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
@@ -491,6 +491,44 @@ public sealed class LocalAiPortLifecycleTests
     }
 
     [Fact]
+    public async Task Restart_AutomaticEndpointCycleAndTeardownFailureReportsTerminalCleanup()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var events = new SynchronizedEventLog();
+        var platform = new FakePlatform();
+        var lifecycle = new FakeLifecycle(events)
+        {
+            QuiesceHandler = (call, _, _) => Task.FromResult(
+                call is 2 or 3
+                    ? LocalAiEndpointLifecycleResult.Failed("automatic withdrawal failed")
+                    : LocalAiEndpointLifecycleResult.Ok()),
+        };
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_765);
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            lifecycle,
+            maxRestartAttempts: 1);
+        LocalAiRuntimeSnapshot started = await runtime.EnsureStartedAsync();
+        Assert.Equal(LocalAiRuntimeState.Healthy, started.State);
+        int settled = events.Count;
+
+        LocalAiRuntimeSnapshot failed = await TriggerExitAndWaitForStateAsync(
+            runtime,
+            host,
+            snapshot => snapshot.State == LocalAiRuntimeState.Failed &&
+                snapshot.Detail?.Contains("Terminal gateway routing could not be restored", StringComparison.Ordinal) == true);
+
+        Assert.Equal(LocalAiOwnership.None, failed.Ownership);
+        Assert.Equal(
+            ["quiesce:EndpointCycle", "quiesce:Teardown"],
+            events.Skip(settled).ToArray());
+    }
+
+    [Fact]
     public async Task Restart_AutomaticEndpointCycleFailureCompletesTeardown()
     {
         using var temp = new TempDirectory("local-ai-port-");
@@ -1396,6 +1434,84 @@ public sealed class LocalAiPortLifecycleTests
     }
 
     [Fact]
+    public async Task RestartAsync_SuccessfulCleanupRetryStopsPreservedListener()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var events = new SynchronizedEventLog();
+        var platform = new FakePlatform();
+        var lifecycle = new FakeLifecycle(events)
+        {
+            QuiesceHandler = (call, _, _) => Task.FromResult(
+                call == 4
+                    ? LocalAiEndpointLifecycleResult.Failed("terminal teardown failed")
+                    : LocalAiEndpointLifecycleResult.Ok()),
+        };
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_769);
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            lifecycle);
+        LocalAiRuntimeSnapshot started = await runtime.EnsureStartedAsync();
+        Assert.Equal(LocalAiRuntimeState.Healthy, started.State);
+        lifecycle.FailPublish = true;
+        events.Clear();
+
+        LocalAiRuntimeSnapshot failed = await runtime.RestartAsync();
+
+        Assert.Equal(LocalAiRuntimeState.Failed, failed.State);
+        Assert.Equal(LocalAiOwnership.None, failed.Ownership);
+        Assert.Null(failed.ProcessId);
+        Assert.True(host.Process!.HasExited);
+        Assert.Equal("Local AI restart did not complete.", failed.Detail);
+        Assert.Equal(
+            [
+                "quiesce:EndpointCycle",
+                "stop",
+                "quiesce:EndpointCycle",
+                "start",
+                "probe:28769",
+                "publish:28769",
+                "quiesce:Teardown",
+                "quiesce:Teardown",
+                "stop",
+            ],
+            events);
+    }
+
+    [Fact]
+    public async Task RestartAsync_CancellationAfterEndpointCycleStopStillCompletesTeardown()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        using var cancellation = new CancellationTokenSource();
+        var events = new SynchronizedEventLog();
+        var platform = new FakePlatform();
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_769);
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            new FakeLifecycle(events));
+        LocalAiRuntimeSnapshot started = await runtime.EnsureStartedAsync();
+        Assert.Equal(LocalAiRuntimeState.Healthy, started.State);
+        host.Process!.AfterStop = cancellation.Cancel;
+        events.Clear();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => runtime.RestartAsync(cancellation.Token));
+
+        Assert.Equal(LocalAiRuntimeState.Failed, runtime.Snapshot.State);
+        Assert.Equal(LocalAiOwnership.None, runtime.Snapshot.Ownership);
+        Assert.Equal(
+            ["quiesce:EndpointCycle", "stop", "quiesce:Teardown"],
+            events);
+    }
+
+    [Fact]
     public async Task RestartAsync_NotInstalledOutcomeWithdrawsRetainedRoute()
     {
         using var temp = new TempDirectory("local-ai-port-");
@@ -1781,6 +1897,7 @@ public sealed class LocalAiPortLifecycleTests
         public DateTimeOffset StartedAtUtc { get; } = startedAtUtc;
         public bool HasExited { get; private set; }
         public int StopCount { get; private set; }
+        public Action? AfterStop { get; set; }
 
         /// <summary>Marks the child as exited without going through StopAsync.</summary>
         public void MarkExited() => HasExited = true;
@@ -1792,6 +1909,7 @@ public sealed class LocalAiPortLifecycleTests
             StopCount++;
             HasExited = true;
             platform.Listeners.Clear();
+            AfterStop?.Invoke();
             return Task.CompletedTask;
         }
 

--- a/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
+++ b/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
@@ -1424,6 +1424,78 @@ public sealed class LocalAiPortLifecycleTests
     }
 
     [Fact]
+    public async Task Stop_FailedWithdrawalLatchesIntentAndPreventsAutomaticRestart()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var events = new SynchronizedEventLog();
+        var platform = new FakePlatform();
+        var lifecycle = new FakeLifecycle(events)
+        {
+            QuiesceHandler = (call, _, _) => call switch
+            {
+                2 => Task.FromException<LocalAiEndpointLifecycleResult>(
+                    new IOException("stop withdrawal interrupted")),
+                3 => Task.FromResult(LocalAiEndpointLifecycleResult.Failed("stop teardown failed")),
+                _ => Task.FromResult(LocalAiEndpointLifecycleResult.Ok()),
+            },
+        };
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_769);
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            lifecycle,
+            maxRestartAttempts: 2);
+        LocalAiRuntimeSnapshot started = await runtime.EnsureStartedAsync();
+        Assert.Equal(LocalAiRuntimeState.Healthy, started.State);
+        events.Clear();
+
+        await Assert.ThrowsAsync<IOException>(() => runtime.StopAsync());
+        Assert.Equal(LocalAiOwnership.CompanionManaged, runtime.Snapshot.Ownership);
+        int settled = events.Count;
+
+        LocalAiRuntimeSnapshot exited = await TriggerExitAndWaitForStateAsync(
+            runtime,
+            host,
+            snapshot => snapshot.Detail?.Contains("exited unexpectedly", StringComparison.Ordinal) == true);
+
+        Assert.Equal(LocalAiRuntimeState.Failed, exited.State);
+        Assert.Equal(["quiesce:Teardown"], events.Skip(settled).ToArray());
+        Assert.DoesNotContain(events.Skip(settled), value => value is "start" || value.StartsWith("publish:", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Stop_FromFailClosedConflictCompletesTerminalTeardown()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var events = new SynchronizedEventLog();
+        var platform = new FakePlatform();
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_769);
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            new FakeLifecycle(events));
+        LocalAiRuntimeSnapshot started = await runtime.EnsureStartedAsync();
+        Assert.Equal(LocalAiRuntimeState.Healthy, started.State);
+        platform.Ipv4Complete = false;
+
+        LocalAiRuntimeSnapshot conflict = await runtime.RefreshAsync();
+        Assert.Equal(LocalAiRuntimeState.Conflict, conflict.State);
+        Assert.Equal(LocalAiOwnership.None, conflict.Ownership);
+        events.Clear();
+
+        LocalAiRuntimeSnapshot stopped = await runtime.StopAsync();
+
+        Assert.Equal(LocalAiRuntimeState.Stopped, stopped.State);
+        Assert.Equal(["quiesce:Teardown"], events);
+    }
+
+    [Fact]
     public async Task RestartAsync_UsesEndpointCycleUntilReplacementIsPublished()
     {
         using var temp = new TempDirectory("local-ai-port-");

--- a/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
+++ b/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
@@ -165,10 +165,8 @@ public sealed class LocalAiPortLifecycleTests
     }
 
     [Fact]
-    public async Task Restart_ReusesLastVerifiedPortAndNeverWithdrawsThePublishedRoute()
+    public async Task Startup_WithdrawsProviderBeforeBindingFreshAutomaticPort()
     {
-        // The published route stays valid for the whole startup, so the gateway is
-        // never left without a Local AI provider to fall back from.
         using var temp = new TempDirectory("local-ai-port-");
         LocalAiPaths paths = await PrepareInstallAsync(temp);
         var store = new LocalAiManifestStore(paths);
@@ -177,16 +175,18 @@ public sealed class LocalAiPortLifecycleTests
 
         var events = new List<string>();
         var platform = new FakePlatform();
-        var host = new FakeProcessHost(platform, events, selectedPort: 28_765);
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_766);
         var client = new FakeClient(events);
         await using var runtime = CreateRuntime(paths, host, platform, client, new FakeLifecycle(events));
 
         LocalAiRuntimeSnapshot snapshot = await runtime.EnsureStartedAsync();
 
         Assert.Equal(LocalAiRuntimeState.Healthy, snapshot.State);
-        Assert.Equal("28765", ArgumentAfter(host.LastSpec!.Arguments, "--port"));
-        Assert.Equal(["start", "probe:28765", "publish:28765"], events);
-        Assert.DoesNotContain(events, e => e.StartsWith("quiesce", StringComparison.Ordinal));
+        Assert.Equal(28_766, snapshot.Endpoint.Port);
+        Assert.Equal("0", ArgumentAfter(host.LastSpec!.Arguments, "--port"));
+        Assert.Equal(
+            ["quiesce:EndpointCycle", "start", "probe:28766", "publish:28766"],
+            events);
     }
 
     [Fact]
@@ -345,9 +345,8 @@ public sealed class LocalAiPortLifecycleTests
     }
 
     [Fact]
-    public async Task Restart_WithdrawsRetainedRouteWhenStartupNeverBecomesHealthy()
+    public async Task Restart_RestoresTerminalRoutingWhenStartupNeverBecomesHealthy()
     {
-        // Nothing will answer the retained route, so it must not be left published.
         using var temp = new TempDirectory("local-ai-port-");
         LocalAiPaths paths = await PrepareInstallAsync(temp);
         var store = new LocalAiManifestStore(paths);
@@ -369,14 +368,14 @@ public sealed class LocalAiPortLifecycleTests
         LocalAiRuntimeSnapshot snapshot = await runtime.EnsureStartedAsync();
 
         Assert.Equal(LocalAiRuntimeState.Failed, snapshot.State);
-        Assert.Equal(["start", "quiesce:Teardown", "stop"], events);
+        Assert.Equal(
+            ["quiesce:EndpointCycle", "start", "quiesce:Teardown", "stop"],
+            events);
     }
 
     [Fact]
-    public async Task Restart_LaunchExceptionWithdrawsRetainedRouteAsTeardown()
+    public async Task Restart_LaunchExceptionRestoresTerminalRouting()
     {
-        // A launch exception is terminal: the retained route must be withdrawn
-        // before the gateway is left pointing at a port nothing will serve.
         using var temp = new TempDirectory("local-ai-port-");
         LocalAiPaths paths = await PrepareInstallAsync(temp);
         var store = new LocalAiManifestStore(paths);
@@ -396,7 +395,7 @@ public sealed class LocalAiPortLifecycleTests
         LocalAiRuntimeSnapshot snapshot = await runtime.EnsureStartedAsync();
 
         Assert.Equal(LocalAiRuntimeState.Failed, snapshot.State);
-        Assert.Equal(["quiesce:Teardown"], events);
+        Assert.Equal(["quiesce:EndpointCycle", "quiesce:Teardown"], events);
         Assert.Null(host.LastSpec);
         LocalAiResolvedInstall? saved = await new LocalAiManifestStore(paths).LoadAsync();
         Assert.Equal(28_765, saved!.Endpoint!.Port);
@@ -455,6 +454,45 @@ public sealed class LocalAiPortLifecycleTests
                 "publish:28765",
                 "quiesce:Teardown",
             ],
+            events.Skip(settled).ToArray());
+    }
+
+    [Fact]
+    public async Task Restart_AutomaticEndpointCycleFailureCompletesTeardown()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var events = new List<string>();
+        var platform = new FakePlatform();
+        var lifecycle = new FakeLifecycle(events)
+        {
+            QuiesceHandler = (call, _, _) => Task.FromResult(
+                call == 2
+                    ? LocalAiEndpointLifecycleResult.Failed("automatic endpoint-cycle failed")
+                    : LocalAiEndpointLifecycleResult.Ok()),
+        };
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_765);
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            lifecycle,
+            maxRestartAttempts: 1);
+        LocalAiRuntimeSnapshot started = await runtime.EnsureStartedAsync();
+        Assert.Equal(LocalAiRuntimeState.Healthy, started.State);
+        int settled = events.Count;
+
+        host.Process!.MarkExited();
+        host.LastExitCallback!(new LocalAiManagedProcessExit(
+            host.Process.ProcessId,
+            host.Process.StartedAtUtc,
+            1));
+        await WaitForEventAsync(events, "quiesce:Teardown", settled);
+
+        Assert.Equal(LocalAiRuntimeState.Failed, runtime.Snapshot.State);
+        Assert.Equal(
+            ["quiesce:EndpointCycle", "quiesce:Teardown"],
             events.Skip(settled).ToArray());
     }
 
@@ -523,7 +561,9 @@ public sealed class LocalAiPortLifecycleTests
             () => runtime.EnsureStartedAsync(cancellation.Token));
 
         Assert.Equal(LocalAiRuntimeState.Stopped, runtime.Snapshot.State);
-        Assert.Equal(["start", "quiesce:Teardown", "stop"], events);
+        Assert.Equal(
+            ["quiesce:EndpointCycle", "start", "quiesce:Teardown", "stop"],
+            events);
     }
 
     [Fact]
@@ -554,8 +594,45 @@ public sealed class LocalAiPortLifecycleTests
             () => runtime.EnsureStartedAsync(cancellation.Token));
 
         Assert.Equal(LocalAiRuntimeState.Stopped, runtime.Snapshot.State);
-        Assert.Equal(["quiesce:Teardown"], events);
+        Assert.Equal(["quiesce:EndpointCycle", "quiesce:Teardown"], events);
         Assert.Null(host.LastSpec);
+    }
+
+    [Fact]
+    public async Task Restart_TeardownFailurePreservesLiveManagedListener()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var events = new List<string>();
+        var platform = new FakePlatform();
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_765)
+        {
+            SuppressListener = true,
+        };
+        var lifecycle = new FakeLifecycle(events)
+        {
+            QuiesceHandler = (call, _, _) => Task.FromResult(
+                call == 1
+                    ? LocalAiEndpointLifecycleResult.Ok()
+                    : LocalAiEndpointLifecycleResult.Failed("teardown failed")),
+        };
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            lifecycle,
+            startupTimeout: TimeSpan.FromMilliseconds(5));
+
+        LocalAiRuntimeSnapshot snapshot = await runtime.EnsureStartedAsync();
+
+        Assert.Equal(LocalAiRuntimeState.Failed, snapshot.State);
+        Assert.Equal(LocalAiOwnership.CompanionManaged, snapshot.Ownership);
+        Assert.Equal(host.Process!.ProcessId, snapshot.ProcessId);
+        Assert.False(host.Process.HasExited);
+        Assert.Equal(
+            ["quiesce:EndpointCycle", "start", "quiesce:Teardown"],
+            events);
     }
 
     [Theory]
@@ -681,7 +758,7 @@ public sealed class LocalAiPortLifecycleTests
     }
 
     [Fact]
-    public async Task Refresh_QuiesceFailureStopsUnverifiedManagedProcess()
+    public async Task Refresh_TeardownFailurePreservesUnverifiedManagedProcess()
     {
         using var temp = new TempDirectory("local-ai-port-");
         LocalAiPaths paths = await PrepareInstallAsync(temp);
@@ -705,14 +782,54 @@ public sealed class LocalAiPortLifecycleTests
         LocalAiRuntimeSnapshot refreshed = await runtime.RefreshAsync();
 
         Assert.Equal(LocalAiRuntimeState.Failed, refreshed.State);
-        Assert.Equal(LocalAiOwnership.None, refreshed.Ownership);
-        Assert.Null(refreshed.ProcessId);
-        Assert.True(host.Process!.HasExited);
-        Assert.Equal(["probe:28776", "quiesce:EndpointCycle", "stop"], events);
+        Assert.Equal(LocalAiOwnership.CompanionManaged, refreshed.Ownership);
+        Assert.Equal(host.Process!.ProcessId, refreshed.ProcessId);
+        Assert.False(host.Process.HasExited);
+        Assert.Equal(
+            ["probe:28776", "quiesce:EndpointCycle", "quiesce:Teardown"],
+            events);
     }
 
     [Fact]
-    public async Task Refresh_QuiesceExceptionStopsManagedProcessBeforePropagating()
+    public async Task Refresh_EndpointCycleFailureUsesTeardownBeforeStopping()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var events = new List<string>();
+        var platform = new FakePlatform();
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_776);
+        var client = new FakeClient(events, (expectedModelPath, probeNumber) => probeNumber == 1
+            ? ReadyProbe(expectedModelPath)
+            : new(
+                false,
+                LocalAiModelAvailabilityState.Unknown,
+                null,
+                "The managed model is not ready."));
+        var lifecycle = new FakeLifecycle(events)
+        {
+            QuiesceHandler = (call, _, _) => Task.FromResult(
+                call == 2
+                    ? LocalAiEndpointLifecycleResult.Failed("endpoint-cycle failed")
+                    : LocalAiEndpointLifecycleResult.Ok()),
+        };
+        await using var runtime = CreateRuntime(paths, host, platform, client, lifecycle);
+        LocalAiRuntimeSnapshot started = await runtime.EnsureStartedAsync();
+        Assert.Equal(LocalAiRuntimeState.Healthy, started.State);
+        events.Clear();
+
+        LocalAiRuntimeSnapshot refreshed = await runtime.RefreshAsync();
+
+        Assert.Equal(LocalAiRuntimeState.Failed, refreshed.State);
+        Assert.Equal(LocalAiOwnership.None, refreshed.Ownership);
+        Assert.Null(refreshed.ProcessId);
+        Assert.True(host.Process!.HasExited);
+        Assert.Equal(
+            ["probe:28776", "quiesce:EndpointCycle", "quiesce:Teardown", "stop"],
+            events);
+    }
+
+    [Fact]
+    public async Task Refresh_QuiesceExceptionPreservesManagedProcessWhenTeardownAlsoFails()
     {
         using var temp = new TempDirectory("local-ai-port-");
         LocalAiPaths paths = await PrepareInstallAsync(temp);
@@ -736,10 +853,12 @@ public sealed class LocalAiPortLifecycleTests
 
         Assert.Equal("route withdrawal failed", error.Message);
         Assert.Equal(LocalAiRuntimeState.Failed, runtime.Snapshot.State);
-        Assert.Equal(LocalAiOwnership.None, runtime.Snapshot.Ownership);
-        Assert.Null(runtime.Snapshot.ProcessId);
-        Assert.True(host.Process!.HasExited);
-        Assert.Equal(["quiesce:EndpointCycle", "stop"], events);
+        Assert.Equal(LocalAiOwnership.CompanionManaged, runtime.Snapshot.Ownership);
+        Assert.Equal(host.Process!.ProcessId, runtime.Snapshot.ProcessId);
+        Assert.False(host.Process.HasExited);
+        Assert.Equal(
+            ["quiesce:EndpointCycle", "quiesce:Teardown"],
+            events);
     }
 
     [Fact]
@@ -945,6 +1064,40 @@ public sealed class LocalAiPortLifecycleTests
 
         Assert.Equal(LocalAiRuntimeState.Stopped, stopped.State);
         Assert.Equal(["quiesce:Teardown", "stop"], events);
+    }
+
+    [Fact]
+    public async Task RestartAsync_UsesEndpointCycleUntilReplacementIsPublished()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var events = new List<string>();
+        var platform = new FakePlatform();
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_769);
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            new FakeLifecycle(events));
+        LocalAiRuntimeSnapshot started = await runtime.EnsureStartedAsync();
+        Assert.Equal(LocalAiRuntimeState.Healthy, started.State);
+        events.Clear();
+
+        LocalAiRuntimeSnapshot restarted = await runtime.RestartAsync();
+
+        Assert.Equal(LocalAiRuntimeState.Healthy, restarted.State);
+        Assert.Equal(
+            [
+                "quiesce:EndpointCycle",
+                "stop",
+                "quiesce:EndpointCycle",
+                "start",
+                "probe:28769",
+                "publish:28769",
+            ],
+            events);
+        Assert.DoesNotContain("quiesce:Teardown", events);
     }
 
     [Fact]

--- a/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
+++ b/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
@@ -1691,6 +1691,43 @@ public sealed class LocalAiPortLifecycleTests
     }
 
     [Fact]
+    public async Task Stop_ProcessShutdownExceptionPublishesRetryableFailure()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var events = new SynchronizedEventLog();
+        var platform = new FakePlatform();
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_769);
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            new FakeLifecycle(events));
+        LocalAiRuntimeSnapshot started = await runtime.EnsureStartedAsync();
+        Assert.Equal(LocalAiRuntimeState.Healthy, started.State);
+        host.Process!.StopException = new IOException("process shutdown failed");
+        events.Clear();
+
+        IOException error = await Assert.ThrowsAsync<IOException>(() => runtime.StopAsync());
+
+        Assert.Equal("process shutdown failed", error.Message);
+        Assert.Equal(LocalAiRuntimeState.Failed, runtime.Snapshot.State);
+        Assert.Equal(LocalAiOwnership.CompanionManaged, runtime.Snapshot.Ownership);
+        Assert.False(host.Process.HasExited);
+        Assert.Contains("managed listener remains running", runtime.Snapshot.Detail, StringComparison.Ordinal);
+        Assert.Equal(["quiesce:Teardown", "stop"], events);
+
+        host.Process.StopException = null;
+        events.Clear();
+        LocalAiRuntimeSnapshot stopped = await runtime.StopAsync();
+
+        Assert.Equal(LocalAiRuntimeState.Stopped, stopped.State);
+        Assert.True(host.Process.HasExited);
+        Assert.Equal(["quiesce:Teardown", "stop"], events);
+    }
+
+    [Fact]
     public async Task Stop_FailedWithdrawalLatchesIntentAndPreventsAutomaticRestart()
     {
         using var temp = new TempDirectory("local-ai-port-");
@@ -2441,6 +2478,7 @@ public sealed class LocalAiPortLifecycleTests
         public bool HasExited { get; private set; }
         public int StopCount { get; private set; }
         public Action? AfterStop { get; set; }
+        public Exception? StopException { get; set; }
 
         /// <summary>Marks the child as exited without going through StopAsync.</summary>
         public void MarkExited() => HasExited = true;
@@ -2450,6 +2488,8 @@ public sealed class LocalAiPortLifecycleTests
             cancellationToken.ThrowIfCancellationRequested();
             events.Add("stop");
             StopCount++;
+            if (StopException is not null)
+                throw StopException;
             HasExited = true;
             platform.Listeners.Clear();
             AfterStop?.Invoke();

--- a/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
+++ b/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
@@ -145,7 +145,7 @@ public sealed class LocalAiPortLifecycleTests
     {
         using var temp = new TempDirectory("local-ai-port-");
         LocalAiPaths paths = await PrepareInstallAsync(temp);
-        var events = new List<string>();
+        var events = new SynchronizedEventLog();
         var platform = new FakePlatform();
         var host = new FakeProcessHost(platform, events, selectedPort: 28_765);
         var client = new FakeClient(events);
@@ -173,7 +173,7 @@ public sealed class LocalAiPortLifecycleTests
         LocalAiResolvedInstall install = (await store.LoadAsync())!;
         await store.SaveAsync(install.Manifest with { Endpoint = "http://127.0.0.1:28765/v1" });
 
-        var events = new List<string>();
+        var events = new SynchronizedEventLog();
         var platform = new FakePlatform();
         var host = new FakeProcessHost(platform, events, selectedPort: 28_766);
         var client = new FakeClient(events);
@@ -190,6 +190,43 @@ public sealed class LocalAiPortLifecycleTests
     }
 
     [Fact]
+    public async Task Refresh_QuiesceExceptionStopsManagedProcessAfterFallbackTeardown()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var events = new SynchronizedEventLog();
+        var platform = new FakePlatform();
+        var lifecycle = new FakeLifecycle(events)
+        {
+            QuiesceHandler = (call, _, _) => call == 2
+                ? Task.FromException<LocalAiEndpointLifecycleResult>(
+                    new IOException("endpoint-cycle withdrawal failed"))
+                : Task.FromResult(LocalAiEndpointLifecycleResult.Ok()),
+        };
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_784);
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            lifecycle);
+        LocalAiRuntimeSnapshot started = await runtime.EnsureStartedAsync();
+        Assert.Equal(LocalAiRuntimeState.Healthy, started.State);
+        events.Clear();
+        platform.Listeners.Clear();
+
+        IOException error = await Assert.ThrowsAsync<IOException>(() => runtime.RefreshAsync());
+
+        Assert.Equal("endpoint-cycle withdrawal failed", error.Message);
+        Assert.Equal(LocalAiRuntimeState.Failed, runtime.Snapshot.State);
+        Assert.Equal(LocalAiOwnership.None, runtime.Snapshot.Ownership);
+        Assert.True(host.Process!.HasExited);
+        Assert.Equal(
+            ["quiesce:EndpointCycle", "quiesce:Teardown", "stop"],
+            events);
+    }
+
+    [Fact]
     public async Task Restart_WithdrawsStaleRouteWhenTheLastVerifiedPortIsTaken()
     {
         using var temp = new TempDirectory("local-ai-port-");
@@ -198,7 +235,7 @@ public sealed class LocalAiPortLifecycleTests
         LocalAiResolvedInstall install = (await store.LoadAsync())!;
         await store.SaveAsync(install.Manifest with { Endpoint = "http://127.0.0.1:28765/v1" });
 
-        var events = new List<string>();
+        var events = new SynchronizedEventLog();
         var platform = new FakePlatform();
         platform.Listeners.Add(new WindowsTcpListenerInfo(
             IPAddress.Loopback,
@@ -229,7 +266,7 @@ public sealed class LocalAiPortLifecycleTests
         LocalAiResolvedInstall install = (await store.LoadAsync())!;
         await store.SaveAsync(install.Manifest with { Endpoint = "http://127.0.0.1:28765/v1" });
 
-        var events = new List<string>();
+        var events = new SynchronizedEventLog();
         var platform = new FakePlatform();
         platform.Listeners.Add(new WindowsTcpListenerInfo(
             IPAddress.Loopback,
@@ -264,7 +301,7 @@ public sealed class LocalAiPortLifecycleTests
         LocalAiResolvedInstall install = (await store.LoadAsync())!;
         await store.SaveAsync(install.Manifest with { Endpoint = "http://127.0.0.1:28765/v1" });
 
-        var events = new List<string>();
+        var events = new SynchronizedEventLog();
         var platform = new FakePlatform();
         platform.Listeners.Add(new WindowsTcpListenerInfo(
             IPAddress.Loopback,
@@ -306,7 +343,7 @@ public sealed class LocalAiPortLifecycleTests
         LocalAiResolvedInstall install = (await store.LoadAsync())!;
         await store.SaveAsync(install.Manifest with { Endpoint = "http://127.0.0.1:28765/v1" });
 
-        var events = new List<string>();
+        var events = new SynchronizedEventLog();
         var platform = new FakePlatform();
         platform.Listeners.Add(new WindowsTcpListenerInfo(
             IPAddress.Loopback,
@@ -353,7 +390,7 @@ public sealed class LocalAiPortLifecycleTests
         LocalAiResolvedInstall install = (await store.LoadAsync())!;
         await store.SaveAsync(install.Manifest with { Endpoint = "http://127.0.0.1:28765/v1" });
 
-        var events = new List<string>();
+        var events = new SynchronizedEventLog();
         var platform = new FakePlatform();
         var host = new FakeProcessHost(platform, events, selectedPort: 28_765) { SuppressListener = true };
         var client = new FakeClient(events);
@@ -382,7 +419,7 @@ public sealed class LocalAiPortLifecycleTests
         LocalAiResolvedInstall install = (await store.LoadAsync())!;
         await store.SaveAsync(install.Manifest with { Endpoint = "http://127.0.0.1:28765/v1" });
 
-        var events = new List<string>();
+        var events = new SynchronizedEventLog();
         var platform = new FakePlatform();
         var host = new FakeProcessHost(platform, events, selectedPort: 28_765) { ThrowOnStart = true };
         await using var runtime = CreateRuntime(
@@ -414,7 +451,7 @@ public sealed class LocalAiPortLifecycleTests
         LocalAiResolvedInstall install = (await store.LoadAsync())!;
         await store.SaveAsync(install.Manifest with { Endpoint = "http://127.0.0.1:28765/v1" });
 
-        var events = new List<string>();
+        var events = new SynchronizedEventLog();
         var platform = new FakePlatform();
         var host = new FakeProcessHost(platform, events, selectedPort: 28_765);
         await using var runtime = CreateRuntime(
@@ -430,21 +467,17 @@ public sealed class LocalAiPortLifecycleTests
         Assert.Equal(LocalAiRuntimeState.Healthy, started.State);
         int settled = events.Count;
 
-        host.Process!.MarkExited();
-        host.LastExitCallback!(new LocalAiManagedProcessExit(
-            host.Process.ProcessId,
-            host.Process.StartedAtUtc,
-            1));
-        await WaitForRestartSettledAsync(events, settled);
+        await TriggerExitAndWaitForStateAsync(
+            runtime,
+            host,
+            snapshot => snapshot.State == LocalAiRuntimeState.Healthy);
+        LocalAiRuntimeSnapshot exhausted = await TriggerExitAndWaitForStateAsync(
+            runtime,
+            host,
+            snapshot => snapshot.State == LocalAiRuntimeState.Failed &&
+                snapshot.Detail?.Contains("exited unexpectedly", StringComparison.Ordinal) == true);
 
-        host.Process!.MarkExited();
-        host.LastExitCallback!(new LocalAiManagedProcessExit(
-            host.Process.ProcessId,
-            host.Process.StartedAtUtc,
-            1));
-        await WaitForEventAsync(events, "quiesce:Teardown", settled);
-
-        Assert.Equal(LocalAiRuntimeState.Failed, runtime.Snapshot.State);
+        Assert.Equal(LocalAiRuntimeState.Failed, exhausted.State);
         Assert.Equal(
             [
                 "quiesce:EndpointCycle",
@@ -462,7 +495,7 @@ public sealed class LocalAiPortLifecycleTests
     {
         using var temp = new TempDirectory("local-ai-port-");
         LocalAiPaths paths = await PrepareInstallAsync(temp);
-        var events = new List<string>();
+        var events = new SynchronizedEventLog();
         var platform = new FakePlatform();
         var lifecycle = new FakeLifecycle(events)
         {
@@ -483,51 +516,46 @@ public sealed class LocalAiPortLifecycleTests
         Assert.Equal(LocalAiRuntimeState.Healthy, started.State);
         int settled = events.Count;
 
-        host.Process!.MarkExited();
-        host.LastExitCallback!(new LocalAiManagedProcessExit(
-            host.Process.ProcessId,
-            host.Process.StartedAtUtc,
-            1));
-        await WaitForEventAsync(events, "quiesce:Teardown", settled);
+        LocalAiRuntimeSnapshot failed = await TriggerExitAndWaitForStateAsync(
+            runtime,
+            host,
+            snapshot => snapshot.State == LocalAiRuntimeState.Failed &&
+                snapshot.Detail == "automatic endpoint-cycle failed");
 
-        Assert.Equal(LocalAiRuntimeState.Failed, runtime.Snapshot.State);
+        Assert.Equal(LocalAiRuntimeState.Failed, failed.State);
         Assert.Equal(
             ["quiesce:EndpointCycle", "quiesce:Teardown"],
             events.Skip(settled).ToArray());
     }
 
-    /// <summary>
-    /// Waits until the automatic restart scheduled by an unexpected exit has
-    /// either published a fresh endpoint or failed, so the next trigger is not
-    /// racing the previous restart chain.
-    /// </summary>
-    private static async Task WaitForRestartSettledAsync(List<string> events, int settledCount)
+    private static async Task<LocalAiRuntimeSnapshot> TriggerExitAndWaitForStateAsync(
+        LlamaServerRuntimeService runtime,
+        FakeProcessHost host,
+        Func<LocalAiRuntimeSnapshot, bool> predicate)
     {
-        DateTimeOffset deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(10);
-        while (DateTimeOffset.UtcNow < deadline)
+        var completion = new TaskCompletionSource<LocalAiRuntimeSnapshot>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        void OnStateChanged(object? sender, LocalAiRuntimeSnapshotChangedEventArgs args)
         {
-            string[] current = [.. events.Skip(settledCount)];
-            if (current.Contains("publish:28765") && current.LastOrDefault() == "publish:28765")
-                return;
-            await Task.Delay(10);
+            if (predicate(args.Snapshot))
+                completion.TrySetResult(args.Snapshot);
         }
-        Assert.Fail(
-            "Timed out waiting for the restart to settle; saw " +
-            $"[{string.Join(", ", events.Skip(settledCount))}].");
-    }
 
-    private static async Task WaitForEventAsync(List<string> events, string expected, int settledCount)
-    {
-        DateTimeOffset deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(10);
-        while (DateTimeOffset.UtcNow < deadline)
+        runtime.StateChanged += OnStateChanged;
+        try
         {
-            if (events.Skip(settledCount).Contains(expected))
-                return;
-            await Task.Delay(10);
+            FakeProcess process = host.Process!;
+            process.MarkExited();
+            host.LastExitCallback!(new LocalAiManagedProcessExit(
+                process.ProcessId,
+                process.StartedAtUtc,
+                1));
+            return await completion.Task.WaitAsync(TimeSpan.FromSeconds(10));
         }
-        Assert.Fail(
-            $"Timed out waiting for {expected}; saw " +
-            $"[{string.Join(", ", events.Skip(settledCount))}].");
+        finally
+        {
+            runtime.StateChanged -= OnStateChanged;
+        }
     }
 
     [Fact]
@@ -541,7 +569,7 @@ public sealed class LocalAiPortLifecycleTests
         LocalAiResolvedInstall install = (await store.LoadAsync())!;
         await store.SaveAsync(install.Manifest with { Endpoint = "http://127.0.0.1:28765/v1" });
 
-        var events = new List<string>();
+        var events = new SynchronizedEventLog();
         using var cancellation = new CancellationTokenSource();
         var platform = new FakePlatform
         {
@@ -575,7 +603,7 @@ public sealed class LocalAiPortLifecycleTests
         LocalAiResolvedInstall install = (await store.LoadAsync())!;
         await store.SaveAsync(install.Manifest with { Endpoint = "http://127.0.0.1:28765/v1" });
 
-        var events = new List<string>();
+        var events = new SynchronizedEventLog();
         using var cancellation = new CancellationTokenSource();
         var platform = new FakePlatform
         {
@@ -603,7 +631,7 @@ public sealed class LocalAiPortLifecycleTests
     {
         using var temp = new TempDirectory("local-ai-port-");
         LocalAiPaths paths = await PrepareInstallAsync(temp);
-        var events = new List<string>();
+        var events = new SynchronizedEventLog();
         var platform = new FakePlatform();
         var host = new FakeProcessHost(platform, events, selectedPort: 28_765)
         {
@@ -644,7 +672,7 @@ public sealed class LocalAiPortLifecycleTests
     {
         using var temp = new TempDirectory("local-ai-port-");
         LocalAiPaths paths = await PrepareInstallAsync(temp);
-        var events = new List<string>();
+        var events = new SynchronizedEventLog();
         var platform = new FakePlatform();
         var host = new FakeProcessHost(platform, events, selectedPort: 28_774);
         var client = new FakeClient(events, (expectedModelPath, _) => new(
@@ -675,7 +703,7 @@ public sealed class LocalAiPortLifecycleTests
     {
         using var temp = new TempDirectory("local-ai-port-");
         LocalAiPaths paths = await PrepareInstallAsync(temp);
-        var events = new List<string>();
+        var events = new SynchronizedEventLog();
         var platform = new FakePlatform();
         var host = new FakeProcessHost(platform, events, selectedPort: 28_773);
         var client = new FakeClient(events, (expectedModelPath, probeNumber) => probeNumber == 2
@@ -713,16 +741,18 @@ public sealed class LocalAiPortLifecycleTests
     }
 
     [Theory]
-    [InlineData(RefreshOwnershipLoss.Incomplete, LocalAiRuntimeState.Conflict)]
-    [InlineData(RefreshOwnershipLoss.Conflict, LocalAiRuntimeState.Conflict)]
-    [InlineData(RefreshOwnershipLoss.MissingEndpoint, LocalAiRuntimeState.Starting)]
+    [InlineData(RefreshOwnershipLoss.Incomplete, LocalAiRuntimeState.Conflict, LocalAiQuiesceReason.Teardown, true)]
+    [InlineData(RefreshOwnershipLoss.Conflict, LocalAiRuntimeState.Conflict, LocalAiQuiesceReason.Teardown, true)]
+    [InlineData(RefreshOwnershipLoss.MissingEndpoint, LocalAiRuntimeState.Starting, LocalAiQuiesceReason.EndpointCycle, false)]
     public async Task Refresh_QuiescesPublishedRouteWhenEndpointOwnershipIsLost(
         RefreshOwnershipLoss ownershipLoss,
-        LocalAiRuntimeState expectedState)
+        LocalAiRuntimeState expectedState,
+        LocalAiQuiesceReason expectedReason,
+        bool expectedExited)
     {
         using var temp = new TempDirectory("local-ai-port-");
         LocalAiPaths paths = await PrepareInstallAsync(temp);
-        var events = new List<string>();
+        var events = new SynchronizedEventLog();
         var platform = new FakePlatform();
         var host = new FakeProcessHost(platform, events, selectedPort: 28_775);
         await using var runtime = CreateRuntime(
@@ -753,8 +783,164 @@ public sealed class LocalAiPortLifecycleTests
         LocalAiRuntimeSnapshot refreshed = await runtime.RefreshAsync();
 
         Assert.Equal(expectedState, refreshed.State);
-        Assert.Equal(["quiesce:EndpointCycle"], events);
-        Assert.False(host.Process!.HasExited);
+        Assert.Equal(
+            expectedExited
+                ? [$"quiesce:{expectedReason}", "stop"]
+                : [$"quiesce:{expectedReason}"],
+            events);
+        Assert.Equal(expectedExited, host.Process!.HasExited);
+    }
+
+    [Fact]
+    public async Task Startup_TeardownFailureAfterExitedChildPublishesFailedCleanupState()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var events = new SynchronizedEventLog();
+        var platform = new FakePlatform();
+        var lifecycle = new FakeLifecycle(events)
+        {
+            QuiesceHandler = (call, _, _) => Task.FromResult(
+                call == 1
+                    ? LocalAiEndpointLifecycleResult.Ok()
+                    : LocalAiEndpointLifecycleResult.Failed("terminal teardown failed")),
+        };
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_780)
+        {
+            ImmediateExit = true,
+        };
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            lifecycle);
+
+        LocalAiRuntimeSnapshot failed = await runtime.EnsureStartedAsync();
+
+        Assert.Equal(LocalAiRuntimeState.Failed, failed.State);
+        Assert.Equal(LocalAiOwnership.None, failed.Ownership);
+        Assert.Null(failed.ProcessId);
+        Assert.Contains("could not be safely disabled", failed.Detail, StringComparison.Ordinal);
+        Assert.Equal(
+            ["quiesce:EndpointCycle", "start", "quiesce:Teardown", "stop"],
+            events);
+    }
+
+    [Fact]
+    public async Task Startup_CancellationTeardownFailureAfterExitedChildDoesNotPublishStopped()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        using var cancellation = new CancellationTokenSource();
+        var events = new SynchronizedEventLog();
+        FakeProcessHost? host = null;
+        var platform = new FakePlatform
+        {
+            AfterDelay = () =>
+            {
+                host!.Process!.MarkExited();
+                cancellation.Cancel();
+            },
+        };
+        var lifecycle = new FakeLifecycle(events)
+        {
+            QuiesceHandler = (call, _, _) => Task.FromResult(
+                call == 1
+                    ? LocalAiEndpointLifecycleResult.Ok()
+                    : LocalAiEndpointLifecycleResult.Failed("terminal teardown failed")),
+        };
+        host = new FakeProcessHost(platform, events, selectedPort: 28_782)
+        {
+            SuppressListener = true,
+        };
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            lifecycle);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => runtime.EnsureStartedAsync(cancellation.Token));
+
+        Assert.Equal(LocalAiRuntimeState.Failed, runtime.Snapshot.State);
+        Assert.Equal(LocalAiOwnership.None, runtime.Snapshot.Ownership);
+        Assert.Contains("could not be safely disabled", runtime.Snapshot.Detail, StringComparison.Ordinal);
+        Assert.Equal(
+            ["quiesce:EndpointCycle", "start", "quiesce:Teardown", "stop"],
+            events);
+    }
+
+    [Fact]
+    public async Task Startup_EndpointCycleExceptionPublishesFailedState()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var events = new SynchronizedEventLog();
+        var lifecycle = new FakeLifecycle(events)
+        {
+            QuiesceHandler = (call, _, _) => call == 1
+                ? Task.FromException<LocalAiEndpointLifecycleResult>(
+                    new IOException("endpoint-cycle withdrawal failed"))
+                : Task.FromResult(LocalAiEndpointLifecycleResult.Ok()),
+        };
+        var platform = new FakePlatform();
+        await using var runtime = CreateRuntime(
+            paths,
+            new FakeProcessHost(platform, events, selectedPort: 28_783),
+            platform,
+            new FakeClient(events),
+            lifecycle);
+
+        LocalAiRuntimeSnapshot failed = await runtime.EnsureStartedAsync();
+
+        Assert.Equal(LocalAiRuntimeState.Failed, failed.State);
+        Assert.Equal(LocalAiOwnership.None, failed.Ownership);
+        Assert.Equal("endpoint-cycle withdrawal failed", failed.Detail);
+        Assert.Equal(["quiesce:EndpointCycle", "quiesce:Teardown"], events);
+    }
+
+    [Fact]
+    public async Task Startup_PreservedListenerRemainsSupervisedAfterTeardownFailure()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var events = new SynchronizedEventLog();
+        var platform = new FakePlatform();
+        var lifecycle = new FakeLifecycle(events)
+        {
+            QuiesceHandler = (call, _, _) => Task.FromResult(
+                call == 2
+                    ? LocalAiEndpointLifecycleResult.Failed("terminal teardown failed")
+                    : LocalAiEndpointLifecycleResult.Ok()),
+        };
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_781)
+        {
+            SuppressListener = true,
+        };
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            lifecycle,
+            startupTimeout: TimeSpan.FromMilliseconds(2),
+            maxRestartAttempts: 0);
+
+        LocalAiRuntimeSnapshot startupFailure = await runtime.EnsureStartedAsync();
+        Assert.Equal(LocalAiOwnership.CompanionManaged, startupFailure.Ownership);
+
+        LocalAiRuntimeSnapshot exitFailure = await TriggerExitAndWaitForStateAsync(
+            runtime,
+            host,
+            snapshot => snapshot.State == LocalAiRuntimeState.Failed &&
+                snapshot.Detail?.Contains("exited unexpectedly", StringComparison.Ordinal) == true);
+
+        Assert.Equal(LocalAiOwnership.None, exitFailure.Ownership);
+        Assert.Equal(
+            ["quiesce:EndpointCycle", "start", "quiesce:Teardown", "quiesce:Teardown"],
+            events);
     }
 
     [Fact]
@@ -762,7 +948,7 @@ public sealed class LocalAiPortLifecycleTests
     {
         using var temp = new TempDirectory("local-ai-port-");
         LocalAiPaths paths = await PrepareInstallAsync(temp);
-        var events = new List<string>();
+        var events = new SynchronizedEventLog();
         var platform = new FakePlatform();
         var host = new FakeProcessHost(platform, events, selectedPort: 28_776);
         var client = new FakeClient(events, (expectedModelPath, probeNumber) => probeNumber == 1
@@ -795,7 +981,7 @@ public sealed class LocalAiPortLifecycleTests
     {
         using var temp = new TempDirectory("local-ai-port-");
         LocalAiPaths paths = await PrepareInstallAsync(temp);
-        var events = new List<string>();
+        var events = new SynchronizedEventLog();
         var platform = new FakePlatform();
         var host = new FakeProcessHost(platform, events, selectedPort: 28_776);
         var client = new FakeClient(events, (expectedModelPath, probeNumber) => probeNumber == 1
@@ -833,7 +1019,7 @@ public sealed class LocalAiPortLifecycleTests
     {
         using var temp = new TempDirectory("local-ai-port-");
         LocalAiPaths paths = await PrepareInstallAsync(temp);
-        var events = new List<string>();
+        var events = new SynchronizedEventLog();
         var platform = new FakePlatform();
         var host = new FakeProcessHost(platform, events, selectedPort: 28_779);
         var lifecycle = new FakeLifecycle(events);
@@ -866,7 +1052,7 @@ public sealed class LocalAiPortLifecycleTests
     {
         using var temp = new TempDirectory("local-ai-port-");
         LocalAiPaths paths = await PrepareInstallAsync(temp);
-        var events = new List<string>();
+        var events = new SynchronizedEventLog();
         var platform = new FakePlatform();
         var host = new FakeProcessHost(platform, events, selectedPort: 28_777);
         var client = new FakeClient(events, (expectedModelPath, probeNumber) => probeNumber == 2
@@ -902,7 +1088,7 @@ public sealed class LocalAiPortLifecycleTests
     {
         using var temp = new TempDirectory("local-ai-port-");
         LocalAiPaths paths = await PrepareInstallAsync(temp);
-        var events = new List<string>();
+        var events = new SynchronizedEventLog();
         var platform = new FakePlatform();
         var host = new FakeProcessHost(platform, events, selectedPort: 28_778);
         var client = new FakeClient(events, (expectedModelPath, probeNumber) => probeNumber == 2
@@ -970,7 +1156,7 @@ public sealed class LocalAiPortLifecycleTests
             RequestedPort = fixedPort,
             Endpoint = $"http://127.0.0.1:{fixedPort}/v1",
         });
-        var events = new List<string>();
+        var events = new SynchronizedEventLog();
         var platform = new FakePlatform();
         platform.Listeners.Add(new WindowsTcpListenerInfo(
             IPAddress.Loopback,
@@ -997,7 +1183,7 @@ public sealed class LocalAiPortLifecycleTests
         LocalAiPaths paths = await PrepareInstallAsync(temp);
         LocalAiResolvedInstall install = (await new LocalAiManifestStore(paths).LoadAsync())!;
         File.Delete(install.ExecutablePath);
-        var events = new List<string>();
+        var events = new SynchronizedEventLog();
         var platform = new FakePlatform();
         var host = new FakeProcessHost(platform, events, selectedPort: 28_772);
         await using var runtime = CreateRuntime(
@@ -1019,7 +1205,7 @@ public sealed class LocalAiPortLifecycleTests
     {
         using var temp = new TempDirectory("local-ai-port-");
         LocalAiPaths paths = await PrepareInstallAsync(temp);
-        var events = new List<string>();
+        var events = new SynchronizedEventLog();
         var platform = new FakePlatform();
         var host = new FakeProcessHost(
             platform,
@@ -1048,7 +1234,7 @@ public sealed class LocalAiPortLifecycleTests
     {
         using var temp = new TempDirectory("local-ai-port-");
         LocalAiPaths paths = await PrepareInstallAsync(temp);
-        var events = new List<string>();
+        var events = new SynchronizedEventLog();
         var platform = new FakePlatform();
         var host = new FakeProcessHost(platform, events, selectedPort: 28_769);
         await using var runtime = CreateRuntime(
@@ -1071,7 +1257,7 @@ public sealed class LocalAiPortLifecycleTests
     {
         using var temp = new TempDirectory("local-ai-port-");
         LocalAiPaths paths = await PrepareInstallAsync(temp);
-        var events = new List<string>();
+        var events = new SynchronizedEventLog();
         var platform = new FakePlatform();
         var host = new FakeProcessHost(platform, events, selectedPort: 28_769);
         await using var runtime = CreateRuntime(
@@ -1101,11 +1287,145 @@ public sealed class LocalAiPortLifecycleTests
     }
 
     [Fact]
+    public async Task RestartAsync_InitialEndpointCycleExceptionCompletesTeardownBeforeStopping()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var events = new SynchronizedEventLog();
+        var platform = new FakePlatform();
+        var lifecycle = new FakeLifecycle(events)
+        {
+            QuiesceHandler = (call, _, _) => call == 2
+                ? Task.FromException<LocalAiEndpointLifecycleResult>(
+                    new IOException("restart withdrawal failed"))
+                : Task.FromResult(LocalAiEndpointLifecycleResult.Ok()),
+        };
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_769);
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            lifecycle);
+        LocalAiRuntimeSnapshot started = await runtime.EnsureStartedAsync();
+        Assert.Equal(LocalAiRuntimeState.Healthy, started.State);
+        events.Clear();
+
+        IOException error = await Assert.ThrowsAsync<IOException>(() => runtime.RestartAsync());
+
+        Assert.Equal("restart withdrawal failed", error.Message);
+        Assert.Equal(LocalAiRuntimeState.Failed, runtime.Snapshot.State);
+        Assert.Equal(LocalAiOwnership.None, runtime.Snapshot.Ownership);
+        Assert.True(host.Process!.HasExited);
+        Assert.Equal(["quiesce:EndpointCycle", "quiesce:Teardown", "stop"], events);
+    }
+
+    [Fact]
+    public async Task RestartAsync_FirstOperationExceptionStillCompletesTeardown()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var events = new SynchronizedEventLog();
+        var platform = new FakePlatform();
+        var lifecycle = new FakeLifecycle(events)
+        {
+            QuiesceHandler = (call, _, _) => call == 1
+                ? Task.FromException<LocalAiEndpointLifecycleResult>(
+                    new IOException("restart withdrawal failed"))
+                : Task.FromResult(LocalAiEndpointLifecycleResult.Ok()),
+        };
+        await using var runtime = CreateRuntime(
+            paths,
+            new FakeProcessHost(platform, events, selectedPort: 28_769),
+            platform,
+            new FakeClient(events),
+            lifecycle);
+
+        IOException error = await Assert.ThrowsAsync<IOException>(() => runtime.RestartAsync());
+
+        Assert.Equal("restart withdrawal failed", error.Message);
+        Assert.Equal(LocalAiRuntimeState.Failed, runtime.Snapshot.State);
+        Assert.Equal(["quiesce:EndpointCycle", "quiesce:Teardown"], events);
+    }
+
+    [Fact]
+    public async Task RestartAsync_RepeatedTeardownFailureReportsPreservedListener()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var events = new SynchronizedEventLog();
+        var platform = new FakePlatform();
+        var lifecycle = new FakeLifecycle(events)
+        {
+            QuiesceHandler = (call, _, _) => Task.FromResult(
+                call is 4 or 5
+                    ? LocalAiEndpointLifecycleResult.Failed("terminal teardown failed")
+                    : LocalAiEndpointLifecycleResult.Ok()),
+        };
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_769);
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            lifecycle);
+        LocalAiRuntimeSnapshot started = await runtime.EnsureStartedAsync();
+        Assert.Equal(LocalAiRuntimeState.Healthy, started.State);
+        lifecycle.FailPublish = true;
+        events.Clear();
+
+        LocalAiRuntimeSnapshot failed = await runtime.RestartAsync();
+
+        Assert.Equal(LocalAiRuntimeState.Failed, failed.State);
+        Assert.Equal(LocalAiOwnership.CompanionManaged, failed.Ownership);
+        Assert.Equal(host.Process!.ProcessId, failed.ProcessId);
+        Assert.False(host.Process.HasExited);
+        Assert.Contains("managed listener remains running", failed.Detail, StringComparison.Ordinal);
+        Assert.Equal(
+            [
+                "quiesce:EndpointCycle",
+                "stop",
+                "quiesce:EndpointCycle",
+                "start",
+                "probe:28769",
+                "publish:28769",
+                "quiesce:Teardown",
+                "quiesce:Teardown",
+            ],
+            events);
+    }
+
+    [Fact]
+    public async Task RestartAsync_NotInstalledOutcomeWithdrawsRetainedRoute()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var events = new SynchronizedEventLog();
+        var platform = new FakePlatform();
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_769);
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            new FakeLifecycle(events));
+        LocalAiRuntimeSnapshot started = await runtime.EnsureStartedAsync();
+        Assert.Equal(LocalAiRuntimeState.Healthy, started.State);
+        File.Delete(paths.ManifestPath);
+        events.Clear();
+
+        LocalAiRuntimeSnapshot restarted = await runtime.RestartAsync();
+
+        Assert.Equal(LocalAiRuntimeState.NotInstalled, restarted.State);
+        Assert.Equal(["quiesce:EndpointCycle", "stop", "quiesce:Teardown"], events);
+    }
+
+    [Fact]
     public async Task PublishFailure_StopsChildAndLeavesEndpointConsumerQuiesced()
     {
         using var temp = new TempDirectory("local-ai-port-");
         LocalAiPaths paths = await PrepareInstallAsync(temp);
-        var events = new List<string>();
+        var events = new SynchronizedEventLog();
         var platform = new FakePlatform();
         var host = new FakeProcessHost(platform, events, selectedPort: 28_767);
         var lifecycle = new FakeLifecycle(events) { FailPublish = true };
@@ -1336,6 +1656,41 @@ public sealed class LocalAiPortLifecycleTests
         };
     }
 
+    private sealed class SynchronizedEventLog : IReadOnlyCollection<string>
+    {
+        private readonly Lock _gate = new();
+        private readonly List<string> _events = [];
+
+        public int Count
+        {
+            get
+            {
+                lock (_gate)
+                    return _events.Count;
+            }
+        }
+
+        public void Add(string value)
+        {
+            lock (_gate)
+                _events.Add(value);
+        }
+
+        public void Clear()
+        {
+            lock (_gate)
+                _events.Clear();
+        }
+
+        public IEnumerator<string> GetEnumerator()
+        {
+            lock (_gate)
+                return ((IEnumerable<string>)_events.ToArray()).GetEnumerator();
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
     private sealed class FakePlatform : ILlamaServerRuntimePlatform
     {
         public DateTimeOffset UtcNow { get; private set; } = DateTimeOffset.Parse("2026-08-18T12:00:00Z");
@@ -1367,7 +1722,7 @@ public sealed class LocalAiPortLifecycleTests
 
     private sealed class FakeProcessHost(
         FakePlatform platform,
-        List<string> events,
+        SynchronizedEventLog events,
         int selectedPort,
         TimeSpan? listenerStartOffset = null,
         IPAddress? listenerAddress = null) : ILocalAiManagedProcessHost
@@ -1420,7 +1775,7 @@ public sealed class LocalAiPortLifecycleTests
         int processId,
         DateTimeOffset startedAtUtc,
         FakePlatform platform,
-        List<string> events) : ILocalAiManagedProcess
+        SynchronizedEventLog events) : ILocalAiManagedProcess
     {
         public int ProcessId { get; } = processId;
         public DateTimeOffset StartedAtUtc { get; } = startedAtUtc;
@@ -1444,7 +1799,7 @@ public sealed class LocalAiPortLifecycleTests
     }
 
     private sealed class FakeClient(
-        List<string> events,
+        SynchronizedEventLog events,
         Func<string, int, LlamaServerRouterProbeResult>? probeFactory = null) : ILlamaServerClient
     {
         private int _probeCount;
@@ -1471,7 +1826,7 @@ public sealed class LocalAiPortLifecycleTests
         public void Dispose() { }
     }
 
-    private sealed class FakeLifecycle(List<string> events) : ILocalAiEndpointLifecycle
+    private sealed class FakeLifecycle(SynchronizedEventLog events) : ILocalAiEndpointLifecycle
     {
         public bool FailPublish { get; set; }
         public bool FailQuiesce { get; set; }

--- a/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
+++ b/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
@@ -256,6 +256,95 @@ public sealed class LocalAiPortLifecycleTests
     }
 
     [Fact]
+    public async Task Restart_EndpointCycleFailureRestoresTerminalRouting()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var store = new LocalAiManifestStore(paths);
+        LocalAiResolvedInstall install = (await store.LoadAsync())!;
+        await store.SaveAsync(install.Manifest with { Endpoint = "http://127.0.0.1:28765/v1" });
+
+        var events = new List<string>();
+        var platform = new FakePlatform();
+        platform.Listeners.Add(new WindowsTcpListenerInfo(
+            IPAddress.Loopback,
+            28_765,
+            9001,
+            "other-process",
+            @"C:\other\server.exe",
+            platform.UtcNow.UtcDateTime));
+        var lifecycle = new FakeLifecycle(events)
+        {
+            QuiesceHandler = (call, _, _) => Task.FromResult(
+                call == 1
+                    ? LocalAiEndpointLifecycleResult.Failed("endpoint-cycle verification failed")
+                    : LocalAiEndpointLifecycleResult.Ok()),
+        };
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_771);
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            lifecycle);
+
+        LocalAiRuntimeSnapshot snapshot = await runtime.EnsureStartedAsync();
+
+        Assert.Equal(LocalAiRuntimeState.Failed, snapshot.State);
+        Assert.Equal(
+            ["quiesce:EndpointCycle", "quiesce:Teardown"],
+            events);
+        Assert.Null(host.LastSpec);
+    }
+
+    [Fact]
+    public async Task Restart_EndpointCycleCancellationRestoresTerminalRouting()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var store = new LocalAiManifestStore(paths);
+        LocalAiResolvedInstall install = (await store.LoadAsync())!;
+        await store.SaveAsync(install.Manifest with { Endpoint = "http://127.0.0.1:28765/v1" });
+
+        var events = new List<string>();
+        var platform = new FakePlatform();
+        platform.Listeners.Add(new WindowsTcpListenerInfo(
+            IPAddress.Loopback,
+            28_765,
+            9001,
+            "other-process",
+            @"C:\other\server.exe",
+            platform.UtcNow.UtcDateTime));
+        using var cancellation = new CancellationTokenSource();
+        var lifecycle = new FakeLifecycle(events)
+        {
+            QuiesceHandler = (call, _, _) =>
+            {
+                if (call != 1)
+                    return Task.FromResult(LocalAiEndpointLifecycleResult.Ok());
+                cancellation.Cancel();
+                return Task.FromCanceled<LocalAiEndpointLifecycleResult>(cancellation.Token);
+            },
+        };
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_771);
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            lifecycle);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => runtime.EnsureStartedAsync(cancellation.Token));
+
+        Assert.Equal(LocalAiRuntimeState.Stopped, runtime.Snapshot.State);
+        Assert.Equal(
+            ["quiesce:EndpointCycle", "quiesce:Teardown"],
+            events);
+        Assert.Null(host.LastSpec);
+    }
+
+    [Fact]
     public async Task Restart_WithdrawsRetainedRouteWhenStartupNeverBecomesHealthy()
     {
         // Nothing will answer the retained route, so it must not be left published.
@@ -1234,6 +1323,9 @@ public sealed class LocalAiPortLifecycleTests
         public bool FailPublish { get; set; }
         public bool FailQuiesce { get; set; }
         public Exception? QuiesceException { get; set; }
+        public Func<int, LocalAiQuiesceReason, CancellationToken, Task<LocalAiEndpointLifecycleResult>>?
+            QuiesceHandler { get; set; }
+        private int _quiesceCount;
 
         public Task<LocalAiEndpointLifecycleResult> QuiesceAsync(
             LocalAiResolvedInstall install,
@@ -1241,6 +1333,9 @@ public sealed class LocalAiPortLifecycleTests
             CancellationToken cancellationToken = default)
         {
             events.Add($"quiesce:{reason}");
+            int call = ++_quiesceCount;
+            if (QuiesceHandler is not null)
+                return QuiesceHandler(call, reason, cancellationToken);
             if (QuiesceException is not null)
                 return Task.FromException<LocalAiEndpointLifecycleResult>(QuiesceException);
             return Task.FromResult(FailQuiesce

--- a/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
+++ b/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
@@ -1219,7 +1219,7 @@ public sealed class LocalAiPortLifecycleTests
     }
 
     [Fact]
-    public async Task Refresh_RecoveryPublishFailureRemainsFailedAndQuiesced()
+    public async Task Refresh_RecoveryPublishFailureCompletesTerminalTeardown()
     {
         using var temp = new TempDirectory("local-ai-port-");
         LocalAiPaths paths = await PrepareInstallAsync(temp);
@@ -1245,9 +1245,11 @@ public sealed class LocalAiPortLifecycleTests
         LocalAiRuntimeSnapshot failed = await runtime.RefreshAsync();
 
         Assert.Equal(LocalAiRuntimeState.Failed, failed.State);
-        Assert.Equal(LocalAiOwnership.CompanionManaged, failed.Ownership);
-        Assert.False(host.Process!.HasExited);
-        Assert.Equal(["probe:28778", "publish:28778"], events);
+        Assert.Equal(LocalAiOwnership.None, failed.Ownership);
+        Assert.True(host.Process!.HasExited);
+        Assert.Equal(
+            ["probe:28778", "publish:28778", "quiesce:Teardown", "stop"],
+            events);
     }
 
     [Fact]

--- a/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
+++ b/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
@@ -305,15 +305,25 @@ public sealed class LocalAiPortLifecycleTests
     {
         using var temp = new TempDirectory("local-ai-port-");
         LocalAiPaths paths = await PrepareInstallAsync(temp);
+        using var cancellation = new CancellationTokenSource();
         var events = new SynchronizedEventLog();
         var platform = new FakePlatform();
+        var lifecycle = new FakeLifecycle(events)
+        {
+            QuiesceHandler = (call, _, _) =>
+            {
+                if (call == 2)
+                    cancellation.Cancel();
+                return Task.FromResult(LocalAiEndpointLifecycleResult.Ok());
+            },
+        };
         var host = new FakeProcessHost(platform, events, selectedPort: 28_791);
         await using var runtime = CreateRuntime(
             paths,
             host,
             platform,
             new FakeClient(events),
-            new FakeLifecycle(events),
+            lifecycle,
             shutdownTimeout: TimeSpan.FromMilliseconds(20));
         Assert.Equal(LocalAiRuntimeState.Healthy, (await runtime.EnsureStartedAsync()).State);
         platform.Listeners[0] = platform.Listeners[0] with { Port = 28_792 };
@@ -327,7 +337,6 @@ public sealed class LocalAiPortLifecycleTests
             FileMode.OpenOrCreate,
             FileAccess.ReadWrite,
             FileShare.None);
-        using var cancellation = new CancellationTokenSource(TimeSpan.FromMilliseconds(20));
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
             () => runtime.RefreshAsync(cancellation.Token).WaitAsync(TimeSpan.FromSeconds(2)));

--- a/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
+++ b/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
@@ -1544,6 +1544,11 @@ public sealed class LocalAiPortLifecycleTests
         Assert.Equal(LocalAiOwnership.CompanionManaged, runtime.Snapshot.Ownership);
         int settled = events.Count;
 
+        LocalAiRuntimeSnapshot refreshed = await runtime.RefreshAsync();
+
+        Assert.Equal(LocalAiRuntimeState.Failed, refreshed.State);
+        Assert.Equal(settled, events.Count);
+
         LocalAiRuntimeSnapshot exited = await TriggerExitAndWaitForStateAsync(
             runtime,
             host,

--- a/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
+++ b/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
@@ -1694,6 +1694,32 @@ public sealed class LocalAiPortLifecycleTests
     }
 
     [Fact]
+    public async Task Dispose_ProcessShutdownFailureRetriesAndReleasesProcess()
+    {
+        using var temp = new TempDirectory("local-ai-port-");
+        LocalAiPaths paths = await PrepareInstallAsync(temp);
+        var events = new SynchronizedEventLog();
+        var platform = new FakePlatform();
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_769);
+        var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            new FakeLifecycle(events));
+        LocalAiRuntimeSnapshot started = await runtime.EnsureStartedAsync();
+        Assert.Equal(LocalAiRuntimeState.Healthy, started.State);
+        host.Process!.StopException = new IOException("process shutdown failed");
+        events.Clear();
+
+        await runtime.DisposeAsync();
+
+        Assert.Equal(2, host.Process.StopCount);
+        Assert.Equal(1, host.Process.DisposeCount);
+        Assert.Equal(["quiesce:Teardown", "stop", "stop"], events);
+    }
+
+    [Fact]
     public async Task Stop_FailedWithdrawalLatchesIntentAndPreventsAutomaticRestart()
     {
         using var temp = new TempDirectory("local-ai-port-");
@@ -2440,6 +2466,7 @@ public sealed class LocalAiPortLifecycleTests
         public DateTimeOffset StartedAtUtc { get; } = startedAtUtc;
         public bool HasExited { get; private set; }
         public int StopCount { get; private set; }
+        public int DisposeCount { get; private set; }
         public Action? AfterStop { get; set; }
         public Exception? StopException { get; set; }
 
@@ -2458,7 +2485,11 @@ public sealed class LocalAiPortLifecycleTests
             return Task.CompletedTask;
         }
 
-        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        public ValueTask DisposeAsync()
+        {
+            DisposeCount++;
+            return ValueTask.CompletedTask;
+        }
     }
 
     private sealed class FakeClient(

--- a/tests/OpenClaw.SetupEngine.Tests/LocalAiGatewayUninstallTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/LocalAiGatewayUninstallTests.cs
@@ -11,7 +11,7 @@ namespace OpenClaw.SetupEngine.Tests;
 public sealed class LocalAiGatewayUninstallTests
 {
     [Fact]
-    public async Task Repair_AcceptsCompanionPrimaryRetainedDuringEndpointCycle()
+    public async Task Repair_RollbackRestoresFallbackAfterRetainedEndpointCycle()
     {
         using var temp = new TempDirectory("local-ai-gateway-repair-");
         LocalAiResolvedInstall install = await SaveManifestAsync(temp.Path, "openai/gpt-5");
@@ -30,6 +30,32 @@ public sealed class LocalAiGatewayUninstallTests
         Assert.Equal(managedPrimary, commands.PrimaryJson);
         LocalAiResolvedInstall repaired = (await new LocalAiManifestStore(new LocalAiPaths(temp.Path)).LoadAsync())!;
         Assert.Equal("openai/gpt-5", repaired.Manifest.GatewayFallbackModel);
+
+        await new ConfigureLocalAiGatewayStep().RollbackAsync(context, CancellationToken.None);
+
+        Assert.Null(commands.ProviderJson);
+        Assert.Equal(JsonSerializer.Serialize("openai/gpt-5"), commands.PrimaryJson);
+    }
+
+    [Fact]
+    public async Task Repair_RollbackUnsetsPrimaryAfterRetainedEndpointCycleWithoutFallback()
+    {
+        using var temp = new TempDirectory("local-ai-gateway-repair-");
+        LocalAiResolvedInstall install = await SaveManifestAsync(temp.Path);
+        string managedPrimary = JsonSerializer.Serialize(
+            LocalAiGatewayProviderDefinition.BuildPrimaryModel(install));
+        var commands = new GatewayStateCommandRunner(providerJson: null, managedPrimary);
+        SetupContext context = CreateContext(temp.Path, commands);
+        context.LocalAiResolvedInstall = install;
+        context.LocalAiEligibility = LocalInferenceEligibility.Evaluate(CreateSparkHardware());
+        var step = new ConfigureLocalAiGatewayStep();
+
+        StepResult result = await step.ExecuteAsync(context, CancellationToken.None);
+        await step.RollbackAsync(context, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.Success, result.Outcome);
+        Assert.Null(commands.ProviderJson);
+        Assert.Null(commands.PrimaryJson);
     }
 
     [Fact]
@@ -270,6 +296,19 @@ public sealed class LocalAiGatewayUninstallTests
                 return Task.FromResult(new CommandResult(
                     0,
                     "LOCAL_AI_PRIMARY_RESTORED",
+                    "",
+                    TimeSpan.Zero,
+                    TimedOut: false));
+            }
+            if (command.Contains("LOCAL_AI_GATEWAY_RESTORED", StringComparison.Ordinal))
+            {
+                string encoded = Assert.Single(environment!).Value;
+                string batch = Encoding.UTF8.GetString(Convert.FromBase64String(encoded));
+                using JsonDocument document = JsonDocument.Parse(batch);
+                PrimaryJson = document.RootElement[0].GetProperty("value").GetRawText();
+                return Task.FromResult(new CommandResult(
+                    0,
+                    "LOCAL_AI_GATEWAY_RESTORED",
                     "",
                     TimeSpan.Zero,
                     TimedOut: false));

--- a/tests/OpenClaw.SetupEngine.Tests/LocalAiGatewayUninstallTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/LocalAiGatewayUninstallTests.cs
@@ -1,6 +1,8 @@
 using OpenClaw.Connection.LocalAi;
+using OpenClaw.Shared.Inference;
 using OpenClaw.Shared.Inference.Catalog;
 using OpenClaw.TestSupport;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
 
@@ -8,6 +10,28 @@ namespace OpenClaw.SetupEngine.Tests;
 
 public sealed class LocalAiGatewayUninstallTests
 {
+    [Fact]
+    public async Task Repair_AcceptsCompanionPrimaryRetainedDuringEndpointCycle()
+    {
+        using var temp = new TempDirectory("local-ai-gateway-repair-");
+        LocalAiResolvedInstall install = await SaveManifestAsync(temp.Path, "openai/gpt-5");
+        string managedPrimary = JsonSerializer.Serialize(
+            LocalAiGatewayProviderDefinition.BuildPrimaryModel(install));
+        var commands = new GatewayStateCommandRunner(providerJson: null, managedPrimary);
+        SetupContext context = CreateContext(temp.Path, commands);
+        context.LocalAiResolvedInstall = install;
+        context.LocalAiEligibility = LocalInferenceEligibility.Evaluate(CreateSparkHardware());
+
+        StepResult result = await new ConfigureLocalAiGatewayStep()
+            .ExecuteAsync(context, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.Success, result.Outcome);
+        Assert.Equal(LocalAiGatewayProviderDefinition.BuildProviderJson(install), commands.ProviderJson);
+        Assert.Equal(managedPrimary, commands.PrimaryJson);
+        LocalAiResolvedInstall repaired = (await new LocalAiManifestStore(new LocalAiPaths(temp.Path)).LoadAsync())!;
+        Assert.Equal("openai/gpt-5", repaired.Manifest.GatewayFallbackModel);
+    }
+
     [Fact]
     public async Task FreshProcessUninstall_RemovesExactManagedProviderAndPrimary()
     {
@@ -118,7 +142,7 @@ public sealed class LocalAiGatewayUninstallTests
 
     private static SetupContext CreateContext(string localDataDirectory, ICommandRunner commands)
     {
-        var config = new SetupConfig();
+        var config = new SetupConfig { LocalAi = new LocalAiConfig { Enabled = true } };
         var logger = new SetupLogger(filePath: null);
         return new SetupContext(
             config,
@@ -128,6 +152,22 @@ public sealed class LocalAiGatewayUninstallTests
             CancellationToken.None,
             localDataDir: localDataDirectory);
     }
+
+    private static HostHardwareInfo CreateSparkHardware() => new(
+        Architecture.Arm64,
+        128L * 1024 * 1024 * 1024,
+        100L * 1024 * 1024 * 1024,
+        [
+            new GpuInfo(
+                GpuVendor.Nvidia,
+                "NVIDIA RTX Spark N1X (6144-core Blackwell RTX GPU)",
+                GpuVisibleMemoryBytes: 48L * 1024 * 1024 * 1024,
+                FreeGpuVisibleMemoryBytes: 40L * 1024 * 1024 * 1024,
+                DriverVersion: "616.00",
+                CudaMajorVersion: 13,
+                StableId: "GPU-SPARK"),
+        ],
+        VulkanAvailable: false);
 
     private static async Task<LocalAiResolvedInstall> SaveManifestAsync(
         string localDataDirectory,
@@ -207,6 +247,20 @@ public sealed class LocalAiGatewayUninstallTests
         {
             ct.ThrowIfCancellationRequested();
             WslCalls.Add(command);
+            if (command.Contains("LOCAL_AI_GATEWAY_CONFIGURED", StringComparison.Ordinal))
+            {
+                string encoded = Assert.Single(environment!).Value;
+                string batch = Encoding.UTF8.GetString(Convert.FromBase64String(encoded));
+                using JsonDocument document = JsonDocument.Parse(batch);
+                ProviderJson = document.RootElement[0].GetProperty("value").GetRawText();
+                PrimaryJson = document.RootElement[1].GetProperty("value").GetRawText();
+                return Task.FromResult(new CommandResult(
+                    0,
+                    "LOCAL_AI_GATEWAY_CONFIGURED",
+                    "",
+                    TimeSpan.Zero,
+                    TimedOut: false));
+            }
             if (command.Contains("LOCAL_AI_PRIMARY_RESTORED", StringComparison.Ordinal))
             {
                 string encoded = Assert.Single(environment!).Value;

--- a/tests/OpenClaw.Tray.Tests/LocalAiGatewayProviderCoordinatorTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalAiGatewayProviderCoordinatorTests.cs
@@ -29,6 +29,70 @@ public sealed class LocalAiGatewayProviderCoordinatorTests
     }
 
     [Fact]
+    public async Task Quiesce_EndpointCycleRetainsManagedPrimaryWhenNoFallbackExists()
+    {
+        // Unsetting the primary makes the gateway resolve its built-in OpenAI
+        // default, so a prompt sent mid-cycle fails with an unrelated
+        // provider-auth error instead of a Local AI one.
+        LocalAiResolvedInstall install = Install(28_765);
+        string managedPrimary = LocalAiGatewayProviderDefinition.BuildPrimaryModel(install);
+        var commands = new FakeWslCommandRunner(
+            LocalAiGatewayProviderDefinition.BuildProviderJson(install),
+            managedPrimary);
+        var coordinator = CreateCoordinator(commands);
+
+        LocalAiEndpointLifecycleResult result = await coordinator.QuiesceAsync(
+            install,
+            LocalAiQuiesceReason.EndpointCycle);
+
+        Assert.True(result.Success);
+        Assert.Null(commands.ProviderJson);
+        Assert.Equal(managedPrimary, commands.PrimaryModel);
+        Assert.DoesNotContain(
+            commands.Calls,
+            call => call.Contains("unset") &&
+                    call.Contains(LocalAiGatewayProviderDefinition.PrimaryModelPath));
+    }
+
+    [Fact]
+    public async Task Quiesce_EndpointCycleStillRestoresRealPriorModel()
+    {
+        LocalAiResolvedInstall install = Install(28_770, "openai/gpt-5");
+        var commands = new FakeWslCommandRunner(
+            LocalAiGatewayProviderDefinition.BuildProviderJson(install),
+            LocalAiGatewayProviderDefinition.BuildPrimaryModel(install))
+        {
+            PrimaryAfterApply = "openai/gpt-5",
+        };
+        var coordinator = CreateCoordinator(commands);
+
+        LocalAiEndpointLifecycleResult result = await coordinator.QuiesceAsync(
+            install,
+            LocalAiQuiesceReason.EndpointCycle);
+
+        Assert.True(result.Success);
+        Assert.Equal("openai/gpt-5", commands.PrimaryModel);
+    }
+
+    [Fact]
+    public async Task Publish_AcceptsPrimaryRetainedByAnEndpointCycle()
+    {
+        LocalAiResolvedInstall install = Install(28_765);
+        string managedPrimary = LocalAiGatewayProviderDefinition.BuildPrimaryModel(install);
+        var commands = new FakeWslCommandRunner(providerJson: null, primaryModel: managedPrimary)
+        {
+            ProviderAfterApply = LocalAiGatewayProviderDefinition.BuildProviderJson(install),
+            PrimaryAfterApply = managedPrimary,
+        };
+        var coordinator = CreateCoordinator(commands);
+
+        LocalAiEndpointLifecycleResult result = await coordinator.PublishAsync(install);
+
+        Assert.True(result.Success);
+        Assert.Equal(managedPrimary, commands.PrimaryModel);
+    }
+
+    [Fact]
     public async Task Quiesce_AcceptsCliRedactedManagedApiKey()
     {
         LocalAiResolvedInstall install = Install(28_765);

--- a/tests/OpenClaw.Tray.Tests/LocalAiGatewayProviderCoordinatorTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalAiGatewayProviderCoordinatorTests.cs
@@ -31,9 +31,6 @@ public sealed class LocalAiGatewayProviderCoordinatorTests
     [Fact]
     public async Task Quiesce_EndpointCycleRetainsManagedPrimaryWhenNoFallbackExists()
     {
-        // Unsetting the primary makes the gateway resolve its built-in OpenAI
-        // default, so a prompt sent mid-cycle fails with an unrelated
-        // provider-auth error instead of a Local AI one.
         LocalAiResolvedInstall install = Install(28_765);
         string managedPrimary = LocalAiGatewayProviderDefinition.BuildPrimaryModel(install);
         var commands = new FakeWslCommandRunner(

--- a/tests/OpenClaw.Tray.Tests/LocalAiGatewayProviderCoordinatorTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalAiGatewayProviderCoordinatorTests.cs
@@ -55,6 +55,36 @@ public sealed class LocalAiGatewayProviderCoordinatorTests
     }
 
     [Fact]
+    public async Task Quiesce_FailedEndpointCycleCanBeCompletedAsTeardown()
+    {
+        LocalAiResolvedInstall install = Install(28_765);
+        string managedPrimary = LocalAiGatewayProviderDefinition.BuildPrimaryModel(install);
+        var commands = new FakeWslCommandRunner(
+            LocalAiGatewayProviderDefinition.BuildProviderJson(install),
+            managedPrimary)
+        {
+            FailedReadCalls = [2],
+        };
+        var coordinator = CreateCoordinator(commands);
+
+        LocalAiEndpointLifecycleResult interrupted = await coordinator.QuiesceAsync(
+            install,
+            LocalAiQuiesceReason.EndpointCycle);
+
+        Assert.False(interrupted.Success);
+        Assert.Null(commands.ProviderJson);
+        Assert.Equal(managedPrimary, commands.PrimaryModel);
+
+        LocalAiEndpointLifecycleResult teardown = await coordinator.QuiesceAsync(
+            install,
+            LocalAiQuiesceReason.Teardown);
+
+        Assert.True(teardown.Success);
+        Assert.Null(commands.ProviderJson);
+        Assert.Null(commands.PrimaryModel);
+    }
+
+    [Fact]
     public async Task Quiesce_EndpointCycleStillRestoresRealPriorModel()
     {
         LocalAiResolvedInstall install = Install(28_770, "openai/gpt-5");

--- a/tests/OpenClaw.Tray.Tests/LocalAiGatewayProviderCoordinatorTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalAiGatewayProviderCoordinatorTests.cs
@@ -85,7 +85,26 @@ public sealed class LocalAiGatewayProviderCoordinatorTests
     }
 
     [Fact]
-    public async Task Quiesce_EndpointCycleStillRestoresRealPriorModel()
+    public async Task Quiesce_EndpointCycleRetainsManagedPrimaryWhenFallbackExists()
+    {
+        LocalAiResolvedInstall install = Install(28_770, "openai/gpt-5");
+        string managedPrimary = LocalAiGatewayProviderDefinition.BuildPrimaryModel(install);
+        var commands = new FakeWslCommandRunner(
+            LocalAiGatewayProviderDefinition.BuildProviderJson(install),
+            managedPrimary);
+        var coordinator = CreateCoordinator(commands);
+
+        LocalAiEndpointLifecycleResult result = await coordinator.QuiesceAsync(
+            install,
+            LocalAiQuiesceReason.EndpointCycle);
+
+        Assert.True(result.Success);
+        Assert.Null(commands.ProviderJson);
+        Assert.Equal(managedPrimary, commands.PrimaryModel);
+    }
+
+    [Fact]
+    public async Task Quiesce_TeardownRestoresRealPriorModel()
     {
         LocalAiResolvedInstall install = Install(28_770, "openai/gpt-5");
         var commands = new FakeWslCommandRunner(
@@ -98,9 +117,10 @@ public sealed class LocalAiGatewayProviderCoordinatorTests
 
         LocalAiEndpointLifecycleResult result = await coordinator.QuiesceAsync(
             install,
-            LocalAiQuiesceReason.EndpointCycle);
+            LocalAiQuiesceReason.Teardown);
 
         Assert.True(result.Success);
+        Assert.Null(commands.ProviderJson);
         Assert.Equal("openai/gpt-5", commands.PrimaryModel);
     }
 
@@ -108,6 +128,24 @@ public sealed class LocalAiGatewayProviderCoordinatorTests
     public async Task Publish_AcceptsPrimaryRetainedByAnEndpointCycle()
     {
         LocalAiResolvedInstall install = Install(28_765);
+        string managedPrimary = LocalAiGatewayProviderDefinition.BuildPrimaryModel(install);
+        var commands = new FakeWslCommandRunner(providerJson: null, primaryModel: managedPrimary)
+        {
+            ProviderAfterApply = LocalAiGatewayProviderDefinition.BuildProviderJson(install),
+            PrimaryAfterApply = managedPrimary,
+        };
+        var coordinator = CreateCoordinator(commands);
+
+        LocalAiEndpointLifecycleResult result = await coordinator.PublishAsync(install);
+
+        Assert.True(result.Success);
+        Assert.Equal(managedPrimary, commands.PrimaryModel);
+    }
+
+    [Fact]
+    public async Task Publish_AcceptsPrimaryRetainedByEndpointCycleWithFallback()
+    {
+        LocalAiResolvedInstall install = Install(28_765, "openai/gpt-5");
         string managedPrimary = LocalAiGatewayProviderDefinition.BuildPrimaryModel(install);
         var commands = new FakeWslCommandRunner(providerJson: null, primaryModel: managedPrimary)
         {

--- a/tests/OpenClaw.Tray.Tests/Presentation/LocalAiPageViewModelTests.cs
+++ b/tests/OpenClaw.Tray.Tests/Presentation/LocalAiPageViewModelTests.cs
@@ -174,6 +174,7 @@ public sealed class LocalAiPageViewModelTests
 
         await ActivateAndWaitForAvailabilityAsync(viewModel);
 
+        Assert.Equal(ownership == LocalAiOwnership.None, viewModel.CanStart);
         Assert.True(viewModel.CanStop);
         Assert.True(await viewModel.StopAsync());
         Assert.Equal(1, runtime.StopCount);

--- a/tests/OpenClaw.Tray.Tests/Presentation/LocalAiPageViewModelTests.cs
+++ b/tests/OpenClaw.Tray.Tests/Presentation/LocalAiPageViewModelTests.cs
@@ -112,6 +112,38 @@ public sealed class LocalAiPageViewModelTests
     }
 
     [Fact]
+    public async Task FailClosedConflict_AllowsExplicitStopRecovery()
+    {
+        LocalAiRuntimeSnapshot conflict = CreateInstalledSnapshot(LocalAiRuntimeState.Conflict) with
+        {
+            Ownership = LocalAiOwnership.None,
+            ProcessId = null,
+            ProcessStartedAtUtc = null,
+        };
+        var runtime = new FakeLocalAiRuntime(conflict)
+        {
+            StopResult = conflict with
+            {
+                State = LocalAiRuntimeState.Stopped,
+                Ownership = LocalAiOwnership.None,
+            },
+        };
+        using var gatewaySource = new PermissionsPageRuntimeSource(new FakePermissionsPageRuntimeHost());
+        using var viewModel = new LocalAiPageViewModel(
+            runtime,
+            gatewaySource,
+            new FakeAppCommands(),
+            new RecordingUiDispatcher(),
+            new FixedHardwareProbe(HostHardwareInfo.Unknown));
+
+        await ActivateAndWaitForAvailabilityAsync(viewModel);
+
+        Assert.True(viewModel.CanStop);
+        Assert.True(await viewModel.StopAsync());
+        Assert.Equal(1, runtime.StopCount);
+    }
+
+    [Fact]
     public async Task UnsupportedHardware_BlocksFreshSetupRetry()
     {
         var runtime = new FakeLocalAiRuntime(LocalAiRuntimeSnapshot.Initial(
@@ -838,6 +870,7 @@ public sealed class LocalAiPageViewModelTests
         public int StartCount { get; private set; }
         public int StopCount { get; private set; }
         public int RestartCount { get; private set; }
+        public LocalAiRuntimeSnapshot? StopResult { get; init; }
         public event EventHandler<LocalAiRuntimeSnapshotChangedEventArgs>? StateChanged
         {
             add { }
@@ -860,6 +893,7 @@ public sealed class LocalAiPageViewModelTests
         public Task<LocalAiRuntimeSnapshot> StopAsync(CancellationToken cancellationToken = default)
         {
             StopCount++;
+            Snapshot = StopResult ?? Snapshot;
             return Task.FromResult(Snapshot);
         }
 

--- a/tests/OpenClaw.Tray.Tests/Presentation/LocalAiPageViewModelTests.cs
+++ b/tests/OpenClaw.Tray.Tests/Presentation/LocalAiPageViewModelTests.cs
@@ -117,6 +117,7 @@ public sealed class LocalAiPageViewModelTests
         LocalAiRuntimeSnapshot conflict = CreateInstalledSnapshot(LocalAiRuntimeState.Conflict) with
         {
             Ownership = LocalAiOwnership.None,
+            ModelEvidence = LocalAiModelEvidence.Unknown(DateTimeOffset.UtcNow),
             ProcessId = null,
             ProcessStartedAtUtc = null,
         };
@@ -151,6 +152,9 @@ public sealed class LocalAiPageViewModelTests
         LocalAiRuntimeSnapshot failed = CreateInstalledSnapshot(LocalAiRuntimeState.Failed) with
         {
             Ownership = ownership,
+            ModelEvidence = ownership == LocalAiOwnership.None
+                ? LocalAiModelEvidence.Unknown(DateTimeOffset.UtcNow)
+                : CreateInstalledSnapshot().ModelEvidence,
             ProcessId = ownership == LocalAiOwnership.CompanionManaged ? 1234 : null,
             ProcessStartedAtUtc = ownership == LocalAiOwnership.CompanionManaged
                 ? DateTimeOffset.UtcNow
@@ -174,7 +178,7 @@ public sealed class LocalAiPageViewModelTests
 
         await ActivateAndWaitForAvailabilityAsync(viewModel);
 
-        Assert.Equal(ownership == LocalAiOwnership.None, viewModel.CanStart);
+        Assert.False(viewModel.CanStart);
         Assert.True(viewModel.CanStop);
         Assert.True(await viewModel.StopAsync());
         Assert.Equal(1, runtime.StopCount);

--- a/tests/OpenClaw.Tray.Tests/Presentation/LocalAiPageViewModelTests.cs
+++ b/tests/OpenClaw.Tray.Tests/Presentation/LocalAiPageViewModelTests.cs
@@ -143,6 +143,42 @@ public sealed class LocalAiPageViewModelTests
         Assert.Equal(1, runtime.StopCount);
     }
 
+    [Theory]
+    [InlineData(LocalAiOwnership.None)]
+    [InlineData(LocalAiOwnership.CompanionManaged)]
+    public async Task FailedCleanup_AllowsExplicitStopRecovery(LocalAiOwnership ownership)
+    {
+        LocalAiRuntimeSnapshot failed = CreateInstalledSnapshot(LocalAiRuntimeState.Failed) with
+        {
+            Ownership = ownership,
+            ProcessId = ownership == LocalAiOwnership.CompanionManaged ? 1234 : null,
+            ProcessStartedAtUtc = ownership == LocalAiOwnership.CompanionManaged
+                ? DateTimeOffset.UtcNow
+                : null,
+        };
+        var runtime = new FakeLocalAiRuntime(failed)
+        {
+            StopResult = failed with
+            {
+                State = LocalAiRuntimeState.Stopped,
+                Ownership = LocalAiOwnership.None,
+            },
+        };
+        using var gatewaySource = new PermissionsPageRuntimeSource(new FakePermissionsPageRuntimeHost());
+        using var viewModel = new LocalAiPageViewModel(
+            runtime,
+            gatewaySource,
+            new FakeAppCommands(),
+            new RecordingUiDispatcher(),
+            new FixedHardwareProbe(HostHardwareInfo.Unknown));
+
+        await ActivateAndWaitForAvailabilityAsync(viewModel);
+
+        Assert.True(viewModel.CanStop);
+        Assert.True(await viewModel.StopAsync());
+        Assert.Equal(1, runtime.StopCount);
+    }
+
     [Fact]
     public async Task UnsupportedHardware_BlocksFreshSetupRetry()
     {


### PR DESCRIPTION
Supersedes #1321 (fix(local-ai): stop routing to OpenAI while the endpoint restarts).

## What Problem This Solves

Fixes an issue where Local AI-only users could have a prompt routed toward the Gateway's built-in OpenAI default while the managed llama.cpp endpoint was restarting or being rebound.

## Why This Change Was Made

Endpoint cycles now withdraw the `llamacpp` provider while retaining the managed Local AI primary, so requests fail locally instead of falling through to OpenAI. Terminal stop, startup failure, cancellation, retry exhaustion, and disposal paths restore the recorded fallback or unset the managed primary, and process-shutdown failures remain visible and retryable.

Ownership transfer: none. Runtime sequencing remains in `LlamaServerRuntimeService` and `LocalAiEndpointLifecycle`; Gateway route mutation remains in `LocalAiGatewayProviderCoordinator`; setup repair/rollback remains in `LocalAiGatewayConfiguration`; UI action policy remains in `LocalAiPageViewModel`. `App.xaml.cs` is unchanged.

## User Impact

Local AI users keep privacy-safe routing while the endpoint cycles. If restart or cleanup cannot complete, the app reports an actionable failed state and exposes Stop when a managed listener still needs cleanup.

## Evidence

- Endpoint-cycle tests assert `EndpointCycle` retains the managed primary and terminal `Teardown` restores fallback or unsets it.
- Lifecycle stress covers startup failure, cancellation, refresh recovery, explicit restart/stop races, automatic retry exhaustion, unsafe listeners, and process-shutdown failures.
- Setup rollback tests reject restoring a provider-less managed primary.
- Presentation tests expose Stop for production-shaped failed/conflict cleanup states and keep preserved listeners Stop-only.
- Final Codex autoreview and full-branch rubber-duck review reported no actionable findings.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs or instructions
- [x] Tests or validation
- [x] Security hardening
- [ ] Chore or infrastructure

## Scope

- [x] Tray or WinUI UX
- [ ] Windows node capability
- [ ] Local MCP or `winnode`
- [x] Gateway, connection, or pairing
- [x] Setup or onboarding
- [x] Permissions, privacy, or security
- [x] Tests, CI, or docs

## Required proof pools

- `windows-wsl-dgx-blackwell`: validate a real managed Local AI restart and fixed-prompt inference without cloud fallback.
- `windows-wsl-gateway-e2e`: validate Gateway prompt routing while the local provider is temporarily withdrawn.
- `windows-winui-interactive`: validate visible Stop recovery actions for failed/conflict Local AI cleanup states.

## Validation

Exact head: `8d1553395c70fa358c78584dc4b03de2b200b36d`

- `.\build.ps1`: passed.
- `dotnet test .\tests\OpenClaw.Connection.Tests\OpenClaw.Connection.Tests.csproj --no-restore --filter "FullyQualifiedName~LocalAiPortLifecycleTests"`: 79 passed, 0 failed, repeated 3 times.
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore`: 3,991 passed, 32 skipped, 0 failed.
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore`: 2,897 passed, 0 failed.
- `dotnet test .\tests\OpenClaw.Connection.Tests\OpenClaw.Connection.Tests.csproj --no-restore`: 790 passed, 1 skipped, 0 failed.
- `dotnet test .\tests\OpenClaw.SetupEngine.Tests\OpenClaw.SetupEngine.Tests.csproj --no-restore`: 1,136 passed, 0 failed.
- SetupEngine Local AI filter: 7 passed, 0 failed.
- Gateway provider coordinator filter: 25 passed, 0 failed.
- Autoreview: the full branch review found one retained-process state defect; it was fixed. The exact fix commit and final cleanup commit both exited clean with no actionable findings. The full branch exceeds the helper's 180,000-byte single-bundle ceiling, so final review used the helper's split-target guidance.
- Rubber-duck: final full-branch review at `8d155339` reported no actionable findings.

## Real Behavior Proof

- Environment tested: Windows x64 isolated worktree on current `main` (`3ce56b89`).
- PR head or commit tested: `8d1553395c70fa358c78584dc4b03de2b200b36d`.
- Exact steps or command run: the lifecycle suite above, repeated three times, plus full Shared, Tray, Connection, and SetupEngine suites.
- Evidence after fix: all 79 lifecycle tests passed on each run, including deterministic event-order assertions for endpoint-cycle retention, terminal teardown, restart exhaustion with successful and failed cleanup, held-manifest-lock cancellation recovery, and retryable process-shutdown failure.
- Observed result: terminal paths end in teardown-aware state; a retained process is reported as `Failed/CompanionManaged`; exhausted retries do not remain in endpoint-cycle routing state.
- Screenshot or artifact links verified? N/A.
- Not verified or blocked: real Gateway prompt traffic during a GPU-backed llama.cpp restart and current-head interactive WinUI screenshots require the declared capacity-dependent proof pools.

## Security Impact

- New permissions or capabilities? No
- Secrets or tokens handling changed? No
- New or changed network calls? Yes
- Command or tool execution surface changed? No
- Data access scope changed? No
- If any answer is `Yes`, explain the risk and mitigation: Gateway model routing during Local AI endpoint cycles is intentionally changed to retain the managed local primary and prevent unintended fallback toward OpenAI. Terminal cleanup restores the recorded prior route or unsets the managed primary.

## Compatibility and Migration

- Backward compatible? Yes
- Config or environment changes? No
- Migration needed? No
- If yes, list the exact upgrade steps: N/A

## Review Conversations

- [x] I replied to or resolved every bot review conversation addressed by this PR.
- [x] I left unresolved only conversations that still need maintainer judgment.