### PR TITLE
fix(update): suppress verified ordinary extended-stable notices

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -102,6 +102,17 @@ Stable, stable-correction, and alpha tags use the same signed CI release pipelin
   remain as GitVersion history. If the new release is not yet visible through
   the Releases API, cleanup defers until the next alpha publication.
 
+An authenticated Gateway on `extended-stable` may defer an ordinary Windows
+companion update only when the official GitHub release body contains exactly
+one explicit classification marker:
+
+- `<!-- openclaw-update: ordinary -->` permits extended-stable deferral.
+- `<!-- openclaw-update: security-critical -->` keeps the update visible.
+
+Add the applicable marker when reviewing the generated release notes. Missing,
+duplicated, conflicting, or malformed markers are unverified and keep the
+update visible. Release names and prose are not scanned for security keywords.
+
 The validator has no dependency on another repository's release API. Run it
 offline against an explicit current release to preview a decision:
 

--- a/src/OpenClaw.Shared/GatewayUpdateStatus.cs
+++ b/src/OpenClaw.Shared/GatewayUpdateStatus.cs
@@ -1,0 +1,27 @@
+using System.Text.Json;
+
+namespace OpenClaw.Shared;
+
+/// <summary>
+/// The Gateway's authoritative update track for its installed OpenClaw runtime.
+/// </summary>
+public sealed class GatewayUpdateStatus
+{
+    public string? EffectiveChannel { get; init; }
+}
+
+public static class GatewayUpdateStatusParser
+{
+    /// <summary>
+    /// Parses the optional <c>effectiveChannel</c> field from <c>update.status</c>.
+    /// Missing or malformed fields remain unverified so callers can fail open.
+    /// </summary>
+    public static GatewayUpdateStatus Parse(JsonElement payload) => new()
+    {
+        EffectiveChannel = payload.ValueKind == JsonValueKind.Object &&
+                           payload.TryGetProperty("effectiveChannel", out var channel) &&
+                           channel.ValueKind == JsonValueKind.String
+            ? channel.GetString()
+            : null
+    };
+}

--- a/src/OpenClaw.Shared/IOperatorGatewayClient.cs
+++ b/src/OpenClaw.Shared/IOperatorGatewayClient.cs
@@ -138,6 +138,12 @@ public interface IOperatorGatewayClient
     Task<bool> StopChannelAsync(string channelName);
     /// <summary>Fetch the rich channels.status snapshot from the gateway. Mac/web canonical wire method.</summary>
     Task<ChannelsStatusSnapshot?> GetChannelsStatusAsync(bool probe = false, int timeoutMs = 12000);
+    /// <summary>
+    /// Fetches the Gateway's effective update track (<c>update.status</c>).
+    /// Older Gateway client implementations return no status.
+    /// </summary>
+    Task<GatewayUpdateStatus?> GetUpdateStatusAsync(int timeoutMs = 5000) =>
+        Task.FromResult<GatewayUpdateStatus?>(null);
     /// <summary>Log out / unlink a channel (whatsapp, telegram). Sends channels.logout { channel }.</summary>
     Task<bool> LogoutChannelAsync(string channelName, int timeoutMs = 12000);
     /// <summary>Begin a QR linking flow (whatsapp, signal). Sends web.login.start { force, timeoutMs }.</summary>

--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -1878,6 +1878,19 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
         }
     }
 
+    /// <summary>
+    /// Fetches the installed Gateway's effective update channel. RPC failures
+    /// propagate so the companion updater can preserve its fail-open behavior.
+    /// </summary>
+    public async Task<GatewayUpdateStatus?> GetUpdateStatusAsync(int timeoutMs = 5000)
+    {
+        if (!IsConnected)
+            return null;
+
+        var response = await SendWizardRequestAsync("update.status", new { }, timeoutMs);
+        return GatewayUpdateStatusParser.Parse(response);
+    }
+
     /// <summary>Log out / unlink a channel. Sends <c>channels.logout { channel }</c>.</summary>
     public async Task<bool> LogoutChannelAsync(string channelName, int timeoutMs = 12000)
     {

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -636,6 +636,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands, IPer
             AppUpdater,
             _appState,
             _settings,
+            () => _connectionManager?.OperatorClient,
             () => _windowManager?.DialogXamlRoot,
             refreshStatus: UpdateStatusDetailWindow,
             exit: Exit);
@@ -693,19 +694,6 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands, IPer
         // in-progress download/extraction. We still control shutdown
         // explicitly via Application.Exit().
         DispatcherShutdownMode = DispatcherShutdownMode.OnExplicitShutdown;
-
-        // Check for updates before launching. Skip in test instances — no UI dialogs,
-        // no network calls, no startup delay.
-        if (DataDirOverride is null &&
-            Environment.GetEnvironmentVariable("OPENCLAW_SKIP_UPDATE_CHECK") != "1")
-        {
-            var shouldLaunch = await _updateCoordinator.CheckForUpdatesAsync();
-            if (!shouldLaunch)
-            {
-                Exit();
-                return;
-            }
-        }
 
         // Register toast activation handler
         ToastNotificationManagerCompat.OnActivated += OnToastActivated;
@@ -925,6 +913,19 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands, IPer
         _managedLocalAutoRepairMonitor.Start();
 
         InitializeGatewayClient();
