### PR TITLE
fix(setup): allow Local AI setup on busy GPUs and current Gateway

### DIFF
--- a/src/OpenClaw.SetupEngine.UI/Pages/CapabilitiesPage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/CapabilitiesPage.xaml.cs
@@ -399,7 +399,7 @@ public sealed partial class CapabilitiesPage : Page
         LocalAiInstallReviewCard.Visibility = Visibility.Visible;
         LocalAiToggle.Visibility = Visibility.Visible;
         SetLocalAiOptionAvailability(isAvailable: true);
-        _localAiSelectionEligible = eligibility.Status == LocalInferenceEligibilityStatus.Eligible;
+        _localAiSelectionEligible = eligibility.CanInstall;
         _config!.LocalAi.SelectedModelId ??= eligibility.Plan!.Model.Id;
         _config.LocalAi.SelectedProfileId = eligibility.Plan!.Profile.Id;
         PopulateLocalAiModels();
@@ -741,17 +741,13 @@ public sealed partial class CapabilitiesPage : Page
             return;
         }
 
-        _localAiSelectionEligible = eligibility.Status == LocalInferenceEligibilityStatus.Eligible;
+        _localAiSelectionEligible = eligibility.CanInstall;
         _config!.LocalAi.SelectedProfileId = plan.Profile.Id;
         LocalAiHardwareStatusText.Text = eligibility.Status switch
         {
-            LocalInferenceEligibilityStatus.Eligible =>
+            LocalInferenceEligibilityStatus.Eligible or LocalInferenceEligibilityStatus.EligibleButBusy =>
                 $"{FormatMemorySize(eligibility.RequiredTotalMemoryBytes)} required · " +
                 $"{FormatOptionalMemorySize(eligibility.DetectedTotalMemoryBytes)} CUDA-visible on {gpu.Name}",
-            LocalInferenceEligibilityStatus.EligibleButBusy =>
-                $"Detected {gpu.Name}, but only {FormatOptionalMemorySize(eligibility.AvailableFreeMemoryBytes)} of " +
-                $"{FormatMemorySize(eligibility.RequiredFreeMemoryBytes)} required GPU memory is currently free. " +
-                "Close GPU applications and retry setup.",
             _ => DescribeLocalAiUnavailable(eligibility),
         };
         LocalAiEngineDetailText.Text =

--- a/src/OpenClaw.SetupEngine.UI/Pages/CompletePage.xaml
+++ b/src/OpenClaw.SetupEngine.UI/Pages/CompletePage.xaml
@@ -88,7 +88,7 @@
                         <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="14">
                             <FontIcon Grid.Column="0" Glyph="&#xE950;" FontSize="18" VerticalAlignment="Center" />
                             <StackPanel Grid.Column="1" Spacing="2">
-                                <TextBlock x:Name="LocalAiSummaryTitle" Text="Local AI verified"
+                                <TextBlock x:Name="LocalAiSummaryTitle" Text="Local AI installed"
                                            Style="{StaticResource BodyStrongTextBlockStyle}" />
                                 <TextBlock x:Name="LocalAiSummaryDescription"
                                            AutomationProperties.LiveSetting="Polite"

