### PR TITLE
feat(local-ai): safely use the standard Hugging Face hub cache

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -68,6 +68,7 @@ These are the canonical homes. Do not reintroduce private copies elsewhere.
 | Native tool identity, display arguments, payload extraction, and flattened-history projection | `NativeToolProjector` | authoritative |
 | Managed-local listener provenance and strong-credential authorization | `ManagedLocalGatewayPortProvenanceService` | authoritative |
 | Local AI gateway-record ownership and WSL distro binding | `LocalAiGatewayDistroResolver` | authoritative |
+| Local AI model cache acquisition, explicit legacy migration, and active-path receipt selection | `HuggingFaceModelInstaller` + `LocalAiManifestStore` + `LocalAiInstallReconciler` | authoritative |
 | Exact Gateway wizard terminal-restart compatibility and bounded retry policy | `GatewayWizardRestartRecoveryPolicy` | authoritative |
 | Managed-local automatic repair eligibility and orchestration | `ManagedLocalGatewayAutoRepairMonitor` + `ManagedLocalGatewayRepairCoordinator` | authoritative |
 | Permissions page state, settings commands, and exec-approvals presentation | `PermissionsPageViewModel` | authoritative |

--- a/docs/SETUP_ENGINE_REDESIGN.md
+++ b/docs/SETUP_ENGINE_REDESIGN.md
@@ -226,9 +226,13 @@ uninstall reads do not migrate it. Setup reconciliation is the explicit
 promotion gate: it verifies and copies the legacy model, atomically records a
 schema-4 cache receipt, then selects the verified snapshot path as active.
 Fresh installs write schema 4 directly while retaining the legacy relative
-`ModelPath` and a verified app-owned compatibility copy for downgrade and
-recovery. Rollback may remove a compatibility copy created by the current
-transaction, but it never removes the verified shared-cache source.
+`ModelPath` and a verified app-owned compatibility copy for recovery and for
+rollback to schema-4-aware transitional builds containing #1388
+(feat(local-ai): add verified legacy model cache migration). Schema-3-only
+releases do not understand a schema-4 `state.json`; the retained model bytes
+alone do not make a direct downgrade to those releases compatible. Rollback
+may remove a compatibility copy created by the current transaction, but it
+never removes the verified shared-cache source.
 
 Completed cache files and pre-existing resumable partials are shared state.
 Setup rollback and uninstall do not delete them. Unsafe links, reparse points,

--- a/docs/SETUP_ENGINE_REDESIGN.md
+++ b/docs/SETUP_ENGINE_REDESIGN.md
@@ -209,6 +209,32 @@ name such as `node` or `openclaw` alone is insufficient. Conflicts retain the
 port-in-use error and include owning process names when available. Missing
 listener ownership or a failed listener inspection does not bypass the check.
 