+
+        // Resolve the existing connection-manager-owned client before checking
+        // whether its authenticated Gateway channel suppresses an ordinary update.
+        if (DataDirOverride is null &&
+            Environment.GetEnvironmentVariable("OPENCLAW_SKIP_UPDATE_CHECK") != "1")
+        {
+            var shouldLaunch = await _updateCoordinator.CheckForUpdatesAsync();
+            if (!shouldLaunch)
+            {
+                Exit();
+                return;
+            }
+        }
 
         // Pre-warm chat window (WebView2 init takes 1-3s, do it now so left-click is instant)
         if (_settings != null &&

--- a/src/OpenClaw.Tray.WinUI/Services/UpdateCheckPipeline.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/UpdateCheckPipeline.cs
@@ -1,4 +1,5 @@
 using OpenClaw.Shared;
+using OpenClaw.Connection;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -7,6 +8,8 @@ namespace OpenClawTray.Services;
 
 internal sealed record UpdateReleaseCandidate(
     string? TagName,
+    string? Body,
+    bool HasTrustedMetadata,
     bool Draft,
     bool Prerelease,
     bool Published,
@@ -17,12 +20,112 @@ internal interface IUpdateCheckBoundary
 {
     Task<bool> CheckForUpdatesAsync();
 
+    UpdateReleaseCandidate? GetSelectedRelease();
+
     IEnumerable<UpdateReleaseCandidate> GetReleaseCandidates();
 }
 
 internal sealed record UpdateCheckOutcome(
     bool UpdateFound,
+    UpdateReleaseCandidate? SelectedRelease = null,
     string? ActivatedFallbackTag = null);
+
+internal enum ReleaseSecurityClassification
+{
+    Unverified,
+    Ordinary,
+    Security,
+}
+
+internal static class UpdateReleasePolicy
+{
+    internal const string OrdinaryMarker =
+        "<!-- openclaw-update: ordinary -->";
+    internal const string SecurityMarker =
+        "<!-- openclaw-update: security-critical -->";
+
+    public static ReleaseSecurityClassification Classify(
+        UpdateReleaseCandidate? release)
+    {
+        if (release is not { HasTrustedMetadata: true } ||
+            string.IsNullOrWhiteSpace(release.Body))
+        {
+            return ReleaseSecurityClassification.Unverified;
+        }
+
+        var ordinaryMarkerCount = CountMarkers(
+            release.Body,
+            OrdinaryMarker);
+        var securityMarkerCount = CountMarkers(
+            release.Body,
+            SecurityMarker);
+
+        return (ordinaryMarkerCount, securityMarkerCount) switch
+        {
+            (1, 0) => ReleaseSecurityClassification.Ordinary,
+            (0, 1) => ReleaseSecurityClassification.Security,
+            _ => ReleaseSecurityClassification.Unverified,
+        };
+    }
+
+    private static int CountMarkers(string body, string marker)
+    {
+        var count = 0;
+        var startIndex = 0;
+        while ((startIndex = body.IndexOf(
+                   marker,
+                   startIndex,
+                   StringComparison.OrdinalIgnoreCase)) >= 0)
+        {
+            count++;
+            startIndex += marker.Length;
+        }
+
+        return count;
+    }
+}
+
+internal static class CompanionUpdateSuppressionPolicy
+{
+    public static bool ShouldSuppress(
+        GatewayUpdateStatus? gatewayStatus,
+        UpdateCheckOutcome update) =>
+        update.UpdateFound &&
+        UpdateReleasePolicy.Classify(update.SelectedRelease) ==
+            ReleaseSecurityClassification.Ordinary &&
+        string.Equals(
+            gatewayStatus?.EffectiveChannel,
+            "extended-stable",
+            StringComparison.OrdinalIgnoreCase);
+}
+
+internal static class GatewayUpdateStatusLookup
+{
+    public static bool CanQuery(
+        bool hasHandshakeSnapshot,
+        bool isConnected,
+        IReadOnlyList<string> grantedScopes) =>
+        hasHandshakeSnapshot &&
+        isConnected &&
+        OperatorScopeHelper.HasAdminScope(grantedScopes);
+
+    public static async Task<GatewayUpdateStatus?> TryGetAsync(
+        Func<Task<GatewayUpdateStatus?>> request,
+        Action<Exception>? onUnavailable = null)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        try
+        {
+            return await request();
+        }
+        catch (Exception ex)
+        {
+            onUnavailable?.Invoke(ex);
+            return null;
+        }
+    }
+}
 
 internal static class UpdateCheckPipeline
 {
@@ -33,7 +136,11 @@ internal static class UpdateCheckPipeline
         ArgumentNullException.ThrowIfNull(boundary);
 
         if (await boundary.CheckForUpdatesAsync())
-            return new UpdateCheckOutcome(UpdateFound: true);
+        {
+            return new UpdateCheckOutcome(
+                UpdateFound: true,
+                SelectedRelease: boundary.GetSelectedRelease());
+        }
 
         foreach (var release in boundary.GetReleaseCandidates())
         {
@@ -51,6 +158,7 @@ internal static class UpdateCheckPipeline
             release.Activate();
             return new UpdateCheckOutcome(
                 UpdateFound: true,
+                SelectedRelease: release,
                 ActivatedFallbackTag: release.TagName);
         }
 

--- a/src/OpenClaw.Tray.WinUI/Services/UpdateCheckPipeline.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/UpdateCheckPipeline.cs
@@ -44,6 +44,11 @@ internal static class UpdateReleasePolicy
     internal const string SecurityMarker =
         "<!-- openclaw-update: security-critical -->";
 
+    private static readonly System.Text.RegularExpressions.Regex MarkerShapePattern = new(
+        @"<!--\s*openclaw-update\s*:.*?-->",
+        System.Text.RegularExpressions.RegexOptions.IgnoreCase |
+        System.Text.RegularExpressions.RegexOptions.Compiled);
+
     public static ReleaseSecurityClassification Classify(
         UpdateReleaseCandidate? release)
     {
@@ -59,6 +64,17 @@ internal static class UpdateReleasePolicy
         var securityMarkerCount = CountMarkers(
             release.Body,
             SecurityMarker);
+
+        // Any "openclaw-update:" marker-shaped comment that is not an exact recognized
+        // marker (a typo, unknown classification, or other malformed variant) must fail
+        // classification closed rather than silently disappear from the counts above. A
+        // valid ordinary marker combined with such a malformed marker would otherwise be
+        // misread as an unambiguous "ordinary" release.
+        var totalMarkerLikeCount = MarkerShapePattern.Matches(release.Body).Count;
+        if (totalMarkerLikeCount != ordinaryMarkerCount + securityMarkerCount)
+        {
+            return ReleaseSecurityClassification.Unverified;
+        }
 
         return (ordinaryMarkerCount, securityMarkerCount) switch
         {

--- a/src/OpenClaw.Tray.WinUI/Services/UpdateCoordinator.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/UpdateCoordinator.cs
@@ -21,6 +21,7 @@ internal sealed class UpdateCoordinator(
     UpdatumManager updater,
     AppState appState,
     SettingsManager? settings,
+    Func<IOperatorGatewayClient?> getGatewayClient,
     Func<XamlRoot?> getXamlRoot,
     Action refreshStatus,
     Action exit,
@@ -29,6 +30,8 @@ internal sealed class UpdateCoordinator(
     private readonly SettingsManager? _settings = settings;
     private readonly IUpdateCheckBoundary _updateCheckBoundary =
         updateCheckBoundary ?? new UpdatumUpdateCheckBoundary(updater);
+    private readonly Func<IOperatorGatewayClient?> _getGatewayClient =
+        getGatewayClient ?? throw new ArgumentNullException(nameof(getGatewayClient));
 
     // Cross-path concurrency for update checks, split into two phases:
     //  - _updateCheckGate: held only during the metadata/network check.
@@ -72,7 +75,8 @@ internal sealed class UpdateCoordinator(
                 Status = "Skipped",
                 CurrentVersion = AppVersionInfo.Version,
                 CheckedAt = DateTime.UtcNow,
-                Detail = "development build"
+                Detail = LocalizationHelper.GetString(
+                    "Update_Message_Skipped_Dev")
             };
             _updateCheckGate.Release();
             return true;
@@ -87,7 +91,8 @@ internal sealed class UpdateCoordinator(
                 Status = "Skipped",
                 CurrentVersion = AppVersionInfo.Version,
                 CheckedAt = DateTime.UtcNow,
-                Detail = "debug build"
+                Detail = LocalizationHelper.GetString(
+                    "Update_Message_Skipped_Debug")
             };
             return true;
         }
@@ -126,6 +131,25 @@ internal sealed class UpdateCoordinator(
                     CurrentVersion = AppVersionInfo.Version,
                     CheckedAt = DateTime.UtcNow,
                     Detail = "no updates available"
+                };
+                return true;
+            }
+
+            if (UpdateReleasePolicy.Classify(checkOutcome.SelectedRelease) ==
+                    ReleaseSecurityClassification.Ordinary &&
+                CompanionUpdateSuppressionPolicy.ShouldSuppress(
+                    await TryGetGatewayUpdateStatusAsync(_getGatewayClient()),
+                    checkOutcome))
+            {
+                Logger.Info(
+                    "Skipping ordinary companion update: authenticated Gateway is on extended-stable");
+                appState.UpdateInfo = new UpdateCommandCenterInfo
+                {
+                    Status = "Skipped",
+                    CurrentVersion = AppVersionInfo.Version,
+                    CheckedAt = DateTime.UtcNow,
+                    Detail = LocalizationHelper.GetString(
+                        "Update_Message_Skipped_ExtendedStable")
                 };
                 return true;
             }
@@ -326,6 +350,64 @@ internal sealed class UpdateCoordinator(
 #endif
     }
 
+    private static async Task<GatewayUpdateStatus?> TryGetGatewayUpdateStatusAsync(
+        IOperatorGatewayClient? gatewayClient)
+    {
+        if (gatewayClient is null)
+            return null;
+
+        if (!gatewayClient.HasHandshakeSnapshot &&
+            !await WaitForGatewayHandshakeAsync(gatewayClient))
+        {
+            Logger.Info(
+                "Gateway update channel unavailable before deadline; using companion updater");
+            return null;
+        }
+
+        if (!GatewayUpdateStatusLookup.CanQuery(
+                gatewayClient.HasHandshakeSnapshot,
+                gatewayClient.IsConnectedToGateway,
+                gatewayClient.GrantedOperatorScopes))
+        {
+            Logger.Info(
+                "Gateway update channel unavailable or unauthorized; using companion updater");
+            return null;
+        }
+
+        return await GatewayUpdateStatusLookup.TryGetAsync(
+            () => gatewayClient.GetUpdateStatusAsync(),
+            ex => Logger.Info(
+                $"Gateway update channel unavailable; using companion updater: {ex.Message}"));
+    }
+
+    private static async Task<bool> WaitForGatewayHandshakeAsync(
+        IOperatorGatewayClient gatewayClient)
+    {
+        var completion = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        void OnHandshakeSucceeded(object? sender, EventArgs args) =>
+            completion.TrySetResult();
+
+        gatewayClient.HandshakeSucceeded += OnHandshakeSucceeded;
+        try
+        {
+            if (gatewayClient.HasHandshakeSnapshot)
+                return true;
+
+            await completion.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            return gatewayClient.HasHandshakeSnapshot;
+        }
+        catch (TimeoutException)
+        {
+            return false;
+        }
+        finally
+        {
+            gatewayClient.HandshakeSucceeded -= OnHandshakeSucceeded;
+        }
+    }
+
     // Re-entrancy guard: the button/menu/deep-link are all fire-and-forget
     // (`_ = CheckForUpdatesUserInitiatedAsync()`), so a double-click would
     // otherwise open two ContentDialogs on the same XamlRoot which throws
@@ -381,6 +463,7 @@ internal sealed class UpdateCoordinator(
                         await ShowUpdateInfoDialogAsync(
                             "Skipped",
                             LocalizationHelper.GetString("Update_Title_Skipped"),
+                            info.Detail ??
                             LocalizationHelper.GetString(
                                 AppIdentity.IsDev
                                     ? "Update_Message_Skipped_Dev"
@@ -495,17 +578,24 @@ internal sealed class UpdatumUpdateCheckBoundary(UpdatumManager updater) : IUpda
 {
     public Task<bool> CheckForUpdatesAsync() => updater.CheckForUpdatesAsync();
 
+    public UpdateReleaseCandidate? GetSelectedRelease() =>
+        updater.LatestRelease is { } release
+            ? CreateCandidate(release)
+            : null;
+
     public IEnumerable<UpdateReleaseCandidate> GetReleaseCandidates()
     {
         foreach (var release in updater.Releases)
-        {
-            yield return new UpdateReleaseCandidate(
-                release.TagName,
-                release.Draft,
-                release.Prerelease,
-                release.PublishedAt is not null,
-                () => updater.GetCompatibleReleaseAsset(release) is not null,
-                () => updater.ForceTriggerUpdateFromRelease(release));
-        }
+            yield return CreateCandidate(release);
     }
+
+    private UpdateReleaseCandidate CreateCandidate(Octokit.Release release) => new(
+        release.TagName,
+        release.Body,
+        HasTrustedMetadata: true,
+        release.Draft,
+        release.Prerelease,
+        release.PublishedAt is not null,
+        () => updater.GetCompatibleReleaseAsset(release) is not null,
+        () => updater.ForceTriggerUpdateFromRelease(release));
 }

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -398,6 +398,9 @@
   <data name="Update_Message_Skipped_Dev" xml:space="preserve">
     <value>Update checks are disabled in development builds.</value>
   </data>
+  <data name="Update_Message_Skipped_ExtendedStable" xml:space="preserve">
+    <value>The connected Gateway uses extended-stable, so this ordinary Windows update is deferred.</value>
+  </data>
   <data name="Update_OK" xml:space="preserve">
     <value>OK</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -370,6 +370,9 @@
   <data name="Update_Message_Skipped_Dev" xml:space="preserve">
     <value>La vérification des mises à jour est désactivée dans les versions de développement.</value>
   </data>
+  <data name="Update_Message_Skipped_ExtendedStable" xml:space="preserve">
+    <value>La passerelle connectée utilise extended-stable. Cette mise à jour Windows ordinaire est donc différée.</value>
+  </data>
   <data name="Update_OK" xml:space="preserve">
     <value>OK</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -371,6 +371,9 @@
   <data name="Update_Message_Skipped_Dev" xml:space="preserve">
     <value>Updatecontroles zijn uitgeschakeld in ontwikkelbuilds.</value>
   </data>
+  <data name="Update_Message_Skipped_ExtendedStable" xml:space="preserve">
+    <value>De verbonden gateway gebruikt extended-stable. Daarom wordt deze gewone Windows-update uitgesteld.</value>
+  </data>
   <data name="Update_OK" xml:space="preserve">
     <value>OK</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/pt-br/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/pt-br/Resources.resw
@@ -398,6 +398,9 @@
   <data name="Update_Message_Skipped_Dev" xml:space="preserve">
     <value>A verificação de atualizações está desativada em builds de desenvolvimento.</value>
   </data>
+  <data name="Update_Message_Skipped_ExtendedStable" xml:space="preserve">
+    <value>O Gateway conectado usa extended-stable, portanto esta atualização comum do Windows foi adiada.</value>
+  </data>
   <data name="Update_OK" xml:space="preserve">
     <value>OK</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -370,6 +370,9 @@
   <data name="Update_Message_Skipped_Dev" xml:space="preserve">
     <value>开发版本已禁用更新检查。</value>
   </data>
+  <data name="Update_Message_Skipped_ExtendedStable" xml:space="preserve">
+    <value>已连接的网关使用 extended-stable，因此会推迟此普通 Windows 更新。</value>
+  </data>
   <data name="Update_OK" xml:space="preserve">
     <value>确定</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -370,6 +370,9 @@
   <data name="Update_Message_Skipped_Dev" xml:space="preserve">
     <value>開發版本已停用更新檢查。</value>
   </data>
+  <data name="Update_Message_Skipped_ExtendedStable" xml:space="preserve">
+    <value>已連線的閘道使用 extended-stable，因此會延後此一般 Windows 更新。</value>
+  </data>
   <data name="Update_OK" xml:space="preserve">
     <value>確定</value>
   </data>

--- a/tests/OpenClaw.Shared.Tests/GatewayProtocolLiveRoundTripTests.cs
+++ b/tests/OpenClaw.Shared.Tests/GatewayProtocolLiveRoundTripTests.cs
@@ -70,7 +70,12 @@ public sealed class GatewayProtocolLiveRoundTripTests : IDisposable
             // when many test classes run in parallel).
             const int rpc = 20000;
 
-            // ── 1. commands.list (typed catalog read) ──
+            // ── 1. update.status (authoritative effective update channel) ──
+            var updateStatus = await client.GetUpdateStatusAsync(timeoutMs: rpc);
+            Assert.Equal("extended-stable", updateStatus?.EffectiveChannel);
+            Assert.Contains("\"method\":\"update.status\"", server.FrameFor("update.status"));
+
+            // ── 2. commands.list (typed catalog read) ──
             var catalog = await client.ListCommandsAsync(timeoutMs: rpc);
             Assert.True(catalog.IsSupported);
             var cmd = Assert.Single(catalog.Commands);
@@ -78,13 +83,13 @@ public sealed class GatewayProtocolLiveRoundTripTests : IDisposable
             var arg = Assert.Single(cmd.Args);
             Assert.Equal("gpt-5", Assert.Single(arg.Choices).Value);
 
-            // ── 2. sessions.files.get (read; param must be sessionKey, response nested under "file") ──
+            // ── 3. sessions.files.get (read; param must be sessionKey, response nested under "file") ──
             var file = await client.GetSessionFileAsync(key, "src/a.cs", timeoutMs: rpc);
             Assert.True(file.Found);
             Assert.Equal("hello world", file.Content);
             Assert.Contains("\"sessionKey\"", server.FrameFor("sessions.files.get"));
 
-            // ── 3. chat.history (real client transcript export path) ──
+            // ── 4. chat.history (real client transcript export path) ──
             var history = await client.RequestChatHistoryAsync(key, timeoutMs: rpc);
             Assert.Equal("sid-1", history.SessionId);
             var message = Assert.Single(history.Messages);
@@ -92,7 +97,7 @@ public sealed class GatewayProtocolLiveRoundTripTests : IDisposable
             Assert.Equal("done", message.Text);
             Assert.Contains("\"sessionKey\"", server.FrameFor("chat.history"));
 
-            // ── 4. sessions.compaction.list + branch (param key/checkpointId; branch returns sourceKey + new key) ──
+            // ── 5. sessions.compaction.list + branch (param key/checkpointId; branch returns sourceKey + new key) ──
             var checkpoints = await client.ListCompactionCheckpointsAsync(key, timeoutMs: rpc);
             Assert.True(checkpoints.IsSupported);
             Assert.Equal("cp1", Assert.Single(checkpoints.Checkpoints).Id);
@@ -103,7 +108,7 @@ public sealed class GatewayProtocolLiveRoundTripTests : IDisposable
             Assert.Equal("agent:main:branch-1", branch.ResultSessionKey);
             Assert.Contains("\"checkpointId\"", server.FrameFor("sessions.compaction.branch"));
 
-            // ── 5. sessions.patch SET then CLEAR (the tri-state proof) ──
+            // ── 6. sessions.patch SET then CLEAR (the tri-state proof) ──
             // PatchSessionAsync is fire-and-tracked (returns on send, not on
             // response), so wait for the captured frame to arrive on the server.
             var setOk = await client.PatchSessionAsync(key, new SessionPatch { Model = "gpt-5", FastMode = SessionFastMode.Auto });
@@ -118,6 +123,37 @@ public sealed class GatewayProtocolLiveRoundTripTests : IDisposable
             Assert.Contains("\"model\":null", clearFrame);
 
             PrintProof(server);
+        }
+        finally
+        {
+            await client.DisconnectAsync();
+        }
+    }
+
+    [Fact]
+    public async Task UpdateStatus_GatewayError_PropagatesForCallerFailOpen()
+    {
+        using var server = new LoopbackGatewayServer();
+        server.OnMethod(
+            "update.status",
+            _ => LoopbackResponse.Fail("unauthorized update.status"));
+        var client = new OpenClawGatewayClient(
+            server.WebSocketUrl,
+            "test-token",
+            new TestLogger(),
+            tokenIsBootstrapToken: false,
+            bootstrapPairAsNode: false,
+            identityPath: _identityDir);
+
+        try
+        {
+            await ConnectAndWaitAsync(client, server);
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => client.GetUpdateStatusAsync(timeoutMs: 20_000));
+
+            Assert.Contains("unauthorized update.status", exception.Message);
+            Assert.Contains("\"method\":\"update.status\"", server.FrameFor("update.status"));
         }
         finally
         {
@@ -222,6 +258,17 @@ public sealed class GatewayProtocolLiveRoundTripTests : IDisposable
         // (health/sessions.list/subscribe/usage/nodes/agents), keeping this test
         // lightweight so it does not add scheduler/socket contention that could
         // destabilize other timing-sensitive socket tests under parallel load.
+
+        server.OnMethod("update.status", parameters =>
+        {
+            Assert.Equal(JsonValueKind.Object, parameters.ValueKind);
+            Assert.Empty(parameters.EnumerateObject());
+            return new
+            {
+                updateAvailable = (object?)null,
+                effectiveChannel = "extended-stable"
+            };
+        });
 
         server.OnMethod("commands.list", _ => new
         {

--- a/tests/OpenClaw.Shared.Tests/GatewayProtocolModelsTests.cs
+++ b/tests/OpenClaw.Shared.Tests/GatewayProtocolModelsTests.cs
@@ -36,6 +36,7 @@ public class GatewayProtocolModelsTests
             ("CreateSessionAsync", new[] { typeof(SessionCreateRequest), typeof(int) }),
             ("ResetSessionDetailedAsync", new[] { typeof(string), typeof(int) }),
             ("CompactSessionDetailedAsync", new[] { typeof(string), typeof(int) }),
+            ("GetUpdateStatusAsync", new[] { typeof(int) }),
         };
 
         foreach (var (name, args) in newMembers)
@@ -48,6 +49,21 @@ public class GatewayProtocolModelsTests
     }
 
     private static JsonElement Parse(string json) => JsonDocument.Parse(json).RootElement;
+
+    [Fact]
+    public void GatewayUpdateStatusParser_PreservesOnlyStringEffectiveChannel()
+    {
+        var extendedStable = GatewayUpdateStatusParser.Parse(
+            Parse("""{"effectiveChannel":"extended-stable"}"""));
+        var missing = GatewayUpdateStatusParser.Parse(
+            Parse("""{"updateAvailable":null}"""));
+        var malformed = GatewayUpdateStatusParser.Parse(
+            Parse("""{"effectiveChannel":42}"""));
+
+        Assert.Equal("extended-stable", extendedStable.EffectiveChannel);
+        Assert.Null(missing.EffectiveChannel);
+        Assert.Null(malformed.EffectiveChannel);
+    }
 
     [Fact]
     public void ParseSessionCreateResult_RequiresAndPreservesGatewayKey()

--- a/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
@@ -32,7 +32,6 @@ public sealed class AppRefactorContractTests
             "AppUserModelIdRegistrar.RegisterCurrentProcess(AppIdentity.AppUserModelId);",
             "appUserModelIdRegistration.Attempted",
             "_settings = new SettingsManager();",
-            "CheckForUpdatesAsync();",
             "ToastNotificationManagerCompat.OnActivated += OnToastActivated;",
             "InitializeTrayIcon();",
             "_gatewayRegistry = new GatewayRegistry",
@@ -40,7 +39,19 @@ public sealed class AppRefactorContractTests
             "await ShowOnboardingAsync();",
             "EnsureNodeService(_settings);",
             "InitializeGatewayClient();",
+            "CheckForUpdatesAsync();",
             "await _activationRouter.StartForwardedActivationListenerAsync(this, CancellationToken.None);");
+    }
+
+    [Fact]
+    public void ExtendedStableUpdatePolicy_RemainsOutsideAppCompositionRoot()
+    {
+        var source = ReadAppSources();
+
+        Assert.Contains("() => _connectionManager?.OperatorClient,", source);
+        AssertInOrder(source, "InitializeGatewayClient();", "CheckForUpdatesAsync();");
+        Assert.DoesNotContain("extended-stable", source);
+        Assert.DoesNotContain("GetUpdateStatusAsync", source);
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/UpdateCheckPipelineTests.cs
+++ b/tests/OpenClaw.Tray.Tests/UpdateCheckPipelineTests.cs
@@ -1,9 +1,138 @@
+using OpenClaw.Shared;
 using OpenClawTray.Services;
 
 namespace OpenClaw.Tray.Tests;
 
 public sealed class UpdateCheckPipelineTests
 {
+    [Fact]
+    public void Classify_TrustedOrdinaryMarker_DoesNotScanReleaseProse()
+    {
+        var release = Candidate(
+            "v2026.9.1",
+            body:
+                $"{UpdateReleasePolicy.OrdinaryMarker}\n" +
+                "Security team acknowledgements include CVE-2026-1234 and GHSA-abcd-1234-5678.");
+
+        var classification = UpdateReleasePolicy.Classify(release);
+
+        Assert.Equal(ReleaseSecurityClassification.Ordinary, classification);
+    }
+
+    [Fact]
+    public void Classify_TrustedSecurityMarker_IsSecurity()
+    {
+        var release = Candidate(
+            "v2026.9.1",
+            body: UpdateReleasePolicy.SecurityMarker);
+
+        var classification = UpdateReleasePolicy.Classify(release);
+
+        Assert.Equal(ReleaseSecurityClassification.Security, classification);
+    }
+
+    [Theory]
+    [InlineData(null, true)]
+    [InlineData("", true)]
+    [InlineData("<!-- openclaw-update: routine -->", true)]
+    [InlineData("<!-- openclaw-update: ordinary -->", false)]
+    [InlineData(
+        "<!-- openclaw-update: ordinary --><!-- openclaw-update: ordinary -->",
+        true)]
+    [InlineData(
+        "<!-- openclaw-update: ordinary --><!-- openclaw-update: security-critical -->",
+        true)]
+    [InlineData(
+        "<!-- openclaw-update: security-critical --><!-- openclaw-update: security-critical -->",
+        true)]
+    [InlineData(
+        "<!-- openclaw-update: ordinary --><!-- openclaw-update: security-critical --><!-- openclaw-update: security-critical -->",
+        true)]
+    public void Classify_IncompleteMalformedOrUntrustedMetadata_IsUnverified(
+        string? body,
+        bool trusted)
+    {
+        var release = Candidate(
+            "v2026.9.1",
+            body: body,
+            hasTrustedMetadata: trusted);
+
+        var classification = UpdateReleasePolicy.Classify(release);
+
+        Assert.Equal(ReleaseSecurityClassification.Unverified, classification);
+    }
+
+    [Fact]
+    public void ShouldSuppress_OnlyTrustedOrdinaryExtendedStableUpdate()
+    {
+        var ordinary = Outcome(UpdateReleasePolicy.OrdinaryMarker);
+        var security = Outcome(UpdateReleasePolicy.SecurityMarker);
+        var unverified = Outcome(body: null);
+
+        Assert.True(CompanionUpdateSuppressionPolicy.ShouldSuppress(
+            new GatewayUpdateStatus { EffectiveChannel = "extended-stable" },
+            ordinary));
+        Assert.True(CompanionUpdateSuppressionPolicy.ShouldSuppress(
+            new GatewayUpdateStatus { EffectiveChannel = "EXTENDED-STABLE" },
+            ordinary));
+        Assert.False(CompanionUpdateSuppressionPolicy.ShouldSuppress(
+            new GatewayUpdateStatus { EffectiveChannel = "stable" },
+            ordinary));
+        Assert.False(CompanionUpdateSuppressionPolicy.ShouldSuppress(
+            new GatewayUpdateStatus { EffectiveChannel = "extended-stable " },
+            ordinary));
+        Assert.False(CompanionUpdateSuppressionPolicy.ShouldSuppress(null, ordinary));
+        Assert.False(CompanionUpdateSuppressionPolicy.ShouldSuppress(
+            new GatewayUpdateStatus { EffectiveChannel = "extended-stable" },
+            security));
+        Assert.False(CompanionUpdateSuppressionPolicy.ShouldSuppress(
+            new GatewayUpdateStatus { EffectiveChannel = "extended-stable" },
+            unverified));
+        Assert.False(CompanionUpdateSuppressionPolicy.ShouldSuppress(
+            new GatewayUpdateStatus { EffectiveChannel = "extended-stable" },
+            ordinary with { UpdateFound = false }));
+    }
+
+    [Theory]
+    [InlineData(true, true, "operator.admin", true)]
+    [InlineData(false, true, "operator.admin", false)]
+    [InlineData(true, false, "operator.admin", false)]
+    [InlineData(true, true, "operator.read", false)]
+    [InlineData(true, true, "", false)]
+    public void GatewayStatusLookup_RequiresAuthenticatedAdminClient(
+        bool hasHandshake,
+        bool connected,
+        string scope,
+        bool expected)
+    {
+        var scopes = string.IsNullOrEmpty(scope) ? [] : new[] { scope };
+
+        Assert.Equal(
+            expected,
+            GatewayUpdateStatusLookup.CanQuery(
+                hasHandshake,
+                connected,
+                scopes));
+    }
+
+    [Theory]
+    [InlineData("transport")]
+    [InlineData("gateway")]
+    public async Task GatewayStatusLookup_ErrorsRemainUnavailable(string failureKind)
+    {
+        Exception error = failureKind == "transport"
+            ? new IOException("connection closed")
+            : new InvalidOperationException("unauthorized update.status");
+        Exception? observed = null;
+
+        var status = await GatewayUpdateStatusLookup.TryGetAsync(
+            () => Task.FromException<GatewayUpdateStatus?>(error),
+            ex => observed = ex);
+
+        Assert.Null(status);
+        Assert.Same(error, observed);
+    }
+
     [Fact]
     public async Task CheckAsync_WhenOrdinaryCheckDeclinesCorrection_ActivatesCompatibleFallback()
     {
@@ -60,8 +189,12 @@ public sealed class UpdateCheckPipelineTests
     public async Task CheckAsync_WhenOrdinaryCheckFindsUpdate_DoesNotInspectFallbacks()
     {
         var releasesEnumerated = false;
+        var selectedRelease = Candidate(
+            "v2026.7.1-2",
+            body: UpdateReleasePolicy.OrdinaryMarker);
         var boundary = new FakeUpdateCheckBoundary(
             checkForUpdates: () => true,
+            selectedRelease: selectedRelease,
             releasesFactory: () =>
             {
                 releasesEnumerated = true;
@@ -71,16 +204,26 @@ public sealed class UpdateCheckPipelineTests
         var result = await UpdateCheckPipeline.CheckAsync(boundary, "2026.7.1");
 
         Assert.True(result.UpdateFound);
+        Assert.Same(selectedRelease, result.SelectedRelease);
         Assert.Null(result.ActivatedFallbackTag);
         Assert.False(releasesEnumerated);
     }
 
+    private static UpdateCheckOutcome Outcome(string? body) =>
+        new(
+            UpdateFound: true,
+            SelectedRelease: Candidate("v2026.9.1", body: body));
+
     private static UpdateReleaseCandidate Candidate(
         string tagName,
+        string? body = null,
+        bool hasTrustedMetadata = true,
         Func<bool>? hasCompatibleAsset = null,
         Action? activate = null) =>
         new(
             tagName,
+            body,
+            hasTrustedMetadata,
             Draft: false,
             Prerelease: false,
             Published: true,
@@ -91,17 +234,22 @@ public sealed class UpdateCheckPipelineTests
     {
         private readonly Func<bool> _checkForUpdates;
         private readonly Func<IEnumerable<UpdateReleaseCandidate>> _releasesFactory;
+        private readonly UpdateReleaseCandidate? _selectedRelease;
 
         public FakeUpdateCheckBoundary(
             Func<bool> checkForUpdates,
+            UpdateReleaseCandidate? selectedRelease = null,
             IEnumerable<UpdateReleaseCandidate>? releases = null,
             Func<IEnumerable<UpdateReleaseCandidate>>? releasesFactory = null)
         {
             _checkForUpdates = checkForUpdates;
+            _selectedRelease = selectedRelease;
             _releasesFactory = releasesFactory ?? (() => releases ?? []);
         }
 
         public Task<bool> CheckForUpdatesAsync() => Task.FromResult(_checkForUpdates());
+
+        public UpdateReleaseCandidate? GetSelectedRelease() => _selectedRelease;
 
         public IEnumerable<UpdateReleaseCandidate> GetReleaseCandidates() =>
             _releasesFactory();

--- a/tests/OpenClaw.Tray.Tests/UpdateCheckPipelineTests.cs
+++ b/tests/OpenClaw.Tray.Tests/UpdateCheckPipelineTests.cs
@@ -48,6 +48,15 @@ public sealed class UpdateCheckPipelineTests
     [InlineData(
         "<!-- openclaw-update: ordinary --><!-- openclaw-update: security-critical --><!-- openclaw-update: security-critical -->",
         true)]
+    [InlineData(
+        "<!-- openclaw-update: ordinary --><!-- openclaw-update: security-critica -->",
+        true)]
+    [InlineData(
+        "<!-- openclaw-update: ordinary --><!-- openclaw-update:security-critical -->",
+        true)]
+    [InlineData(
+        "<!--openclaw-update: ordinary--><!-- openclaw-update: unknown -->",
+        true)]
     public void Classify_IncompleteMalformedOrUntrustedMetadata_IsUnverified(
         string? body,
         bool trusted)


### PR DESCRIPTION
Supersedes #1299.

A new PR was created from current `main` because the Gateway-aligned release tagging policy changed after #1299 was authored. This replacement uses trusted, explicit release markers (`<!-- openclaw-update: ordinary -->` or `<!-- openclaw-update: security-critical -->`) instead of broad free-text security classification, while preserving current main's correction-aware update ownership and fail-open behavior.

## What Problem This Solves

Fixes an issue where Windows companion users following an authenticated Gateway's `extended-stable` channel could receive ordinary companion update prompts before that channel was ready to advance.

## Why This Change Was Made

The existing correction-aware update pipeline now defers an update only when official release metadata explicitly classifies it as ordinary and the authenticated Gateway reports `extended-stable`. Security and every uncertain or unavailable state keep the update visible. Release prose is not scanned for security keywords, and Gateway connection ownership remains in `GatewayConnectionManager`.

## User Impact

Extended-stable users no longer see verified ordinary Windows companion update notices. Security-related, unclassified, malformed, unauthorized, and error states continue to show the update.

## Evidence

Focused policy tests prove trusted ordinary/security classification, malformed and incomplete marker handling, authorization and RPC fail-open behavior, extended-stable boundaries, normal channels, correction fallback selection, and App ownership. A real loopback WebSocket test captured the authenticated client wire method `update.status` and parsed `effectiveChannel=extended-stable`.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs or instructions
- [x] Tests or validation
- [x] Security hardening
- [ ] Chore or infrastructure

## Scope

- [x] Tray or WinUI UX
- [ ] Windows node capability
- [ ] Local MCP or `winnode`
- [x] Gateway, connection, or pairing
- [ ] Setup or onboarding
- [x] Permissions, privacy, or security
- [x] Tests, CI, or docs

## Required proof pools

- `windows-winui-interactive`: capture the localized `Skipped` update state from a current-head Release build with controlled authenticated Gateway and official ordinary release metadata.

## Validation

- `$env:OPENCLAW_REPO_ROOT=(Get-Location).Path; .\build.ps1`: passed; Shared, CLI, WinNode CLI, SetupEngine, WinUI, docs, and proof-pool gates succeeded.
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore`: 3,944 passed, 34 skipped, 0 failed.
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore`: 2,884 passed, 0 skipped, 0 failed.
- Focused tray policy/ownership suite: 112 passed, 0 failed.
- Focused shared Gateway protocol suite: 36 passed, 0 failed.
- Focused live `update.status` wire proof: 1 passed, 0 failed.
- Rubber-duck rereview: clean after fixing duplicated security-marker handling.
- Autoreview: Not verified / blocked by Codex API `401 Unauthorized`; no findings were produced.

## Real Behavior Proof

- Environment tested: Windows 11 ARM64, isolated repository worktree.
- PR head or commit tested: `d73f7fbe0e8adf0af93bbbbabf6b02812c708f06`.
- Exact steps or command run: focused real WebSocket `GatewayProtocolLiveRoundTripTests.NewProtocolMethods_RealWebSocketRoundTrip_SendCorrectWireFramesAndParseResponses` with detailed console logging.
- Evidence after fix: captured `{"type":"req",...,"method":"update.status","params":{}}`; response parsing returned `effectiveChannel=extended-stable`.
- Observed result: the real operator client sends the canonical Gateway method; deterministic policy tests suppress only trusted explicitly ordinary metadata and preserve visibility for every pinned fail-open state.
- Screenshot or artifact links verified? `N/A`.
- Not verified or blocked: current-head localized WinUI `Skipped` screenshot. Debug/development builds skip release checks, and the Release path requires an authenticated admin-scoped Gateway plus official release metadata carrying the explicit ordinary marker. The `windows-winui-interactive` pool remains declared.

## Security Impact

- New permissions or capabilities? `No`
- Secrets or tokens handling changed? `No`
- New or changed network calls? `Yes`
- Command or tool execution surface changed? `No`
- Data access scope changed? `No`
- If any answer is `Yes`, explain the risk and mitigation: the existing authenticated operator client calls `update.status` only after handshake and only with `operator.admin`. Missing authorization and all protocol/transport failures keep the companion update visible. Release suppression requires trusted exact metadata and fails open on every ambiguous marker state.

## Compatibility and Migration

- Backward compatible? `Yes`
- Config or environment changes? `No`
- Migration needed? `No`
- If yes, list the exact upgrade steps: N/A. Older Gateways and unclassified releases retain the existing visible update behavior.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation addressed by this PR.
- [ ] I left unresolved only conversations that still need maintainer judgment.