### PR TITLE
fix(chat): prevent bubble text truncation

### DIFF
--- a/src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj
+++ b/src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj
@@ -82,8 +82,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
-    <PackageReference Include="Microsoft.UI.Reactor" Version="0.1.0-preview.14" />
-    <PackageReference Include="Microsoft.UI.Reactor.Advanced" Version="0.1.0-preview.14" />
+    <PackageReference Include="Microsoft.UI.Reactor" Version="0.1.0-preview.15" />
+    <PackageReference Include="Microsoft.UI.Reactor.Advanced" Version="0.1.0-preview.15" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="$(MicrosoftWindowsAppSDKVersion)" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$(MicrosoftWindowsSdkBuildToolsVersion)" />
     <PackageReference Include="OpenTelemetry" Version="1.16.0" />


### PR DESCRIPTION
Closes #1362

## What Problem This Solves

Fixes an issue where users reading chat bubbles could see text lines cut off mid-display.

## Why This Change Was Made

Updates both `Microsoft.UI.Reactor` and `Microsoft.UI.Reactor.Advanced` from `0.1.0-preview.14` to `0.1.0-preview.15`. This Reactor release contains Barbara's upstream fix for the chat bubble text truncation reported in #1362.

## User Impact

Chat bubble text can use the corrected Reactor text layout behavior instead of truncating lines during display.

## Evidence

`dotnet list .\src\OpenClaw.Tray.WinUI\OpenClaw.Tray.WinUI.csproj package --include-transitive` resolves both Reactor packages to `0.1.0-preview.15`. The full WinUI build and required shared and tray test suites pass on the current commit.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs or instructions
- [ ] Tests or validation
- [ ] Security hardening
- [ ] Chore or infrastructure

## Scope

- [x] Tray or WinUI UX
- [ ] Windows node capability
- [ ] Local MCP or `winnode`
- [ ] Gateway, connection, or pairing
- [ ] Setup or onboarding
- [ ] Permissions, privacy, or security
- [ ] Tests, CI, or docs

## Required proof pools

- `windows-winui-interactive`: confirm the upstream Reactor layout fix against the original chat bubble truncation reproduction.

## Validation

- `./build.ps1`: passed, all 5 projects built successfully for `win-arm64`.
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore`: passed, 3,989 passed, 34 skipped, 0 failed.
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore`: passed, 2,898 passed, 0 skipped, 0 failed.
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore --filter "FullyQualifiedName=OpenClaw.Shared.Tests.McpHttpServerTests.Dispose_DuringInFlightHandler_DoesNotSurfaceObjectDisposedException"`: passed, 1 passed, 0 failed after a transient failure in an earlier full-suite run.

## Real Behavior Proof

- Environment tested: Windows 11 ARM64, .NET SDK 10.0.400.
- PR head or commit tested: `c43c1dbd`.
- Exact steps or command run: resolved the tray project's package graph with `dotnet list ... package --include-transitive`, then ran the required build and test suite.
- Evidence after fix: `Microsoft.UI.Reactor` and `Microsoft.UI.Reactor.Advanced` both resolve to `0.1.0-preview.15`; the WinUI project builds successfully.
- Observed result: the application compiles against the Reactor release containing Barbara's fix.
- Screenshot or artifact links verified? (`Yes`/`No`/`N/A`): N/A.
- Not verified or blocked: the original issue's live chat reproduction state was not available in this isolated worktree, so current-head visual confirmation remains scheduled through `windows-winui-interactive`.

## Security Impact

- New permissions or capabilities? (`Yes`/`No`): No
- Secrets or tokens handling changed? (`Yes`/`No`): No
- New or changed network calls? (`Yes`/`No`): No
- Command or tool execution surface changed? (`Yes`/`No`): No
- Data access scope changed? (`Yes`/`No`): No
- If any answer is `Yes`, explain the risk and mitigation: N/A

## Compatibility and Migration

- Backward compatible? (`Yes`/`No`): Yes
- Config or environment changes? (`Yes`/`No`): No
- Migration needed? (`Yes`/`No`): No
- If yes, list the exact upgrade steps: N/A

## Review Conversations

- [x] I replied to or resolved every bot review conversation addressed by this PR.
- [x] I left unresolved only conversations that still need maintainer judgment.