--- a/src/OpenClaw.SetupEngine.UI/Pages/CompletePage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/CompletePage.xaml.cs
@@ -46,7 +46,7 @@ public sealed partial class CompletePage : Page
                 LocalAiSummaryCard.Visibility = review.LocalAiEnabled ? Visibility.Visible : Visibility.Collapsed;
                 if (review.LocalAiEnabled)
                 {
-                    LocalAiSummaryTitle.Text = review.LocalAiTitle ?? "Local AI verified";
+                    LocalAiSummaryTitle.Text = review.LocalAiTitle ?? "Local AI installed";
                     LocalAiSummaryDescription.Text = review.LocalAiDescription ??
                         "The native llama-server router is ready. The model loads on the first request.";
                     SubtitleText.Text = "OpenClaw and Local AI are ready";

--- a/src/OpenClaw.SetupEngine.UI/Pages/ProgressPage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/ProgressPage.xaml.cs
@@ -40,7 +40,7 @@ public sealed partial class ProgressPage : Page
         ("wsl-platform", "Prepare WSL", ["ensure-wsl-platform"]),
         ("local-ai-engine", "Install Local AI", ["acquire-local-ai-runtime"]),
         ("local-ai-model", "Download AI model", ["acquire-local-ai-model"]),
-        ("local-ai-verify", "Verify Local AI", ["persist-local-ai-manifest", "start-local-ai-runtime", "capture-local-ai-gpu-baseline", "verify-local-ai-inference", "verify-local-ai-gpu-load"]),
+        ("local-ai-verify", "Prepare Local AI router", ["persist-local-ai-manifest", "start-local-ai-runtime"]),
         ("wsl-networking", "Connect WSL to Local AI", ["configure-local-ai-wsl-networking"]),
         ("cleanup", "Remove existing gateway", ["cleanup-distro", "cleanup-gateway"]),
         ("port", "Check gateway port", ["preflight-port"]),

--- a/src/OpenClaw.SetupEngine/LocalAiGatewayConfiguration.cs
+++ b/src/OpenClaw.SetupEngine/LocalAiGatewayConfiguration.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Text.Json;
 using OpenClaw.Connection.LocalAi;
+using OpenClaw.Shared;
 
 namespace OpenClaw.SetupEngine;
 
@@ -58,6 +59,7 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
     private const string ProviderMarker = "OPENCLAW_LOCAL_AI_PROVIDER_B64=";
     private const string PrimaryMarker = "OPENCLAW_LOCAL_AI_PRIMARY_B64=";
     private const string MissingValue = "MISSING";
+    private const string FailedValuePrefix = "FAILED:";
     private const string BatchVariable = "OPENCLAW_LOCAL_AI_BATCH_B64";
     private const int MaximumSnapshotBytes = 1024 * 1024;
 
@@ -347,12 +349,20 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
               error_file="$(mktemp)"
               if openclaw config get "$key" --json >"$temp_file" 2>"$error_file"; then
                 printf '%s%s\n' "$marker" "$(base64 -w0 <"$temp_file")"
-              elif grep -Fq "Config path not found: $key" "$error_file"; then
-                printf '%s{{MissingValue}}\n' "$marker"
               else
-                cat "$error_file" >&2
-                rm -f "$temp_file" "$error_file"
-                return 1
+                config_exit=$?
+                if [ "$config_exit" -eq 1 ]; then
+                  if grep -Fxq -e "Config path not found: $key" \
+                      -e "Config path not found: $key. Run openclaw config validate to inspect config shape." "$error_file"; then
+                    printf '%s{{MissingValue}}\n' "$marker"
+                  else
+                    printf '%s{{FailedValuePrefix}}%s\n' "$marker" "$(base64 -w0 <"$temp_file")"
+                  fi
+                else
+                  cat "$error_file" >&2
+                  rm -f "$temp_file" "$error_file"
+                  return 1
+                fi
               fi
               rm -f "$temp_file" "$error_file"
             }
@@ -391,12 +401,14 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
 
     private static LocalAiGatewayPriorState ParseSnapshot(string stdout)
     {
-        (bool providerExists, string? provider) = ParseMarker(stdout, ProviderMarker);
-        (bool primaryExists, string? primary) = ParseMarker(stdout, PrimaryMarker);
+        (bool providerExists, string? provider) = ParseMarker(
+            stdout, ProviderMarker, LocalAiGatewayConfigBuilder.ProviderPath);
+        (bool primaryExists, string? primary) = ParseMarker(
+            stdout, PrimaryMarker, LocalAiGatewayConfigBuilder.PrimaryModelPath);
         return new(providerExists, provider, primaryExists, primary);
     }
 
-    private static (bool Exists, string? Json) ParseMarker(string stdout, string marker)
+    private static (bool Exists, string? Json) ParseMarker(string stdout, string marker, string path)
     {
         string? value = stdout.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)
             .SingleOrDefault(line => line.StartsWith(marker, StringComparison.Ordinal))?[marker.Length..];
@@ -404,6 +416,9 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
             throw new InvalidDataException($"Missing configuration marker '{marker}'.");
         if (string.Equals(value, MissingValue, StringComparison.Ordinal))
             return (false, null);
+        bool commandFailed = value.StartsWith(FailedValuePrefix, StringComparison.Ordinal);
+        if (commandFailed)
+            value = value[FailedValuePrefix.Length..];
         if (value.Length > MaximumSnapshotBytes * 2)
             throw new InvalidDataException("The configuration snapshot is too large.");
 
@@ -411,7 +426,13 @@ public sealed class ConfigureLocalAiGatewayStep : SetupStep
         if (bytes.Length > MaximumSnapshotBytes)
             throw new InvalidDataException("The configuration snapshot is too large.");
         string json = Encoding.UTF8.GetString(bytes);
-        using JsonDocument _ = JsonDocument.Parse(json, new JsonDocumentOptions { MaxDepth = 32 });
+        using JsonDocument document = JsonDocument.Parse(json, new JsonDocumentOptions { MaxDepth = 32 });
+        if (commandFailed)
+        {
+            if (GatewayConfigCliCompatibility.IsUnsetError(document.RootElement, path))
+                return (false, null);
+            throw new InvalidDataException("The gateway configuration read failed.");
+        }
         return (true, json);
     }
 