+### Local AI Hugging Face cache rollout
+
+Normal Local AI model acquisition writes verified GGUF files to the standard
+Hugging Face hub cache selected by `HF_HUB_CACHE`,
+`HUGGINGFACE_HUB_CACHE`, or the platform default. The installer reuses a
+snapshot or content-addressed blob only through
+`HuggingFaceHubCache.TryOpenVerifiedCacheFileAsync`, and cross-volume
+materialization copies from that same verified open handle. A configured cache
+root equal to or below the app-owned `LocalAI` directory is rejected before
+mutation because uninstall removes that managed tree recursively.
+
+Manifest schema 3 remains the compatibility format for existing app-owned
+model paths. Passive manifest loads, status refresh, recovery inspection, and
+uninstall reads do not migrate it. Setup reconciliation is the explicit
+promotion gate: it verifies and copies the legacy model, atomically records a
+schema-4 cache receipt, then selects the verified snapshot path as active.
+Fresh installs write schema 4 directly while retaining the legacy relative
+`ModelPath` and a verified app-owned compatibility copy for downgrade and
+recovery. Rollback may remove a compatibility copy created by the current
+transaction, but it never removes the verified shared-cache source.
+
+Completed cache files and pre-existing resumable partials are shared state.
+Setup rollback and uninstall do not delete them. Unsafe links, reparse points,
+hard-linked partials, destination conflicts, receipt mismatches, and concurrent
+manifest changes fail closed.
+
 ### Step Base Class
 
 ```csharp

--- a/src/OpenClaw.Connection/LocalAi/LlamaServerRouterConfiguration.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerRouterConfiguration.cs
@@ -44,7 +44,7 @@ public static class LlamaServerRouterConfiguration
         LocalModelInfo model = LocalModelCatalog.FindInstalled(manifest.ModelCatalogId)
             ?? throw new InvalidDataException("The managed local AI model is no longer qualified.");
 
-        LocalInferenceRunProfile profile = ValidateQualifiedReceipt(manifest, runtime, model);
+        LocalInferenceRunProfile profile = ResolveQualifiedReceipt(manifest, runtime, model);
 
         string presetPath = paths.ResolveContainedPath(
             Path.GetRelativePath(paths.RootDirectory, paths.RouterPresetPath),
@@ -73,7 +73,24 @@ public static class LlamaServerRouterConfiguration
             model.Id);
     }
 
-    private static LocalInferenceRunProfile ValidateQualifiedReceipt(
+    private static LocalInferenceRunProfile ResolveQualifiedReceipt(
+        LocalAiInstallManifest manifest,
+        LlamaRuntimeVariant runtime,
+        LocalModelInfo model)
+    {
+        ValidateArtifactReceipts(manifest, runtime, model);
+        return LocalModelCatalog.FindProfile(
+            model,
+            manifest.ContextLength,
+            manifest.KeyCachePrecision,
+            manifest.ValueCachePrecision,
+            manifest.DraftKeyCachePrecision,
+            manifest.DraftValueCachePrecision)
+            ?? throw new InvalidDataException(
+                "The managed local AI context and KV cache receipt do not match a qualified catalog profile.");
+    }
+
+    internal static void ValidateArtifactReceipts(
         LocalAiInstallManifest manifest,
         LlamaRuntimeVariant runtime,
         LocalModelInfo model)
@@ -94,16 +111,6 @@ public static class LlamaServerRouterConfiguration
             throw new InvalidDataException("The managed local AI model recipe receipt does not match the qualified catalog.");
         }
 
-        LocalInferenceRunProfile profile = LocalModelCatalog.FindProfile(
-            model,
-            manifest.ContextLength,
-            manifest.KeyCachePrecision,
-            manifest.ValueCachePrecision,
-            manifest.DraftKeyCachePrecision,
-            manifest.DraftValueCachePrecision)
-            ?? throw new InvalidDataException(
-                "The managed local AI context and KV cache receipt do not match a qualified catalog profile.");
-
         if (manifest.RuntimeAssets.Length != runtime.Artifacts.Count ||
             runtime.Artifacts.Any(artifact => !manifest.RuntimeAssets.Any(receipt =>
                 string.Equals(receipt.FileName, Path.GetFileName(artifact.RelativePath), StringComparison.Ordinal) &&
@@ -123,8 +130,6 @@ public static class LlamaServerRouterConfiguration
         {
             throw new InvalidDataException("The managed model artifact receipt does not match the qualified catalog.");
         }
-
-        return profile;
     }
 
     private static string BuildPreset(

--- a/src/OpenClaw.Connection/LocalAi/LlamaServerRouterConfiguration.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerRouterConfiguration.cs
@@ -30,10 +30,25 @@ public static class LlamaServerRouterConfiguration
     public static LlamaServerRouterLaunchPlan Build(
         LocalAiPaths paths,
         LocalAiResolvedInstall install,
-        int? listenPort = null)
+        int? listenPort = null) =>
+        BuildCore(paths, install, install.ModelPath, listenPort);
+
+    internal static LlamaServerRouterLaunchPlan BuildForVerifiedRuntime(
+        LocalAiPaths paths,
+        LocalAiResolvedInstall install,
+        string verifiedModelPath,
+        int? listenPort = null) =>
+        BuildCore(paths, install, verifiedModelPath, listenPort);
+
+    private static LlamaServerRouterLaunchPlan BuildCore(
+        LocalAiPaths paths,
+        LocalAiResolvedInstall install,
+        string modelPath,
+        int? listenPort)
     {
         ArgumentNullException.ThrowIfNull(paths);
         ArgumentNullException.ThrowIfNull(install);
+        ArgumentException.ThrowIfNullOrWhiteSpace(modelPath);
 
         LocalAiInstallManifest manifest = install.Manifest;
         int port = listenPort ?? manifest.RequestedPort;
@@ -69,7 +84,7 @@ public static class LlamaServerRouterConfiguration
                 .WithComparers(StringComparer.OrdinalIgnoreCase)
                 .Add("CUDA_VISIBLE_DEVICES", manifest.SelectedGpuId),
             presetPath,
-            BuildPreset(model, profile, install.ModelPath),
+            BuildPreset(model, profile, modelPath),
             model.Id);
     }
 

--- a/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
@@ -11,6 +11,7 @@
 //   await using var _ = runtime; // StopAsync/RestartAsync/RefreshAsync also available on ILocalAiRuntime
 // </summary>
 using OpenClaw.Shared;
+using OpenClaw.Shared.Inference.Catalog;
 using System.Net;
 using System.Text;
 
@@ -64,6 +65,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
     private readonly object _snapshotGate = new();
     private LocalAiRuntimeSnapshot _snapshot;
     private ILocalAiManagedProcess? _managedProcess;
+    private FileStream? _verifiedModelHandle;
     private LocalAiResolvedInstall? _install;
     private long _generation;
     private int _restartAttempts;
@@ -314,7 +316,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         LlamaServerRouterLaunchPlan launchPlan;
         try
         {
-            ValidateInstalledFiles(install);
+            await ValidateInstalledFilesAsync(install, cancellationToken).ConfigureAwait(false);
             LocalAiPortPolicy.Validate(requestedPort);
             launchPlan = LlamaServerRouterConfiguration.Build(
                 _options.Paths,
@@ -461,7 +463,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
 
         try
         {
-            ValidateInstalledFiles(_install!);
+            ValidateInstalledFilesForStatus(_install!);
         }
         catch (InvalidDataException ex)
         {
@@ -794,7 +796,33 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         return false;
     }
 
-    private static void ValidateInstalledFiles(LocalAiResolvedInstall install)
+    private async Task ValidateInstalledFilesAsync(
+        LocalAiResolvedInstall install,
+        CancellationToken cancellationToken)
+    {
+        DisposeVerifiedModelHandle();
+        ValidateInstalledFilesForStatus(install);
+
+        if (install.Manifest.SchemaVersion != LocalAiInstallManifest.HubCacheReceiptSchemaVersion)
+            return;
+
+        _verifiedModelHandle =
+            await HuggingFaceHubCache.TryOpenVerifiedCacheFileAsync(
+                    install.Manifest.ModelCacheRoot!,
+                    install.ModelPath,
+                    install.Manifest.ModelAsset.SizeBytes,
+                    new Sha256Digest(install.Manifest.ModelAsset.Sha256),
+                    progress: null,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        if (_verifiedModelHandle is null)
+        {
+            throw new InvalidDataException(
+                "The shared Hugging Face cache model is unsafe or no longer matches its receipt.");
+        }
+    }
+
+    private static void ValidateInstalledFilesForStatus(LocalAiResolvedInstall install)
     {
         if (!File.Exists(install.ExecutablePath))
             throw new InvalidDataException("The managed llama-server executable is missing.");
@@ -1078,6 +1106,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         if (_managedProcess is not null)
             await _managedProcess.DisposeAsync().ConfigureAwait(false);
         _managedProcess = null;
+        DisposeVerifiedModelHandle();
         return PublishTerminalCleanupFailure(detail ?? fallbackDetail);
     }
 
@@ -1116,7 +1145,10 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         ILocalAiManagedProcess? process = _managedProcess;
         _managedProcess = null;
         if (process is null)
+        {
+            DisposeVerifiedModelHandle();
             return;
+        }
         bool preserved = false;
         try
         {
@@ -1157,7 +1189,10 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         finally
         {
             if (!preserved)
+            {
                 await process.DisposeAsync().ConfigureAwait(false);
+                DisposeVerifiedModelHandle();
+            }
         }
     }
 
@@ -1188,6 +1223,7 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                 _managedProcess = null;
                 if (exited is not null)
                     await exited.DisposeAsync().ConfigureAwait(false);
+                DisposeVerifiedModelHandle();
 
                 bool willRestart = !_explicitStopRequested &&
                     _restartAttempts < _options.MaxRestartAttempts;
@@ -1554,6 +1590,12 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
     }
 
     private void ThrowIfDisposed() => ObjectDisposedException.ThrowIf(_disposed, this);
+
+    private void DisposeVerifiedModelHandle()
+    {
+        _verifiedModelHandle?.Dispose();
+        _verifiedModelHandle = null;
+    }
 
     private static LlamaServerRuntimeOptions ValidateOptions(LlamaServerRuntimeOptions options)
     {

--- a/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
+++ b/src/OpenClaw.Connection/LocalAi/LlamaServerRuntimeService.cs
@@ -46,6 +46,57 @@ internal sealed class SystemLlamaServerRuntimePlatform : ILlamaServerRuntimePlat
     public Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken) => Task.Delay(delay, cancellationToken);
 }
 
+internal sealed class LocalAiVerifiedModelLease : IDisposable
+{
+    private readonly IDisposable _handle;
+
+    public LocalAiVerifiedModelLease(IDisposable handle, string resolvedPath)
+    {
+        _handle = handle ?? throw new ArgumentNullException(nameof(handle));
+        ResolvedPath = string.IsNullOrWhiteSpace(resolvedPath)
+            ? throw new ArgumentException("The resolved model path is required.", nameof(resolvedPath))
+            : resolvedPath;
+    }
+
+    public string ResolvedPath { get; }
+
+    public void Dispose() => _handle.Dispose();
+}
+
+internal interface ILocalAiModelFileVerifier
+{
+    Task<LocalAiVerifiedModelLease?> TryOpenAsync(
+        string cacheRoot,
+        string candidatePath,
+        long expectedSizeBytes,
+        Sha256Digest expectedSha256,
+        CancellationToken cancellationToken);
+}
+
+internal sealed class HuggingFaceLocalAiModelFileVerifier : ILocalAiModelFileVerifier
+{
+    public async Task<LocalAiVerifiedModelLease?> TryOpenAsync(
+        string cacheRoot,
+        string candidatePath,
+        long expectedSizeBytes,
+        Sha256Digest expectedSha256,
+        CancellationToken cancellationToken)
+    {
+        VerifiedHuggingFaceCacheFile? verified =
+            await HuggingFaceHubCache.TryOpenVerifiedCacheEntryAsync(
+                    cacheRoot,
+                    candidatePath,
+                    expectedSizeBytes,
+                    expectedSha256,
+                    progress: null,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        return verified is null
+            ? null
+            : new LocalAiVerifiedModelLease(verified, verified.ResolvedPath);
+    }
+}
+
 /// <summary>
 /// Owns the native llama-server router for the lifetime of the Windows companion.
 /// The router starts without a model; the first inference request triggers the
@@ -59,13 +110,15 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
     private readonly ILocalAiManagedProcessHost _processHost;
     private readonly ILlamaServerRuntimePlatform _platform;
     private readonly ILlamaServerClient _client;
+    private readonly ILocalAiModelFileVerifier _modelFileVerifier;
     private readonly SemaphoreSlim _operationGate = new(1, 1);
     private readonly object _exitTasksGate = new();
     private readonly HashSet<Task> _exitTasks = [];
     private readonly object _snapshotGate = new();
     private LocalAiRuntimeSnapshot _snapshot;
     private ILocalAiManagedProcess? _managedProcess;
-    private FileStream? _verifiedModelHandle;
+    private LocalAiVerifiedModelLease? _verifiedModel;
+    private string? _runtimeModelPath;
     private LocalAiResolvedInstall? _install;
     private long _generation;
     private int _restartAttempts;
@@ -82,7 +135,8 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
             logger ?? NullLogger.Instance,
             new WindowsLocalAiManagedProcessHost(logger ?? NullLogger.Instance),
             new SystemLlamaServerRuntimePlatform(),
-            new LlamaServerClient())
+            new LlamaServerClient(),
+            new HuggingFaceLocalAiModelFileVerifier())
     {
     }
 
@@ -91,13 +145,15 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         IOpenClawLogger logger,
         ILocalAiManagedProcessHost processHost,
         ILlamaServerRuntimePlatform platform,
-        ILlamaServerClient client)
+        ILlamaServerClient client,
+        ILocalAiModelFileVerifier? modelFileVerifier = null)
     {
         _options = ValidateOptions(options);
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _processHost = processHost ?? throw new ArgumentNullException(nameof(processHost));
         _platform = platform ?? throw new ArgumentNullException(nameof(platform));
         _client = client ?? throw new ArgumentNullException(nameof(client));
+        _modelFileVerifier = modelFileVerifier ?? new HuggingFaceLocalAiModelFileVerifier();
         _manifestStore = new LocalAiManifestStore(options.Paths);
         _snapshot = LocalAiRuntimeSnapshot.Initial(options.InitialEndpoint, platform.UtcNow);
     }
@@ -318,9 +374,10 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         {
             await ValidateInstalledFilesAsync(install, cancellationToken).ConfigureAwait(false);
             LocalAiPortPolicy.Validate(requestedPort);
-            launchPlan = LlamaServerRouterConfiguration.Build(
+            launchPlan = LlamaServerRouterConfiguration.BuildForVerifiedRuntime(
                 _options.Paths,
                 install,
+                GetRuntimeModelPath(install),
                 requestedPort);
             await WritePresetAtomicallyAsync(launchPlan, cancellationToken).ConfigureAwait(false);
         }
@@ -388,13 +445,14 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                 }
                 if (ownership.Endpoint is not null)
                 {
+                    string runtimeModelPath = GetRuntimeModelPath(install);
                     LlamaServerRouterProbeResult probe = await _client.ProbeManagedModelAsync(
                             ownership.Endpoint,
                             install.Manifest.ModelAlias,
-                            install.ModelPath,
+                            runtimeModelPath,
                             cancellationToken)
                         .ConfigureAwait(false);
-                    if (probe.IsReadyForManagedModel(install.ModelPath))
+                    if (probe.IsReadyForManagedModel(runtimeModelPath))
                     {
                         LocalAiInstallManifest verifiedManifest = install.Manifest with
                         {
@@ -540,13 +598,14 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
                 _managedProcess.StartedAtUtc);
         }
 
+        string runtimeModelPath = GetRuntimeModelPath(install);
         LlamaServerRouterProbeResult probe = await _client.ProbeManagedModelAsync(
                 ownership.Endpoint,
                 install.Manifest.ModelAlias,
-                install.ModelPath,
+                runtimeModelPath,
                 cancellationToken)
             .ConfigureAwait(false);
-        if (probe.IsReadyForManagedModel(install.ModelPath))
+        if (probe.IsReadyForManagedModel(runtimeModelPath))
         {
             bool endpointChanged = install.Endpoint != ownership.Endpoint;
             if (_snapshot.State != LocalAiRuntimeState.Healthy || endpointChanged)
@@ -804,28 +863,40 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
         ValidateInstalledFilesForStatus(install);
 
         if (install.Manifest.SchemaVersion != LocalAiInstallManifest.HubCacheReceiptSchemaVersion)
+        {
+            _runtimeModelPath = install.ModelPath;
             return;
+        }
 
-        _verifiedModelHandle =
-            await HuggingFaceHubCache.TryOpenVerifiedCacheFileAsync(
+        _verifiedModel =
+            await _modelFileVerifier.TryOpenAsync(
                     install.Manifest.ModelCacheRoot!,
                     install.ModelPath,
                     install.Manifest.ModelAsset.SizeBytes,
                     new Sha256Digest(install.Manifest.ModelAsset.Sha256),
-                    progress: null,
                     cancellationToken)
                 .ConfigureAwait(false);
-        if (_verifiedModelHandle is null)
+        if (_verifiedModel is null)
         {
+            _runtimeModelPath = null;
             throw new InvalidDataException(
                 "The shared Hugging Face cache model is unsafe or no longer matches its receipt.");
         }
+
+        _runtimeModelPath = _verifiedModel.ResolvedPath;
     }
 
     private static void ValidateInstalledFilesForStatus(LocalAiResolvedInstall install)
     {
         if (!File.Exists(install.ExecutablePath))
             throw new InvalidDataException("The managed llama-server executable is missing.");
+        if (install.Manifest.SchemaVersion == LocalAiInstallManifest.HubCacheReceiptSchemaVersion)
+        {
+            if (!File.Exists(install.ModelPath))
+                throw new InvalidDataException("The managed GGUF model is missing.");
+            return;
+        }
+
         var model = new FileInfo(install.ModelPath);
         if (!model.Exists || model.Length != install.Manifest.ModelAsset.SizeBytes)
             throw new InvalidDataException("The managed GGUF model is missing or has an unexpected size.");
@@ -1593,8 +1664,18 @@ public sealed class LlamaServerRuntimeService : ILocalAiRuntime
 
     private void DisposeVerifiedModelHandle()
     {
-        _verifiedModelHandle?.Dispose();
-        _verifiedModelHandle = null;
+        _verifiedModel?.Dispose();
+        _verifiedModel = null;
+        _runtimeModelPath = null;
+    }
+
+    private string GetRuntimeModelPath(LocalAiResolvedInstall install)
+    {
+        if (_runtimeModelPath is not null)
+            return _runtimeModelPath;
+        if (install.Manifest.SchemaVersion == LocalAiInstallManifest.HubCacheReceiptSchemaVersion)
+            throw new InvalidOperationException("The verified shared-cache model identity is unavailable.");
+        return install.ModelPath;
     }
 
     private static LlamaServerRuntimeOptions ValidateOptions(LlamaServerRuntimeOptions options)

--- a/src/OpenClaw.Connection/LocalAi/LocalAiManifest.cs
+++ b/src/OpenClaw.Connection/LocalAi/LocalAiManifest.cs
@@ -137,7 +137,16 @@ public sealed record LocalAiAssetReceipt
 
 public sealed record LocalAiInstallManifest
 {
+    /// <summary>
+    /// Legacy app-owned model layout. Kept readable so existing installs and
+    /// downgrade recovery continue to use their original weights in place.
+    /// </summary>
     public const int CurrentSchemaVersion = 3;
+    /// <summary>
+    /// Standard Hugging Face hub-cache layout. A schema-4 receipt is selected
+    /// only after its cache path is structurally validated; callers that execute
+    /// the model must also verify the pinned content before use.
+    /// </summary>
     public const int HubCacheReceiptSchemaVersion = 4;
     public const string SupportedEngine = "llama-server";
 
@@ -158,16 +167,13 @@ public sealed record LocalAiInstallManifest
     public required ImmutableArray<LocalAiAssetReceipt> RuntimeAssets { get; init; }
     public required string ModelPath { get; init; }
     /// <summary>
-    /// Schema-4 migration receipt for the standard Hugging Face hub cache root.
-    /// The legacy <see cref="ModelPath"/> remains authoritative until the model
-    /// acquisition layer switches normal installs and reconciliation to the cache.
+    /// Schema-4 receipt for the standard Hugging Face hub cache root.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? ModelCacheRoot { get; init; }
     /// <summary>
-    /// Schema-4 migration receipt for the verified snapshot copy. Layer 3 may
-    /// promote this path to the active model path after its installer and rollback
-    /// behavior are cache-aware.
+    /// Schema-4 receipt for the verified snapshot copy. Schema-3 manifests keep
+    /// <see cref="ModelPath"/> active; schema-4 manifests select this path.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? CachedModelPath { get; init; }
@@ -309,8 +315,8 @@ public sealed class LocalAiManifestStore
 
     /// <summary>
     /// Copies a canonical schema-3 model into the standard Hugging Face cache and
-    /// records a transitional schema-4 receipt. The active legacy model path is
-    /// intentionally unchanged until the installer and reconciler become cache-aware.
+    /// records a schema-4 receipt whose verified cache snapshot becomes active.
+    /// Passive manifest loads never invoke this operation.
     /// </summary>
     public async Task<LocalAiResolvedInstall?> MigrateLegacyModelToHubCacheAsync(
         IProgress<LocalAiModelMigrationProgress>? progress = null,
@@ -557,13 +563,13 @@ public sealed class LocalAiManifestStore
         if (!string.Equals(Path.GetFileName(executable), "llama-server.exe", StringComparison.OrdinalIgnoreCase))
             throw new InvalidDataException("The managed local AI executable must be llama-server.exe.");
 
-        var model = _paths.ResolveContainedPath(manifest.ModelPath, nameof(manifest.ModelPath));
-        if (!string.Equals(Path.GetExtension(model), ".gguf", StringComparison.OrdinalIgnoreCase))
-            throw new InvalidDataException("The managed local AI model must be a GGUF file.");
-        if (!string.Equals(Path.GetFileName(model), manifest.ModelAsset.FileName, StringComparison.Ordinal))
-            throw new InvalidDataException("The managed model path must match its asset receipt filename.");
-
         ValidateHubCacheReceipt(manifest, provenance);
+        string legacyModel = _paths.ResolveContainedPath(manifest.ModelPath, nameof(manifest.ModelPath));
+        ValidateModelPath(legacyModel, manifest.ModelAsset, "legacy-compatible");
+        string model = manifest.SchemaVersion == LocalAiInstallManifest.HubCacheReceiptSchemaVersion
+            ? ResolveHubCacheModelPath(manifest)
+            : legacyModel;
+        ValidateModelPath(model, manifest.ModelAsset, "active");
 
         LocalAiPortPolicy.Validate(manifest.RequestedPort);
         LocalAiGatewayModelPolicy.ValidateFallbackModel(manifest.GatewayFallbackModel);
@@ -590,6 +596,23 @@ public sealed class LocalAiManifestStore
         }
 
         return new LocalAiResolvedInstall(manifest, executable, model, endpoint);
+    }
+
+    private static void ValidateModelPath(
+        string path,
+        LocalAiAssetReceipt asset,
+        string description)
+    {
+        if (!string.Equals(Path.GetExtension(path), ".gguf", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidDataException(
+                $"The managed {description} Local AI model must be a GGUF file.");
+        }
+        if (!string.Equals(Path.GetFileName(path), asset.FileName, StringComparison.Ordinal))
+        {
+            throw new InvalidDataException(
+                $"The managed {description} model path must match its asset receipt filename.");
+        }
     }
 
     private static void ValidatePlanIdentifier(string? identifier, string fieldName)
@@ -719,6 +742,9 @@ public sealed class LocalAiManifestStore
                     : error);
         }
     }
+
+    private static string ResolveHubCacheModelPath(LocalAiInstallManifest manifest) =>
+        WindowsPathSafety.NormalizePath(manifest.CachedModelPath!);
 
     internal sealed record HuggingFaceModelProvenance(
         string RepositoryId,

--- a/src/OpenClaw.Connection/LocalAi/LocalAiManifestMigration.cs
+++ b/src/OpenClaw.Connection/LocalAi/LocalAiManifestMigration.cs
@@ -10,7 +10,7 @@ namespace OpenClaw.Connection.LocalAi;
 
 /// <summary>
 /// Copies schema-3 model weights into a standard Hugging Face snapshot path and
-/// records the verified destination without changing the active legacy model path.
+/// records the verified destination. Passive manifest reads never invoke this path.
 /// </summary>
 internal static class LocalAiManifestMigration
 {
@@ -439,7 +439,7 @@ internal static class LocalAiManifestMigration
             throw new InvalidDataException("The verified legacy Local AI model changed during cache migration.");
     }
 
-    private static void EnsureSufficientFreeSpace(
+    internal static void EnsureSufficientFreeSpace(
         string destinationDirectory,
         long requiredBytes)
     {
@@ -491,6 +491,71 @@ internal static class LocalAiManifestMigration
             throw new InvalidDataException(
                 "The Hugging Face cache volume capacity could not be inspected safely.",
                 ex);
+        }
+    }
+
+    internal static string ResolveFinalDirectoryPathForComparison(string path)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            throw new PlatformNotSupportedException(
+                "Local AI cache ownership validation requires Windows directory handles.");
+        }
+
+        string current = WindowsPathSafety.NormalizePath(path);
+        var missingSegments = new Stack<string>();
+        while (true)
+        {
+            FileAttributes attributes;
+            try
+            {
+                attributes = File.GetAttributes(current);
+            }
+            catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
+            {
+                string? parent = Path.GetDirectoryName(current);
+                string segment = Path.GetFileName(current);
+                if (string.IsNullOrEmpty(parent) || string.IsNullOrEmpty(segment))
+                {
+                    throw new InvalidDataException(
+                        $"The directory path '{path}' has no existing ancestor that can be validated.",
+                        ex);
+                }
+
+                missingSegments.Push(segment);
+                current = parent;
+                continue;
+            }
+            catch (Exception ex) when (
+                ex is IOException or UnauthorizedAccessException or System.Security.SecurityException)
+            {
+                throw new InvalidDataException(
+                    $"The directory path '{path}' could not be safely inspected: {ex.Message}",
+                    ex);
+            }
+
+            if ((attributes & FileAttributes.Directory) == 0)
+                throw new InvalidDataException($"The directory path '{current}' is an existing file.");
+
+            using SafeFileHandle handle = CreateFileW(
+                current,
+                0,
+                FileShare.ReadWrite | FileShare.Delete,
+                IntPtr.Zero,
+                OpenExisting,
+                FileFlagBackupSemantics,
+                IntPtr.Zero);
+            if (handle.IsInvalid)
+            {
+                throw CreateNativeIOException(
+                    $"The directory path '{current}' could not be opened safely.",
+                    Marshal.GetLastWin32Error());
+            }
+
+            string resolved = GetFinalPathFromHandle(handle);
+            while (missingSegments.TryPop(out string? segment))
+                resolved = Path.Combine(resolved, segment);
+            return WindowsPathSafety.NormalizePath(resolved);
         }
     }
 
@@ -571,7 +636,7 @@ internal static class LocalAiManifestMigration
     /// Roots every cache mutation in directory handles whose identities are checked
     /// against the configured cache root, so path swaps cannot redirect file writes.
     /// </summary>
-    private sealed class SafeCacheDirectory : IDisposable
+    internal sealed class SafeCacheDirectory : IDisposable
     {
         private readonly SafeFileHandle _cacheRootHandle;
         private readonly SafeFileHandle _directoryHandle;
@@ -655,7 +720,7 @@ internal static class LocalAiManifestMigration
             int status = OpenRelativeFile(
                 _directoryHandle,
                 fileName,
-                GenericRead | DeleteAccess | SynchronizeAccess,
+                GenericRead | GenericWrite | DeleteAccess | SynchronizeAccess,
                 FileOpen,
                 out SafeFileHandle? handle);
             if (status != 0)
@@ -668,16 +733,23 @@ internal static class LocalAiManifestMigration
                     error);
             }
 
-            var file = new CacheMigrationFile(handle!, FileAccess.Read, this);
+            var file = new CacheMigrationFile(handle!, FileAccess.ReadWrite, this);
             try
             {
                 BY_HANDLE_FILE_INFORMATION info = GetHandleInformation(handle!);
-                if ((info.FileAttributes & (uint)FileAttributes.ReparsePoint) != 0 ||
-                    info.NumberOfLinks != 1)
+                if ((info.FileAttributes & (uint)FileAttributes.ReparsePoint) != 0)
                 {
-                    file.Delete();
-                    file.Dispose();
-                    return null;
+                    file.Commit();
+                    throw new InvalidDataException(
+                        $"The Hugging Face cache partial '{Path.Combine(_destinationPath, fileName)}' " +
+                        "is a reparse point. Remove it manually and retry setup.");
+                }
+                if (info.NumberOfLinks != 1)
+                {
+                    file.Commit();
+                    throw new InvalidDataException(
+                        $"The Hugging Face cache partial '{Path.Combine(_destinationPath, fileName)}' " +
+                        "has multiple hard links. Remove it manually and retry setup.");
                 }
 
                 RequireContainedFile(handle!, fileName);
@@ -685,6 +757,7 @@ internal static class LocalAiManifestMigration
             }
             catch
             {
+                file.Commit();
                 file.Dispose();
                 throw;
             }
@@ -1015,7 +1088,7 @@ internal static class LocalAiManifestMigration
         }
     }
 
-    private sealed class CacheMigrationFile : IAsyncDisposable, IDisposable
+    internal sealed class CacheMigrationFile : IAsyncDisposable, IDisposable
     {
         private readonly SafeCacheDirectory _directory;
         private bool _deleteOnDispose = true;

--- a/src/OpenClaw.Connection/OpenClaw.Connection.csproj
+++ b/src/OpenClaw.Connection/OpenClaw.Connection.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="OpenClaw.SetupEngine" />
     <InternalsVisibleTo Include="OpenClaw.Connection.Tests" />
     <InternalsVisibleTo Include="OpenClaw.Tray.Tests" />
     <InternalsVisibleTo Include="OpenClaw.SetupEngine.Tests" />

--- a/src/OpenClaw.SetupEngine/HuggingFaceModelInstaller.cs
+++ b/src/OpenClaw.SetupEngine/HuggingFaceModelInstaller.cs
@@ -1,3 +1,4 @@
+using OpenClaw.Connection.LocalAi;
 using OpenClaw.Shared.Inference.Catalog;
 using System.Net;
 using System.Net.Http.Headers;
@@ -11,7 +12,16 @@ internal enum HuggingFaceModelInstallDisposition
     ReusedVerified,
 }
 
-internal sealed record HuggingFaceModelInstallProgress(long CompletedBytes, long TotalBytes)
+internal enum HuggingFaceModelInstallPhase
+{
+    Downloading,
+    Verifying,
+}
+
+internal sealed record HuggingFaceModelInstallProgress(
+    long CompletedBytes,
+    long TotalBytes,
+    HuggingFaceModelInstallPhase Phase = HuggingFaceModelInstallPhase.Downloading)
 {
     public double Fraction => TotalBytes > 0
         ? Math.Clamp((double)CompletedBytes / TotalBytes, 0, 1)
@@ -20,8 +30,11 @@ internal sealed record HuggingFaceModelInstallProgress(long CompletedBytes, long
 
 internal sealed record HuggingFaceModelInstallResult(
     string ModelPath,
+    string? CacheRoot,
     HuggingFaceModelInstallDisposition Disposition,
-    bool CreatedThisRun);
+    bool CreatedThisRun,
+    string? LegacyModelPath = null,
+    bool LegacyCreatedThisRun = false);
 
 internal class HuggingFaceModelInstallException : Exception
 {
@@ -64,8 +77,8 @@ internal interface IHuggingFaceModelAcquirer
 /// <summary>
 /// Downloads one immutable Hugging Face GGUF, verifies its exact byte count and
 /// SHA-256 digest, and atomically promotes it beside its partial file. A partial
-/// left by process termination is resumed with an HTTP range request. Any
-/// observed setup failure or cancellation removes the partial file.
+/// left by process termination is resumed with an HTTP range request. Shared
+/// cache artifacts and resumable partials survive rollback and cancellation.
 /// </summary>
 internal sealed class HuggingFaceModelInstaller : IHuggingFaceModelAcquirer
 {
@@ -76,17 +89,22 @@ internal sealed class HuggingFaceModelInstaller : IHuggingFaceModelAcquirer
 
     private readonly HttpClient _httpClient;
     private readonly Func<TimeSpan, CancellationToken, Task> _retryDelay;
+    private readonly Func<string> _cacheRootResolver;
 
     public HuggingFaceModelInstaller(HttpClient httpClient) =>
-        (_httpClient, _retryDelay) =
-            (httpClient ?? throw new ArgumentNullException(nameof(httpClient)), Task.Delay);
+        (_httpClient, _retryDelay, _cacheRootResolver) =
+            (httpClient ?? throw new ArgumentNullException(nameof(httpClient)),
+             Task.Delay,
+             HuggingFaceHubCache.ResolveCacheRoot);
 
     internal HuggingFaceModelInstaller(
         HttpClient httpClient,
-        Func<TimeSpan, CancellationToken, Task> retryDelay) =>
-        (_httpClient, _retryDelay) =
+        Func<TimeSpan, CancellationToken, Task> retryDelay,
+        Func<string>? cacheRootResolver = null) =>
+        (_httpClient, _retryDelay, _cacheRootResolver) =
             (httpClient ?? throw new ArgumentNullException(nameof(httpClient)),
-             retryDelay ?? throw new ArgumentNullException(nameof(retryDelay)));
+             retryDelay ?? throw new ArgumentNullException(nameof(retryDelay)),
+             cacheRootResolver ?? HuggingFaceHubCache.ResolveCacheRoot);
 
     public event EventHandler<HuggingFaceModelInstallProgress>? ProgressChanged;
 
@@ -106,15 +124,22 @@ internal sealed class HuggingFaceModelInstaller : IHuggingFaceModelAcquirer
                 "The Local AI model must be an immutable Hugging Face weights artifact.");
         }
 
-        if (!LocalAiPathPolicy.TryResolve(localDataDirectory, component, out LocalAiSetupPaths paths, out string pathError) ||
-            !LocalAiPathPolicy.TryGetModelPaths(
-                paths,
+        string cacheRoot = _cacheRootResolver();
+        if (!TryValidateCacheRootOwnershipBoundary(
+                localDataDirectory,
+                cacheRoot,
+                out string cacheRootError))
+        {
+            throw new HuggingFaceModelInstallException(cacheRootError);
+        }
+        if (!HuggingFaceHubCache.TryGetSnapshotPaths(
+                cacheRoot,
                 source.RepositoryId,
                 source.RevisionSha,
                 model.Weights.RelativePath,
                 out string modelPath,
                 out string partialPath,
-                out pathError))
+                out string pathError))
         {
             throw new HuggingFaceModelInstallException(pathError);
         }
@@ -124,60 +149,110 @@ internal sealed class HuggingFaceModelInstaller : IHuggingFaceModelAcquirer
         if (Directory.Exists(partialPath))
             throw new HuggingFaceModelInstallException("The managed Local AI partial model path is an existing directory.");
 
-        if (File.Exists(modelPath))
+        var expectedSha256 = model.Weights.Sha256;
+        await using (FileStream? verified =
+            await HuggingFaceHubCache.TryOpenVerifiedCacheFileAsync(
+                    cacheRoot,
+                    modelPath,
+                    model.Weights.SizeBytes,
+                    expectedSha256,
+                    new VerificationProgress(this, progress, model.Weights.SizeBytes),
+                    cancellationToken)
+                .ConfigureAwait(false))
         {
-            if (await VerifyFileAsync(modelPath, model.Weights, cancellationToken).ConfigureAwait(false))
+            if (verified is not null)
             {
+                (string legacyModelPath, bool legacyCreatedThisRun) =
+                    await EnsureLegacyCompatibilityCopyAsync(
+                            localDataDirectory,
+                            component,
+                            model,
+                            verified,
+                            progress,
+                            cancellationToken)
+                        .ConfigureAwait(false);
                 return new HuggingFaceModelInstallResult(
                     modelPath,
+                    cacheRoot,
                     HuggingFaceModelInstallDisposition.ReusedVerified,
-                    CreatedThisRun: false);
+                    CreatedThisRun: false,
+                    legacyModelPath,
+                    legacyCreatedThisRun);
             }
-
-            if (!LocalAiPathPolicy.TryValidateManagedDeleteTarget(
-                    localDataDirectory,
-                    modelPath,
-                    out string invalidModelPath,
-                    out pathError))
-            {
-                throw new HuggingFaceModelInstallException(pathError);
-            }
-            File.Delete(invalidModelPath);
         }
 
-        Directory.CreateDirectory(Path.GetDirectoryName(modelPath)!);
-        var promoted = false;
-        var preservePartial = false;
+        if (PathEntryExists(modelPath))
+        {
+            throw new HuggingFaceModelInstallException(
+                $"The Hugging Face cache destination '{modelPath}' is unsafe or does not match " +
+                "the pinned model. Remove it manually and retry setup.");
+        }
+
+        string destinationDirectory = Path.GetDirectoryName(modelPath)
+            ?? throw new HuggingFaceModelInstallException(
+                "The Hugging Face cache destination has no parent directory.");
+        string destinationFileName = Path.GetFileName(modelPath);
+        string partialFileName = Path.GetFileName(partialPath);
+        LocalAiManifestMigration.SafeCacheDirectory? directory = null;
+        LocalAiManifestMigration.CacheMigrationFile? partial = null;
+        bool partialExistedBeforeInstall = false;
+        HuggingFaceModelInstallDisposition disposition = HuggingFaceModelInstallDisposition.Downloaded;
         try
         {
-            bool verifiedCompletePartial = File.Exists(partialPath) &&
-                new FileInfo(partialPath).Length == model.Weights.SizeBytes &&
-                await VerifyFileAsync(partialPath, model.Weights, cancellationToken).ConfigureAwait(false);
-            if (!verifiedCompletePartial)
-            {
-                if (File.Exists(partialPath) &&
-                    new FileInfo(partialPath).Length >= model.Weights.SizeBytes)
-                {
-                    TryDeletePartial(localDataDirectory, partialPath);
-                }
+            directory = LocalAiManifestMigration.SafeCacheDirectory.OpenOrCreate(
+                cacheRoot,
+                destinationDirectory);
+            partial = directory.TryOpenExisting(partialFileName);
+            partialExistedBeforeInstall = partial is not null;
 
-                await DownloadAndVerifyAsync(
+            bool partialVerified = partial is not null &&
+                partial.Stream.Length == model.Weights.SizeBytes &&
+                await VerifyOpenFileAsync(
+                        partial.Stream,
                         model.Weights,
-                        localDataDirectory,
-                        partialPath,
                         progress,
                         cancellationToken)
                     .ConfigureAwait(false);
+            if (partial is not null &&
+                partial.Stream.Length >= model.Weights.SizeBytes &&
+                !partialVerified)
+            {
+                partial.Stream.SetLength(0);
+                partial.Stream.Position = 0;
+            }
+
+            if (!partialVerified)
+            {
+                partial ??= directory.CreateNew(partialFileName);
+                if (partial.Stream.Length == 0 &&
+                    await TryCopyVerifiedBlobAsync(
+                            cacheRoot,
+                            source.RepositoryId,
+                            model.Weights,
+                            partial.Stream,
+                            progress,
+                            cancellationToken)
+                        .ConfigureAwait(false))
+                {
+                    disposition = HuggingFaceModelInstallDisposition.ReusedVerified;
+                }
+                else
+                {
+                    await DownloadAndVerifyAsync(
+                            model.Weights,
+                            partial.Stream,
+                            progress,
+                            cancellationToken)
+                        .ConfigureAwait(false);
+                }
             }
 
             cancellationToken.ThrowIfCancellationRequested();
-            if (!LocalAiPathPolicy.TryResolve(
-                    localDataDirectory,
-                    component,
-                    out LocalAiSetupPaths revalidatedPaths,
-                    out pathError) ||
-                !LocalAiPathPolicy.TryGetModelPaths(
-                    revalidatedPaths,
+            LocalAiManifestMigration.CacheMigrationFile activePartial = partial
+                ?? throw new HuggingFaceModelInstallException(
+                    "The Hugging Face cache partial was not created.");
+            if (!HuggingFaceHubCache.TryGetSnapshotPaths(
+                    cacheRoot,
                     source.RepositoryId,
                     source.RevisionSha,
                     model.Weights.RelativePath,
@@ -193,54 +268,121 @@ internal sealed class HuggingFaceModelInstaller : IHuggingFaceModelAcquirer
                         : pathError);
             }
 
-            if (File.Exists(modelPath))
+            if (!await VerifyOpenFileAsync(
+                    activePartial.Stream,
+                    model.Weights,
+                    progress,
+                    cancellationToken).ConfigureAwait(false))
             {
                 throw new HuggingFaceModelInstallException(
-                    "The Local AI model target appeared while the download was in progress.");
+                    "The Hugging Face cache partial does not match the pinned model.");
             }
 
-            File.Move(partialPath, modelPath);
-            promoted = true;
+            try
+            {
+                activePartial.Promote(destinationFileName);
+            }
+            catch (IOException ex)
+            {
+                if (partialExistedBeforeInstall)
+                    activePartial.Commit();
+                activePartial.Dispose();
+                partial = null;
+                await using FileStream? winner =
+                    await HuggingFaceHubCache.TryOpenVerifiedCacheFileAsync(
+                            cacheRoot,
+                            modelPath,
+                            model.Weights.SizeBytes,
+                            expectedSha256,
+                            new VerificationProgress(this, progress, model.Weights.SizeBytes),
+                            cancellationToken)
+                        .ConfigureAwait(false);
+                if (winner is null)
+                {
+                    throw new HuggingFaceModelInstallException(
+                        "The Hugging Face cache destination changed before promotion.",
+                        ex);
+                }
+
+                (string legacyModelPath, bool legacyCreatedThisRun) =
+                    await EnsureLegacyCompatibilityCopyAsync(
+                            localDataDirectory,
+                            component,
+                            model,
+                            winner,
+                            progress,
+                            cancellationToken)
+                        .ConfigureAwait(false);
+                return new HuggingFaceModelInstallResult(
+                    modelPath,
+                    cacheRoot,
+                    HuggingFaceModelInstallDisposition.ReusedVerified,
+                    CreatedThisRun: false,
+                    legacyModelPath,
+                    legacyCreatedThisRun);
+            }
+
+            if (partialExistedBeforeInstall)
+                activePartial.Commit();
+            directory.RequirePromotedFile(activePartial.Stream.SafeFileHandle, destinationFileName);
+            activePartial.Commit();
+            (string createdLegacyModelPath, bool createdLegacyThisRun) =
+                await EnsureLegacyCompatibilityCopyAsync(
+                        localDataDirectory,
+                        component,
+                        model,
+                        activePartial.Stream,
+                        progress,
+                        cancellationToken)
+                    .ConfigureAwait(false);
             return new HuggingFaceModelInstallResult(
                 modelPath,
-                HuggingFaceModelInstallDisposition.Downloaded,
-                CreatedThisRun: true);
+                cacheRoot,
+                disposition,
+                CreatedThisRun: true,
+                createdLegacyModelPath,
+                createdLegacyThisRun);
         }
         catch (OperationCanceledException)
         {
-            preservePartial = File.Exists(partialPath);
+            partial?.Commit();
             throw;
         }
         catch (Exception exception) when (
             exception is IOException or HttpRequestException or TransientHuggingFaceModelInstallException)
         {
-            preservePartial = File.Exists(partialPath);
+            partial?.Commit();
+            throw;
+        }
+        catch (HuggingFaceModelInstallException) when (partialExistedBeforeInstall)
+        {
+            // A later run can truncate and retry a non-resumable complete partial.
+            // Preserve bytes that existed before this setup transaction.
+            partial?.Commit();
             throw;
         }
         finally
         {
-            if (!promoted && !preservePartial)
-                TryDeletePartial(localDataDirectory, partialPath);
+            partial?.Dispose();
+            directory?.Dispose();
         }
     }
 
     public void RemoveInstalledModel(string localDataDirectory, HuggingFaceModelInstallResult install)
     {
         ArgumentNullException.ThrowIfNull(install);
-        if (!install.CreatedThisRun)
+        // Final hub-cache artifacts are shared and survive rollback/uninstall.
+        if (!install.LegacyCreatedThisRun || string.IsNullOrWhiteSpace(install.LegacyModelPath))
             return;
-
         if (!LocalAiPathPolicy.TryValidateManagedDeleteTarget(
                 localDataDirectory,
-                install.ModelPath,
+                install.LegacyModelPath,
                 out string deletePath,
                 out string error))
         {
             throw new InvalidDataException(error);
         }
-
-        if (File.Exists(deletePath))
-            File.Delete(deletePath);
+        File.Delete(deletePath);
     }
 
     public void RemovePartialModel(
@@ -250,46 +392,31 @@ internal sealed class HuggingFaceModelInstaller : IHuggingFaceModelAcquirer
     {
         ArgumentNullException.ThrowIfNull(component);
         ArgumentNullException.ThrowIfNull(model);
-        if (model.Weights.Source is not HuggingFaceRevisionSource source)
-            throw new InvalidDataException("The Local AI model does not have immutable Hugging Face provenance.");
-        if (!LocalAiPathPolicy.TryResolve(
+        // Partials live in a shared cache and may predate this setup transaction.
+        // The installer removes only a newly created invalid partial before returning.
+        if (model.Weights.Source is not HuggingFaceRevisionSource source ||
+            !LocalAiPathPolicy.TryResolve(
                 localDataDirectory,
                 component,
                 out LocalAiSetupPaths paths,
-                out string error) ||
+                out _) ||
             !LocalAiPathPolicy.TryGetModelPaths(
                 paths,
                 source.RepositoryId,
                 source.RevisionSha,
                 model.Weights.RelativePath,
+                out string legacyModelPath,
                 out _,
-                out string partialPath,
-                out error))
+                out _))
         {
-            throw new InvalidDataException(
-                string.IsNullOrWhiteSpace(error) ? "The Local AI partial model path is invalid." : error);
+            return;
         }
-
-        if (Directory.Exists(partialPath))
-            throw new InvalidDataException("The Local AI partial model path is an existing directory.");
-        if (File.Exists(partialPath))
-        {
-            if (!LocalAiPathPolicy.TryValidateManagedDeleteTarget(
-                    localDataDirectory,
-                    partialPath,
-                    out string deletePath,
-                    out error))
-            {
-                throw new InvalidDataException(error);
-            }
-            File.Delete(deletePath);
-        }
+        CleanupLegacyCompatibilityPartials(localDataDirectory, legacyModelPath);
     }
 
     private async Task DownloadAndVerifyAsync(
         PinnedArtifact artifact,
-        string localDataDirectory,
-        string partialPath,
+        FileStream partial,
         IProgress<HuggingFaceModelInstallProgress>? progress,
         CancellationToken cancellationToken)
     {
@@ -299,8 +426,7 @@ internal sealed class HuggingFaceModelInstaller : IHuggingFaceModelAcquirer
             {
                 await DownloadAndVerifyAttemptAsync(
                         artifact,
-                        localDataDirectory,
-                        partialPath,
+                        partial,
                         progress,
                         cancellationToken)
                     .ConfigureAwait(false);
@@ -319,17 +445,20 @@ internal sealed class HuggingFaceModelInstaller : IHuggingFaceModelAcquirer
 
     private async Task DownloadAndVerifyAttemptAsync(
         PinnedArtifact artifact,
-        string localDataDirectory,
-        string partialPath,
+        FileStream partial,
         IProgress<HuggingFaceModelInstallProgress>? progress,
         CancellationToken cancellationToken)
     {
-        long resumeOffset = File.Exists(partialPath) ? new FileInfo(partialPath).Length : 0;
+        long resumeOffset = partial.Length;
         if (resumeOffset < 0 || resumeOffset >= artifact.SizeBytes)
         {
-            TryDeletePartial(localDataDirectory, partialPath);
+            partial.SetLength(0);
             resumeOffset = 0;
         }
+
+        using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        if (resumeOffset > 0)
+            await HashExistingPartialAsync(partial, hash, cancellationToken).ConfigureAwait(false);
 
         using HttpResponseMessage response = await SendWithValidatedRedirectsAsync(
                 artifact.DownloadUri,
@@ -361,6 +490,8 @@ internal sealed class HuggingFaceModelInstaller : IHuggingFaceModelAcquirer
         else
         {
             resumeOffset = 0;
+            partial.SetLength(0);
+            hash.GetHashAndReset();
         }
 
         long expectedBodyBytes = artifact.SizeBytes - resumeOffset;
@@ -370,18 +501,8 @@ internal sealed class HuggingFaceModelInstaller : IHuggingFaceModelAcquirer
                 $"The Hugging Face response declared {contentLength} bytes; expected {expectedBodyBytes} bytes.");
         }
 
-        using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
-        if (append)
-            await HashExistingPartialAsync(partialPath, hash, cancellationToken).ConfigureAwait(false);
-
         await using var source = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
-        await using var destination = new FileStream(
-            partialPath,
-            append ? FileMode.Append : FileMode.Create,
-            FileAccess.Write,
-            FileShare.None,
-            BufferSize,
-            FileOptions.Asynchronous | FileOptions.SequentialScan | FileOptions.WriteThrough);
+        partial.Position = resumeOffset;
 
         long completed = resumeOffset;
         long lastReported = completed;
@@ -397,7 +518,7 @@ internal sealed class HuggingFaceModelInstaller : IHuggingFaceModelAcquirer
             if (completed > artifact.SizeBytes)
                 throw new HuggingFaceModelInstallException("The Hugging Face response exceeded the pinned model size.");
             hash.AppendData(buffer, 0, read);
-            await destination.WriteAsync(buffer.AsMemory(0, read), cancellationToken).ConfigureAwait(false);
+            await partial.WriteAsync(buffer.AsMemory(0, read), cancellationToken).ConfigureAwait(false);
 
             if (completed - lastReported >= ProgressIntervalBytes)
             {
@@ -406,8 +527,8 @@ internal sealed class HuggingFaceModelInstaller : IHuggingFaceModelAcquirer
             }
         }
 
-        await destination.FlushAsync(cancellationToken).ConfigureAwait(false);
-        destination.Flush(flushToDisk: true);
+        await partial.FlushAsync(cancellationToken).ConfigureAwait(false);
+        partial.Flush(flushToDisk: true);
         if (completed != artifact.SizeBytes)
         {
             throw new HuggingFaceModelInstallException(
@@ -507,25 +628,256 @@ internal sealed class HuggingFaceModelInstaller : IHuggingFaceModelAcquirer
         (int)statusCode is >= 500 and <= 599;
 
     private static async Task HashExistingPartialAsync(
-        string partialPath,
+        FileStream partial,
         IncrementalHash hash,
         CancellationToken cancellationToken)
     {
-        await using var stream = new FileStream(
-            partialPath,
-            FileMode.Open,
-            FileAccess.Read,
-            FileShare.Read,
-            BufferSize,
-            FileOptions.Asynchronous | FileOptions.SequentialScan);
+        partial.Position = 0;
         var buffer = new byte[BufferSize];
+        while (true)
+        {
+            int read = await partial.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+            if (read == 0)
+            {
+                partial.Position = partial.Length;
+                return;
+            }
+            hash.AppendData(buffer, 0, read);
+        }
+    }
+
+    private async Task<bool> TryCopyVerifiedBlobAsync(
+        string cacheRoot,
+        string repositoryId,
+        PinnedArtifact artifact,
+        FileStream destination,
+        IProgress<HuggingFaceModelInstallProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        if (!HuggingFaceHubCache.TryGetBlobPath(
+                cacheRoot,
+                repositoryId,
+                artifact.Sha256,
+                out string blobPath,
+                out _))
+        {
+            return false;
+        }
+
+        await using FileStream? source =
+            await HuggingFaceHubCache.TryOpenVerifiedCacheFileAsync(
+                    cacheRoot,
+                    blobPath,
+                    artifact.SizeBytes,
+                    artifact.Sha256,
+                    new VerificationProgress(this, progress, artifact.SizeBytes),
+                    cancellationToken)
+                .ConfigureAwait(false);
+        if (source is null)
+            return false;
+
+        destination.SetLength(0);
+        destination.Position = 0;
+        var buffer = new byte[BufferSize];
+        long completed = 0;
+        Report(progress, completed, artifact.SizeBytes, HuggingFaceModelInstallPhase.Downloading);
+        while (true)
+        {
+            int read = await source.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+            if (read == 0)
+                break;
+            await destination.WriteAsync(buffer.AsMemory(0, read), cancellationToken)
+                .ConfigureAwait(false);
+            completed += read;
+            Report(progress, completed, artifact.SizeBytes, HuggingFaceModelInstallPhase.Downloading);
+        }
+        await destination.FlushAsync(cancellationToken).ConfigureAwait(false);
+        destination.Flush(flushToDisk: true);
+        destination.Position = 0;
+        return completed == artifact.SizeBytes;
+    }
+
+    private async Task<(string Path, bool CreatedThisRun)> EnsureLegacyCompatibilityCopyAsync(
+        string localDataDirectory,
+        LocalAiComponentIdentity component,
+        LocalModelInfo model,
+        FileStream verifiedSource,
+        IProgress<HuggingFaceModelInstallProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        HuggingFaceRevisionSource source = (HuggingFaceRevisionSource)model.Weights.Source;
+        if (!LocalAiPathPolicy.TryResolve(
+                localDataDirectory,
+                component,
+                out LocalAiSetupPaths paths,
+                out string error) ||
+            !LocalAiPathPolicy.TryGetModelPaths(
+                paths,
+                source.RepositoryId,
+                source.RevisionSha,
+                model.Weights.RelativePath,
+                out string legacyModelPath,
+                out _,
+                out error))
+        {
+            throw new HuggingFaceModelInstallException(error);
+        }
+        CleanupLegacyCompatibilityPartials(localDataDirectory, legacyModelPath);
+
+        if (Directory.Exists(legacyModelPath))
+        {
+            throw new HuggingFaceModelInstallException(
+                "The legacy-compatible Local AI model path is an existing directory.");
+        }
+        if (File.Exists(legacyModelPath))
+        {
+            if (await VerifyFileAsync(legacyModelPath, model.Weights, cancellationToken)
+                    .ConfigureAwait(false))
+            {
+                return (legacyModelPath, false);
+            }
+
+            if (!LocalAiPathPolicy.TryValidateManagedDeleteTarget(
+                    localDataDirectory,
+                    legacyModelPath,
+                    out string invalidLegacyModelPath,
+                    out error))
+            {
+                throw new HuggingFaceModelInstallException(error);
+            }
+            File.Delete(invalidLegacyModelPath);
+        }
+
+        Directory.CreateDirectory(Path.GetDirectoryName(legacyModelPath)!);
+        LocalAiManifestMigration.EnsureSufficientFreeSpace(
+            Path.GetDirectoryName(legacyModelPath)!,
+            model.Weights.SizeBytes);
+        string temporaryPath = legacyModelPath + $".compat-{Guid.NewGuid():N}.partial";
+        try
+        {
+            await using var temporary = new FileStream(
+                temporaryPath,
+                FileMode.CreateNew,
+                FileAccess.ReadWrite,
+                FileShare.None,
+                BufferSize,
+                FileOptions.Asynchronous | FileOptions.SequentialScan);
+            verifiedSource.Position = 0;
+            await verifiedSource.CopyToAsync(temporary, BufferSize, cancellationToken)
+                .ConfigureAwait(false);
+            await temporary.FlushAsync(cancellationToken).ConfigureAwait(false);
+            temporary.Flush(flushToDisk: true);
+            if (!await VerifyOpenFileAsync(
+                    temporary,
+                    model.Weights,
+                    progress,
+                    cancellationToken).ConfigureAwait(false))
+            {
+                throw new HuggingFaceModelInstallException(
+                    "The legacy-compatible Local AI model copy does not match the pinned model.");
+            }
+
+            if (!LocalAiPathPolicy.TryResolve(
+                    localDataDirectory,
+                    component,
+                    out LocalAiSetupPaths revalidatedPaths,
+                    out error) ||
+                !LocalAiPathPolicy.TryGetModelPaths(
+                    revalidatedPaths,
+                    source.RepositoryId,
+                    source.RevisionSha,
+                    model.Weights.RelativePath,
+                    out string revalidatedLegacyModelPath,
+                    out _,
+                    out error) ||
+                !string.Equals(
+                    legacyModelPath,
+                    revalidatedLegacyModelPath,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                throw new HuggingFaceModelInstallException(
+                    string.IsNullOrWhiteSpace(error)
+                        ? "The legacy-compatible Local AI model path changed before promotion."
+                        : error);
+            }
+            if (PathEntryExists(legacyModelPath))
+            {
+                throw new HuggingFaceModelInstallException(
+                    "The legacy-compatible Local AI model path appeared before promotion.");
+            }
+
+            temporary.Close();
+            File.Move(temporaryPath, legacyModelPath);
+            return (legacyModelPath, true);
+        }
+        finally
+        {
+            if (File.Exists(temporaryPath))
+            {
+                try
+                {
+                    File.Delete(temporaryPath);
+                }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                {
+                    // Cleanup must not replace the actionable acquisition failure.
+                }
+            }
+        }
+    }
+
+    private static void CleanupLegacyCompatibilityPartials(
+        string localDataDirectory,
+        string legacyModelPath)
+    {
+        string directory = Path.GetDirectoryName(legacyModelPath)!;
+        if (!Directory.Exists(directory))
+            return;
+
+        string pattern = Path.GetFileName(legacyModelPath) + ".compat-*.partial";
+        foreach (string candidate in Directory.EnumerateFiles(directory, pattern))
+        {
+            if (!LocalAiPathPolicy.TryValidateManagedDeleteTarget(
+                    localDataDirectory,
+                    candidate,
+                    out string deletePath,
+                    out string error))
+            {
+                throw new InvalidDataException(error);
+            }
+            File.Delete(deletePath);
+        }
+    }
+
+    private async Task<bool> VerifyOpenFileAsync(
+        FileStream stream,
+        PinnedArtifact artifact,
+        IProgress<HuggingFaceModelInstallProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        if (stream.Length != artifact.SizeBytes)
+            return false;
+
+        stream.Position = 0;
+        using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        var buffer = new byte[BufferSize];
+        long completed = 0;
+        Report(progress, completed, artifact.SizeBytes, HuggingFaceModelInstallPhase.Verifying);
         while (true)
         {
             int read = await stream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
             if (read == 0)
-                return;
+                break;
             hash.AppendData(buffer, 0, read);
+            completed += read;
+            Report(progress, completed, artifact.SizeBytes, HuggingFaceModelInstallPhase.Verifying);
         }
+
+        stream.Position = 0;
+        return completed == artifact.SizeBytes &&
+            CryptographicOperations.FixedTimeEquals(
+                hash.GetHashAndReset(),
+                Convert.FromHexString(artifact.Sha256.Value));
     }
 
     internal static async Task<bool> VerifyFileAsync(
@@ -550,30 +902,89 @@ internal sealed class HuggingFaceModelInstaller : IHuggingFaceModelAcquirer
     private void Report(
         IProgress<HuggingFaceModelInstallProgress>? progress,
         long completed,
-        long total)
+        long total,
+        HuggingFaceModelInstallPhase phase = HuggingFaceModelInstallPhase.Downloading)
     {
-        var value = new HuggingFaceModelInstallProgress(completed, total);
+        var value = new HuggingFaceModelInstallProgress(completed, total, phase);
         progress?.Report(value);
         ProgressChanged?.Invoke(this, value);
     }
 
-    private static void TryDeletePartial(string localDataDirectory, string partialPath)
+    private static bool PathEntryExists(string path)
     {
         try
         {
-            if (LocalAiPathPolicy.TryValidateManagedDeleteTarget(
-                    localDataDirectory,
-                    partialPath,
-                    out string deletePath,
-                    out _) &&
-                File.Exists(deletePath))
+            _ = File.GetAttributes(path);
+            return true;
+        }
+        catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
+        {
+            try
             {
-                File.Delete(deletePath);
+                return new FileInfo(path).LinkTarget is not null;
+            }
+            catch (Exception linkException) when (
+                linkException is IOException or
+                    UnauthorizedAccessException or
+                    NotSupportedException)
+            {
+                return true;
             }
         }
-        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+    }
+
+    internal static bool TryValidateCacheRootOwnershipBoundary(
+        string localDataDirectory,
+        string cacheRoot,
+        out string error)
+    {
+        string managedRoot;
+        string normalizedCacheRoot;
+        try
         {
-            // Best-effort cleanup must not mask the acquisition result.
+            managedRoot = LocalAiManifestMigration.ResolveFinalDirectoryPathForComparison(
+                new LocalAiPaths(localDataDirectory).RootDirectory);
+            normalizedCacheRoot = LocalAiManifestMigration.ResolveFinalDirectoryPathForComparison(
+                cacheRoot);
         }
+        catch (Exception ex) when (
+            ex is ArgumentException or
+                IOException or
+                InvalidDataException or
+                NotSupportedException or
+                UnauthorizedAccessException or
+                System.Security.SecurityException)
+        {
+            error = $"The Hugging Face cache root is invalid: {ex.Message}";
+            return false;
+        }
+
+        string relative = Path.GetRelativePath(managedRoot, normalizedCacheRoot);
+        bool isManagedRootOrDescendant =
+            string.Equals(relative, ".", StringComparison.Ordinal) ||
+            (!Path.IsPathRooted(relative) &&
+             !string.Equals(relative, "..", StringComparison.Ordinal) &&
+             !relative.StartsWith(
+                 $"..{Path.DirectorySeparatorChar}",
+                 StringComparison.Ordinal));
+        if (!isManagedRootOrDescendant)
+        {
+            error = "";
+            return true;
+        }
+
+        error =
+            $"The Hugging Face cache root '{normalizedCacheRoot}' must be outside the " +
+            $"app-owned Local AI directory '{managedRoot}' so uninstall cannot remove shared cache artifacts.";
+        return false;
+    }
+
+    private sealed class VerificationProgress(
+        HuggingFaceModelInstaller owner,
+        IProgress<HuggingFaceModelInstallProgress>? progress,
+        long totalBytes) : IProgress<long>
+    {
+        public void Report(long value) =>
+            owner.Report(progress, value, totalBytes, HuggingFaceModelInstallPhase.Verifying);
     }
 }

--- a/src/OpenClaw.SetupEngine/LocalAiInstallReconciler.cs
+++ b/src/OpenClaw.SetupEngine/LocalAiInstallReconciler.cs
@@ -14,16 +14,37 @@ internal sealed record LocalAiReconcileResult(
 
 internal interface ILocalAiModelFileVerifier
 {
-    Task<bool> VerifyAsync(string path, PinnedArtifact artifact, CancellationToken cancellationToken);
+    Task<bool> VerifyAsync(
+        LocalAiResolvedInstall install,
+        PinnedArtifact artifact,
+        CancellationToken cancellationToken);
 }
 
 internal sealed class LocalAiModelFileVerifier : ILocalAiModelFileVerifier
 {
-    public Task<bool> VerifyAsync(
-        string path,
+    public async Task<bool> VerifyAsync(
+        LocalAiResolvedInstall install,
         PinnedArtifact artifact,
-        CancellationToken cancellationToken) =>
-        HuggingFaceModelInstaller.VerifyFileAsync(path, artifact, cancellationToken);
+        CancellationToken cancellationToken)
+    {
+        if (install.Manifest.SchemaVersion != LocalAiInstallManifest.HubCacheReceiptSchemaVersion)
+        {
+            return await HuggingFaceModelInstaller
+                .VerifyFileAsync(install.ModelPath, artifact, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        await using FileStream? verified =
+            await HuggingFaceHubCache.TryOpenVerifiedCacheFileAsync(
+                    install.Manifest.ModelCacheRoot!,
+                    install.ModelPath,
+                    artifact.SizeBytes,
+                    artifact.Sha256,
+                    progress: null,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        return verified is not null;
+    }
 }
 
 /// <summary>
@@ -35,25 +56,32 @@ internal sealed class LocalAiInstallReconciler
 {
     private readonly ILlamaRuntimeInspector _runtimeInspector;
     private readonly ILocalAiModelFileVerifier _modelVerifier;
+    private readonly Func<string> _cacheRootResolver;
 
     public LocalAiInstallReconciler()
-        : this(new WindowsLlamaRuntimeInspector(), new LocalAiModelFileVerifier())
+        : this(
+            new WindowsLlamaRuntimeInspector(),
+            new LocalAiModelFileVerifier(),
+            HuggingFaceHubCache.ResolveCacheRoot)
     {
     }
 
     internal LocalAiInstallReconciler(
         ILlamaRuntimeInspector runtimeInspector,
-        ILocalAiModelFileVerifier modelVerifier)
+        ILocalAiModelFileVerifier modelVerifier,
+        Func<string>? cacheRootResolver = null)
     {
         _runtimeInspector = runtimeInspector ?? throw new ArgumentNullException(nameof(runtimeInspector));
         _modelVerifier = modelVerifier ?? throw new ArgumentNullException(nameof(modelVerifier));
+        _cacheRootResolver = cacheRootResolver ?? HuggingFaceHubCache.ResolveCacheRoot;
     }
 
     public async Task<LocalAiReconcileResult> ReconcileAsync(
         string localDataDirectory,
         LocalInferencePlan plan,
         string selectedGpuId,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        IProgress<LocalAiModelMigrationProgress>? migrationProgress = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(localDataDirectory);
         ArgumentNullException.ThrowIfNull(plan);
@@ -66,11 +94,30 @@ internal sealed class LocalAiInstallReconciler
             .ConfigureAwait(false);
         if (install is null)
             return LocalAiReconcileResult.NotInstalled;
+        ValidateRecipeMatch(install, plan, selectedGpuId, localDataDirectory);
+        if (install.Manifest.SchemaVersion == LocalAiInstallManifest.CurrentSchemaVersion)
+        {
+            string cacheRoot = _cacheRootResolver();
+            if (!HuggingFaceModelInstaller.TryValidateCacheRootOwnershipBoundary(
+                    localDataDirectory,
+                    cacheRoot,
+                    out string cacheRootError))
+            {
+                throw new InvalidDataException(cacheRootError);
+            }
+
+            var migrationStore = new LocalAiManifestStore(paths, () => cacheRoot);
+            install = await migrationStore
+                .MigrateLegacyModelToHubCacheAsync(migrationProgress, cancellationToken)
+                .ConfigureAwait(false)
+                ?? throw new InvalidDataException(
+                    "The Local AI installation manifest disappeared during cache migration.");
+            ValidateRecipeMatch(install, plan, selectedGpuId, localDataDirectory);
+        }
 
         bool migrateLegacyGpuId =
             !string.Equals(install.Manifest.SelectedGpuId, selectedGpuId, StringComparison.Ordinal) &&
             GpuIdsMatch(install.Manifest.SelectedGpuId, selectedGpuId);
-        ValidateRecipeMatch(install, plan, selectedGpuId, localDataDirectory);
 
         LlamaRuntimeInspection inspection = await _runtimeInspector
             .InspectAsync(Path.GetDirectoryName(install.ExecutablePath)!, cancellationToken)
@@ -82,7 +129,7 @@ internal sealed class LocalAiInstallReconciler
         }
 
         if (!await _modelVerifier
-                .VerifyAsync(install.ModelPath, plan.Model.Weights, cancellationToken)
+                .VerifyAsync(install, plan.Model.Weights, cancellationToken)
                 .ConfigureAwait(false))
         {
             throw new InvalidDataException(
@@ -111,8 +158,13 @@ internal sealed class LocalAiInstallReconciler
             Rollback: null);
         var modelInstall = new HuggingFaceModelInstallResult(
             install.ModelPath,
+            install.Manifest.ModelCacheRoot,
             HuggingFaceModelInstallDisposition.ReusedVerified,
-            CreatedThisRun: false);
+            CreatedThisRun: false,
+            new LocalAiPaths(localDataDirectory).ResolveContainedPath(
+                install.Manifest.ModelPath,
+                nameof(install.Manifest.ModelPath)),
+            LegacyCreatedThisRun: false);
         return new LocalAiReconcileResult(true, install, runtimeInstall, modelInstall);
     }
 
@@ -144,10 +196,6 @@ internal sealed class LocalAiInstallReconciler
                 "The existing managed Local AI installation does not match the selected runtime, GPU, and model recipe.");
         }
 
-        // This performs the complete catalog receipt comparison, including
-        // runtime and model URLs, sizes, hashes, revision, alias, and context.
-        _ = LlamaServerRouterConfiguration.Build(new LocalAiPaths(localDataDirectory), install);
-
         LocalAiComponentIdentity component = LlamaRuntimeInstaller.Component(plan.Runtime);
         if (!LocalAiPathPolicy.TryResolve(
                 localDataDirectory,
@@ -165,16 +213,52 @@ internal sealed class LocalAiInstallReconciler
                     : error);
         }
 
-        if (plan.Model.Weights.Source is not HuggingFaceRevisionSource source ||
-            !LocalAiPathPolicy.TryGetModelPaths(
-                setupPaths,
-                source.RepositoryId,
-                source.RevisionSha,
-                plan.Model.Weights.RelativePath,
-                out string expectedModelPath,
-                out _,
-                out error) ||
-            !string.Equals(install.ModelPath, expectedModelPath, StringComparison.OrdinalIgnoreCase))
+        if (plan.Model.Weights.Source is not HuggingFaceRevisionSource source)
+        {
+            throw new InvalidDataException(
+                "The managed model does not have immutable Hugging Face provenance.");
+        }
+        LlamaServerRouterConfiguration.ValidateArtifactReceipts(
+            manifest,
+            plan.Runtime,
+            plan.Model);
+
+        bool modelPathMatches;
+        if (manifest.SchemaVersion == LocalAiInstallManifest.HubCacheReceiptSchemaVersion)
+        {
+            modelPathMatches =
+                !string.IsNullOrWhiteSpace(manifest.ModelCacheRoot) &&
+                HuggingFaceHubCache.TryGetSnapshotPaths(
+                    manifest.ModelCacheRoot,
+                    source.RepositoryId,
+                    source.RevisionSha,
+                    plan.Model.Weights.RelativePath,
+                    out string expectedModelPath,
+                    out _,
+                    out error) &&
+                string.Equals(
+                    install.ModelPath,
+                    expectedModelPath,
+                    StringComparison.OrdinalIgnoreCase);
+        }
+        else
+        {
+            modelPathMatches =
+                LocalAiPathPolicy.TryGetModelPaths(
+                    setupPaths,
+                    source.RepositoryId,
+                    source.RevisionSha,
+                    plan.Model.Weights.RelativePath,
+                    out string expectedModelPath,
+                    out _,
+                    out error) &&
+                string.Equals(
+                    install.ModelPath,
+                    expectedModelPath,
+                    StringComparison.OrdinalIgnoreCase);
+        }
+
+        if (!modelPathMatches)
         {
             throw new InvalidDataException(
                 string.IsNullOrWhiteSpace(error)

--- a/src/OpenClaw.SetupEngine/LocalAiSetupSteps.cs
+++ b/src/OpenClaw.SetupEngine/LocalAiSetupSteps.cs
@@ -260,8 +260,22 @@ public sealed class ReconcileLocalAiInstallationStep : SetupStep
 
         try
         {
+            var migrationProgress = new SynchronousProgress<LocalAiModelMigrationProgress>(value =>
+                ctx.DetailProgress?.Report(new SetupDetailProgressEvent(
+                    Id,
+                    value.Phase switch
+                    {
+                        LocalAiModelMigrationPhase.VerifyingLegacyModel =>
+                            "Verifying the existing Local AI model",
+                        LocalAiModelMigrationPhase.CopyingToCache =>
+                            "Copying the existing Local AI model to the Hugging Face cache",
+                        _ => "Verifying the Hugging Face cache copy",
+                    },
+                    value.CompletedBytes,
+                    value.TotalBytes,
+                    SetupDetailProgressUnit.Bytes)));
             LocalAiReconcileResult result = await _reconciler
-                .ReconcileAsync(ctx.LocalDataDir, plan, selectedGpuId, ct)
+                .ReconcileAsync(ctx.LocalDataDir, plan, selectedGpuId, ct, migrationProgress)
                 .ConfigureAwait(false);
             if (!result.Reused)
                 return StepResult.Skip("No completed managed Local AI installation was found.");
@@ -435,7 +449,9 @@ public sealed class AcquireLocalAiModelStep : SetupStep
             var progress = new SynchronousProgress<HuggingFaceModelInstallProgress>(value =>
                 ctx.DetailProgress?.Report(new SetupDetailProgressEvent(
                     Id,
-                    $"Downloading {plan.Model.Weights.RelativePath}",
+                    value.Phase == HuggingFaceModelInstallPhase.Verifying
+                        ? $"Verifying {plan.Model.Weights.RelativePath}"
+                        : $"Downloading {plan.Model.Weights.RelativePath}",
                     value.CompletedBytes,
                     value.TotalBytes,
                     SetupDetailProgressUnit.Bytes)));
@@ -463,6 +479,7 @@ public sealed class AcquireLocalAiModelStep : SetupStep
             ex is HuggingFaceModelInstallException
             or IOException
             or UnauthorizedAccessException
+            or InvalidDataException
             or HttpRequestException)
         {
             return StepResult.Fail($"Hugging Face model installation failed: {ex.Message}", ex);
@@ -507,7 +524,11 @@ public sealed class PersistLocalAiManifestStep : SetupStep
             ctx.LocalAiEligibility.SelectedGpu is not { StableId: { Length: > 0 } gpuId } ||
             ctx.LocalAiPort is not { } requestedPort ||
             ctx.LocalAiRuntimeInstall is not { } runtimeInstall ||
-            ctx.LocalAiModelInstall is not { } modelInstall)
+            ctx.LocalAiModelInstall is not
+            {
+                CacheRoot: { Length: > 0 },
+                LegacyModelPath: { Length: > 0 },
+            } modelInstall)
         {
             return StepResult.Terminal(
                 "The Local AI installation receipt requires completed hardware, runtime, and model steps.");
@@ -521,6 +542,34 @@ public sealed class PersistLocalAiManifestStep : SetupStep
         var paths = new LocalAiPaths(ctx.LocalDataDir);
         if (File.Exists(paths.ManifestPath))
             return StepResult.Terminal("A managed Local AI installation receipt already exists.");
+        LocalAiComponentIdentity component = LlamaRuntimeInstaller.Component(plan.Runtime);
+        if (!LocalAiPathPolicy.TryResolve(
+                ctx.LocalDataDir,
+                component,
+                out LocalAiSetupPaths setupPaths,
+                out string modelPathError) ||
+            !LocalAiPathPolicy.TryGetModelPaths(
+                setupPaths,
+                modelSource.RepositoryId,
+                modelSource.RevisionSha,
+                plan.Model.Weights.RelativePath,
+                out string legacyModelPath,
+                out _,
+                out modelPathError))
+        {
+            return StepResult.Terminal(
+                string.IsNullOrWhiteSpace(modelPathError)
+                    ? "The legacy-compatible Local AI model path is invalid."
+                    : modelPathError);
+        }
+        if (!string.Equals(
+                legacyModelPath,
+                modelInstall.LegacyModelPath,
+                StringComparison.OrdinalIgnoreCase))
+        {
+            return StepResult.Terminal(
+                "The Local AI model compatibility path does not match the selected recipe.");
+        }
 
         ImmutableArray<LocalAiAssetReceipt> runtimeAssets;
         try
@@ -534,6 +583,7 @@ public sealed class PersistLocalAiManifestStep : SetupStep
 
         var manifest = new LocalAiInstallManifest
         {
+            SchemaVersion = LocalAiInstallManifest.HubCacheReceiptSchemaVersion,
             EngineVersion = LlamaRuntimeCatalog.ReleaseTag,
             Architecture = plan.Runtime.Architecture switch
             {
@@ -546,7 +596,9 @@ public sealed class PersistLocalAiManifestStep : SetupStep
             SelectedGpuId = gpuId,
             ExecutablePath = Path.GetRelativePath(paths.RootDirectory, runtimeInstall.ExecutablePath),
             RuntimeAssets = runtimeAssets,
-            ModelPath = Path.GetRelativePath(paths.RootDirectory, modelInstall.ModelPath),
+            ModelPath = Path.GetRelativePath(paths.RootDirectory, modelInstall.LegacyModelPath),
+            ModelCacheRoot = modelInstall.CacheRoot,
+            CachedModelPath = modelInstall.ModelPath,
             ModelId = $"{modelSource.RepositoryId}@{modelSource.RevisionSha}",
             ModelAlias = plan.Model.Id,
             ModelAsset = new LocalAiAssetReceipt

--- a/src/OpenClaw.Shared/Inference/Catalog/HuggingFaceHubCache.cs
+++ b/src/OpenClaw.Shared/Inference/Catalog/HuggingFaceHubCache.cs
@@ -7,6 +7,29 @@ using System.Text;
 namespace OpenClaw.Shared.Inference.Catalog;
 
 /// <summary>
+/// Owns a verified Hugging Face cache file and the physical path resolved from
+/// that same open handle.
+/// </summary>
+public sealed class VerifiedHuggingFaceCacheFile : IDisposable, IAsyncDisposable
+{
+    internal VerifiedHuggingFaceCacheFile(FileStream stream, string resolvedPath)
+    {
+        Stream = stream ?? throw new ArgumentNullException(nameof(stream));
+        ResolvedPath = string.IsNullOrWhiteSpace(resolvedPath)
+            ? throw new ArgumentException("The resolved cache path is required.", nameof(resolvedPath))
+            : resolvedPath;
+    }
+
+    public FileStream Stream { get; }
+
+    public string ResolvedPath { get; }
+
+    public void Dispose() => Stream.Dispose();
+
+    public ValueTask DisposeAsync() => Stream.DisposeAsync();
+}
+
+/// <summary>
 /// Resolves and validates paths in the standard Hugging Face hub cache layout.
 /// </summary>
 /// <remarks>
@@ -260,7 +283,8 @@ public static class HuggingFaceHubCache
             return true;
         }
         catch (Exception ex) when (
-            ex is IOException or
+            ex is ArgumentException or
+                IOException or
                 UnauthorizedAccessException or
                 System.Security.SecurityException or
                 NotSupportedException)
@@ -346,6 +370,47 @@ public static class HuggingFaceHubCache
         {
             if (!returnStream)
                 await stream!.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Returns a verified open cache file together with the physical path resolved
+    /// from that same handle. The caller can pass <see cref="VerifiedHuggingFaceCacheFile.ResolvedPath"/>
+    /// to a native reader while retaining the returned handle, preventing a later
+    /// snapshot-link replacement from changing the file identity the reader opens.
+    /// </summary>
+    public static async Task<VerifiedHuggingFaceCacheFile?> TryOpenVerifiedCacheEntryAsync(
+        string cacheRoot,
+        string candidatePath,
+        long expectedSizeBytes,
+        Sha256Digest expectedSha256,
+        IProgress<long>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        FileStream? stream = await TryOpenVerifiedCacheFileAsync(
+                cacheRoot,
+                candidatePath,
+                expectedSizeBytes,
+                expectedSha256,
+                progress,
+                cancellationToken)
+            .ConfigureAwait(false);
+        if (stream is null)
+            return null;
+
+        try
+        {
+            string resolvedPath = GetFinalPathFromHandle(stream.SafeFileHandle, candidatePath);
+            return new VerifiedHuggingFaceCacheFile(stream, resolvedPath);
+        }
+        catch (Exception ex) when (
+            ex is IOException or
+                UnauthorizedAccessException or
+                System.Security.SecurityException or
+                NotSupportedException)
+        {
+            await stream.DisposeAsync().ConfigureAwait(false);
+            return null;
         }
     }
 

--- a/tests/OpenClaw.Connection.Tests/LocalAiManifestMigrationTests.cs
+++ b/tests/OpenClaw.Connection.Tests/LocalAiManifestMigrationTests.cs
@@ -39,7 +39,7 @@ public sealed class LocalAiManifestMigrationTests
             new InlineProgress<LocalAiModelMigrationProgress>(progress.Add)))!;
 
         Assert.Equal(LocalAiInstallManifest.HubCacheReceiptSchemaVersion, migrated.Manifest.SchemaVersion);
-        Assert.Equal(fixture.LegacyModelPath, migrated.ModelPath);
+        Assert.Equal(fixture.CachedModelPath, migrated.ModelPath);
         Assert.Equal(fixture.CacheRoot, migrated.Manifest.ModelCacheRoot);
         Assert.Equal(fixture.CachedModelPath, migrated.Manifest.CachedModelPath);
         Assert.Equal(fixture.Content, await File.ReadAllBytesAsync(fixture.CachedModelPath));
@@ -185,7 +185,7 @@ public sealed class LocalAiManifestMigrationTests
     }
 
     [Fact]
-    public async Task Migration_ReplacesHardLinkedPartialWithoutChangingItsOtherLink()
+    public async Task Migration_RejectsHardLinkedPartialWithoutChangingEitherLink()
     {
         using var temp = new TempDirectory("local-ai-cache-migration-");
         MigrationFixture fixture = await CreateFixtureAsync(temp);
@@ -199,11 +199,16 @@ public sealed class LocalAiManifestMigrationTests
         await File.WriteAllBytesAsync(outside, outsideContent);
         Assert.True(TryCreateHardLink(partial, outside));
 
-        LocalAiResolvedInstall migrated = (await fixture.Store.MigrateLegacyModelToHubCacheAsync())!;
+        InvalidDataException error = await Assert.ThrowsAsync<InvalidDataException>(
+            () => fixture.Store.MigrateLegacyModelToHubCacheAsync());
 
-        Assert.Equal(LocalAiInstallManifest.HubCacheReceiptSchemaVersion, migrated.Manifest.SchemaVersion);
+        Assert.Contains("multiple hard links", error.Message, StringComparison.Ordinal);
         Assert.Equal(outsideContent, await File.ReadAllBytesAsync(outside));
-        Assert.Equal(fixture.Content, await File.ReadAllBytesAsync(fixture.CachedModelPath));
+        Assert.Equal(outsideContent, await File.ReadAllBytesAsync(partial));
+        Assert.False(File.Exists(fixture.CachedModelPath));
+        Assert.Equal(
+            LocalAiInstallManifest.CurrentSchemaVersion,
+            await ReadPersistedSchemaVersionAsync(fixture.Paths.ManifestPath));
     }
 
     [Fact]
@@ -496,6 +501,23 @@ public sealed class LocalAiManifestMigrationTests
             () => fixture.Store.LoadAsync());
 
         Assert.Contains("cache migration receipt", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Load_RejectsSchemaFourWithInvalidLegacyCompatibilityPath()
+    {
+        using var temp = new TempDirectory("local-ai-cache-migration-");
+        MigrationFixture fixture = await CreateFixtureAsync(temp);
+        _ = await fixture.Store.MigrateLegacyModelToHubCacheAsync();
+        JsonObject persisted =
+            (JsonNode.Parse(await File.ReadAllTextAsync(fixture.Paths.ManifestPath)) as JsonObject)!;
+        persisted["modelPath"] = "models/not-the-receipted-model.gguf";
+        await File.WriteAllTextAsync(fixture.Paths.ManifestPath, persisted.ToJsonString());
+
+        InvalidDataException error = await Assert.ThrowsAsync<InvalidDataException>(
+            () => fixture.Store.LoadAsync());
+
+        Assert.Contains("legacy-compatible", error.Message, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
+++ b/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
@@ -198,6 +198,89 @@ public sealed class LocalAiPortLifecycleTests
         Assert.Null(host.LastSpec);
     }
 
+    [ConnectionSymbolicLinkFact]
+    public async Task Runtime_BindsNativeModelPathToVerifiedBlobAfterSnapshotLinkReplacement()
+    {
+        using var temp = new TempDirectory("local-ai-cache-runtime-link-");
+        using var outside = new TempDirectory("local-ai-cache-runtime-outside-");
+        var paths = new LocalAiPaths(temp.Path);
+        byte[] content = "verified-cache-model"u8.ToArray();
+        LocalAiInstallManifest manifest = ValidManifest();
+        string cacheRoot = temp.Combine("hf-cache");
+        const string repositoryId = "unsloth/Qwen3.6-35B-A3B-MTP-GGUF";
+        const string revision = "5bc3e238d916f48a861bac2f8a1990a0e9b7e98d";
+        Assert.True(HuggingFaceHubCache.TryGetSnapshotPaths(
+            cacheRoot,
+            repositoryId,
+            revision,
+            "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
+            out string cachedModelPath,
+            out _,
+            out string error), error);
+        Assert.True(HuggingFaceHubCache.TryGetBlobPath(
+            cacheRoot,
+            repositoryId,
+            new Sha256Digest(manifest.ModelAsset.Sha256),
+            out string blobPath,
+            out error), error);
+        manifest = manifest with
+        {
+            SchemaVersion = LocalAiInstallManifest.HubCacheReceiptSchemaVersion,
+            ModelCacheRoot = cacheRoot,
+            CachedModelPath = cachedModelPath,
+        };
+
+        string executable = paths.ResolveContainedPath(
+            manifest.ExecutablePath,
+            nameof(manifest.ExecutablePath));
+        Directory.CreateDirectory(Path.GetDirectoryName(executable)!);
+        Directory.CreateDirectory(Path.GetDirectoryName(cachedModelPath)!);
+        Directory.CreateDirectory(Path.GetDirectoryName(blobPath)!);
+        await File.WriteAllTextAsync(executable, "test executable");
+        await File.WriteAllBytesAsync(blobPath, content);
+        File.CreateSymbolicLink(
+            cachedModelPath,
+            Path.GetRelativePath(Path.GetDirectoryName(cachedModelPath)!, blobPath));
+        await new LocalAiManifestStore(paths).SaveAsync(manifest);
+
+        string outsidePath = outside.Combine("replacement.gguf");
+        await File.WriteAllBytesAsync(outsidePath, content);
+        string? probedModelPath = null;
+        var events = new SynchronizedEventLog();
+        var platform = new FakePlatform();
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_765)
+        {
+            BeforeStart = _ =>
+            {
+                string preset = File.ReadAllText(paths.RouterPresetPath);
+                Assert.Contains($"model = {blobPath}", preset, StringComparison.OrdinalIgnoreCase);
+                File.Delete(cachedModelPath);
+                File.CreateSymbolicLink(cachedModelPath, outsidePath);
+            },
+        };
+        var client = new FakeClient(events, (expectedModelPath, _) =>
+        {
+            probedModelPath = expectedModelPath;
+            return ReadyProbe(expectedModelPath);
+        });
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            client,
+            new FakeLifecycle(events),
+            modelFileVerifier: new FakeModelFileVerifier(blobPath));
+
+        LocalAiRuntimeSnapshot snapshot = await runtime.EnsureStartedAsync();
+
+        Assert.True(
+            snapshot.State == LocalAiRuntimeState.Healthy,
+            $"Expected a healthy runtime but got {snapshot.State}: {snapshot.Detail}");
+        Assert.Equal(blobPath, probedModelPath, ignoreCase: true);
+        Assert.Contains("start", events);
+        Assert.NotNull(host.LastSpec);
+    }
+
     [Fact]
     public async Task AutomaticPort_IsBoundByChildAndPersistedOnlyAfterOwnedHealth()
     {
@@ -2308,7 +2391,8 @@ public sealed class LocalAiPortLifecycleTests
         ILocalAiEndpointLifecycle lifecycle,
         TimeSpan? startupTimeout = null,
         int maxRestartAttempts = 2,
-        TimeSpan? shutdownTimeout = null) => new(
+        TimeSpan? shutdownTimeout = null,
+        ILocalAiModelFileVerifier? modelFileVerifier = null) => new(
             new LlamaServerRuntimeOptions
             {
                 Paths = paths,
@@ -2322,7 +2406,8 @@ public sealed class LocalAiPortLifecycleTests
             NullLogger.Instance,
             host,
             platform,
-            client);
+            client,
+            modelFileVerifier);
 
     private static async Task<LocalAiPaths> PrepareInstallAsync(TempDirectory temp)
     {
@@ -2585,6 +2670,8 @@ public sealed class LocalAiPortLifecycleTests
 
         public bool ImmediateExit { get; init; }
 
+        public Action<LocalAiProcessStartSpec>? BeforeStart { get; init; }
+
         public Task<ILocalAiManagedProcess> StartProcessAsync(
             LocalAiProcessStartSpec spec,
             Action<LocalAiManagedProcessExit> exited,
@@ -2593,8 +2680,9 @@ public sealed class LocalAiPortLifecycleTests
             cancellationToken.ThrowIfCancellationRequested();
             if (ThrowOnStart)
                 throw new IOException("The managed llama-server process could not be launched.");
-            events.Add("start");
             LastSpec = spec;
+            BeforeStart?.Invoke(spec);
+            events.Add("start");
             LastExitCallback = exited;
             Process = new FakeProcess(4201, platform.UtcNow, platform, events);
             if (ImmediateExit)
@@ -2678,6 +2766,21 @@ public sealed class LocalAiPortLifecycleTests
         }
 
         public void Dispose() { }
+    }
+
+    private sealed class FakeModelFileVerifier(string resolvedPath) : ILocalAiModelFileVerifier
+    {
+        public Task<LocalAiVerifiedModelLease?> TryOpenAsync(
+            string cacheRoot,
+            string candidatePath,
+            long expectedSizeBytes,
+            Sha256Digest expectedSha256,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult<LocalAiVerifiedModelLease?>(
+                new LocalAiVerifiedModelLease(new MemoryStream(), resolvedPath));
+        }
     }
 
     private sealed class FakeLifecycle(SynchronizedEventLog events) : ILocalAiEndpointLifecycle

--- a/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
+++ b/tests/OpenClaw.Connection.Tests/LocalAiPortLifecycleTests.cs
@@ -4,6 +4,7 @@ using OpenClaw.Shared.Inference.Catalog;
 using OpenClaw.TestSupport;
 using System.Collections.Immutable;
 using System.Net;
+using System.Security.Cryptography;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 
@@ -138,6 +139,63 @@ public sealed class LocalAiPortLifecycleTests
 
         await Assert.ThrowsAsync<InvalidDataException>(() =>
             store.SaveAsync(ValidManifest() with { GatewayFallbackModel = fallbackModel }));
+    }
+
+    [Fact]
+    public async Task Runtime_RejectsSchemaFourCacheContentBeforeProcessStart()
+    {
+        using var temp = new TempDirectory("local-ai-cache-runtime-");
+        var paths = new LocalAiPaths(temp.Path);
+        byte[] expected = "expected-cache-model"u8.ToArray();
+        byte[] tampered = "tampered-cache-model"u8.ToArray();
+        Assert.Equal(expected.Length, tampered.Length);
+        LocalAiInstallManifest manifest = ValidManifest();
+        string cacheRoot = temp.Combine("hf-cache");
+        const string repositoryId = "unsloth/Qwen3.6-35B-A3B-MTP-GGUF";
+        const string revision = "5bc3e238d916f48a861bac2f8a1990a0e9b7e98d";
+        Assert.True(HuggingFaceHubCache.TryGetSnapshotPaths(
+            cacheRoot,
+            repositoryId,
+            revision,
+            "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
+            out string cachedModelPath,
+            out _,
+            out string error), error);
+        manifest = manifest with
+        {
+            SchemaVersion = LocalAiInstallManifest.HubCacheReceiptSchemaVersion,
+            ModelCacheRoot = cacheRoot,
+            CachedModelPath = cachedModelPath,
+            ModelAsset = manifest.ModelAsset with
+            {
+                SizeBytes = expected.Length,
+                Sha256 = Convert.ToHexString(SHA256.HashData(expected)).ToLowerInvariant(),
+            },
+        };
+        string executable = paths.ResolveContainedPath(
+            manifest.ExecutablePath,
+            nameof(manifest.ExecutablePath));
+        Directory.CreateDirectory(Path.GetDirectoryName(executable)!);
+        Directory.CreateDirectory(Path.GetDirectoryName(cachedModelPath)!);
+        await File.WriteAllTextAsync(executable, "test executable");
+        await File.WriteAllBytesAsync(cachedModelPath, tampered);
+        await new LocalAiManifestStore(paths).SaveAsync(manifest);
+        var events = new SynchronizedEventLog();
+        var platform = new FakePlatform();
+        var host = new FakeProcessHost(platform, events, selectedPort: 28_765);
+        await using var runtime = CreateRuntime(
+            paths,
+            host,
+            platform,
+            new FakeClient(events),
+            new FakeLifecycle(events));
+
+        LocalAiRuntimeSnapshot snapshot = await runtime.EnsureStartedAsync();
+
+        Assert.Equal(LocalAiRuntimeState.Failed, snapshot.State);
+        Assert.Contains("no longer matches", snapshot.Detail, StringComparison.Ordinal);
+        Assert.DoesNotContain("start", events);
+        Assert.Null(host.LastSpec);
     }
 
     [Fact]

--- a/tests/OpenClaw.SetupEngine.Tests/LocalAiInstallRecoveryTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/LocalAiInstallRecoveryTests.cs
@@ -6,6 +6,7 @@ using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using OpenClaw.Connection.LocalAi;
 using OpenClaw.Shared.Inference.Catalog;
+using OpenClaw.TestSupport;
 
 namespace OpenClaw.SetupEngine.Tests;
 
@@ -36,7 +37,7 @@ public sealed class LocalAiInstallRecoveryTests
             return response;
         }));
 
-        var result = await new HuggingFaceModelInstaller(client).InstallAsync(
+        var result = await CreateModelInstaller(client, temp.Path).InstallAsync(
             temp.Path,
             component,
             model,
@@ -46,6 +47,7 @@ public sealed class LocalAiInstallRecoveryTests
         Assert.Equal("bytes=4-", observedRange?.ToString());
         Assert.Equal(modelPath, result.ModelPath);
         Assert.Equal(modelBytes, await File.ReadAllBytesAsync(modelPath));
+        Assert.Equal(modelBytes, await File.ReadAllBytesAsync(result.LegacyModelPath!));
         Assert.False(File.Exists(partialPath));
     }
 
@@ -64,7 +66,7 @@ public sealed class LocalAiInstallRecoveryTests
             Content = new ByteArrayContent(modelBytes),
         }));
 
-        await new HuggingFaceModelInstaller(client).InstallAsync(
+        await CreateModelInstaller(client, temp.Path).InstallAsync(
             temp.Path,
             component,
             model,
@@ -75,7 +77,7 @@ public sealed class LocalAiInstallRecoveryTests
     }
 
     [Fact]
-    public async Task ModelInstall_InvalidRangeDeletesUntrustedPartial()
+    public async Task ModelInstall_InvalidRangePreservesPreexistingPartial()
     {
         using var temp = new TempDirectory();
         byte[] modelBytes = "verified-model"u8.ToArray();
@@ -98,14 +100,14 @@ public sealed class LocalAiInstallRecoveryTests
         }));
 
         await Assert.ThrowsAsync<HuggingFaceModelInstallException>(() =>
-            new HuggingFaceModelInstaller(client).InstallAsync(
+            CreateModelInstaller(client, temp.Path).InstallAsync(
                 temp.Path,
                 component,
                 model,
                 progress: null,
                 CancellationToken.None));
 
-        Assert.False(File.Exists(partialPath));
+        Assert.Equal(modelBytes[..4], await File.ReadAllBytesAsync(partialPath));
     }
 
     [Fact]
@@ -136,7 +138,8 @@ public sealed class LocalAiInstallRecoveryTests
         }));
         var installer = new HuggingFaceModelInstaller(
             client,
-            (_, _) => Task.CompletedTask);
+            (_, _) => Task.CompletedTask,
+            () => CacheRoot(temp.Path));
 
         await Assert.ThrowsAsync<IOException>(() => installer.InstallAsync(
             temp.Path,
@@ -162,7 +165,7 @@ public sealed class LocalAiInstallRecoveryTests
         using var client = new HttpClient(new DelegateHandler(_ =>
             throw new InvalidOperationException("HTTP must not be used for a verified complete partial.")));
 
-        await new HuggingFaceModelInstaller(client).InstallAsync(
+        await CreateModelInstaller(client, temp.Path).InstallAsync(
             temp.Path,
             component,
             model,
@@ -171,6 +174,501 @@ public sealed class LocalAiInstallRecoveryTests
 
         Assert.Equal(modelBytes, await File.ReadAllBytesAsync(modelPath));
         Assert.False(File.Exists(partialPath));
+    }
+
+    [Fact]
+    public async Task ModelInstall_MismatchedCompletePartialIsNotPromotedAndDownloadsFresh()
+    {
+        using var temp = new TempDirectory();
+        byte[] modelBytes = "verified-model"u8.ToArray();
+        byte[] mismatched = Enumerable.Repeat((byte)'x', modelBytes.Length).ToArray();
+        LocalModelInfo model = CreateModel(modelBytes);
+        LocalAiComponentIdentity component = TestComponent();
+        (_, string partialPath) = ResolveModelPaths(temp.Path, component, model);
+        Directory.CreateDirectory(Path.GetDirectoryName(partialPath)!);
+        await File.WriteAllBytesAsync(partialPath, mismatched);
+        int requests = 0;
+        using var client = new HttpClient(new DelegateHandler(_ =>
+        {
+            requests++;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(modelBytes),
+            };
+        }));
+
+        HuggingFaceModelInstallResult result = await CreateModelInstaller(client, temp.Path)
+            .InstallAsync(
+                temp.Path,
+                component,
+                model,
+                progress: null,
+                CancellationToken.None);
+
+        Assert.Equal(1, requests);
+        Assert.Equal(modelBytes, await File.ReadAllBytesAsync(result.ModelPath));
+        Assert.False(File.Exists(partialPath));
+    }
+
+    [Fact]
+    public async Task ModelInstall_ReusesVerifiedSnapshotWithoutHttp()
+    {
+        using var temp = new TempDirectory();
+        byte[] modelBytes = "verified-model"u8.ToArray();
+        LocalModelInfo model = CreateModel(modelBytes);
+        LocalAiComponentIdentity component = TestComponent();
+        (string modelPath, _) = ResolveModelPaths(temp.Path, component, model);
+        Directory.CreateDirectory(Path.GetDirectoryName(modelPath)!);
+        await File.WriteAllBytesAsync(modelPath, modelBytes);
+        using var client = new HttpClient(new DelegateHandler(_ =>
+            throw new InvalidOperationException("HTTP must not be used for a verified snapshot.")));
+
+        HuggingFaceModelInstallResult result = await CreateModelInstaller(client, temp.Path)
+            .InstallAsync(temp.Path, component, model, progress: null, CancellationToken.None);
+
+        Assert.Equal(HuggingFaceModelInstallDisposition.ReusedVerified, result.Disposition);
+        Assert.False(result.CreatedThisRun);
+        Assert.Equal(modelBytes, await File.ReadAllBytesAsync(modelPath));
+        Assert.Equal(modelBytes, await File.ReadAllBytesAsync(result.LegacyModelPath!));
+    }
+
+    [Fact]
+    public async Task ModelInstall_ReusesVerifiedBlobByCopyingFromOpenHandle()
+    {
+        using var temp = new TempDirectory();
+        byte[] modelBytes = "verified-blob-model"u8.ToArray();
+        LocalModelInfo model = CreateModel(modelBytes);
+        LocalAiComponentIdentity component = TestComponent();
+        string cacheRoot = CacheRoot(temp.Path);
+        HuggingFaceRevisionSource source = Assert.IsType<HuggingFaceRevisionSource>(
+            model.Weights.Source);
+        Assert.True(HuggingFaceHubCache.TryGetBlobPath(
+            cacheRoot,
+            source.RepositoryId,
+            model.Weights.Sha256,
+            out string blobPath,
+            out string error), error);
+        Directory.CreateDirectory(Path.GetDirectoryName(blobPath)!);
+        await File.WriteAllBytesAsync(blobPath, modelBytes);
+        using var client = new HttpClient(new DelegateHandler(_ =>
+            throw new InvalidOperationException("HTTP must not be used for a verified blob.")));
+
+        HuggingFaceModelInstallResult result = await CreateModelInstaller(client, temp.Path)
+            .InstallAsync(temp.Path, component, model, progress: null, CancellationToken.None);
+
+        Assert.Equal(HuggingFaceModelInstallDisposition.ReusedVerified, result.Disposition);
+        Assert.True(result.CreatedThisRun);
+        Assert.Equal(modelBytes, await File.ReadAllBytesAsync(result.ModelPath));
+        Assert.Equal(modelBytes, await File.ReadAllBytesAsync(blobPath));
+    }
+
+    [SetupCrossVolumeFact]
+    public async Task ModelInstall_MaterializesLegacyCompatibilityCopyAcrossConfiguredVolume()
+    {
+        string configuredRoot = Environment.GetEnvironmentVariable("OPENCLAW_TEST_HF_CACHE_ROOT")!;
+        using var temp = new TempDirectory();
+        string cacheRoot = Path.Combine(
+            Path.GetFullPath(configuredRoot),
+            $"openclaw-model-install-{Guid.NewGuid():N}");
+        Assert.False(string.Equals(
+            Path.GetPathRoot(temp.Path),
+            Path.GetPathRoot(cacheRoot),
+            StringComparison.OrdinalIgnoreCase));
+        byte[] modelBytes = "verified-cross-volume-model"u8.ToArray();
+        LocalModelInfo model = CreateModel(modelBytes);
+        LocalAiComponentIdentity component = TestComponent();
+        using var client = new HttpClient(new DelegateHandler(_ =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(modelBytes),
+            }));
+        var installer = new HuggingFaceModelInstaller(
+            client,
+            (_, _) => Task.CompletedTask,
+            () => cacheRoot);
+        try
+        {
+            HuggingFaceModelInstallResult result = await installer.InstallAsync(
+                temp.Path,
+                component,
+                model,
+                progress: null,
+                CancellationToken.None);
+
+            Assert.Equal(modelBytes, await File.ReadAllBytesAsync(result.ModelPath));
+            Assert.Equal(modelBytes, await File.ReadAllBytesAsync(result.LegacyModelPath!));
+            Assert.NotEqual(
+                Path.GetPathRoot(result.ModelPath),
+                Path.GetPathRoot(result.LegacyModelPath));
+        }
+        finally
+        {
+            if (Directory.Exists(cacheRoot))
+                Directory.Delete(cacheRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ModelInstall_RejectsMismatchedDestinationWithoutChangingIt()
+    {
+        using var temp = new TempDirectory();
+        byte[] modelBytes = "verified-model"u8.ToArray();
+        byte[] mismatched = Enumerable.Repeat((byte)'x', modelBytes.Length).ToArray();
+        LocalModelInfo model = CreateModel(modelBytes);
+        LocalAiComponentIdentity component = TestComponent();
+        (string modelPath, _) = ResolveModelPaths(temp.Path, component, model);
+        Directory.CreateDirectory(Path.GetDirectoryName(modelPath)!);
+        await File.WriteAllBytesAsync(modelPath, mismatched);
+        using var client = new HttpClient(new DelegateHandler(_ =>
+            throw new InvalidOperationException("HTTP must not replace a mismatched shared artifact.")));
+
+        HuggingFaceModelInstallException error = await Assert.ThrowsAsync<HuggingFaceModelInstallException>(
+            () => CreateModelInstaller(client, temp.Path).InstallAsync(
+                temp.Path,
+                component,
+                model,
+                progress: null,
+                CancellationToken.None));
+
+        Assert.Contains("does not match", error.Message, StringComparison.Ordinal);
+        Assert.Equal(mismatched, await File.ReadAllBytesAsync(modelPath));
+    }
+
+    [Fact]
+    public async Task ModelInstall_ReplacesMismatchedAppOwnedCompatibilityCopy()
+    {
+        using var temp = new TempDirectory();
+        byte[] modelBytes = "verified-model"u8.ToArray();
+        byte[] mismatched = Enumerable.Repeat((byte)'x', modelBytes.Length).ToArray();
+        LocalModelInfo model = CreateModel(modelBytes);
+        LocalAiComponentIdentity component = TestComponent();
+        (string modelPath, _) = ResolveModelPaths(temp.Path, component, model);
+        Directory.CreateDirectory(Path.GetDirectoryName(modelPath)!);
+        await File.WriteAllBytesAsync(modelPath, modelBytes);
+        Assert.True(LocalAiPathPolicy.TryResolve(
+            temp.Path,
+            component,
+            out LocalAiSetupPaths setupPaths,
+            out string error), error);
+        var source = Assert.IsType<HuggingFaceRevisionSource>(model.Weights.Source);
+        Assert.True(LocalAiPathPolicy.TryGetModelPaths(
+            setupPaths,
+            source.RepositoryId,
+            source.RevisionSha,
+            model.Weights.RelativePath,
+            out string legacyModelPath,
+            out _,
+            out error), error);
+        Directory.CreateDirectory(Path.GetDirectoryName(legacyModelPath)!);
+        await File.WriteAllBytesAsync(legacyModelPath, mismatched);
+        using var client = new HttpClient(new DelegateHandler(_ =>
+            throw new InvalidOperationException("HTTP must not run when the cache artifact is verified.")));
+
+        HuggingFaceModelInstallResult result = await CreateModelInstaller(client, temp.Path)
+            .InstallAsync(temp.Path, component, model, progress: null, CancellationToken.None);
+
+        Assert.Equal(modelBytes, await File.ReadAllBytesAsync(legacyModelPath));
+        Assert.Equal(legacyModelPath, result.LegacyModelPath);
+        Assert.True(result.LegacyCreatedThisRun);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ModelInstall_RejectsCacheRootInsideManagedInstallTree(bool useDescendant)
+    {
+        using var temp = new TempDirectory();
+        byte[] modelBytes = "verified-model"u8.ToArray();
+        LocalModelInfo model = CreateModel(modelBytes);
+        LocalAiComponentIdentity component = TestComponent();
+        string managedRoot = new LocalAiPaths(temp.Path).RootDirectory;
+        string cacheRoot = useDescendant
+            ? Path.Combine(managedRoot, "shared-hf-cache")
+            : managedRoot;
+        using var client = new HttpClient(new DelegateHandler(_ =>
+            throw new InvalidOperationException("HTTP must not run for an unsafe cache root.")));
+        var installer = new HuggingFaceModelInstaller(
+            client,
+            (_, _) => Task.CompletedTask,
+            () => cacheRoot);
+
+        HuggingFaceModelInstallException error =
+            await Assert.ThrowsAsync<HuggingFaceModelInstallException>(() =>
+                installer.InstallAsync(
+                    temp.Path,
+                    component,
+                    model,
+                    progress: null,
+                    CancellationToken.None));
+
+        Assert.Contains("must be outside", error.Message, StringComparison.Ordinal);
+        Assert.False(Directory.Exists(cacheRoot));
+    }
+
+    [Fact]
+    public async Task ModelInstall_RejectsCacheRootAliasToManagedInstallTree()
+    {
+        using var temp = new TempDirectory();
+        byte[] modelBytes = "verified-model"u8.ToArray();
+        LocalModelInfo model = CreateModel(modelBytes);
+        LocalAiComponentIdentity component = TestComponent();
+        string managedRoot = new LocalAiPaths(temp.Path).RootDirectory;
+        Directory.CreateDirectory(managedRoot);
+        string cacheAlias = Path.Combine(temp.Path, "hf-cache-alias");
+        CreateJunction(cacheAlias, managedRoot);
+        using var client = new HttpClient(new DelegateHandler(_ =>
+            throw new InvalidOperationException("HTTP must not run for an aliased cache root.")));
+        var installer = new HuggingFaceModelInstaller(
+            client,
+            (_, _) => Task.CompletedTask,
+            () => cacheAlias);
+        try
+        {
+            HuggingFaceModelInstallException error =
+                await Assert.ThrowsAsync<HuggingFaceModelInstallException>(() =>
+                    installer.InstallAsync(
+                        temp.Path,
+                        component,
+                        model,
+                        progress: null,
+                        CancellationToken.None));
+
+            Assert.Contains("must be outside", error.Message, StringComparison.Ordinal);
+            Assert.Empty(Directory.EnumerateFileSystemEntries(managedRoot));
+        }
+        finally
+        {
+            if (Directory.Exists(cacheAlias))
+                Directory.Delete(cacheAlias);
+        }
+    }
+
+    internal sealed class SetupCrossVolumeFactAttribute : FactAttribute
+    {
+        public SetupCrossVolumeFactAttribute()
+        {
+            if (string.IsNullOrWhiteSpace(
+                    Environment.GetEnvironmentVariable("OPENCLAW_TEST_HF_CACHE_ROOT")))
+            {
+                Skip = "Set OPENCLAW_TEST_HF_CACHE_ROOT to a directory on a distinct volume.";
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ModelInstall_RollbackPreservesVerifiedSharedCacheArtifact()
+    {
+        using var temp = new TempDirectory();
+        byte[] modelBytes = "verified-model"u8.ToArray();
+        LocalModelInfo model = CreateModel(modelBytes);
+        LocalAiComponentIdentity component = TestComponent();
+        using var client = new HttpClient(new DelegateHandler(_ =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(modelBytes),
+            }));
+        HuggingFaceModelInstaller installer = CreateModelInstaller(client, temp.Path);
+        HuggingFaceModelInstallResult result = await installer.InstallAsync(
+            temp.Path,
+            component,
+            model,
+            progress: null,
+            CancellationToken.None);
+
+        installer.RemoveInstalledModel(temp.Path, result);
+
+        Assert.Equal(modelBytes, await File.ReadAllBytesAsync(result.ModelPath));
+        Assert.False(File.Exists(result.LegacyModelPath));
+    }
+
+    [Fact]
+    public async Task ModelInstall_ConcurrentWriterFailsClosedAndWinnerRemainsVerified()
+    {
+        using var temp = new TempDirectory();
+        byte[] modelBytes = "verified-concurrent-model"u8.ToArray();
+        LocalModelInfo model = CreateModel(modelBytes);
+        LocalAiComponentIdentity component = TestComponent();
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var firstClient = new HttpClient(new AsyncDelegateHandler(_ =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StreamContent(
+                    new BlockingReadStream(modelBytes, entered, release)),
+            })));
+        using var secondClient = new HttpClient(new DelegateHandler(_ =>
+            throw new InvalidOperationException("The losing writer must not start another download.")));
+        HuggingFaceModelInstaller firstInstaller = CreateModelInstaller(firstClient, temp.Path);
+        HuggingFaceModelInstaller secondInstaller = CreateModelInstaller(secondClient, temp.Path);
+
+        Task<HuggingFaceModelInstallResult> winner = firstInstaller.InstallAsync(
+            temp.Path,
+            component,
+            model,
+            progress: null,
+            CancellationToken.None);
+        await entered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        await Assert.ThrowsAsync<IOException>(() => secondInstaller.InstallAsync(
+            temp.Path,
+            component,
+            model,
+            progress: null,
+            CancellationToken.None));
+
+        release.SetResult();
+        HuggingFaceModelInstallResult result = await winner;
+        Assert.Equal(modelBytes, await File.ReadAllBytesAsync(result.ModelPath));
+    }
+
+    [Fact]
+    public async Task ModelInstall_PromotionRaceAcceptsValidWinnerAndPreservesPreexistingPartial()
+    {
+        using var temp = new TempDirectory();
+        byte[] modelBytes = "verified-promotion-winner"u8.ToArray();
+        LocalModelInfo model = CreateModel(modelBytes);
+        LocalAiComponentIdentity component = TestComponent();
+        (string modelPath, string partialPath) = ResolveModelPaths(temp.Path, component, model);
+        byte[] prefix = modelBytes[..5];
+        Directory.CreateDirectory(Path.GetDirectoryName(partialPath)!);
+        await File.WriteAllBytesAsync(partialPath, prefix);
+        using var client = new HttpClient(new DelegateHandler(_ =>
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.PartialContent)
+            {
+                Content = new StreamContent(new EofCallbackStream(
+                    modelBytes[prefix.Length..],
+                    () => File.WriteAllBytes(modelPath, modelBytes))),
+            };
+            response.Content.Headers.ContentRange = new ContentRangeHeaderValue(
+                prefix.Length,
+                modelBytes.Length - 1,
+                modelBytes.Length);
+            return response;
+        }));
+
+        HuggingFaceModelInstallResult result = await CreateModelInstaller(client, temp.Path)
+            .InstallAsync(temp.Path, component, model, progress: null, CancellationToken.None);
+
+        Assert.Equal(HuggingFaceModelInstallDisposition.ReusedVerified, result.Disposition);
+        Assert.Equal(modelBytes, await File.ReadAllBytesAsync(modelPath));
+        Assert.Equal(modelBytes, await File.ReadAllBytesAsync(partialPath));
+    }
+
+    [Fact]
+    public async Task ModelInstall_PromotionRaceWithoutValidWinnerPreservesPreexistingPartial()
+    {
+        using var temp = new TempDirectory();
+        byte[] modelBytes = "verified-promotion-failure"u8.ToArray();
+        byte[] mismatched = Enumerable.Repeat((byte)'x', modelBytes.Length).ToArray();
+        LocalModelInfo model = CreateModel(modelBytes);
+        LocalAiComponentIdentity component = TestComponent();
+        (string modelPath, string partialPath) = ResolveModelPaths(temp.Path, component, model);
+        byte[] prefix = modelBytes[..5];
+        Directory.CreateDirectory(Path.GetDirectoryName(partialPath)!);
+        await File.WriteAllBytesAsync(partialPath, prefix);
+        using var client = new HttpClient(new DelegateHandler(_ =>
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.PartialContent)
+            {
+                Content = new StreamContent(new EofCallbackStream(
+                    modelBytes[prefix.Length..],
+                    () => File.WriteAllBytes(modelPath, mismatched))),
+            };
+            response.Content.Headers.ContentRange = new ContentRangeHeaderValue(
+                prefix.Length,
+                modelBytes.Length - 1,
+                modelBytes.Length);
+            return response;
+        }));
+
+        await Assert.ThrowsAsync<HuggingFaceModelInstallException>(() =>
+            CreateModelInstaller(client, temp.Path).InstallAsync(
+                temp.Path,
+                component,
+                model,
+                progress: null,
+                CancellationToken.None));
+
+        Assert.Equal(modelBytes, await File.ReadAllBytesAsync(partialPath));
+        Assert.Equal(mismatched, await File.ReadAllBytesAsync(modelPath));
+    }
+
+    [Fact]
+    public async Task ModelInstall_ResumedDigestMismatchPreservesPreexistingPartial()
+    {
+        using var temp = new TempDirectory();
+        byte[] modelBytes = "verified-resume-digest"u8.ToArray();
+        LocalModelInfo model = CreateModel(modelBytes);
+        LocalAiComponentIdentity component = TestComponent();
+        (_, string partialPath) = ResolveModelPaths(temp.Path, component, model);
+        byte[] prefix = modelBytes[..5];
+        byte[] badRemainder = Enumerable.Repeat(
+            (byte)'x',
+            modelBytes.Length - prefix.Length).ToArray();
+        Directory.CreateDirectory(Path.GetDirectoryName(partialPath)!);
+        await File.WriteAllBytesAsync(partialPath, prefix);
+        using var client = new HttpClient(new DelegateHandler(_ =>
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.PartialContent)
+            {
+                Content = new ByteArrayContent(badRemainder),
+            };
+            response.Content.Headers.ContentRange = new ContentRangeHeaderValue(
+                prefix.Length,
+                modelBytes.Length - 1,
+                modelBytes.Length);
+            return response;
+        }));
+
+        await Assert.ThrowsAsync<HuggingFaceModelInstallException>(() =>
+            CreateModelInstaller(client, temp.Path).InstallAsync(
+                temp.Path,
+                component,
+                model,
+                progress: null,
+                CancellationToken.None));
+
+        byte[] preserved = await File.ReadAllBytesAsync(partialPath);
+        Assert.Equal(modelBytes.Length, preserved.Length);
+        Assert.Equal(prefix, preserved[..prefix.Length]);
+    }
+
+    [Fact]
+    public async Task ModelInstall_OversizedResponsePreservesPreexistingPartial()
+    {
+        using var temp = new TempDirectory();
+        byte[] modelBytes = "verified-oversized-response"u8.ToArray();
+        LocalModelInfo model = CreateModel(modelBytes);
+        LocalAiComponentIdentity component = TestComponent();
+        (_, string partialPath) = ResolveModelPaths(temp.Path, component, model);
+        byte[] prefix = modelBytes[..5];
+        byte[] oversized = [.. modelBytes[prefix.Length..], (byte)'!'];
+        Directory.CreateDirectory(Path.GetDirectoryName(partialPath)!);
+        await File.WriteAllBytesAsync(partialPath, prefix);
+        using var client = new HttpClient(new DelegateHandler(_ =>
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.PartialContent)
+            {
+                Content = new StreamContent(new MemoryStream(oversized)),
+            };
+            response.Content.Headers.ContentRange = new ContentRangeHeaderValue(
+                prefix.Length,
+                modelBytes.Length - 1,
+                modelBytes.Length);
+            return response;
+        }));
+
+        await Assert.ThrowsAsync<HuggingFaceModelInstallException>(() =>
+            CreateModelInstaller(client, temp.Path).InstallAsync(
+                temp.Path,
+                component,
+                model,
+                progress: null,
+                CancellationToken.None));
+
+        byte[] preserved = await File.ReadAllBytesAsync(partialPath);
+        Assert.Equal(prefix, preserved);
     }
 
     [Fact]
@@ -491,6 +989,79 @@ public sealed class LocalAiInstallRecoveryTests
     }
 
     [Fact]
+    public async Task Reconciler_ExplicitlyMigratesAndAdoptsVerifiedSchemaFourReceipt()
+    {
+        using var temp = new TempDirectory();
+        using var environment = new EnvironmentScope(
+            "HF_HUB_CACHE",
+            CacheRoot(temp.Path));
+        byte[] modelBytes = "verified-reconcile-model"u8.ToArray();
+        byte[] runtimeZip = CreateZip(("llama-server.exe", "server"u8.ToArray()));
+        byte[] dependencyZip = CreateZip(("dependency.dll", "dependency"u8.ToArray()));
+        LocalModelInfo model = CreateModel(modelBytes);
+        LlamaRuntimeVariant runtime = CreateRuntime(runtimeZip, dependencyZip);
+        var profile = new LocalInferenceRunProfile(
+            "test-profile",
+            128,
+            KvCachePrecision.F16,
+            KvCachePrecision.F16,
+            KvCachePrecision.F16,
+            KvCachePrecision.F16,
+            runtimeWorkspaceBytes: 1);
+        var plan = new LocalInferencePlan(
+            runtime,
+            model,
+            profile,
+            LocalInferenceModelSelectionOrigin.Default);
+        var paths = new LocalAiPaths(temp.Path);
+        LocalAiInstallManifest manifest = CreateManifest(temp.Path, plan, "GPU-0");
+        string legacyModelPath = paths.ResolveContainedPath(manifest.ModelPath, "modelPath");
+        Directory.CreateDirectory(Path.GetDirectoryName(legacyModelPath)!);
+        await File.WriteAllBytesAsync(legacyModelPath, modelBytes);
+        await new LocalAiManifestStore(paths).SaveAsync(manifest);
+
+        LocalAiReconcileResult result = await new LocalAiInstallReconciler(
+                new ValidRuntimeInspector(),
+                new LocalAiModelFileVerifier())
+            .ReconcileAsync(temp.Path, plan, "GPU-0", CancellationToken.None);
+
+        LocalAiResolvedInstall resolved = Assert.IsType<LocalAiResolvedInstall>(
+            result.ResolvedInstall);
+        Assert.Equal(LocalAiInstallManifest.HubCacheReceiptSchemaVersion, resolved.Manifest.SchemaVersion);
+        Assert.Equal(resolved.Manifest.CachedModelPath, resolved.ModelPath);
+        Assert.Equal(modelBytes, await File.ReadAllBytesAsync(resolved.ModelPath));
+        Assert.Equal(modelBytes, await File.ReadAllBytesAsync(legacyModelPath));
+    }
+
+    [Fact]
+    public async Task Reconciler_RejectsMigrationCacheRootInsideManagedInstallTree()
+    {
+        using var temp = new TempDirectory();
+        LocalInferencePlan plan = CatalogPlan();
+        const string gpuId = "GPU-0";
+        var paths = new LocalAiPaths(temp.Path);
+        string cacheRoot = Path.Combine(paths.RootDirectory, "shared-hf-cache");
+        using var environment = new EnvironmentScope("HF_HUB_CACHE", cacheRoot);
+        var store = new LocalAiManifestStore(paths);
+        await store.SaveAsync(CreateManifest(temp.Path, plan, gpuId));
+        byte[] original = await File.ReadAllBytesAsync(paths.ManifestPath);
+        var reconciler = new LocalAiInstallReconciler(
+            new ValidRuntimeInspector(),
+            new AcceptingModelVerifier());
+
+        InvalidDataException error = await Assert.ThrowsAsync<InvalidDataException>(() =>
+            reconciler.ReconcileAsync(
+                temp.Path,
+                plan,
+                gpuId,
+                CancellationToken.None));
+
+        Assert.Contains("must be outside", error.Message, StringComparison.Ordinal);
+        Assert.Equal(original, await File.ReadAllBytesAsync(paths.ManifestPath));
+        Assert.False(Directory.Exists(cacheRoot));
+    }
+
+    [Fact]
     public async Task Reconciler_MigratesLegacyCudaPrefixedUuidSelector()
     {
         using var temp = new TempDirectory();
@@ -540,9 +1111,12 @@ public sealed class LocalAiInstallRecoveryTests
     {
         using var temp = new TempDirectory();
         string root = new LocalAiPaths(temp.Path).RootDirectory;
+        string sharedCacheModel = Path.Combine(temp.Path, "hf-cache", "models--owner--repo", "snapshots", new string('a', 40), "model.gguf");
         Directory.CreateDirectory(Path.Combine(root, "engines", "runtime"));
+        Directory.CreateDirectory(Path.GetDirectoryName(sharedCacheModel)!);
         await File.WriteAllTextAsync(Path.Combine(root, "state.json"), "corrupt but app-owned");
         await File.WriteAllTextAsync(Path.Combine(root, "engines", "runtime", "file.bin"), "data");
+        await File.WriteAllTextAsync(sharedCacheModel, "shared");
         SetupContext context = CreateContext(temp.Path, confirmDestructive: true);
 
         PipelineResult result = await new SetupPipeline([new PersistLocalAiManifestStep()])
@@ -550,6 +1124,7 @@ public sealed class LocalAiInstallRecoveryTests
 
         Assert.Equal(PipelineOutcome.Success, result.Outcome);
         Assert.False(Directory.Exists(root));
+        Assert.Equal("shared", await File.ReadAllTextAsync(sharedCacheModel));
     }
 
     [Fact]
@@ -741,21 +1316,24 @@ public sealed class LocalAiInstallRecoveryTests
         LocalModelInfo model)
     {
         var source = Assert.IsType<HuggingFaceRevisionSource>(model.Weights.Source);
-        Assert.True(LocalAiPathPolicy.TryResolve(
-            localDataDirectory,
-            component,
-            out LocalAiSetupPaths paths,
-            out string error), error);
-        Assert.True(LocalAiPathPolicy.TryGetModelPaths(
-            paths,
+        Assert.True(HuggingFaceHubCache.TryGetSnapshotPaths(
+            CacheRoot(localDataDirectory),
             source.RepositoryId,
             source.RevisionSha,
             model.Weights.RelativePath,
             out string modelPath,
             out string partialPath,
-            out error), error);
+            out string error), error);
         return (modelPath, partialPath);
     }
+
+    private static HuggingFaceModelInstaller CreateModelInstaller(
+        HttpClient client,
+        string localDataDirectory) =>
+        new(client, Task.Delay, () => CacheRoot(localDataDirectory));
+
+    private static string CacheRoot(string localDataDirectory) =>
+        Path.Combine(localDataDirectory, "hf-cache");
 
     private static LocalAiComponentIdentity TestComponent() =>
         new("llama-server", "v1", "win-x64");
@@ -815,6 +1393,72 @@ public sealed class LocalAiInstallRecoveryTests
             CancellationToken cancellationToken) => Task.FromResult(handler(request));
     }
 
+    private sealed class AsyncDelegateHandler(
+        Func<HttpRequestMessage, Task<HttpResponseMessage>> handler) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) => handler(request);
+    }
+
+    private sealed class BlockingReadStream(
+        byte[] bytes,
+        TaskCompletionSource entered,
+        TaskCompletionSource release) : MemoryStream(bytes, writable: false)
+    {
+        private bool _blocked;
+
+        public override async ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            if (!_blocked)
+            {
+                _blocked = true;
+                entered.SetResult();
+                await release.Task.WaitAsync(cancellationToken);
+            }
+            return await base.ReadAsync(buffer, cancellationToken);
+        }
+    }
+
+    private sealed class EofCallbackStream(byte[] bytes, Action callback)
+        : MemoryStream(bytes, writable: false)
+    {
+        private bool _called;
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            int read = base.Read(buffer, offset, count);
+            InvokeOnEof(read);
+            return read;
+        }
+
+        public override int Read(Span<byte> buffer)
+        {
+            int read = base.Read(buffer);
+            InvokeOnEof(read);
+            return read;
+        }
+
+        public override async ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            int read = await base.ReadAsync(buffer, cancellationToken);
+            InvokeOnEof(read);
+            return read;
+        }
+
+        private void InvokeOnEof(int read)
+        {
+            if (read != 0 || _called)
+                return;
+            _called = true;
+            callback();
+        }
+    }
+
     private sealed class ThrowAfterPrefixStream(byte[] bytes, int prefixLength) : Stream
     {
         private int _position;
@@ -864,7 +1508,7 @@ public sealed class LocalAiInstallRecoveryTests
     private sealed class AcceptingModelVerifier : ILocalAiModelFileVerifier
     {
         public Task<bool> VerifyAsync(
-            string path,
+            LocalAiResolvedInstall install,
             PinnedArtifact artifact,
             CancellationToken cancellationToken) => Task.FromResult(true);
     }

--- a/tests/OpenClaw.SetupEngine.Tests/LocalAiPortHandoffTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/LocalAiPortHandoffTests.cs
@@ -74,6 +74,16 @@ public sealed class LocalAiPortHandoffTests
         Assert.NotNull(saved);
         Assert.Equal(0, saved.Manifest.RequestedPort);
         Assert.Null(saved.Endpoint);
+        Assert.Equal(LocalAiInstallManifest.HubCacheReceiptSchemaVersion, saved.Manifest.SchemaVersion);
+        Assert.Equal(context.LocalAiModelInstall.CacheRoot, saved.Manifest.ModelCacheRoot);
+        Assert.Equal(context.LocalAiModelInstall.ModelPath, saved.Manifest.CachedModelPath);
+        Assert.Equal(context.LocalAiModelInstall.ModelPath, saved.ModelPath);
+        Assert.NotEqual(saved.Manifest.ModelPath, saved.Manifest.CachedModelPath);
+        Assert.Equal(
+            context.LocalAiModelInstall.LegacyModelPath,
+            new LocalAiPaths(temp.Path).ResolveContainedPath(
+                saved.Manifest.ModelPath,
+                nameof(saved.Manifest.ModelPath)));
     }
 
     [Fact]
@@ -192,10 +202,42 @@ public sealed class LocalAiPortHandoffTests
 
     private static HuggingFaceModelInstallResult ModelInstall(
         string localDataDirectory,
-        LocalModelInfo model) => new(
-            Path.Combine(localDataDirectory, "LocalAI", "models", model.Weights.RelativePath),
+        LocalModelInfo model)
+    {
+        string cacheRoot = Path.Combine(localDataDirectory, "hf-cache");
+        HuggingFaceRevisionSource source = Assert.IsType<HuggingFaceRevisionSource>(
+            model.Weights.Source);
+        Assert.True(HuggingFaceHubCache.TryGetSnapshotPaths(
+            cacheRoot,
+            source.RepositoryId,
+            source.RevisionSha,
+            model.Weights.RelativePath,
+            out string modelPath,
+            out _,
+            out string error), error);
+        LocalAiComponentIdentity component = LlamaRuntimeInstaller.Component(
+            LlamaRuntimeCatalog.Find(Architecture.Arm64)!);
+        Assert.True(LocalAiPathPolicy.TryResolve(
+            localDataDirectory,
+            component,
+            out LocalAiSetupPaths paths,
+            out error), error);
+        Assert.True(LocalAiPathPolicy.TryGetModelPaths(
+            paths,
+            source.RepositoryId,
+            source.RevisionSha,
+            model.Weights.RelativePath,
+            out string legacyModelPath,
+            out _,
+            out error), error);
+        return new(
+            modelPath,
+            cacheRoot,
             HuggingFaceModelInstallDisposition.Downloaded,
-            CreatedThisRun: true);
+            CreatedThisRun: true,
+            legacyModelPath,
+            LegacyCreatedThisRun: true);
+    }
 
     private sealed class FakeHardwareProbe(HostHardwareInfo hardware) : IHostHardwareProbe
     {

--- a/tests/OpenClaw.Shared.Tests/HuggingFaceHubCacheTests.cs
+++ b/tests/OpenClaw.Shared.Tests/HuggingFaceHubCacheTests.cs
@@ -271,12 +271,17 @@ public sealed class HuggingFaceHubCacheTests
         await File.WriteAllBytesAsync(blobPath, content);
         File.CreateSymbolicLink(snapshotPath, Path.GetRelativePath(snapshots, blobPath));
 
-        await using FileStream? verified = await HuggingFaceHubCache.TryOpenVerifiedCacheFileAsync(
+        await using VerifiedHuggingFaceCacheFile? verified =
+            await HuggingFaceHubCache.TryOpenVerifiedCacheEntryAsync(
             cache.Path,
             snapshotPath,
             content.Length,
             digest);
         Assert.NotNull(verified);
+        Assert.Equal(
+            WindowsPathSafety.NormalizePath(blobPath),
+            verified.ResolvedPath,
+            ignoreCase: true);
 
         File.Delete(snapshotPath);
         string outsidePath = Path.Combine(outside.Path, "model.gguf");


### PR DESCRIPTION
## Summary

Completes layer 3 of #1288 (feat(local-ai): store downloaded models in the standard HF hub cache) with the compatibility, migration, ownership, rollback, uninstall, recovery, and runtime verification contracts needed for existing installs.

This replacement preserves and credits Pedro Larroy (@larroy) as the author of the original #1288 direction and implementation. It builds on the already-merged cache primitives and migration work, while keeping schema-3 installs active and making schema 4 the explicit verified-cache rollout gate.

## What changed

- Acquire fresh models into the standard Hugging Face snapshot cache and reuse verified snapshot or blob content through open-handle verification.
- Keep `LocalAiManifestStore.LoadAsync` passive. Migration occurs only during explicit setup reconciliation.
- Preserve schema-3 installs and write schema-4 receipts only after verified cache adoption.
- Retain a verified app-owned compatibility copy for recovery and schema-4-aware transitional builds.
- Resolve the runtime model path from the same handle that verified the cache content, retain that lease for the managed process lifetime, and use only the physical resolved path in the router preset and readiness probes.
- Preserve shared cache artifacts and pre-existing partials across rollback, uninstall, cancellation, failures, and concurrent writers.
- Fail closed on traversal, unsafe links or reparse points, hard-linked partials, digest or size mismatch, destination races, manifest races, unavailable verified identity, and cache roots that physically resolve inside the recursively deleted `LocalAI` tree.
- Restore safe self-healing for mismatched app-owned compatibility copies.

## Required proof pools

- `none`: this changes Local AI cache acquisition and receipt handling, but does not require a custom GPU, gateway, installer, ARM64, Smart App Control, or interactive WinUI host. Cross-volume, filesystem-identity, and lifecycle behavior are covered by current-head deterministic Windows tests, including explicit non-skipping tests on a distinct volume.

## Validation

Current head: `8b2d28d527dae1177eeee823a756127dcf7ea616`

- `.\build.ps1`: passed, including documentation and proof-pool validation.
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore`: 3,991 passed, 32 skipped, 0 failed.
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore`: 2,897 passed, 0 skipped, 0 failed.
- `dotnet test .\tests\OpenClaw.Connection.Tests\OpenClaw.Connection.Tests.csproj --no-restore`: 793 passed, 1 capacity-gated cross-volume test skipped, 0 failed.
- `dotnet test .\tests\OpenClaw.SetupEngine.Tests\OpenClaw.SetupEngine.Tests.csproj --no-restore`: 1,152 passed, 1 capacity-gated cross-volume test skipped, 0 failed.
- Focused cache and runtime authority-chain tests: 28 passed, 0 skipped, 0 failed.
- Explicit cross-volume SetupEngine proof with `OPENCLAW_TEST_HF_CACHE_ROOT=D:\openclaw-test-hf-cache`: 1 passed, 0 skipped.
- Explicit cross-volume Connection migration proof with the same distinct-volume root: 1 passed, 0 skipped.
- Exact #1388 (feat(local-ai): add verified legacy model cache migration) reader proof at commit `3ce56b89`: `LocalAiManifestMigrationTests.Load_CopiesVerifiedLegacyWeightsAndRecordsTransitionalReceipt` passed 1, skipped 0, failed 0. The test asserts the schema-4 receipt loads with the legacy `ModelPath` active.
- One unrelated timing failure occurred in `GatewayConnectionManagerTests.AuthenticationFailed_DeviceTokenMismatch_SharedTokenFallback_RecoversWithSharedToken`; the exact test passed 5/5 immediately afterward and the complete Connection suite passed on rerun.
- `git diff --check`: passed; worktree clean after the four-commit portable stack.

## Real behavior proof

- Fresh acquisition writes and verifies the pinned model at the standard hub snapshot path.
- Verified pre-existing snapshot and content-addressed blob artifacts are reused without network download.
- A complete verified partial promotes with a handler that throws if HTTP is attempted, proving the no-network path.
- Cross-volume fresh-install compatibility materialization copied from the verified open cache handle and passed without skips on this Windows host.
- Cross-volume schema-3 migration copied from the verified open legacy handle and passed without skips on this Windows host.
- The current-head Windows symbolic-link proof opens and verifies a standard snapshot link, resolves the physical blob path from that same handle, replaces the snapshot link before process start, and proves both the router preset and readiness probe remain bound to the original verified blob identity.
- A current-head external Windows harness referenced the built production `OpenClaw.Shared` and `OpenClaw.Connection` assemblies, used `HuggingFaceHubCache.TryOpenVerifiedCacheEntryAsync`, invoked the production runtime router-preset builder, replaced the snapshot link, and then used a real `cmd.exe` child to open the preset model path. Redacted output:

```text
PROOF verified_api=production
PROOF router_preset=handle_resolved_physical_path
PROOF snapshot_substitution=observed_on_snapshot_only
PROOF native_child_read=original_verified_blob
PROOF verified_blob_rename_while_leased=blocked
RESULT PASS
```

- The retained handle uses read-only sharing without write or delete sharing and remains owned until managed process teardown, so the physical model identity cannot be replaced while the native runtime may open it.
- Rollback and uninstall tests prove shared final artifacts survive, while only transaction-owned compatibility files are removed.
- Runtime tampering tests prove schema-4 cache content is rejected before process launch.
- Nested and junction-aliased cache roots are rejected before install or migration mutation so recursive uninstall cannot remove shared cache state.
- Direct downgrade to schema-3-only releases is not claimed. Recovery and rollback to the declared oldest schema-4-aware transitional reader is proven by running the exact #1388 commit test above, which retains the legacy model bytes and selects the legacy `ModelPath` from its schema-4 receipt.

## Review

- Structured autoreview command: `python .agents\skills\autoreview\scripts\autoreview --mode local --engine codex --model gpt-5.6-sol --thinking high`.
- ClawSweeper's prior-head native identity finding was accepted and fixed by carrying the verified handle-resolved physical path through preset generation and readiness probes.
- A follow-up autoreview finding was accepted: schema 4 now leaves the runtime path unset until verification returns a valid lease, rather than temporarily caching the replaceable snapshot path.
- Final autoreview: clean, no accepted or actionable findings. Overall patch correct, confidence 0.87.
- Final rubber-duck review found no blocking issues after tracing cache containment, handle sharing, process lifetime, startup failure cleanup, and probe consistency.
- Earlier accepted review findings also fixed cache-root ownership on install and migration, filesystem-alias bypasses, recovery of mismatched app-owned compatibility copies, and preservation of pre-existing partials after promotion validation failures.

Supersedes #1288 (feat(local-ai): store downloaded models in the standard HF hub cache) after preserving Pedro Larroy's original contribution and closing its remaining compatibility and safety gaps.