### PR TITLE
fix(chat): work around WinUI session-switch crash

### DIFF
--- a/docs/TEST_COVERAGE.md
+++ b/docs/TEST_COVERAGE.md
@@ -50,6 +50,7 @@ authoritative runtime totals.
 ### OpenClaw.Tray.Tests
 
 - **Tray UI and state** - app state, menu display/position/sizing, tray tooltip formatting, activity streams, async list loading, diagnostics contracts, markup regressions, and chat timeline/markdown handling.
+- **Chat scroll lifetime** - `ChatTimelinePresentationTests` guards the workaround for [microsoft/microsoft-ui-xaml#11865](https://github.com/microsoft/microsoft-ui-xaml/issues/11865): automatic tail navigation must not use `ItemsView.StartBringItemIntoView`, which can retain a recycled row as an invalid anchor and throw `E_INVALIDARG` during subsequent layout. Tail requests use non-animated `ScrollView` extent navigation with stable bottom anchoring. Runtime proof should repeatedly switch between large, mixed-height histories, verify the final message is visible, and check that a scrolled-up reader is not pulled to the bottom by new messages.
 - **Connection and pairing** - connection manager node connector tests, connection page approval/channel metrics/row state, operator and Windows tray node pairing approval, and gateway action transport.
 - **Settings and startup** - settings round-trip/isolation, consent and settings save, auto-start defaults, startup setup state, existing config guard policy, and local setup progress stage mapping.
 - **Onboarding and local gateway setup** - onboarding completion/chat bootstrapper/existing config guard, wizard flow/selection/error/step parsing, setup code decoding, local gateway setup diagnostics, uninstall, WSL keep-alive, and auto-pair flags.

--- a/src/OpenClaw.Tray.WinUI/Chat/ReactorItemsViewScrollController.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ReactorItemsViewScrollController.cs
@@ -3,6 +3,7 @@ using Microsoft.UI.Reactor.Core;
 using Microsoft.UI.Reactor.Core.V1Protocol;
 using Microsoft.UI.Reactor.Input;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
 using System.Runtime.CompilerServices;
 using WinUIAnnotatedScrollBar = Microsoft.UI.Xaml.Controls.AnnotatedScrollBar;
 using WinUIItemsView = Microsoft.UI.Xaml.Controls.ItemsView;
@@ -253,7 +254,7 @@ file sealed class InitialTailPositioner : IDisposable
 
     private bool StartTailRequest(TailNavigationRequest request)
     {
-        if (itemsView.ScrollView is not { IsLoaded: true })
+        if (itemsView.ScrollView is not { IsLoaded: true } scrollView)
             return false;
 
         if (!TailNavigationPolicy.CanExecute(
@@ -266,11 +267,12 @@ file sealed class InitialTailPositioner : IDisposable
         }
 
         _following = true;
-        itemsView.StartBringItemIntoView(request.Index, new BringIntoViewOptions
-        {
-            AnimationDesired = false,
-            VerticalAlignmentRatio = 1.0,
-        });
+        // Work around microsoft/microsoft-ui-xaml#11865 without retaining a row
+        // as a bring-into-view anchor across history replacement.
+        scrollView.ScrollTo(
+            scrollView.HorizontalOffset,
+            scrollView.ScrollableHeight,
+            new ScrollingScrollOptions(ScrollingAnimationMode.Disabled, ScrollingSnapPointsMode.Ignore));
         return true;
     }
 

--- a/tests/OpenClaw.Tray.Tests/ChatTimelinePresentationTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ChatTimelinePresentationTests.cs
@@ -66,8 +66,11 @@ public sealed class ChatTimelinePresentationTests
         Assert.Contains("itemsView.Loaded += OnLoaded", binding);
         Assert.Contains("itemsView.LayoutUpdated += OnLayoutUpdated", binding);
         Assert.Contains("itemsView.DispatcherQueue.TryEnqueue", binding);
-        Assert.Contains("itemsView.StartBringItemIntoView(", binding);
-        Assert.Contains("VerticalAlignmentRatio = 1.0", binding);
+        Assert.Contains("scrollView.ScrollTo(", binding);
+        Assert.Contains("scrollView.HorizontalOffset,", binding);
+        Assert.Contains("scrollView.ScrollableHeight,", binding);
+        Assert.Contains("ScrollingAnimationMode.Disabled, ScrollingSnapPointsMode.Ignore", binding);
+        Assert.DoesNotContain("StartBringItemIntoView", binding);
         Assert.Contains("!string.Equals(_displayedTailKey, displayedTailKey, StringComparison.Ordinal)", binding);
         Assert.Contains("_following = IsNearBottom(sender)", binding);
         Assert.Contains("_scrollView.VerticalAnchorRatio = 1.0", binding);
@@ -83,7 +86,6 @@ public sealed class ChatTimelinePresentationTests
         Assert.DoesNotContain("ChangeView", binding);
         Assert.DoesNotContain("UpdateLayout", binding);
         Assert.DoesNotContain("TailSettle", binding);
-        Assert.DoesNotContain("ScrollTo(", binding);
         Assert.DoesNotContain("ScrollCompleted", binding);
         Assert.DoesNotContain("DispatcherTimer", binding);
         Assert.DoesNotContain("TextLength != current.TextLength", binding);
@@ -96,6 +98,7 @@ public sealed class ChatTimelinePresentationTests
         var viewChanged = binding[viewChangedStart..tailRequestStart];
         Assert.DoesNotContain("VerticalAnchorRatio", viewChanged);
         Assert.DoesNotContain("StartBringItemIntoView", viewChanged);
+        Assert.DoesNotContain("ScrollTo(", viewChanged);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

**This is an application-side workaround for [microsoft/microsoft-ui-xaml#11865](https://github.com/microsoft/microsoft-ui-xaml/issues/11865), not a fix in WinUI.**

Repeated chat-session switching can recycle a row retained by `ItemsView.StartBringItemIntoView`. A later native anchor request then rejects that row with `E_INVALIDARG`, terminating the app. The upstream issue includes the minimal reproducer and native failure details.

Replace automatic tail navigation with non-animated `ScrollView.ScrollTo`, using the current horizontal offset and scrollable height. This avoids the retained bring-into-view target. Keep the existing tail identity, generation, loaded-state, queue, and bottom-follow guards unchanged. Add a source regression guard against reintroducing the affected API and document the runtime proof path.

Ownership remains in `InitialTailPositioner` in `ReactorItemsViewScrollController.cs`. There is no new realization logic, layout loop, timer, or exception suppression.

Related: #1167. This targets the confirmed crash; it does not establish that the separately reported sustained UI-thread hang is resolved.

## Required proof pools

- `windows-11-arm64`: native ARM64 build and runtime validation on the architecture where the crash was investigated.
- `windows-winui-interactive`: chat session navigation and visible timeline behavior.

## Validation

- `.\build.ps1`: passed, including repository documentation checks.
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore`: 3,998 passed, 34 skipped, 0 failed.
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore`: 2,976 passed, 0 failed.
- Rubber-duck review of the final diff and controller lifecycle: no actionable findings.
- Structured autoreview: blocked. `python .agents\skills\autoreview\scripts\autoreview --mode local` exited 9009 because Python is not installed; Codex is also unavailable on PATH. No clean Codex review is claimed.

## Real behavior proof

The developer confirmed the original ScrollView workaround worked. The PR preserves that small workaround.

The final ARM64 Debug build was also launched with isolated tray settings against a loopback-only synthetic gateway serving two 77-message, mixed-height histories. After selecting **Workaround two**, the app remained responsive, the composer was visible, and an inspected screenshot showed the final row completely:

```text
Session: Workaround two
Workaround two: message 77
FINAL MESSAGE: Workaround two
```

The locally built WinApp CLI was used for UI automation, screenshots, ETW recording, and `perf analyze`. No private chat content, credentials, dumps, or raw traces are published.

### Not verified / blocked

- The extended automated switching loop did not complete: its session-row selector failed after one successful selection. This is not a passing 20-switch stress test.
- ETW analysis returned partial evidence: 0 lost events/buffers, 1 decode error, and 51 incomplete scope boundaries. No timing or performance conclusion is claimed.
- Streaming arrivals while scrolled up, tail positioning across every history shape, and the original sustained hang were not independently established by this closeout.