--- a/src/OpenClaw.SetupEngine/LocalAiSetupSteps.cs
+++ b/src/OpenClaw.SetupEngine/LocalAiSetupSteps.cs
@@ -61,15 +61,6 @@ public sealed class PreflightLocalAiHardwareStep : SetupStep
                 $"({eligibility.FailureCode}, {eligibility.SelectionFailureCode})."));
         }
 
-        if (eligibility.Status == LocalInferenceEligibilityStatus.EligibleButBusy)
-        {
-            long requiredMiB = eligibility.RequiredFreeMemoryBytes / (1024 * 1024);
-            long availableMiB = (eligibility.AvailableFreeMemoryBytes ?? 0) / (1024 * 1024);
-            return Task.FromResult(StepResult.Terminal(
-                $"The selected GPU is supported but currently busy. Local AI needs {requiredMiB:N0} MiB free; " +
-                $"{availableMiB:N0} MiB is available. Close GPU applications and retry."));
-        }
-
         if (eligibility.Plan is null || eligibility.SelectedGpu is null)
         {
             return Task.FromResult(StepResult.Terminal(

--- a/src/OpenClaw.SetupEngine/SetupPipeline.cs
+++ b/src/OpenClaw.SetupEngine/SetupPipeline.cs
@@ -45,6 +45,17 @@ public sealed record StepProgressEvent(string StepId, string DisplayName, StepOu
 
 public static class SetupStepFactory
 {
+    /// <summary>
+    /// Opt-in inference proof for diagnostics and release validation after the managed
+    /// router is installed. These steps load the model and must not gate installation.
+    /// </summary>
+    public static List<SetupStep> BuildLocalAiInferenceProofSteps() =>
+    [
+        new CaptureLocalAiGpuBaselineStep(),
+        new VerifyLocalAiInferenceStep(),
+        new VerifyLocalAiGpuLoadStep(),
+    ];
+
     public static List<SetupStep> BuildWizardOnlySteps() =>
     [
         new RunGatewayWizardStep(),
@@ -66,9 +77,6 @@ public static class SetupStepFactory
             new AcquireLocalAiModelStep(),
             new PersistLocalAiManifestStep(),
             new StartLocalAiRuntimeStep(),
-            new CaptureLocalAiGpuBaselineStep(),
-            new VerifyLocalAiInferenceStep(),
-            new VerifyLocalAiGpuLoadStep(),
             new ConfigureLocalAiWslNetworkingStep(),
             new CleanupStaleDistroStep(),
             new CleanupStaleGatewayStep(),

--- a/src/OpenClaw.SetupEngine/WindowsNodeBootstrapContextStep.cs
+++ b/src/OpenClaw.SetupEngine/WindowsNodeBootstrapContextStep.cs
@@ -407,9 +407,7 @@ public sealed class WindowsNodeBootstrapContextStep : SetupStep
             // Validated releases report an absent key with exit 1. Only that
             // known case may select the default; other read failures must not
             // be persisted by the subsequent `setup --workspace` call.
-            if (!result.Stderr.Contains(
-                    "Config path not found: agents.defaults.workspace",
-                    StringComparison.Ordinal))
+            if (!IsUnsetDefaultWorkspace(result))
                 return null;
 
             raw = $"{home.TrimEnd('/')}/.openclaw/workspace";
@@ -429,6 +427,10 @@ public sealed class WindowsNodeBootstrapContextStep : SetupStep
 
         return ExpandLinuxPath(raw, home);
     }
+
+    private static bool IsUnsetDefaultWorkspace(CommandResult result) =>
+        GatewayConfigCliCompatibility.IsUnsetError(
+            result.ExitCode, result.Stdout, result.Stderr, "agents.defaults.workspace");
 
     internal static string? ExtractDefaultAgentWorkspaceFromAgentsOutput(string stdout)
     {

--- a/src/OpenClaw.Shared/GatewayConfigCliCompatibility.cs
+++ b/src/OpenClaw.Shared/GatewayConfigCliCompatibility.cs
@@ -1,0 +1,44 @@
+using System.Text.Json;
+
+namespace OpenClaw.Shared;
+
+/// <summary>
+/// Recognizes only known unset-path CLI errors, never unknown paths or operational failures.
+/// Callers retain transport timeout checks and snapshot-specific decoding and size limits.
+/// </summary>
+public static class GatewayConfigCliCompatibility
+{
+    public static bool IsUnsetError(int exitCode, string stdout, string stderr, string path)
+    {
+        if (exitCode != 1 || stdout.Length > 64 * 1024)
+            return false;
+        if (string.IsNullOrWhiteSpace(stdout))
+        {
+            string legacy = $"Config path not found: {path}";
+            string error = stderr.Trim();
+            return error == legacy ||
+                error == legacy + ". Run openclaw config validate to inspect config shape.";
+        }
+
+        try
+        {
+            using JsonDocument document = JsonDocument.Parse(stdout, new JsonDocumentOptions { MaxDepth = 16 });
+            return IsUnsetError(document.RootElement, path);
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    // Gateway 2026.9 reports a valid, unset path as a structured stdout error.
+    // Snapshot callers already check the command exit code and parse bounded JSON.
+    public static bool IsUnsetError(JsonElement root, string path) =>
+        root.ValueKind == JsonValueKind.Object &&
+        root.TryGetProperty("ok", out JsonElement ok) && ok.ValueKind == JsonValueKind.False &&
+        root.TryGetProperty("error", out JsonElement error) && error.ValueKind == JsonValueKind.Object &&
+        error.TryGetProperty("type", out JsonElement type) && type.ValueKind == JsonValueKind.String &&
+        type.GetString() == "cli_error" &&
+        error.TryGetProperty("message", out JsonElement message) && message.ValueKind == JsonValueKind.String &&
+        message.GetString() == $"Config path is valid but unset: {path}. The runtime default applies until you set an authored value with openclaw config set {path} <value>.";
+}

--- a/src/OpenClaw.Tray.WinUI/Services/LocalAiGatewayProviderCoordinator.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/LocalAiGatewayProviderCoordinator.cs
@@ -241,11 +241,15 @@ internal sealed class LocalAiGatewayProviderCoordinator : ILocalAiEndpointLifecy
         WslCommandResult direct = routed.Result!;
         if (direct.Success)
             return new(true, true, direct.StandardOutput, null);
-        string missing = $"Config path not found: {path}";
-        return direct.StandardError.Contains(missing, StringComparison.Ordinal)
+        return IsUnsetSetting(direct, path)
             ? new(true, false, null, null)
             : new(false, false, null, $"The app-owned gateway setting '{path}' could not be read.");
     }
+
+    private static bool IsUnsetSetting(WslCommandResult result, string path) =>
+        result.StandardError.Length <= 64 * 1024 &&
+        GatewayConfigCliCompatibility.IsUnsetError(
+            result.ExitCode, result.StandardOutput, result.StandardError, path);
 
     private async Task<LocalAiEndpointLifecycleResult> SetPrimaryAsync(
         string model,
@@ -282,12 +286,19 @@ internal sealed class LocalAiGatewayProviderCoordinator : ILocalAiEndpointLifecy
         CancellationToken cancellationToken)
     {
         string encoded = Convert.ToBase64String(Encoding.UTF8.GetBytes(batch));
+        // Gateway requires a regular batch file. Send this script through stdin
+        // so wsl.exe cannot expand the Linux temporary-file variable in argv.
         string script =
-            $"set -e\nprintf '%s' '{encoded}' | base64 -d | openclaw config set --batch-file /dev/stdin --dry-run\n" +
-            $"printf '%s' '{encoded}' | base64 -d | openclaw config set --batch-file /dev/stdin";
+            "set -e\n" +
+            "batch_file=\"$(mktemp)\"\n" +
+            "trap 'rm -f \"$batch_file\"' EXIT\n" +
+            $"printf '%s' '{encoded}' | base64 -d > \"$batch_file\"\n" +
+            "openclaw config set --batch-file \"$batch_file\" --dry-run\n" +
+            "openclaw config set --batch-file \"$batch_file\"\n";
         return RunInManagedDistroAsync(
-            ["/usr/bin/env", $"PATH={FixedPath}", "/bin/sh", "-c", script],
-            cancellationToken);
+            ["/usr/bin/env", $"PATH={FixedPath}", "/bin/sh", "-s"],
+            cancellationToken,
+            standardInput: script);
     }
 
     private static JsonDocument ParseBounded(string value)
@@ -313,7 +324,8 @@ internal sealed class LocalAiGatewayProviderCoordinator : ILocalAiEndpointLifecy
 
     private async Task<RoutedCommandResult> RunInManagedDistroAsync(
         IReadOnlyList<string> command,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        string? standardInput = null)
     {
         LocalAiGatewayDistroResolution resolution = _distroResolver.Resolve();
         if (!resolution.Success)
@@ -322,7 +334,8 @@ internal sealed class LocalAiGatewayProviderCoordinator : ILocalAiEndpointLifecy
         WslCommandResult result = await _commands.RunInDistroAsync(
                 resolution.DistroName!,
                 command,
-                cancellationToken)
+                cancellationToken,
+                standardInput: standardInput)
             .ConfigureAwait(false);
         return new(result, null);
     }

--- a/tests/OpenClaw.SetupEngine.Tests/SetupPipelineTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupPipelineTests.cs
@@ -99,7 +99,7 @@ public class SetupPipelineTests
     {
         var steps = SetupStepFactory.BuildDefaultSteps();
 
-        Assert.Equal(37, steps.Count);
+        Assert.Equal(34, steps.Count);
         Assert.IsType<ValidateDistroInstallPathStep>(steps[0]);
         Assert.IsType<PreflightOsStep>(steps[1]);
         Assert.IsType<PreflightLocalAiHardwareStep>(steps[2]);
@@ -111,12 +111,9 @@ public class SetupPipelineTests
         Assert.IsType<AcquireLocalAiModelStep>(steps[8]);
         Assert.IsType<PersistLocalAiManifestStep>(steps[9]);
         Assert.IsType<StartLocalAiRuntimeStep>(steps[10]);
-        Assert.IsType<CaptureLocalAiGpuBaselineStep>(steps[11]);
-        Assert.IsType<VerifyLocalAiInferenceStep>(steps[12]);
-        Assert.IsType<VerifyLocalAiGpuLoadStep>(steps[13]);
-        Assert.IsType<ConfigureLocalAiWslNetworkingStep>(steps[14]);
-        Assert.IsType<CleanupStaleDistroStep>(steps[15]);
-        Assert.IsType<CleanupStaleGatewayStep>(steps[16]);
+        Assert.IsType<ConfigureLocalAiWslNetworkingStep>(steps[11]);
+        Assert.IsType<CleanupStaleDistroStep>(steps[12]);
+        Assert.IsType<CleanupStaleGatewayStep>(steps[13]);
         Assert.Contains(steps, s => s is ValidateWslLockdownStep);
         var lockdownIndex = steps.FindIndex(s => s is ValidateWslLockdownStep);
         var cliInstallIndex = steps.FindIndex(s => s is InstallCliStep);
@@ -162,9 +159,6 @@ public class SetupPipelineTests
             steps.Single(step => step is AcquireLocalAiModelStep),
             steps.Single(step => step is PersistLocalAiManifestStep),
             steps.Single(step => step is StartLocalAiRuntimeStep),
-            steps.Single(step => step is CaptureLocalAiGpuBaselineStep),
-            steps.Single(step => step is VerifyLocalAiInferenceStep),
-            steps.Single(step => step is VerifyLocalAiGpuLoadStep),
             steps.Single(step => step is ConfigureLocalAiWslNetworkingStep),
             steps.Single(step => step is VerifyLocalAiWslStep),
             steps.Single(step => step is ConfigureLocalAiGatewayStep),
@@ -173,6 +167,29 @@ public class SetupPipelineTests
         Assert.All(localAiSteps, step => Assert.True(step.CanSkip(ctx), step.Id));
         Assert.False(steps.Single(step => step is PreflightWslStep).CanSkip(ctx));
         Assert.False(steps.Single(step => step is EnsureWslPlatformStep).CanSkip(ctx));
+    }
+
+    [Fact]
+    public void ModelLoadingProof_IsOptInAndNeverPartOfDefaultSetup()
+    {
+        var setup = SetupStepFactory.BuildDefaultSteps();
+        var proof = SetupStepFactory.BuildLocalAiInferenceProofSteps();
+
+        Assert.Collection(proof,
+            step => Assert.IsType<CaptureLocalAiGpuBaselineStep>(step),
+            step => Assert.IsType<VerifyLocalAiInferenceStep>(step),
+            step => Assert.IsType<VerifyLocalAiGpuLoadStep>(step));
+        Assert.All(proof, step => Assert.DoesNotContain(setup, candidate => candidate.Id == step.Id));
+        Assert.All(proof, step => Assert.True(step.CanSkip(CreateContext(new SetupConfig
+        {
+            LocalAi = new LocalAiConfig { Enabled = false }
+        }))));
+
+        string wslProbe = VerifyLocalAiWslStep.BuildProbeScript(49152);
+        Assert.Contains("/health", wslProbe);
+        Assert.Contains("/models?autoload=false", wslProbe);
+        Assert.DoesNotContain("/completion", wslProbe);
+        Assert.DoesNotContain("/models/load", wslProbe);
     }
 
     [Theory]

--- a/tests/OpenClaw.Tray.Tests/LocalAiGatewayProviderCoordinatorTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalAiGatewayProviderCoordinatorTests.cs
@@ -316,9 +316,21 @@ public sealed class LocalAiGatewayProviderCoordinatorTests
         Assert.True(LocalAiGatewayProviderDefinition.MatchesProviderJson(commands.ProviderJson!, install));
         Assert.Equal(LocalAiGatewayProviderDefinition.BuildPrimaryModel(install), commands.PrimaryModel);
         IReadOnlyList<string> apply = Assert.Single(commands.Calls, call => call.Contains("/bin/sh"));
-        string script = apply[^1];
-        Assert.Contains("--dry-run", script, StringComparison.Ordinal);
-        Assert.DoesNotContain('$', script);
+        Assert.Equal("-s", apply[^1]);
+        Assert.DoesNotContain("-c", apply);
+        Assert.DoesNotContain(apply, argument => argument.Contains("base64", StringComparison.Ordinal));
+        string script = Assert.IsType<string>(commands.StandardInputs[
+            commands.Calls.FindIndex(call => call.Contains("/bin/sh"))]);
+        Assert.StartsWith("set -e\n", script, StringComparison.Ordinal);
+        Assert.Contains("batch_file=\"$(mktemp)\"\n", script, StringComparison.Ordinal);
+        Assert.Contains("trap 'rm -f \"$batch_file\"' EXIT\n", script, StringComparison.Ordinal);
+        Assert.Contains("| base64 -d > \"$batch_file\"\n", script, StringComparison.Ordinal);
+        Assert.Contains(
+            "openclaw config set --batch-file \"$batch_file\" --dry-run\n" +
+            "openclaw config set --batch-file \"$batch_file\"\n",
+            script, StringComparison.Ordinal);
+        Assert.DoesNotContain("/dev/stdin", script, StringComparison.Ordinal);
+        Assert.DoesNotContain('\r', script);
         Assert.All(commands.Distros, distro => Assert.Equal("CustomGateway", distro));
     }
 
@@ -399,6 +411,10 @@ public sealed class LocalAiGatewayProviderCoordinatorTests
         int unsetIndex = commands.Calls.FindIndex(call =>
             call.Contains("unset") && call.Contains(LocalAiGatewayProviderDefinition.ProviderPath));
         Assert.True(restoreIndex >= 0 && unsetIndex > restoreIndex);
+        Assert.Equal("-s", commands.Calls[restoreIndex][^1]);
+        string restoreScript = Assert.IsType<string>(commands.StandardInputs[restoreIndex]);
+        Assert.Contains("--batch-file \"$batch_file\" --dry-run", restoreScript, StringComparison.Ordinal);
+        Assert.DoesNotContain("/dev/stdin", restoreScript, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -584,6 +600,7 @@ public sealed class LocalAiGatewayProviderCoordinatorTests
         public HashSet<int> FailedReadCalls { get; init; } = [];
         public Action<int>? CommandObserved { get; init; }
         public List<IReadOnlyList<string>> Calls { get; } = [];
+        public List<string?> StandardInputs { get; } = [];
         public List<string> Distros { get; } = [];
         private int _readCalls;
 
@@ -597,6 +614,7 @@ public sealed class LocalAiGatewayProviderCoordinatorTests
             cancellationToken.ThrowIfCancellationRequested();
             Distros.Add(name);
             Calls.Add(command.ToArray());
+            StandardInputs.Add(standardInput);
             CommandObserved?.Invoke(Calls.Count);
             bool providerRead = command.Contains("get") &&
                 command.Contains(LocalAiGatewayProviderDefinition.ProviderPath);

--- a/tests/OpenClaw.Tray.Tests/LocalAiSetupUxContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalAiSetupUxContractTests.cs
@@ -5,6 +5,26 @@ namespace OpenClaw.Tray.Tests;
 public sealed class LocalAiSetupUxContractTests
 {
     [Fact]
+    public void LocalAiSetupProgressAndCompletion_DoNotPromiseInferenceVerification()
+    {
+        string root = TestRepositoryPaths.GetRepositoryRoot();
+        string pages = Path.Combine(root, "src", "OpenClaw.SetupEngine.UI", "Pages");
+        string progress = File.ReadAllText(Path.Combine(pages, "ProgressPage.xaml.cs"));
+        string complete = File.ReadAllText(Path.Combine(pages, "CompletePage.xaml.cs"));
+        string completeXaml = File.ReadAllText(Path.Combine(pages, "CompletePage.xaml"));
+
+        Assert.Contains("Prepare Local AI router", progress);
+        Assert.DoesNotContain("capture-local-ai-gpu-baseline", progress);
+        Assert.DoesNotContain("verify-local-ai-inference", progress);
+        Assert.DoesNotContain("verify-local-ai-gpu-load", progress);
+        Assert.Contains("Local AI installed", complete);
+        Assert.Contains("Local AI installed", completeXaml);
+        Assert.Contains("The model loads on the first request.", complete);
+        Assert.DoesNotContain("Local AI verified", complete);
+        Assert.DoesNotContain("Local AI verified", completeXaml);
+    }
+
+    [Fact]
     public void WelcomePage_ShowsLocalAiCompatibilityDetails()
     {
         string root = TestRepositoryPaths.GetRepositoryRoot();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users setting up Local AI on a supported GPU would have installation blocked when another application temporarily occupied VRAM. Also fixes setup and managed-provider failures with current Gateway config CLI output and batch-file handling.

Addresses the setup portion of #1391. Fixes #1398.

## Why This Change Was Made

Installation eligibility should use GPU capabilities and total supported memory, not require enough free VRAM to load the model during onboarding. Model loading remains deferred until use.

This PR contains exactly three contributor-authored commits:

1. `c5f6e740`: allow supported-but-busy GPUs through Local AI selection and hardware preflight.
2. `69d4e85b`: remove model-loading/inference proof steps from the installation pipeline, retain them as opt-in diagnostics, and describe completion as installed rather than inference-verified.
3. `9add27bc`: support known legacy stderr and current structured stdout unset-config errors, and send Gateway config batches through a regular temporary file. One shared parser owns the exact error recognition across setup snapshots, workspace resolution, and the runtime provider coordinator.

Unknown config paths, operational errors, malformed responses, timeout checks, size limits, ownership checks, and rollback protections remain fail-closed. The final parser extraction removes 22 production lines and preserves behavior.

Non-goals: no new OOM chat UI, no changed post-setup model-load error UX, and no Gateway version-policy change. Diagnostic proof harnesses remain local-only and are not part of this branch.

## User Impact

Users can download and complete Local AI setup while a capable GPU is temporarily busy. Setup still installs and starts the managed router, but does not load the model to prove inference. Actual inference still requires sufficient memory when the model loads.

## Required proof pools

- `windows-wsl-dgx-blackwell`: contributor hardware proof on the exact remote head, with RTX 5090 temporary VRAM pressure and successful inference after pressure release.
- `windows-wsl-gateway-e2e`: exact-head CI setup/connect E2E passed against current `main`; current Gateway 2026.9.3 publication/restoration was also exercised live on isolated port 18790.
- `windows-winui-interactive`: contributor screenshot/comment on the exact remote head demonstrates completed setup and deferred model-load failure.

## Validation

The contributor head remains `9add27bc2ffed3b87fdceac334cbad84158d0e6e`. No maintainer commit was pushed, preserving Joel/@joelagnel's exact-head proof and attribution.

GitHub's exact-head PR test merge used current `main` at `7dab793673ff00a43fd74259ed83321894ef601e` from #1397 (feat(local-ai): safely use the standard Hugging Face hub cache). [CI run 34537565845](https://github.com/openclaw/openclaw-windows-node/actions/runs/34537565845) is green for the CI Gate, Core and CLI tests, Tray/setup/integration tests, UI/functional/accessibility tests, Setup and connect E2E, Revocation recovery E2E, Network recovery E2E, fast validation, and proof-pool contracts.

Maintainer integration head `f390967db41909332501002ee7cf905dc021bf90` is a local-only clean merge of `7dab7936` into `9add27bc`. It was not pushed because the effective 13-file PR delta merges cleanly and no attributable blocking defect was found.

| Command | Integration result at `f390967d` |
| --- | --- |
| `.\build.ps1` | Passed |
| `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore` | Passed full rerun: 3,991 passed, 32 skipped |
| `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore` | 2,898 passed, 0 skipped |
| `dotnet test .\tests\OpenClaw.SetupEngine.Tests\OpenClaw.SetupEngine.Tests.csproj --no-restore` | 1,153 passed, 1 skipped |
| `dotnet test .\tests\OpenClaw.Connection.Tests\OpenClaw.Connection.Tests.csproj --no-restore` | 793 passed, 1 skipped |
| `dotnet test .\tests\OpenClaw.Tray.UITests\OpenClaw.Tray.UITests.csproj -r win-x64` | 136 passed |
| `dotnet test .\tests\OpenClawTray.FunctionalUI.Tests\OpenClawTray.FunctionalUI.Tests.csproj -r win-x64` | 19 passed |
| `OPENCLAW_RUN_INTEGRATION=1` Tray integration suite | 22 passed |
| `python .agents\skills\autoreview\scripts\autoreview --mode branch --base origin/main` | Clean, no accepted/actionable findings; patch judged correct with 0.84 confidence |
| Independent rubber-duck review | No blocking finding; high-confidence merge recommendation |

The reported Shared/CLI failures were reproduced and classified rather than hidden:

- `DeviceIdentityFailClosedTests.OperatorCli_WhenPersistedIdentityIsCorrupt_ReturnsSafeFailureWithoutStackTrace` passed 2/2 on the PR and current main.
- `McpHttpServerTests.Dispose_DuringInFlightHandler_DoesNotSurfaceObjectDisposedException` intermittently observed an unhandled `ObjectDisposedException` race in full-suite execution. It also reproduces on current main, passed 10/10 focused reruns after the latest failure, and a full `f390967d` Shared rerun passed 3,991/3,991 non-skipped tests. This is not attributable to this PR.
- Local `validate-mxc-e2e.ps1` reached the setup fixture, then failed before any PR-specific or MXC assertion because the host WSL fresh-install path could not attach its temporary `swap.vhdx` (`Access is denied`). Eleven tests passed and six fixture-dependent tests failed. The exact-head CI Setup and connect E2E lane is green, and an earlier hardware run passed all 17 MXC tests with no skips.

## Real behavior proof

### Exact-head busy-GPU setup

Joel's [proof comment](https://github.com/openclaw/openclaw-windows-node/pull/1399#issuecomment-5626327113) was posted after final contributor head `9add27bc` and explicitly records that setup completed while model loading remained deferred to inference. The attached screenshot shows the connected application and the deferred `Agent error` during temporary memory pressure. The recorded run used Windows x64, Gateway 2026.9.3, and an NVIDIA RTX 5090 with a 24 GiB allocation held during onboarding:

- Setup completed with 27 successful steps, two skipped steps, and zero failed steps.
- Model loading did not run as a mandatory setup step.
- Inference initially failed while pressure remained, then succeeded after the allocation was released.

This is the required busy-GPU behavior: install eligibility depends on supported total GPU memory, while actual model loading remains deferred until first use.

### Live current Gateway 2026.9.3 lifecycle

Maintainer proof used isolated Node 24.16.0, OpenClaw Gateway `2026.9.3 (1391f7c)`, isolated state, and a live Gateway listening on `127.0.0.1:18790`. No user Gateway config or port 18789 process was modified.

1. Both initially absent paths returned exit code 1 with the current structured JSON message `Config path is valid but unset`: `models.providers.llamacpp` and `agents.defaults.model.primary`.
2. A regular JSON batch file passed `config set --batch-file ... --dry-run --json` with two operations, schema validation, and complete resolvability.
3. Applying that same regular file published the `llamacpp` provider and selected `llamacpp/qwen3.8-27b-mtp-ud-q4-k-m`.
4. Read-back returned the complete provider with the API key redacted by the CLI.
5. The running Gateway logged config change detection and successful hot reload for both the provider and primary-model paths.
6. A second regular batch restored the prior primary model `openai/gpt-5.6-sol`; provider withdrawal succeeded; the running Gateway hot-reloaded both changes.
7. Final read-back preserved `openai/gpt-5.6-sol`, the provider again returned the exact structured unset response with exit code 1, and `config validate` passed.

Repository tests additionally assert the production coordinator sends its shell script through `/bin/sh -s` stdin, writes the batch to a regular `mktemp` file, performs dry-run before apply, and cleans the file on exit.

### Integration with current main

`f390967d` merges current `main` from #1397 (feat(local-ai): safely use the standard Hugging Face hub cache) into the contributor head without conflicts. The combined tree built and passed the targeted Local AI, setup, connection, WinUI, functional UI, tray integration, and mandatory Tray suites. The PR's effective source/test delta remains the contributor's 13 files.

## Review

ClawSweeper Revision 3 reviewed `9add27bc` against current `main` and reported no code or security finding. Its remaining asks were current-head behavior, Gateway lifecycle, and validation provenance, supplied above.

Final structured autoreview reported no accepted/actionable findings. Independent rubber-duck review found no merge blocker and confirmed the busy-GPU, parser, batch transport, rollback ownership, and merged-base behavior. It noted one non-blocking diagnostic-quality edge case: an unknown config-read failure during uninstall can surface an internal parser exception after failing closed. That does not weaken ownership checks, permit unsafe removal, or affect the setup/runtime paths fixed here, so it is not used to stale the proven contributor head.

## Security Impact

- New permissions/capabilities or data-access scope: No.
- Credential/token handling: unchanged.
- New network destinations: No.
- Gateway CLI transport: changed from a `/dev/stdin` batch to a temporary regular file with cleanup; scripts go over stdin rather than shell-expanded argv. Validation runs before mutation. Existing managed-route ownership and rollback behavior remain intact.

## Compatibility and Migration

- Known legacy and current Gateway unset-config responses are supported.
- Gateway remains on the repository's existing latest-stable installation policy; this PR does not upgrade or pin a version independently.
- No configuration migration or user action is required by the source change.
- #1384 (fix(local-ai): add non-destructive recovery) should refresh onto this PR after it lands.